### PR TITLE
Fix to address the issues in using params from group_vars/inventory

### DIFF
--- a/plugins/doc_fragments/modules.py
+++ b/plugins/doc_fragments/modules.py
@@ -55,20 +55,17 @@ options:
     - If C(no), it will not use a proxy, even if one is defined in an environment variable on the target hosts.
     - If the value is not specified in the task, the value of environment variable C(ND_USE_PROXY) will be used instead.
     type: bool
-    default: yes
   use_ssl:
     description:
     - If C(no), an HTTP connection will be used instead of the default HTTPS connection.
     - If the value is not specified in the task, the value of environment variable C(ND_USE_SSL) will be used instead.
     type: bool
-    default: yes
   validate_certs:
     description:
     - If C(no), SSL certificates will not be validated.
     - This should only set to C(no) when used on personally controlled sites using self-signed certificates.
     - If the value is not specified in the task, the value of environment variable C(ND_VALIDATE_CERTS) will be used instead.
     type: bool
-    default: yes
   login_domain:
     description:
     - The login domain name to use for authentication.

--- a/plugins/httpapi/nd.py
+++ b/plugins/httpapi/nd.py
@@ -65,7 +65,7 @@ class HttpApi(HttpApiBase):
 
     def set_backup_hosts(self):
         try:
-            list_of_hosts = re.sub(r'[[\]]', '', self.connection.get_option("host")).split(",")
+            list_of_hosts = re.sub(r'[[\]]', '', self.connection.get_option('host')).split(",")
             # ipaddress.ip_address(list_of_hosts[0])
             return list_of_hosts
         except Exception:
@@ -160,27 +160,27 @@ class HttpApi(HttpApiBase):
             except FileNotFoundError:
                 pass
             try:
-                self.connection.set_option("host", self.backup_hosts[self.host_counter])
+                self.connection.set_option('host', self.backup_hosts[self.host_counter])
             except (IndexError, TypeError):
                 pass
 
         if self.params.get('port') is not None:
-            self.connection.set_option("port", self.params.get('port'))
+            self.connection.set_option('port', self.params.get('port'))
 
         if self.params.get('username') is not None:
-            self.connection.set_option("remote_user", self.params.get('username'))
+            self.connection.set_option('remote_user', self.params.get('username'))
 
         if self.params.get('password') is not None:
-            self.connection.set_option("password", self.params.get('password'))
+            self.connection.set_option('password', self.params.get('password'))
 
         if self.params.get('use_proxy') is not None:
-            self.connection.set_option("use_proxy", self.params.get('use_proxy'))
+            self.connection.set_option('use_proxy', self.params.get('use_proxy'))
 
         if self.params.get('use_ssl') is not None:
-            self.connection.set_option("use_ssl", self.params.get('use_ssl'))
+            self.connection.set_option('use_ssl', self.params.get('use_ssl'))
 
         if self.params.get('validate_certs') is not None:
-            self.connection.set_option("validate_certs", self.params.get('validate_certs'))
+            self.connection.set_option('validate_certs', self.params.get('validate_certs'))
 
         # Perform some very basic path input validation.
         path = str(path)
@@ -208,10 +208,10 @@ class HttpApi(HttpApiBase):
         with open('my_hosts.pk', 'wb') as host_file:
             pickle.dump(self.host_counter, host_file)
         try:
-            self.connection.set_option("host", self.backup_hosts[self.host_counter])
+            self.connection.set_option('host', self.backup_hosts[self.host_counter])
         except IndexError:
             pass
-        self.login(self.connection.get_option("remote_user"), self.connection.get_option("password"))
+        self.login(self.connection.get_option('remote_user'), self.connection.get_option('password'))
         return True
 
     def _verify_response(self, response, method, path, data):

--- a/plugins/httpapi/nd.py
+++ b/plugins/httpapi/nd.py
@@ -84,7 +84,14 @@ class HttpApi(HttpApiBase):
         if self.params.get('login_domain') != 'local':
             login_domain = self.params.get('login_domain')
 
-        payload = {'username': self.params.get('username'), 'password': self.params.get('password'), 'domain': login_domain}
+        payload = {'username': self.connection.get_option('remote_user'), 'password': self.connection.get_option('password'), 'domain': login_domain}
+
+        # Override the global username/password with the ones specified per task
+        if self.params.get('username') is not None:
+            payload['username'] = self.params.get('username')
+        if self.params.get('password') is not None:
+            payload['password'] = self.params.get('password')
+
         data = json.dumps(payload)
         try:
             self.connection.queue_message('vvvv', 'login() - connection.send({0}, {1}, {2}, {3})'.format(path, data, method, self.headers))
@@ -154,7 +161,7 @@ class HttpApi(HttpApiBase):
                 pass
             try:
                 self.connection.set_option("host", self.backup_hosts[self.host_counter])
-            except IndexError:
+            except (IndexError, TypeError):
                 pass
 
         if self.params.get('port') is not None:

--- a/plugins/module_utils/nd.py
+++ b/plugins/module_utils/nd.py
@@ -90,8 +90,8 @@ def nd_argument_spec():
         password=dict(type='str', required=False, no_log=True, fallback=(env_fallback, ['ND_PASSWORD', 'ANSIBLE_NET_PASSWORD'])),
         output_level=dict(type='str', default='normal', choices=['debug', 'info', 'normal'], fallback=(env_fallback, ['ND_OUTPUT_LEVEL'])),
         timeout=dict(type='int', default=30, fallback=(env_fallback, ['ND_TIMEOUT'])),
-        use_proxy=dict(type='bool', default=True, fallback=(env_fallback, ['ND_USE_PROXY'])),
-        use_ssl=dict(type='bool', default=True, fallback=(env_fallback, ['ND_USE_SSL'])),
+        use_proxy=dict(type='bool', fallback=(env_fallback, ['ND_USE_PROXY'])),
+        use_ssl=dict(type='bool', fallback=(env_fallback, ['ND_USE_SSL'])),
         validate_certs=dict(type='bool', fallback=(env_fallback, ['ND_VALIDATE_CERTS'])),
         login_domain=dict(type='str', default='local', fallback=(env_fallback, ['ND_LOGIN_DOMAIN'])),
     )

--- a/plugins/module_utils/nd.py
+++ b/plugins/module_utils/nd.py
@@ -92,7 +92,7 @@ def nd_argument_spec():
         timeout=dict(type='int', default=30, fallback=(env_fallback, ['ND_TIMEOUT'])),
         use_proxy=dict(type='bool', default=True, fallback=(env_fallback, ['ND_USE_PROXY'])),
         use_ssl=dict(type='bool', default=True, fallback=(env_fallback, ['ND_USE_SSL'])),
-        validate_certs=dict(type='bool', default=True, fallback=(env_fallback, ['ND_VALIDATE_CERTS'])),
+        validate_certs=dict(type='bool', fallback=(env_fallback, ['ND_VALIDATE_CERTS'])),
         login_domain=dict(type='str', default='local', fallback=(env_fallback, ['ND_LOGIN_DOMAIN'])),
     )
 

--- a/tests/integration/targets/nd_version/tasks/main.yml
+++ b/tests/integration/targets/nd_version/tasks/main.yml
@@ -1,5 +1,6 @@
 # Test code for the ND modules
 # Copyright: (c) 2020, Lionel Hercot (@lhercot) <lhercot@cisco.com>
+# Copyright: (c) 2021, Cindy Zhao (@cizhao) <cizhao@cisco.com>
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -87,3 +88,31 @@
     - nm_non_existing_state is not changed
     - cm_non_existing_state == nm_non_existing_state
     - cm_non_existing_state.msg == nm_non_existing_state.msg == "value of state must be one of{{':'}} query, got{{':'}} non-existing-state"
+
+- name: Query ND version by global parameters (check_mode)
+  cisco.nd.nd_version:
+    state: query
+  check_mode: yes
+  register: cm_query_global_params
+
+- name: Query ND version (normal mode)
+  cisco.nd.nd_version:
+    state: query
+  register: nm_query_global_params
+
+- name: Verify query
+  assert:
+    that:
+      - nm_query_global_params is not changed
+      - nm_query_global_params.current.major is defined
+      - nm_query_global_params.current.minor is defined
+      - nm_query_global_params.current.maintenance is defined
+      - nm_query_global_params.current.patch is defined
+      - nm_query_global_params.current.commit_id is defined
+      - nm_query_global_params.current.product_name == "Nexus Dashboard"
+      - nm_query_global_params.current.major == cm_query_global_params.current.major
+      - nm_query_global_params.current.minor == cm_query_global_params.current.minor
+      - nm_query_global_params.current.maintenance == cm_query_global_params.current.maintenance
+      - nm_query_global_params.current.patch == cm_query_global_params.current.patch
+      - nm_query_global_params.current.commit_id == cm_query_global_params.current.commit_id
+      - nm_query_global_params.current.product_name == cm_query_global_params.current.product_name


### PR DESCRIPTION
Fix to address the issues in using params from group_vars/inventory files.

- Password and Username by default will be from global values, it will be overridden if username and password is specified in particular task.
- Handled an exception
- Removed the default ("true") for "validate_certs". It is already set to true through inheritance from uri module. Setting it to true by default at nd, makes it part of params and this in-turn makes it always override the global setting(ansible_httpapi_validate_certs). This makes users to set it false explicitly for each task in playbook. 
