### PR TITLE
Fix login_domain passed as null in httapi connection plugin when used…

### DIFF
--- a/plugins/httpapi/nd.py
+++ b/plugins/httpapi/nd.py
@@ -81,7 +81,7 @@ class HttpApi(HttpApiBase):
         full_path = self.connection.get_option('host') + path
         # TODO: Fix when username and password are not used in ND module
         login_domain = 'DefaultAuth'
-        if self.params.get('login_domain') != 'local':
+        if self.params.get('login_domain') and self.params.get('login_domain') != 'local':
             login_domain = self.params.get('login_domain')
 
         payload = {'userName': self.connection.get_option('remote_user'), 'userPasswd': self.connection.get_option('password'), 'domain': login_domain}


### PR DESCRIPTION
… with cisco.mso collection