### PR TITLE
[bugfix] allow 'local' to be specified as login domain

### DIFF
--- a/plugins/httpapi/nd.py
+++ b/plugins/httpapi/nd.py
@@ -80,8 +80,7 @@ class HttpApi(HttpApiBase):
         path = '/login'
         full_path = self.connection.get_option('host') + path
         # TODO: Fix when username and password are not used in ND module
-        login_domain = 'DefaultAuth'
-        if self.params.get('login_domain') and self.params.get('login_domain') != 'local':
+        if self.params.get('login_domain'):
             login_domain = self.params.get('login_domain')
 
         payload = {'userName': self.connection.get_option('remote_user'), 'userPasswd': self.connection.get_option('password'), 'domain': login_domain}

--- a/plugins/module_utils/nd.py
+++ b/plugins/module_utils/nd.py
@@ -93,7 +93,7 @@ def nd_argument_spec():
         use_proxy=dict(type='bool', fallback=(env_fallback, ['ND_USE_PROXY'])),
         use_ssl=dict(type='bool', fallback=(env_fallback, ['ND_USE_SSL'])),
         validate_certs=dict(type='bool', fallback=(env_fallback, ['ND_VALIDATE_CERTS'])),
-        login_domain=dict(type='str', default='local', fallback=(env_fallback, ['ND_LOGIN_DOMAIN'])),
+        login_domain=dict(type='str', default='DefaultAuth', fallback=(env_fallback, ['ND_LOGIN_DOMAIN'])),
     )
 
 


### PR DESCRIPTION
- remove condition self.params.get('login_domain') != 'local' to allow 'local' being set as login domain. 
- set DefaultAuth as default value for login_domain