### PR TITLE
First PR to comply with requirements for inclusion in Ansible package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Modules supporting new features introduced in ND API in specific ND versions mig
 *Note: This collection is not compatible with versions of Ansible before v2.8.*
 
 ## Requirements
-- Ansible v2.14 or newer
+- Ansible (ansible-core) v2.15 or newer
+- Python 3.9 or newer
 
 ## Install
 Ansible must be installed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -24,7 +24,7 @@ tags:
   - networking
   - sdn
 dependencies:
-  "ansible.netcommon": "*"
+  "ansible.netcommon": ">=2.6.1"
 repository: https://github.com/CiscoDevNet/ansible-nd
 #documentation: https://docs.ansible.com/ansible/latest/scenario_guides/guide_nd.html
 homepage: https://cisco.com/go/nexusdashboard

--- a/plugins/doc_fragments/check_mode.py
+++ b/plugins/doc_fragments/check_mode.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, Lionel Hercot (@LHercot) <lhercot@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    # Standard files documentation fragment
+    DOCUMENTATION = r"""
+attributes:
+  check_mode:
+    description: The check_mode / dry run support.
+    support: full
+"""

--- a/plugins/modules/nd_backup.py
+++ b/plugins/modules/nd_backup.py
@@ -47,7 +47,9 @@ options:
     type: str
     choices: [ backup, query, absent ]
     default: backup
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_backup_restore.py
+++ b/plugins/modules/nd_backup_restore.py
@@ -49,7 +49,9 @@ options:
     type: str
     choices: [ restore, query, absent ]
     default: restore
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_cluster_config_route.py
+++ b/plugins/modules/nd_cluster_config_route.py
@@ -38,7 +38,9 @@ options:
     type: str
     choices: [ present, query, absent ]
     default: present
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_compliance_analysis.py
+++ b/plugins/modules/nd_compliance_analysis.py
@@ -38,7 +38,9 @@ options:
     - The id of the epoch.
     - When epoch id is not provided it will retrieve the latest known epoch id.
     type: str
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_compliance_requirement_config_import.py
+++ b/plugins/modules/nd_compliance_requirement_config_import.py
@@ -32,6 +32,7 @@ options:
     default: false
 extends_documentation_fragment:
 - cisco.nd.modules
+- cisco.nd.check_mode
 - cisco.nd.ndi_compliance_base
 """
 

--- a/plugins/modules/nd_compliance_requirement_config_manual.py
+++ b/plugins/modules/nd_compliance_requirement_config_manual.py
@@ -148,6 +148,7 @@ regex, exact, at_least, at_most, all, none, at_least_one]
         required: true
 extends_documentation_fragment:
 - cisco.nd.modules
+- cisco.nd.check_mode
 - cisco.nd.ndi_compliance_base
 """
 

--- a/plugins/modules/nd_compliance_requirement_config_snapshot.py
+++ b/plugins/modules/nd_compliance_requirement_config_snapshot.py
@@ -38,6 +38,7 @@ options:
     default: false
 extends_documentation_fragment:
 - cisco.nd.modules
+- cisco.nd.check_mode
 - cisco.nd.ndi_compliance_base
 """
 

--- a/plugins/modules/nd_compliance_requirement_config_template.py
+++ b/plugins/modules/nd_compliance_requirement_config_template.py
@@ -32,6 +32,7 @@ options:
     default: false
 extends_documentation_fragment:
 - cisco.nd.modules
+- cisco.nd.check_mode
 - cisco.nd.ndi_compliance_base
 """
 

--- a/plugins/modules/nd_delta_analysis.py
+++ b/plugins/modules/nd_delta_analysis.py
@@ -68,7 +68,9 @@ options:
     type: str
     choices: [ absent, present, query, validate ]
     default: query
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_epoch.py
+++ b/plugins/modules/nd_epoch.py
@@ -58,7 +58,9 @@ options:
     description:
     - When range is selected, max amount epoch IDs to be returned.
     type: int
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_federation_member.py
+++ b/plugins/modules/nd_federation_member.py
@@ -56,7 +56,9 @@ options:
     type: str
     default: present
     choices: [ absent, present, query ]
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 notes:
 - The M(cisco.aci.nd_federation) module can be used for this.
 """

--- a/plugins/modules/nd_pcv.py
+++ b/plugins/modules/nd_pcv.py
@@ -57,7 +57,9 @@ options:
     type: str
     choices: [ absent, present, query, wait_and_query ]
     default: query
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_pcv_compliance.py
+++ b/plugins/modules/nd_pcv_compliance.py
@@ -39,7 +39,9 @@ options:
     type: str
     required: true
     aliases: [ site ]
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_pcv_delta_analysis.py
+++ b/plugins/modules/nd_pcv_delta_analysis.py
@@ -60,7 +60,9 @@ options:
     - Option to exclude anomalies which is acknowledged
     type: bool
     default: false
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_service.py
+++ b/plugins/modules/nd_service.py
@@ -38,7 +38,9 @@ options:
     type: str
     choices: [ present, query, absent ]
     default: present
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_service_instance.py
+++ b/plugins/modules/nd_service_instance.py
@@ -46,7 +46,9 @@ options:
     type: str
     choices: [ enable, query, restart, update, disable, delete]
     default: enable
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_setup.py
+++ b/plugins/modules/nd_setup.py
@@ -255,8 +255,9 @@ options:
     type: str
     default: present
     choices: [ present, query ]
-extends_documentation_fragment: cisco.nd.modules
-
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 notes:
 - This module only supports setting up the Nexus Dashboard having version 2.3.2d or higher.
 """

--- a/plugins/modules/nd_site.py
+++ b/plugins/modules/nd_site.py
@@ -78,7 +78,9 @@ options:
     type: str
     choices: [ absent, present, query ]
     default: present
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_version.py
+++ b/plugins/modules/nd_version.py
@@ -26,7 +26,9 @@ options:
     type: str
     choices: [ query ]
     default: query
-extends_documentation_fragment: cisco.nd.modules
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
See https://github.com/ansible-collections/ansible-inclusion/discussions/77 for details

This PR addresses the following items:

**Standards and documentation:**
- [x] follows the [Ansible documentation standards](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html) and the [style guide](https://docs.ansible.com/ansible/devel/dev_guide/style_guide/index.html#style-guide)
MUST FIX: check mode support is not reflected in docs
- [x] supports [all Python versions supported by all ansible-core versions its supports](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix). If it does not, read the [full guidelines](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#python-compatibility) to see if you qualify for an exception and document the unsupported [Python versions](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix) in the collection README.md and in every module and plugin (or in doc fragments)
COMMENT: does the collection support all Python versions required ^? Anyway, i would suggest including this info to README explicitly

**Collection management:**
- [x]  collection dependencies must have a lower bound on the version which is at least 1.0.0, and are all part of the ansible package
MUST FIX: Please set the lower bound for ansible.netcommon explicitly
- [x] meta/runtime.yml defines the minimal version of Ansible which the collection works with
SHOULD FIX: I see requires_ansible: '>=2.15.0' but in README it's 2.14+. Please update README if it's irrelevant (and in other places if needed).
