### PR TITLE
[ignore] Fixed galaxy-importer after ansible-compat 25.0.0 cache change. (DCNE-290)

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -84,8 +84,11 @@ jobs:
       - name: Install galaxy-importer
         run: pip install galaxy-importer
 
-      - name: Create galaxy-importer directory
-        run: sudo mkdir -p /etc/galaxy-importer
+      - name: Create galaxy-importer directories
+        run: |
+          sudo mkdir -p /etc/galaxy-importer \
+           && sudo mkdir -p /.ansible/roles \
+           && sudo mkdir -p /.ansible/collections
 
       - name: Create galaxy-importer.cfg
         run: |


### PR DESCRIPTION
A breaking change in ansible-compat v25.0.0 broke our galaxy-importer CI step. This library is used as part of the ansible-lint check and the library changed a cache directory location.