### PR TITLE
[minor_change] Added support to the cisco.nd.nd HTTPAPI plugin for authorization using user API keys. (DCNE-381)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Once the collection is installed, you can use it in a playbook by specifying the
 
 With the following inventory file:
 
-```yaml
+```ini
 [nd]
 nd1 ansible_host=10.0.0.1 ansible_user=admin ansible_ssh_pass="MySuperPassword"
 
@@ -135,6 +135,22 @@ You can also use the ND HTTPAPI connection plugin with your cisco.mso Ansible co
   - name: Get MSO version from MSO >= 3.2
     cisco.mso.mso_version:
       state: query
+```
+
+User API Key authorization is also supported in the ND HTTPAPI connection plugin. Use the `ansible_httpapi_session_key` option to specify the key instead of a password. The session key option must be defined as a dictionary.
+
+See the [Authorization Using API Key](https://developer.cisco.com/docs/nexus-dashboard/latest/getting-started/#authorization-using-api-key) documentation for more information.
+
+```ini
+[nd]
+nd1 ansible_host=10.0.0.1 ansible_user=admin ansible_httpapi_session_key='{"key": "MySuperSecretUserApiKey"}'
+
+[nd:vars]
+ansible_connection=ansible.netcommon.httpapi
+ansible_network_os=cisco.nd.nd
+ansible_httpapi_validate_certs=False
+ansible_httpapi_use_ssl=True
+ansible_httpapi_use_proxy=True
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -137,7 +137,11 @@ You can also use the ND HTTPAPI connection plugin with your cisco.mso Ansible co
       state: query
 ```
 
-User API Key authorization is also supported in the ND HTTPAPI connection plugin. Use the `ansible_httpapi_session_key` option to specify the key instead of a password. The session key option must be defined as a dictionary.
+User API Key authorization is also supported in the ND HTTPAPI connection plugin. Use the `ansible_httpapi_session_key` option to specify the key instead of a password. The `ansible_httpapi_session_key` option takes precedence over the `ansible_password` option if defined. If authorization fails using the API Key, the plugin will fallback to using the password. The session key option must be defined as a dictionary. The dictionary can either be formated in two ways:
+
+1. Using a single key-value dictionary eg. `{"keyname": "<APIKEY>"}`. Only the dictionary value is used with the `ansible_user` option to format the ND authorization header.
+
+2. Providing the ND authorization header manually eg. `{"X-Nd-Username": "admin", "X-Nd-Apikey": "<APIKEY>"}`. The `ansible_httpapi_session_key` option will be used as-is and the `ansible_user` option is ignored.
 
 See the [Authorization Using API Key](https://developer.cisco.com/docs/nexus-dashboard/latest/getting-started/#authorization-using-api-key) documentation for more information.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can also use the ND HTTPAPI connection plugin with your cisco.mso Ansible co
 
 User API Key authorization is also supported in the ND HTTPAPI connection plugin. Use the `ansible_httpapi_session_key` option to specify the key instead of a password. The `ansible_httpapi_session_key` option takes precedence over the `ansible_password` option if defined. If authorization fails using the API Key, the plugin will fallback to using the password. The session key option must be defined as a dictionary. The dictionary can either be formated in two ways:
 
-1. Using a single key-value dictionary eg. `{"keyname": "<APIKEY>"}`. Only the dictionary value is used with the `ansible_user` option to format the ND authorization header.
+1. Using a single key-value dictionary eg. `{"key": "<APIKEY>"}`. Only the dictionary value is used with the `ansible_user` option to format the ND authorization header.
 
 2. Providing the ND authorization header manually eg. `{"X-Nd-Username": "admin", "X-Nd-Apikey": "<APIKEY>"}`. The `ansible_httpapi_session_key` option will be used as-is and the `ansible_user` option is ignored.
 

--- a/plugins/httpapi/nd.py
+++ b/plugins/httpapi/nd.py
@@ -204,6 +204,15 @@ class HttpApi(HttpApiBase):
         if self.params.get("timeout") is not None:
             self.connection.set_option("persistent_command_timeout", self.params.get("timeout"))
 
+        # Support ND User API Key authentication within the session_key option.
+        session_key = self.connection.get_option("session_key")
+        if session_key and "X-Nd-Username" not in session_key.keys():
+            session_key_header = {
+                "X-Nd-Username" : self.connection.get_option("remote_user"),
+                "X-Nd-Apikey": list(session_key.values())[0]
+            }
+            self.connection.set_option("session_key", session_key_header)
+
         # Perform some very basic path input validation.
         path = str(path)
         if path[0] != "/":

--- a/plugins/httpapi/nd.py
+++ b/plugins/httpapi/nd.py
@@ -208,8 +208,8 @@ class HttpApi(HttpApiBase):
         session_key = self.connection.get_option("session_key")
         if session_key and "X-Nd-Username" not in session_key.keys():
             session_key_header = {
-                "X-Nd-Username" : self.connection.get_option("remote_user"),
-                "X-Nd-Apikey": list(session_key.values())[0]
+                "X-Nd-Username": self.connection.get_option("remote_user"),
+                "X-Nd-Apikey": list(session_key.values())[0],
             }
             self.connection.set_option("session_key", session_key_header)
 


### PR DESCRIPTION
Added authorization suport of user API keys instead of passwords in. The `cisco.nd.nd` HTTPAPI plugin can now authorize requests using the `ansible_httpapi_session_key` option.

Closes #122 
Closed #115 