### PR TITLE
Add support for more l3out classes (DCNE-442)

### DIFF
--- a/plugins/module_utils/ndi.py
+++ b/plugins/module_utils/ndi.py
@@ -424,6 +424,10 @@ class NDI:
             return "l3extLNodeP"
         elif prefix == "rsnodeL3OutAtt":
             return "l3extRsNodeL3OutAtt"
+        elif prefix == "rspathL3OutAtt":
+            return "l3extRsPathL3OutAtt"
+        elif prefix == "mem":
+            return "l3extMember"
         elif prefix == "rt":
             return "ipRouteP"
         elif prefix == "nh":


### PR DESCRIPTION
Currently the JSON parsing tree will fail for the added classes and the failure is extremwely confusing:

```
Traceback (most recent call last):
  File "/home/cisco/.ansible/tmp/ansible-local-2482762vd0b7ecp/ansible-tmp-1749107285.3955288-2482775-158418581667417/AnsiballZ_nd_pcv.py", line 107, in <module>
    _ansiballz_main()
  File "/home/cisco/.ansible/tmp/ansible-local-2482762vd0b7ecp/ansible-tmp-1749107285.3955288-2482775-158418581667417/AnsiballZ_nd_pcv.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/cisco/.ansible/tmp/ansible-local-2482762vd0b7ecp/ansible-tmp-1749107285.3955288-2482775-158418581667417/AnsiballZ_nd_pcv.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.cisco.nd.plugins.modules.nd_pcv', init_globals=dict(_module_fqn='ansible_collections.cisco.nd.plugins.modules.nd_pcv', _modlib_path=modlib_path),
  File "<frozen runpy>", line 226, in run_module
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/ansible_cisco.nd.nd_pcv_payload_1hm_psjq/ansible_cisco.nd.nd_pcv_payload.zip/ansible_collections/cisco/nd/plugins/modules/nd_pcv.py", line 256, in <module>
  File "/tmp/ansible_cisco.nd.nd_pcv_payload_1hm_psjq/ansible_cisco.nd.nd_pcv_payload.zip/ansible_collections/cisco/nd/plugins/modules/nd_pcv.py", line 237, in main
  File "/tmp/ansible_cisco.nd.nd_pcv_payload_1hm_psjq/ansible_cisco.nd.nd_pcv_payload.zip/ansible_collections/cisco/nd/plugins/module_utils/ndi.py", line 574, in create_structured_data
AttributeError: 'NDI' object has no attribute 'module'
```

This PR add the missing classes I need and a meaningful error message 