### PR TITLE
Update README for certified content (DCNE-585)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ To find EOL announcements for ND versions, refer to the [End-of-Life and End-of-
 
 ## Release Notes
 
-See the [Changelog](CHANGELOG.rst) for full release notes.
+See the [Changelog](https://github.com/CiscoDevNet/ansible-nd/blob/master/CHANGELOG.rst) for full release notes.
 
 ## Related Information
 
@@ -190,4 +190,4 @@ For further information, refer to the following:
 
 ## License Information
 
-This collection is licensed under the [GNU General Public License v3.0](LICENSE)
+This collection is licensed under the [GNU General Public License v3.0](https://github.com/CiscoDevNet/ansible-nd/blob/master/LICENSE)


### PR DESCRIPTION
These changes align the project readme with the [template for certified content ](https://access.redhat.com/articles/7068606)on Ansible Automation Hub.