### PR TITLE
Fix broken unit-test imports after nd42_rest_send restructuring

### DIFF
--- a/plugins/module_utils/endpoints/base.py
+++ b/plugins/module_utils/endpoints/base.py
@@ -14,10 +14,7 @@ from __future__ import absolute_import, annotations, division, print_function
 
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Literal
+from typing import Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     BaseModel,

--- a/plugins/module_utils/endpoints/v1/infra/clusterhealth_config.py
+++ b/plugins/module_utils/endpoints/v1/infra/clusterhealth_config.py
@@ -11,10 +11,7 @@ in the ND Infra API.
 from __future__ import absolute_import, annotations, division, print_function
 
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Literal
+from typing import Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,

--- a/plugins/module_utils/endpoints/v1/infra/clusterhealth_status.py
+++ b/plugins/module_utils/endpoints/v1/infra/clusterhealth_status.py
@@ -11,10 +11,7 @@ in the ND Infra API.
 from __future__ import absolute_import, annotations, division, print_function
 
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Literal
+from typing import Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,

--- a/plugins/module_utils/endpoints/v1/infra/login.py
+++ b/plugins/module_utils/endpoints/v1/infra/login.py
@@ -12,10 +12,7 @@ This module contains the endpoint definition for the ND Infra login operation.
 from __future__ import absolute_import, annotations, division, print_function
 
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Literal
+from typing import Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,

--- a/tests/unit/module_utils/common_utils.py
+++ b/tests/unit/module_utils/common_utils.py
@@ -15,7 +15,7 @@ __metaclass__ = type  # pylint: disable=invalid-name
 from contextlib import contextmanager
 
 import pytest
-from ansible_collections.cisco.nd.plugins.module_utils.log import Log
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import Log
 from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
 from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender as SenderFile

--- a/tests/unit/module_utils/endpoints/test_base_model.py
+++ b/tests/unit/module_utils/endpoints/test_base_model.py
@@ -22,12 +22,9 @@ __metaclass__ = type
 # pylint: disable=too-few-public-methods
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import Literal
 
 import pytest
-
-if TYPE_CHECKING:
-    from typing import Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,

--- a/tests/unit/module_utils/test_sender_nd.py
+++ b/tests/unit/module_utils/test_sender_nd.py
@@ -600,7 +600,7 @@ def test_sender_nd_00700():
     instance.verb = HttpVerbEnum.GET
 
     with patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.sender_nd.Connection",
+        "ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd.Connection",
         return_value=mock_connection,
     ):
         with does_not_raise():
@@ -643,7 +643,7 @@ def test_sender_nd_00710():
     instance.payload = {"name": "test"}
 
     with patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.sender_nd.Connection",
+        "ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd.Connection",
         return_value=mock_connection,
     ):
         with does_not_raise():
@@ -686,7 +686,7 @@ def test_sender_nd_00720():
     instance.verb = HttpVerbEnum.GET
 
     with patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.sender_nd.Connection",
+        "ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd.Connection",
         return_value=mock_connection,
     ):
         match = r"Sender\.commit:.*ConnectionError occurred"
@@ -722,7 +722,7 @@ def test_sender_nd_00730():
     instance.verb = HttpVerbEnum.GET
 
     with patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.sender_nd.Connection",
+        "ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd.Connection",
         return_value=mock_connection,
     ):
         match = r"Sender\.commit:.*Unexpected error occurred"
@@ -758,7 +758,7 @@ def test_sender_nd_00740():
     }
 
     with patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.sender_nd.Connection",
+        "ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd.Connection",
         return_value=mock_connection,
     ) as mock_conn_class:
         instance = Sender()
@@ -809,7 +809,7 @@ def test_sender_nd_00750():
     instance.verb = HttpVerbEnum.GET
 
     with patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.sender_nd.Connection",
+        "ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd.Connection",
         return_value=mock_connection,
     ):
         with does_not_raise():
@@ -851,7 +851,7 @@ def test_sender_nd_00760():
     instance.payload = {"status": "active"}
 
     with patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.sender_nd.Connection",
+        "ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd.Connection",
         return_value=mock_connection,
     ):
         with does_not_raise():
@@ -896,7 +896,7 @@ def test_sender_nd_00770():
     instance.verb = HttpVerbEnum.DELETE
 
     with patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.sender_nd.Connection",
+        "ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd.Connection",
         return_value=mock_connection,
     ):
         with does_not_raise():


### PR DESCRIPTION
## Summary

- Fix `Log` import path (`module_utils.log` -> `module_utils.common.log`) in test `common_utils.py`
- Move `Literal` out of `TYPE_CHECKING` guards in endpoint models — Pydantic needs it at runtime to evaluate field annotations (safe since Python >= 3.11)
- Update `patch()` targets in `test_sender_nd.py` (`module_utils.sender_nd` -> `module_utils.rest.sender_nd`)

## Test plan

- [x] All 263 unit tests pass (`python -m pytest tests/unit/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)