### PR TITLE
Add Bulk create and delete operation support

### DIFF
--- a/plugins/module_utils/nd_config_collection.py
+++ b/plugins/module_utils/nd_config_collection.py
@@ -65,6 +65,15 @@ class NDConfigCollection:
 
         return key
 
+    def add_many(self, items: List[NDBaseModel]) -> List[IdentifierKey]:
+        """
+        Add multiple items to collection (O(k) operation).
+        """
+        keys = []
+        for item in items:
+            keys.append(self.add(item))
+        return keys
+
     def get(self, key: IdentifierKey) -> Optional[NDBaseModel]:
         """
         Get item by identifier key (O(1) operation).
@@ -116,6 +125,27 @@ class NDConfigCollection:
         self._rebuild_index()
 
         return True
+
+    def delete_many(self, keys: List[IdentifierKey]) -> List[IdentifierKey]:
+        """
+        Delete multiple items with single index rebuild (O(n) operation).
+        """
+        deleted = []
+        indices_to_remove = []
+
+        for key in keys:
+            index = self._index.get(key)
+            if index is not None:
+                indices_to_remove.append(index)
+                deleted.append(key)
+
+        if indices_to_remove:
+            # Remove in reverse order to preserve indices
+            for index in sorted(indices_to_remove, reverse=True):
+                del self._items[index]
+            self._rebuild_index()
+
+        return deleted
 
     # Diff Operations
 

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -109,6 +109,7 @@ class NDStateMachine:
         items_to_update: List[NDBaseModel] = []
 
         for proposed_item in self.proposed:
+            identifier = None
             try:
                 # Extract identifier
                 identifier = proposed_item.get_identifier_value()
@@ -142,7 +143,10 @@ class NDStateMachine:
                     items_to_create.append(final_item)
 
             except Exception as e:
-                error_msg = f"Failed to process {identifier}: {e}"
+                if identifier:
+                    error_msg = f"Failed to process {identifier}: {e}"
+                else:
+                    error_msg = f"Failed to process: {e}"
                 if not self.ignore_errors:
                     raise NDStateMachineError(error_msg) from e
 

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Type, Union, List
+from typing import Type
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import NDModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
@@ -38,6 +38,12 @@ class NDStateMachine:
 
         self.model_class = self.model_orchestrator.model_class
         self.state = self.module.params["state"]
+
+        # Cached flags
+        self.check_mode = self.module.check_mode
+        self.ignore_errors = self.module.params.get("ignore_errors", False)
+        self.supports_bulk_create = getattr(self.model_orchestrator, "supports_bulk_create", False)
+        self.supports_bulk_delete = getattr(self.model_orchestrator, "supports_bulk_delete", False)
 
         # Initialize collections
         try:
@@ -78,7 +84,7 @@ class NDStateMachine:
         """
         Handle merged/replaced/overridden states.
         """
-        items_to_create_bulk: List = []
+        items_to_create_bulk = []
 
         for proposed_item in self.proposed:
             # Extract identifier
@@ -109,92 +115,88 @@ class NDStateMachine:
 
                 # Execute API operation
                 if diff_status == "changed":
-                    if not self.module.check_mode:
+                    if not self.check_mode:
                         self.model_orchestrator.update(final_item)
                 elif diff_status == "new":
-                    if not self.module.check_mode:
-                        if getattr(self.model_orchestrator, "supports_bulk_create", False):
+                    if not self.check_mode:
+                        if self.supports_bulk_create:
                             items_to_create_bulk.append(final_item)
                         else:
                             self.model_orchestrator.create(final_item)
                 self.sent.add(final_item)
 
-                # Log operation
-                self.output.assign(after=self.existing)
-
             except Exception as e:
                 error_msg = f"Failed to process {identifier}: {e}"
-                if not self.module.params.get("ignore_errors", False):
+                if not self.ignore_errors:
                     raise NDStateMachineError(error_msg) from e
 
         # Execute API bulk create operation
         if items_to_create_bulk:
-            self.model_orchestrator.create_bulk(items_to_create_bulk)
+            try:
+                self.model_orchestrator.create_bulk(items_to_create_bulk)
+            except Exception as e:
+                error_msg = f"Failed to create in bulk: {e}"
+                if not self.ignore_errors:
+                    raise NDStateMachineError(error_msg) from e
+
+        # Log operation
+        self.output.assign(after=self.existing)
 
     def _manage_override_deletions(self) -> None:
         """
         Delete items not in proposed config (for overridden state).
         """
         diff_identifiers = self.before.get_diff_identifiers(self.proposed)
-
-        items_to_delete_bulk: List = []
+        items_to_delete = []
 
         for identifier in diff_identifiers:
-            try:
-                existing_item = self.existing.get(identifier)
-                if not existing_item:
-                    continue
+            existing_item = self.existing.get(identifier)
+            if existing_item:
+                items_to_delete.append(existing_item)
 
-                # Execute delete
-                if not self.module.check_mode:
-                    if getattr(self.model_orchestrator, "supports_bulk_delete", False):
-                        items_to_delete_bulk.append(existing_item)
-                    else:
-                        self.model_orchestrator.delete(existing_item)
-
-                # Remove from collection
-                self.existing.delete(identifier)
-
-                # Log deletion
-                self.output.assign(after=self.existing)
-
-            except Exception as e:
-                error_msg = f"Failed to delete {identifier}: {e}"
-                if not self.module.params.get("ignore_errors", False):
-                    raise NDStateMachineError(error_msg) from e
-
-            if items_to_delete_bulk:
-                self.model_orchestrator.delete_bulk(items_to_delete_bulk)
+        self._delete_items(items_to_delete)
 
     def _manage_delete_state(self) -> None:
         """Handle deleted state."""
-        items_to_delete_bulk: List = []
+        items_to_delete = []
 
         for proposed_item in self.proposed:
+            identifier = proposed_item.get_identifier_value()
+            existing_item = self.existing.get(identifier)
+            if existing_item:
+                items_to_delete.append(existing_item)
+
+        self._delete_items(items_to_delete)
+
+    def _delete_items(self, items) -> None:
+        """Delete a list of items individually or in bulk."""
+        items_to_delete_bulk = []
+
+        for item in items:
             try:
-                identifier = proposed_item.get_identifier_value()
+                identifier = item.get_identifier_value()
 
-                existing_item = self.existing.get(identifier)
-                if not existing_item:
-                    continue
-
-                # Execute delete
-                if not self.module.check_mode:
-                    if getattr(self.model_orchestrator, "supports_bulk_delete", False):
-                        items_to_delete_bulk.append(existing_item)
+                if not self.check_mode:
+                    if self.supports_bulk_delete:
+                        items_to_delete_bulk.append(item)
                     else:
-                        self.model_orchestrator.delete(existing_item)
+                        self.model_orchestrator.delete(item)
 
                 # Remove from collection
                 self.existing.delete(identifier)
 
-                # Log deletion
-                self.output.assign(after=self.existing)
-
             except Exception as e:
                 error_msg = f"Failed to delete {identifier}: {e}"
-                if not self.module.params.get("ignore_errors", False):
+                if not self.ignore_errors:
                     raise NDStateMachineError(error_msg) from e
 
         if items_to_delete_bulk:
-            self.model_orchestrator.delete_bulk(items_to_delete_bulk)
+            try:
+                self.model_orchestrator.delete_bulk(items_to_delete_bulk)
+            except Exception as e:
+                error_msg = f"Failed to delete in bulk: {e}"
+                if not self.ignore_errors:
+                    raise NDStateMachineError(error_msg) from e
+
+        # Log deletion
+        self.output.assign(after=self.existing)

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -5,7 +5,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Type
+from typing import Type, Union
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import NDModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
@@ -19,7 +19,7 @@ class NDStateMachine:
     Generic State Machine for Nexus Dashboard (Bulk Support).
     """
 
-    def __init__(self, module: AnsibleModule, model_orchestrator: Type[NDBaseOrchestrator]):
+    def __init__(self, module: AnsibleModule, model_orchestrator: Union[Type[NDBaseOrchestrator], NDBaseOrchestrator]):
         """
         Initialize the ND State Machine.
         """
@@ -31,10 +31,12 @@ class NDStateMachine:
 
         # Configuration
         # Accept either an orchestrator instance or a class.
-        if isinstance(model_orchestrator, type):
+        if isinstance(model_orchestrator, type) and issubclass(model_orchestrator, NDBaseOrchestrator):
             self.model_orchestrator = model_orchestrator(sender=self.nd_module)
-        else:
+        elif isinstance(model_orchestrator, NDBaseOrchestrator):
             self.model_orchestrator = model_orchestrator
+        else:
+            raise NDStateMachineError(f"model_orchestrator must be an NDBaseOrchestrator class or instance. Got: {type(model_orchestrator)}")
 
         self.model_class = self.model_orchestrator.model_class
         self.state = self.module.params["state"]

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -42,8 +42,8 @@ class NDStateMachine:
         # Cached flags
         self.check_mode = self.module.check_mode
         self.ignore_errors = self.module.params.get("ignore_errors", False)
-        self.supports_bulk_create = getattr(self.model_orchestrator, "supports_bulk_create", False)
-        self.supports_bulk_delete = getattr(self.model_orchestrator, "supports_bulk_delete", False)
+        self.supports_bulk_create = self.model_orchestrator.supports_bulk_create
+        self.supports_bulk_delete = self.model_orchestrator.supports_bulk_delete
 
         # Initialize collections
         try:

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -5,12 +5,14 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Type, Union
+from typing import Type, Union, List, Any, Callable, Optional
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import NDModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 
 
@@ -69,7 +71,6 @@ class NDStateMachine:
         """
         Manage state according to desired configuration.
         """
-        # Execute state operations
         if self.state in ["merged", "replaced", "overridden"]:
             self._manage_create_update_state()
 
@@ -82,16 +83,35 @@ class NDStateMachine:
         else:
             raise NDStateMachineError(f"Invalid state: {self.state}")
 
+    def _execute_operation(
+        self,
+        operation: Callable[..., ResponseType],
+        *args: Any,
+        error_msg_prefix: str = "Operation failed",
+        **kwargs: Any,
+    ) -> Optional[ResponseType]:
+        """Execute an API operation with standardized error handling."""
+        try:
+            if not self.check_mode:
+                return operation(*args, **kwargs)
+            return None
+        except Exception as e:
+            error_msg = f"{error_msg_prefix}: {e}"
+            if not self.ignore_errors:
+                raise NDStateMachineError(error_msg) from e
+        return None
+
     def _manage_create_update_state(self) -> None:
         """
         Handle merged/replaced/overridden states.
         """
-        items_to_create_bulk = []
+        items_to_create: List[NDBaseModel] = []
+        items_to_update: List[NDBaseModel] = []
 
         for proposed_item in self.proposed:
-            # Extract identifier
-            identifier = proposed_item.get_identifier_value()
             try:
+                # Extract identifier
+                identifier = proposed_item.get_identifier_value()
                 # Determine diff status
                 # For merged state, only compare fields explicitly provided by
                 # the user so that Pydantic default values do not trigger false
@@ -108,38 +128,40 @@ class NDStateMachine:
                     # Merge with existing
                     final_item = self.existing.merge(proposed_item)
                 else:
-                    # Replace or create
+                    # Replace or creates
                     if diff_status == "changed":
                         self.existing.replace(proposed_item)
                     else:
                         self.existing.add(proposed_item)
                     final_item = proposed_item
 
-                # Execute API operation
+                # Categorize by operation type
                 if diff_status == "changed":
-                    if not self.check_mode:
-                        self.model_orchestrator.update(final_item)
+                    items_to_update.append(final_item)
                 elif diff_status == "new":
-                    if not self.check_mode:
-                        if self.supports_bulk_create:
-                            items_to_create_bulk.append(final_item)
-                        else:
-                            self.model_orchestrator.create(final_item)
-                self.sent.add(final_item)
+                    items_to_create.append(final_item)
 
             except Exception as e:
                 error_msg = f"Failed to process {identifier}: {e}"
                 if not self.ignore_errors:
                     raise NDStateMachineError(error_msg) from e
 
-        # Execute API bulk create operation
-        if items_to_create_bulk:
-            try:
-                self.model_orchestrator.create_bulk(items_to_create_bulk)
-            except Exception as e:
-                error_msg = f"Failed to create in bulk: {e}"
-                if not self.ignore_errors:
-                    raise NDStateMachineError(error_msg) from e
+        # Execute updates (always individual)
+        for item in items_to_update:
+            self._execute_operation(self.model_orchestrator.update, item, error_msg_prefix=f"Failed to update {item.get_identifier_value()}")
+
+        # Execute creates (bulk or individual)
+        if items_to_create:
+            if self.supports_bulk_create:
+                self._execute_operation(self.model_orchestrator.create_bulk, items_to_create, error_msg_prefix="Failed to create in bulk")
+            else:
+                for item in items_to_create:
+                    self._execute_operation(self.model_orchestrator.create, item, error_msg_prefix=f"Failed to create {item.get_identifier_value()}")
+
+        # Mark as sent only after successful API operations
+        successfully_sent = items_to_update + items_to_create
+        if successfully_sent:
+            self.sent.add_many(successfully_sent)
 
         # Log operation
         self.output.assign(after=self.existing)
@@ -149,56 +171,31 @@ class NDStateMachine:
         Delete items not in proposed config (for overridden state).
         """
         diff_identifiers = self.before.get_diff_identifiers(self.proposed)
-        items_to_delete = []
-
-        for identifier in diff_identifiers:
-            existing_item = self.existing.get(identifier)
-            if existing_item:
-                items_to_delete.append(existing_item)
-
+        items_to_delete = [existing_item for identifier in diff_identifiers if (existing_item := self.existing.get(identifier)) is not None]
         self._delete_items(items_to_delete)
 
     def _manage_delete_state(self) -> None:
         """Handle deleted state."""
-        items_to_delete = []
-
-        for proposed_item in self.proposed:
-            identifier = proposed_item.get_identifier_value()
-            existing_item = self.existing.get(identifier)
-            if existing_item:
-                items_to_delete.append(existing_item)
-
+        items_to_delete = [
+            existing_item for proposed_item in self.proposed if (existing_item := self.existing.get(proposed_item.get_identifier_value())) is not None
+        ]
         self._delete_items(items_to_delete)
 
-    def _delete_items(self, items) -> None:
+    def _delete_items(self, items: List[NDBaseModel]) -> None:
         """Delete a list of items individually or in bulk."""
-        items_to_delete_bulk = []
+        if not items:
+            return
 
-        for item in items:
-            try:
-                identifier = item.get_identifier_value()
+        # Execute deletes (bulk or individual)
+        if self.supports_bulk_delete:
+            self._execute_operation(self.model_orchestrator.delete_bulk, items, error_msg_prefix="Failed to delete in bulk")
+        else:
+            for item in items:
+                self._execute_operation(self.model_orchestrator.delete, item, error_msg_prefix=f"Failed to delete {item.get_identifier_value()}")
 
-                if not self.check_mode:
-                    if self.supports_bulk_delete:
-                        items_to_delete_bulk.append(item)
-                    else:
-                        self.model_orchestrator.delete(item)
-
-                # Remove from collection
-                self.existing.delete(identifier)
-
-            except Exception as e:
-                error_msg = f"Failed to delete {identifier}: {e}"
-                if not self.ignore_errors:
-                    raise NDStateMachineError(error_msg) from e
-
-        if items_to_delete_bulk:
-            try:
-                self.model_orchestrator.delete_bulk(items_to_delete_bulk)
-            except Exception as e:
-                error_msg = f"Failed to delete in bulk: {e}"
-                if not self.ignore_errors:
-                    raise NDStateMachineError(error_msg) from e
+        # Batch remove from collection (single index rebuild)
+        keys_to_delete = [item.get_identifier_value() for item in items]
+        self.existing.delete_many(keys_to_delete)
 
         # Log deletion
         self.output.assign(after=self.existing)

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -1,10 +1,11 @@
 # Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+# Copyright: (c) 2026, Shreyas Srish (@shrsr) <ssrish@cisco.com>
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Type
+from typing import Type, Union, List
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import NDModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
@@ -15,7 +16,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import 
 
 class NDStateMachine:
     """
-    Generic State Machine for Nexus Dashboard.
+    Generic State Machine for Nexus Dashboard (Bulk Support).
     """
 
     def __init__(self, module: AnsibleModule, model_orchestrator: Type[NDBaseOrchestrator]):
@@ -29,7 +30,12 @@ class NDStateMachine:
         self.output = NDOutput(output_level=module.params.get("output_level", "normal"))
 
         # Configuration
-        self.model_orchestrator = model_orchestrator(sender=self.nd_module)
+        # Accept either an orchestrator instance or a class.
+        if isinstance(model_orchestrator, type):
+            self.model_orchestrator = model_orchestrator(sender=self.nd_module)
+        else:
+            self.model_orchestrator = model_orchestrator
+
         self.model_class = self.model_orchestrator.model_class
         self.state = self.module.params["state"]
 
@@ -72,6 +78,8 @@ class NDStateMachine:
         """
         Handle merged/replaced/overridden states.
         """
+        items_to_create_bulk: List = []
+
         for proposed_item in self.proposed:
             # Extract identifier
             identifier = proposed_item.get_identifier_value()
@@ -105,7 +113,10 @@ class NDStateMachine:
                         self.model_orchestrator.update(final_item)
                 elif diff_status == "new":
                     if not self.module.check_mode:
-                        self.model_orchestrator.create(final_item)
+                        if getattr(self.model_orchestrator, "supports_bulk_create", False):
+                            items_to_create_bulk.append(final_item)
+                        else:
+                            self.model_orchestrator.create(final_item)
                 self.sent.add(final_item)
 
                 # Log operation
@@ -116,11 +127,17 @@ class NDStateMachine:
                 if not self.module.params.get("ignore_errors", False):
                     raise NDStateMachineError(error_msg) from e
 
+        # Execute API bulk create operation
+        if items_to_create_bulk:
+            self.model_orchestrator.create_bulk(items_to_create_bulk)
+
     def _manage_override_deletions(self) -> None:
         """
         Delete items not in proposed config (for overridden state).
         """
         diff_identifiers = self.before.get_diff_identifiers(self.proposed)
+
+        items_to_delete_bulk: List = []
 
         for identifier in diff_identifiers:
             try:
@@ -130,7 +147,10 @@ class NDStateMachine:
 
                 # Execute delete
                 if not self.module.check_mode:
-                    self.model_orchestrator.delete(existing_item)
+                    if getattr(self.model_orchestrator, "supports_bulk_delete", False):
+                        items_to_delete_bulk.append(existing_item)
+                    else:
+                        self.model_orchestrator.delete(existing_item)
 
                 # Remove from collection
                 self.existing.delete(identifier)
@@ -143,8 +163,13 @@ class NDStateMachine:
                 if not self.module.params.get("ignore_errors", False):
                     raise NDStateMachineError(error_msg) from e
 
+            if items_to_delete_bulk:
+                self.model_orchestrator.delete_bulk(items_to_delete_bulk)
+
     def _manage_delete_state(self) -> None:
         """Handle deleted state."""
+        items_to_delete_bulk: List = []
+
         for proposed_item in self.proposed:
             try:
                 identifier = proposed_item.get_identifier_value()
@@ -155,7 +180,10 @@ class NDStateMachine:
 
                 # Execute delete
                 if not self.module.check_mode:
-                    self.model_orchestrator.delete(existing_item)
+                    if getattr(self.model_orchestrator, "supports_bulk_delete", False):
+                        items_to_delete_bulk.append(existing_item)
+                    else:
+                        self.model_orchestrator.delete(existing_item)
 
                 # Remove from collection
                 self.existing.delete(identifier)
@@ -167,3 +195,6 @@ class NDStateMachine:
                 error_msg = f"Failed to delete {identifier}: {e}"
                 if not self.module.params.get("ignore_errors", False):
                     raise NDStateMachineError(error_msg) from e
+
+        if items_to_delete_bulk:
+            self.model_orchestrator.delete_bulk(items_to_delete_bulk)

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 from functools import wraps
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict, model_validator
 from typing import ClassVar, Type, Optional, Generic, TypeVar, List
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd import NDModule
@@ -49,6 +49,10 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     query_one_endpoint: Type[NDEndpointBaseModel]
     query_all_endpoint: Type[NDEndpointBaseModel]
 
+    # NOTE: Conditionally required
+    create_bulk_endpoint: Optional[Type[NDEndpointBaseModel]] = None
+    delete_bulk_endpoint: Optional[Type[NDEndpointBaseModel]] = None
+
     # NOTE: Module Field is always required
     sender: NDModule
 
@@ -91,6 +95,14 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
             return result or []
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
+
+    @model_validator(mode="after")
+    def validate_bulk_endpoints(self):
+        if self.supports_bulk_create and self.create_bulk_endpoint is None:
+            raise ValueError(f"'{self.__class__.__name__}' has 'supports_bulk_create=True' but 'create_bulk_endpoint' is not defined.")
+        if self.supports_bulk_delete and self.delete_bulk_endpoint is None:
+            raise ValueError(f"'{self.__class__.__name__}' has 'supports_bulk_delete=True' but 'delete_bulk_endpoint' is not defined.")
+        return self
 
     @requires_bulk_support("supports_bulk_create")
     def create_bulk(self, model_instances: List[ModelType], **kwargs) -> ResponseType:

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -106,8 +106,8 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
 
     @requires_bulk_support("supports_bulk_create")
     def create_bulk(self, model_instances: List[ModelType], **kwargs) -> ResponseType:
-        pass
+        raise NotImplementedError
 
     @requires_bulk_support("supports_bulk_delete")
     def delete_bulk(self, model_instances: List[ModelType], **kwargs) -> ResponseType:
-        pass
+        raise NotImplementedError

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -4,14 +4,30 @@
 
 from __future__ import absolute_import, division, print_function
 
+from functools import wraps
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict
-from typing import ClassVar, Type, Optional, Generic, TypeVar
+from typing import ClassVar, Type, Optional, Generic, TypeVar, List
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd import NDModule
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 ModelType = TypeVar("ModelType", bound=NDBaseModel)
+
+
+def requires_bulk_support(flag_name: str):
+    """Decorator that restricts method access based on a ClassVar boolean flag."""
+
+    def decorator(method):
+        @wraps(method)
+        def wrapper(self, *args, **kwargs):
+            if not getattr(self, flag_name, False):
+                raise AttributeError(f"'{method.__name__}' is not available when '{flag_name}' is disabled on '{self.__class__.__name__}'.")
+            return method(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
@@ -76,8 +92,10 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
 
-    def create_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
+    @requires_bulk_support("supports_bulk_create")
+    def create_bulk(self, model_instances: List[ModelType], **kwargs) -> ResponseType:
         pass
 
-    def delete_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
+    @requires_bulk_support("supports_bulk_delete")
+    def delete_bulk(self, model_instances: List[ModelType], **kwargs) -> ResponseType:
         pass

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -23,6 +23,8 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     )
 
     model_class: ClassVar[Type[NDBaseModel]] = NDBaseModel
+    supports_bulk_create: ClassVar[bool] = False
+    supports_bulk_delete: ClassVar[bool] = False
 
     # NOTE: if not defined by subclasses, return an error as they are required
     create_endpoint: Type[NDEndpointBaseModel]
@@ -73,3 +75,9 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
             return result or []
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
+
+    def create_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
+        pass
+
+    def delete_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
+        pass


### PR DESCRIPTION
<html><head></head><body><h2>Summary of Changes (backwards compatible with existing modules)</h2>

<p>Introduced <strong>optional bulk operation support</strong> across three layers:</p>
<h3>1. Orchestrator Layer (<code>NDBaseOrchestrator</code>)</h3>
<ul>
<li>Added <code>supports_bulk_create</code> / <code>supports_bulk_delete</code> class variable flags (default <code>False</code>)</li>
<li>Added <code>create_bulk</code> / <code>delete_bulk</code> methods guarded by a <code>requires_bulk_support</code> decorator — calling them on an unsupported orchestrator raises <code>AttributeError</code></li>
<li>Added <code>create_bulk_endpoint</code> / <code>delete_bulk_endpoint</code> as conditionally required fields — validated at instantiation via <code>@model_validator</code>, only required when their respective flag is <code>True</code></li>
<li>Subclasses opt-in by setting the flag and defining the endpoint:</li>
</ul>
<pre><code class="language-python">class MyOrchestrator(NDBaseOrchestrator[MyModel]):
    supports_bulk_create: ClassVar[bool] = True
    create_bulk_endpoint = EpMyModelBulkPost
</code></pre>
<h3>2. Collection Layer (<code>NDConfigCollection</code>)</h3>
<ul>
<li>Added <code>add_many()</code> / <code>delete_many()</code> to support batch mutations</li>
<li><code>delete_many()</code> performs a <strong>single index rebuild</strong> instead of one per deletion, reducing complexity from O(D×N) to O(N)</li>
</ul>
<h3>3. State Machine Layer (<code>NDStateMachine</code>)</h3>
<ul>
<li>Adopted a <strong>categorize-then-execute</strong> pattern: items are first classified (create/update/delete), then executed in batch</li>
<li>When bulk is supported → single API call for all creates/deletes</li>
<li>When bulk is not supported → falls back to individual API calls transparently</li>
<li><code>self.sent</code> tracking deferred until <strong>after</strong> successful API execution to ensure correctness</li>
</ul>

<p>Bulk support is <strong>fully opt-in</strong> — existing orchestrators require zero changes.</p>
</body></html>