### PR TITLE
Replace NDModule (nd.py) with RestSend in orchestrator framework (NDA-26)

### DIFF
--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -5,15 +5,18 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Type, Union, List, Any, Callable, Optional
+from typing import Any, Callable, List, Optional, Type, Union
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.nd import NDModule
-from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
 
 
 class NDStateMachine:
@@ -26,7 +29,19 @@ class NDStateMachine:
         Initialize the ND State Machine.
         """
         self.module = module
-        self.nd_module = NDModule(self.module)
+
+        # REST infrastructure
+        sender = Sender()
+        sender.ansible_module = self.module
+
+        self.rest_send = RestSend(
+            {
+                "check_mode": self.module.check_mode,
+                "state": self.module.params.get("state"),
+            }
+        )
+        self.rest_send.sender = sender
+        self.rest_send.response_handler = ResponseHandler()
 
         # Operation tracking
         self.output = NDOutput(output_level=module.params.get("output_level", "normal"))
@@ -34,7 +49,7 @@ class NDStateMachine:
         # Configuration
         # Accept either an orchestrator instance or a class.
         if isinstance(model_orchestrator, type) and issubclass(model_orchestrator, NDBaseOrchestrator):
-            self.model_orchestrator = model_orchestrator(sender=self.nd_module)
+            self.model_orchestrator = model_orchestrator(rest_send=self.rest_send)
         elif isinstance(model_orchestrator, NDBaseOrchestrator):
             self.model_orchestrator = model_orchestrator
         else:

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -76,12 +76,8 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
             self.rest_send.payload = data
         self.rest_send.commit()
 
-        result = self.rest_send.result_current
-        if not result.get("success", False):
-            response = self.rest_send.response_current
-            msg = response.get("MESSAGE", "Unknown error")
-            code = response.get("RETURN_CODE", -1)
-            raise Exception(f"Request failed ({code}): {msg}")
+        if not self.rest_send.success:
+            raise Exception(f"Request failed {self.rest_send.error_summary}")
 
         return self.rest_send.response_current.get("DATA", {})
 
@@ -101,14 +97,10 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         self.rest_send.verb = HttpVerbEnum.GET
         self.rest_send.commit()
 
-        result = self.rest_send.result_current
-        if not result.get("success", False):
-            response = self.rest_send.response_current
-            if response.get("RETURN_CODE") == 404:
+        if not self.rest_send.success:
+            if self.rest_send.return_code == 404:
                 return {}
-            msg = response.get("MESSAGE", "Unknown error")
-            code = response.get("RETURN_CODE", -1)
-            raise Exception(f"Query failed ({code}): {msg}")
+            raise Exception(f"Query failed {self.rest_send.error_summary}")
 
         return self.rest_send.response_current.get("DATA", {})
 

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -5,12 +5,14 @@
 from __future__ import absolute_import, division, print_function
 
 from functools import wraps
+from typing import Any, ClassVar, Dict, Generic, List, Optional, Type, TypeVar
+
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict, model_validator
-from typing import ClassVar, Type, Optional, Generic, TypeVar, List
-from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd import NDModule
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 
 ModelType = TypeVar("ModelType", bound=NDBaseModel)
 
@@ -53,14 +55,68 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     create_bulk_endpoint: Optional[Type[NDEndpointBaseModel]] = None
     delete_bulk_endpoint: Optional[Type[NDEndpointBaseModel]] = None
 
-    # NOTE: Module Field is always required
-    sender: NDModule
+    # REST infrastructure
+    rest_send: RestSend
+
+    def _request(self, path: str, verb: HttpVerbEnum, data: Optional[Dict[str, Any]] = None) -> ResponseType:
+        """
+        # Summary
+
+        Send a REST request via RestSend and return the response DATA.
+
+        ## Raises
+
+        ### Exception
+
+        - If the request fails (non-success result from the controller).
+        """
+        self.rest_send.path = path
+        self.rest_send.verb = verb
+        if data is not None:
+            self.rest_send.payload = data
+        self.rest_send.commit()
+
+        result = self.rest_send.result_current
+        if not result.get("success", False):
+            response = self.rest_send.response_current
+            msg = response.get("MESSAGE", "Unknown error")
+            code = response.get("RETURN_CODE", -1)
+            raise Exception(f"Request failed ({code}): {msg}")
+
+        return self.rest_send.response_current.get("DATA", {})
+
+    def _query_obj(self, path: str) -> Dict[str, Any]:
+        """
+        # Summary
+
+        GET the given path and return the DATA dict, or empty dict if not found.
+
+        ## Raises
+
+        ### Exception
+
+        - If the request fails with a non-404 error.
+        """
+        self.rest_send.path = path
+        self.rest_send.verb = HttpVerbEnum.GET
+        self.rest_send.commit()
+
+        result = self.rest_send.result_current
+        if not result.get("success", False):
+            response = self.rest_send.response_current
+            if response.get("RETURN_CODE") == 404:
+                return {}
+            msg = response.get("MESSAGE", "Unknown error")
+            code = response.get("RETURN_CODE", -1)
+            raise Exception(f"Query failed ({code}): {msg}")
+
+        return self.rest_send.response_current.get("DATA", {})
 
     # NOTE: Generic CRUD API operations for simple endpoints with single identifier (e.g. "api/v1/infra/aaa/LocalUsers/{loginID}")
     def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
         try:
             api_endpoint = self.create_endpoint()
-            return self.sender.request(path=api_endpoint.path, method=api_endpoint.verb, data=model_instance.to_payload())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload())
         except Exception as e:
             raise Exception(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -68,7 +124,7 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.update_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self.sender.request(path=api_endpoint.path, method=api_endpoint.verb, data=model_instance.to_payload())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload())
         except Exception as e:
             raise Exception(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -76,7 +132,7 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.delete_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self.sender.request(path=api_endpoint.path, method=api_endpoint.verb)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
         except Exception as e:
             raise Exception(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -84,14 +140,14 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.query_one_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self.sender.request(path=api_endpoint.path, method=api_endpoint.verb)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
         except Exception as e:
             raise Exception(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
     def query_all(self, model_instance: Optional[ModelType] = None, **kwargs) -> ResponseType:
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self.sender.query_obj(api_endpoint.path)
+            result = self._query_obj(api_endpoint.path)
             return result or []
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -77,9 +77,13 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
             self.rest_send.payload = data
         self.rest_send.commit()
 
+        # Check not_found_ok before success because ResponseHandler treats
+        # GET 404 as success=True (found=False).  Without this early return,
+        # a GET 404 would fall through and return the raw 404 DATA body.
+        if not_found_ok and self.rest_send.return_code == 404:
+            return {}
+
         if not self.rest_send.success:
-            if not_found_ok and self.rest_send.return_code == 404:
-                return {}
             raise Exception(f"Request failed {self.rest_send.error_summary}")
 
         return self.rest_send.response_current.get("DATA", {})

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -58,7 +58,7 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     # REST infrastructure
     rest_send: RestSend
 
-    def _request(self, path: str, verb: HttpVerbEnum, data: Optional[Dict[str, Any]] = None) -> ResponseType:
+    def _request(self, path: str, verb: HttpVerbEnum, data: Optional[Dict[str, Any]] = None, not_found_ok: bool = False) -> ResponseType:
         """
         # Summary
 
@@ -69,6 +69,7 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         ### Exception
 
         - If the request fails (non-success result from the controller).
+        - If `not_found_ok` is False and the controller returns a 404.
         """
         self.rest_send.path = path
         self.rest_send.verb = verb
@@ -77,30 +78,9 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         self.rest_send.commit()
 
         if not self.rest_send.success:
-            raise Exception(f"Request failed {self.rest_send.error_summary}")
-
-        return self.rest_send.response_current.get("DATA", {})
-
-    def _query_obj(self, path: str) -> Dict[str, Any]:
-        """
-        # Summary
-
-        GET the given path and return the DATA dict, or empty dict if not found.
-
-        ## Raises
-
-        ### Exception
-
-        - If the request fails with a non-404 error.
-        """
-        self.rest_send.path = path
-        self.rest_send.verb = HttpVerbEnum.GET
-        self.rest_send.commit()
-
-        if not self.rest_send.success:
-            if self.rest_send.return_code == 404:
+            if not_found_ok and self.rest_send.return_code == 404:
                 return {}
-            raise Exception(f"Query failed {self.rest_send.error_summary}")
+            raise Exception(f"Request failed {self.rest_send.error_summary}")
 
         return self.rest_send.response_current.get("DATA", {})
 
@@ -139,7 +119,7 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     def query_all(self, model_instance: Optional[ModelType] = None, **kwargs) -> ResponseType:
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self._query_obj(api_endpoint.path)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
             return result or []
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -4,18 +4,19 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Type, ClassVar
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from typing import ClassVar, Type
+
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.infra.aaa_local_users import (
-    EpInfraAaaLocalUsersPost,
-    EpInfraAaaLocalUsersPut,
     EpInfraAaaLocalUsersDelete,
     EpInfraAaaLocalUsersGet,
+    EpInfraAaaLocalUsersPost,
+    EpInfraAaaLocalUsersPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 
 class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):
@@ -33,7 +34,7 @@ class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):
         """
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self.sender.query_obj(api_endpoint.path)
+            result = self._query_obj(api_endpoint.path)
             return result.get("localusers", []) or []
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -34,7 +34,7 @@ class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):
         """
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self._query_obj(api_endpoint.path)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
             return result.get("localusers", []) or []
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_fabric_ebgp.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_ebgp.py
@@ -40,7 +40,7 @@ class ManageEbgpFabricOrchestrator(NDBaseOrchestrator):
         """
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self._query_obj(api_endpoint.path)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
             fabrics = result.get("fabrics", []) or []
             return [f for f in fabrics if f.get("management", {}).get("type") == "vxlanEbgp"]
         except Exception as e:

--- a/plugins/module_utils/orchestrators/manage_fabric_ebgp.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_ebgp.py
@@ -9,18 +9,19 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from typing import Type
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ebgp import FabricEbgpModel
+
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import (
+    EpManageFabricsDelete,
     EpManageFabricsGet,
     EpManageFabricsListGet,
     EpManageFabricsPost,
     EpManageFabricsPut,
-    EpManageFabricsDelete,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ebgp import FabricEbgpModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 
 class ManageEbgpFabricOrchestrator(NDBaseOrchestrator):
@@ -39,7 +40,7 @@ class ManageEbgpFabricOrchestrator(NDBaseOrchestrator):
         """
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self.sender.query_obj(api_endpoint.path)
+            result = self._query_obj(api_endpoint.path)
             fabrics = result.get("fabrics", []) or []
             return [f for f in fabrics if f.get("management", {}).get("type") == "vxlanEbgp"]
         except Exception as e:

--- a/plugins/module_utils/orchestrators/manage_fabric_external.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_external.py
@@ -40,7 +40,7 @@ class ManageExternalFabricOrchestrator(NDBaseOrchestrator):
         """
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self._query_obj(api_endpoint.path)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
             fabrics = result.get("fabrics", []) or []
             return [f for f in fabrics if f.get("management", {}).get("type") == "externalConnectivity"]
         except Exception as e:

--- a/plugins/module_utils/orchestrators/manage_fabric_external.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_external.py
@@ -9,18 +9,19 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from typing import Type
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_external import FabricExternalConnectivityModel
+
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import (
+    EpManageFabricsDelete,
     EpManageFabricsGet,
     EpManageFabricsListGet,
     EpManageFabricsPost,
     EpManageFabricsPut,
-    EpManageFabricsDelete,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_external import FabricExternalConnectivityModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 
 class ManageExternalFabricOrchestrator(NDBaseOrchestrator):
@@ -39,7 +40,7 @@ class ManageExternalFabricOrchestrator(NDBaseOrchestrator):
         """
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self.sender.query_obj(api_endpoint.path)
+            result = self._query_obj(api_endpoint.path)
             fabrics = result.get("fabrics", []) or []
             return [f for f in fabrics if f.get("management", {}).get("type") == "externalConnectivity"]
         except Exception as e:

--- a/plugins/module_utils/orchestrators/manage_fabric_ibgp.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_ibgp.py
@@ -9,18 +9,19 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from typing import Type
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ibgp import FabricIbgpModel
+
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import (
+    EpManageFabricsDelete,
     EpManageFabricsGet,
     EpManageFabricsListGet,
     EpManageFabricsPost,
     EpManageFabricsPut,
-    EpManageFabricsDelete,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ibgp import FabricIbgpModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 
 class ManageIbgpFabricOrchestrator(NDBaseOrchestrator):
@@ -39,7 +40,7 @@ class ManageIbgpFabricOrchestrator(NDBaseOrchestrator):
         """
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self.sender.query_obj(api_endpoint.path)
+            result = self._query_obj(api_endpoint.path)
             fabrics = result.get("fabrics", []) or []
             return [f for f in fabrics if f.get("management", {}).get("type") == "vxlanIbgp"]
         except Exception as e:

--- a/plugins/module_utils/orchestrators/manage_fabric_ibgp.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_ibgp.py
@@ -40,7 +40,7 @@ class ManageIbgpFabricOrchestrator(NDBaseOrchestrator):
         """
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self._query_obj(api_endpoint.path)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
             fabrics = result.get("fabrics", []) or []
             return [f for f in fabrics if f.get("management", {}).get("type") == "vxlanIbgp"]
         except Exception as e:

--- a/plugins/module_utils/rest/protocols/sender.py
+++ b/plugins/module_utils/rest/protocols/sender.py
@@ -84,7 +84,7 @@ class SenderProtocol(Protocol):
         ...
 
     @payload.setter
-    def payload(self, value: dict) -> None:
+    def payload(self, value: Optional[dict]) -> None:
         """Set the optional payload for the REST request."""
         ...
 

--- a/plugins/module_utils/rest/rest_send.py
+++ b/plugins/module_utils/rest/rest_send.py
@@ -292,6 +292,7 @@ class RestSend:
             self._response.append(self.response_current)
             self._result.append(self.result_current)
             self._committed_payload = copy.deepcopy(self._payload)
+            self._payload = None
         except (TypeError, ValueError) as error:
             msg = f"{self.class_name}.{method_name}: "
             msg += "Error building response/result. "

--- a/plugins/module_utils/rest/rest_send.py
+++ b/plugins/module_utils/rest/rest_send.py
@@ -374,6 +374,47 @@ class RestSend:
         self._payload = None
 
     @property
+    def success(self) -> bool:
+        """
+        # Summary
+
+        Whether the most recent commit was successful.
+
+        ## Raises
+
+        None
+        """
+        return self._result_current.get("success", False)
+
+    @property
+    def return_code(self) -> int:
+        """
+        # Summary
+
+        The HTTP return code from the most recent commit.
+
+        ## Raises
+
+        None
+        """
+        return self._response_current.get("RETURN_CODE", -1)
+
+    @property
+    def error_summary(self) -> str:
+        """
+        # Summary
+
+        A short error string combining the return code and message from the most recent commit.
+
+        ## Raises
+
+        None
+        """
+        code = self._response_current.get("RETURN_CODE", -1)
+        msg = self._response_current.get("MESSAGE", "Unknown error")
+        return f"({code}): {msg}"
+
+    @property
     def check_mode(self) -> bool:
         """
         # Summary

--- a/plugins/module_utils/rest/rest_send.py
+++ b/plugins/module_utils/rest/rest_send.py
@@ -234,7 +234,7 @@ class RestSend:
         self.log.debug(msg)
 
         try:
-            if self.check_mode is True:
+            if self.check_mode is True and self.verb != HttpVerbEnum.GET:
                 self._commit_check_mode()
             else:
                 self._commit_normal_mode()

--- a/plugins/module_utils/rest/rest_send.py
+++ b/plugins/module_utils/rest/rest_send.py
@@ -319,8 +319,7 @@ class RestSend:
 
         self.sender.path = self.path
         self.sender.verb = self.verb
-        if self.payload is not None:
-            self.sender.payload = self.payload
+        self.sender.payload = self.payload
         success = False
         while timeout > 0 and success is False:
             msg = f"{self.class_name}.{method_name}: "

--- a/plugins/module_utils/rest/sender_nd.py
+++ b/plugins/module_utils/rest/sender_nd.py
@@ -249,11 +249,11 @@ class Sender:
         return self._payload
 
     @payload.setter
-    def payload(self, value: dict):
+    def payload(self, value: Optional[dict]):
         method_name = "payload"
-        if not isinstance(value, dict):
+        if value is not None and not isinstance(value, dict):
             msg = f"{self.class_name}.{method_name}: "
-            msg += f"{method_name} must be a dict. "
+            msg += f"{method_name} must be a dict or None. "
             msg += f"Got type {type(value).__name__}, "
             msg += f"value {value}."
             raise TypeError(msg)

--- a/tests/unit/module_utils/fixtures/fixture_data/test_rest_send.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_rest_send.json
@@ -78,24 +78,13 @@
         }
     },
     "test_rest_send_00300a": {
-        "TEST_NOTES": ["First response in retry sequence - failure"],
-        "RETURN_CODE": 500,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/test/retry",
-        "MESSAGE": "Internal Server Error",
-        "DATA": {
-            "error": "Temporary error"
-        }
-    },
-    "test_rest_send_00300b": {
-        "TEST_NOTES": ["Second response in retry sequence - success"],
+        "TEST_NOTES": ["GET request in check_mode bypasses simulation and returns real response"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/test/retry",
+        "REQUEST_PATH": "/api/v1/test/checkmode",
         "MESSAGE": "OK",
         "DATA": {
-            "status": "success",
-            "result": "data after retry"
+            "status": "success"
         }
     },
     "test_rest_send_00400a": {

--- a/tests/unit/module_utils/test_rest_send.py
+++ b/tests/unit/module_utils/test_rest_send.py
@@ -503,30 +503,32 @@ def test_rest_send_00300():
     """
     # Summary
 
-    Verify commit() in check_mode for GET request
+    Verify commit() in check_mode for GET request bypasses simulation.
 
     ## Test
 
-    - GET requests in check_mode return simulated success response
-    - response_current contains check mode indicator
+    - GET requests in check_mode go through normal mode (real controller call)
+    - response_current contains actual controller data, not simulated data
     - result_current shows success
 
     ## Classes and Methods
 
     - RestSend.commit()
-    - RestSend._commit_check_mode()
+    - RestSend._commit_normal_mode()
     """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
     params = {"check_mode": True}
 
     def responses():
-        yield {}
+        yield responses_rest_send(key)
+        yield responses_rest_send(key)
 
     gen_responses = ResponseGenerator(responses())
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
-    sender.path = "/api/v1/test"
-    sender.verb = HttpVerbEnum.GET
 
     with does_not_raise():
         instance = RestSend(params)
@@ -541,11 +543,11 @@ def test_rest_send_00300():
         instance.verb = HttpVerbEnum.GET
         instance.commit()
 
-    # Verify check mode response
+    # Verify real response (not simulated check_mode response)
     assert instance.response_current["RETURN_CODE"] == 200
-    assert instance.response_current["METHOD"] == HttpVerbEnum.GET
-    assert instance.response_current["REQUEST_PATH"] == "/api/v1/test/checkmode"
-    assert instance.response_current["CHECK_MODE"] is True
+    assert instance.response_current["METHOD"] == "GET"
+    assert instance.response_current["DATA"]["status"] == "success"
+    assert instance.response_current.get("CHECK_MODE") is None
     assert instance.result_current["success"] is True
     assert instance.result_current["found"] is True
 


### PR DESCRIPTION
## Summary

This PR removes the legacy `NDModule` (`nd.py`) dependency from the orchestrator framework, wiring `RestSend` + `Sender` + `ResponseHandler` directly into `NDBaseOrchestrator` and `NDStateMachine`.

Both `nd.py` and `nd_v2.py` are planned for removal. This is the first step — decoupling the orchestrator layer so it talks directly to the RestSend infrastructure instead of going through the `NDModule` middleman.

### Before

```
Module → NDStateMachine → NDModule (nd.py) → Connection (httpapi)
                              ↓
                    NDBaseOrchestrator
                    sender: NDModule
                    self.sender.request(path, method, data)
                    self.sender.query_obj(path)
```

### After

```
Module → NDStateMachine → RestSend → Sender → Connection (httpapi)
                              ↓          ↓
                    NDBaseOrchestrator  ResponseHandler
                    rest_send: RestSend
                    self._request(path, verb, data)
                    self._request(path, verb, not_found_ok=True)
```

## Changes

### `plugins/module_utils/rest/rest_send.py`

- **Added** `success` property — returns `bool` from `_result_current["success"]`, avoiding a deepcopy of `result_current` on the success path.
- **Added** `return_code` property — returns the HTTP return code from `_response_current["RETURN_CODE"]`. Used by the orchestrator for 404 detection without deepcopying the full response.
- **Added** `error_summary` property — returns a formatted `"({code}): {msg}"` string from the current response, centralizing error message construction that was previously duplicated in every caller.
- **Fixed** `commit()` — GET requests now always go through `_commit_normal_mode()` regardless of `check_mode`. Previously, `_commit_check_mode()` returned hardcoded simulated data for all verbs including GET, which broke `query_all()` during `NDStateMachine` init (fake data instead of real controller state produced incorrect diffs and output).
- **Fixed** `_commit_normal_mode()` — now unconditionally sets `self.sender.payload` (including `None`) each commit instead of only setting it when non-None. Previously, a payload from a prior POST/PUT would persist in `Sender._payload` and leak into subsequent GET/DELETE requests.

### `plugins/module_utils/rest/sender_nd.py`

- **Updated** `payload` setter to accept `Optional[dict]` (allowing `None`), enabling `RestSend` to explicitly clear stale payloads between requests.

### `plugins/module_utils/rest/protocols/sender.py`

- **Updated** `SenderProtocol.payload` setter type from `dict` to `Optional[dict]` to match `Sender` implementation.

### `plugins/module_utils/orchestrators/base.py`

- **Replaced** `sender: NDModule` field with `rest_send: RestSend`
- **Added** `_request(path, verb, data, not_found_ok)` — sets path/verb/payload on RestSend, calls `commit()`, checks `rest_send.success`, returns `response_current["DATA"]`. Raises on failure with `rest_send.error_summary`. When `not_found_ok=True`, 404 responses return `{}` instead of raising.
- **Removed** `_query_obj()` — consolidated into `_request()` via the `not_found_ok` parameter, eliminating a separate method that only differed in its 404 handling.
- **Fixed** `_request()` — `not_found_ok` with `return_code == 404` check now runs before the `success` check. Previously it was nested inside the `if not success` block, but `ResponseHandler` treats GET 404 as `success=True` (`found=False`), so the `not_found_ok` path was unreachable for GET requests. This caused `query_all()` to return the raw 404 response body instead of `{}`.
- **Simplified** error handling — reduced from 5 lines (deepcopy result, check success, deepcopy response, extract message/code, raise) to 2 lines (`if not self.rest_send.success: raise`).
- **Updated** all CRUD methods (`create`, `update`, `delete`, `query_one`, `query_all`) to use `_request()`.

### `plugins/module_utils/nd_state_machine.py`

- **Replaced** `NDModule` creation with `Sender` + `ResponseHandler` + `RestSend` wiring.
- Passes `rest_send=self.rest_send` to orchestrator instead of `sender=self.nd_module`.
- `RestSend` receives `check_mode` and `state` from module params.

### Orchestrator subclasses (4 files)

- `local_user.py`, `manage_fabric_ebgp.py`, `manage_fabric_external.py`, `manage_fabric_ibgp.py`
- Changed `self.sender.query_obj(...)` → `self._request(..., not_found_ok=True)` in their `query_all()` overrides.
- No other changes — these subclasses inherit the updated base CRUD methods.

## What's NOT changed

- `nd.py` / `nd_v2.py` — left in place, still available for other legacy code
- Module files (`nd_local_user.py`, `nd_manage_fabric_*.py`) — unchanged, wiring happens in `NDStateMachine`

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infa
* [ ] manage
* [ ] onemanage
* [x] other (Common infra)

## Test plan

- [x] All 309 unit tests pass (including 35 RestSend tests)
- [x] `nd_manage_fabric_ebgp` integration tests pass against live ND
- [x] `nd_manage_fabric_external` integration tests pass against live ND
- [x] `nd_manage_fabric_ibgp` integration tests pass against live ND
- [x] Import smoke test — all orchestrators and NDStateMachine import cleanly
- [x] `black`, `isort` clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)