### PR TITLE
[ND 4.2+] Add verbosity gated results (NDA-20)

### DIFF
--- a/plugins/doc_fragments/modules.py
+++ b/plugins/doc_fragments/modules.py
@@ -40,6 +40,9 @@ options:
     - C(normal) means the standard output, incl. C(current) dict
     - C(info) adds informational output, incl. C(previous), C(proposed) and C(sent) dicts
     - C(debug) adds debugging output, incl. C(filter_string), C(method), C(response), C(status) and C(url) information
+    - Additionally, Ansible CLI verbosity flags control API call detail in module output.
+    - C(-vv) adds C(api_paths) and C(api_verbs) listing the endpoints called for write operations.
+    - C(-vvv) adds full controller detail including C(api_response), C(api_result), C(api_diff), C(api_metadata), and C(api_payload) for all operations.
     - If the value is not specified in the task, the value of environment variable C(ND_OUTPUT_LEVEL) will be used instead.
     type: str
     choices: [ debug, info, normal ]

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Dict, Any, Optional, List, Union
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
 
 class NDOutput:
@@ -40,6 +41,59 @@ class NDOutput:
             output.update(self._extra)
 
         output.update(**kwargs)
+
+        return output
+
+    def format_with_verbosity(self, verbosity: int, results: Optional[Results] = None, **kwargs) -> Dict[str, Any]:
+        """
+        Build output dict filtered by CLI verbosity level.
+
+        Level 0-1 (default / -v): changed, failed only.
+        Level 2 (-vv): Add API call summary (path, verb) for write operations.
+        Level 3+ (-vvv): Add full controller detail (response, result, diff,
+                         metadata, payload) for all operations.
+
+        The ``results`` argument should be a Results instance that has had
+        ``build_final_result()`` called.  If *None*, only config-level output
+        from :meth:`format` is returned.
+        """
+        output = self.format(**kwargs)
+
+        if results is None or verbosity < 2:
+            return output
+
+        # Build the final aggregated result if not already built.
+        try:
+            final = results.final_result
+        except ValueError:
+            results.build_final_result()
+            final = results.final_result
+
+        # Merge changed/failed from Results (API-level) with NDOutput (config-level).
+        if final.get("changed"):
+            output["changed"] = True
+        if final.get("failed"):
+            output["failed"] = True
+
+        # Filter tasks by verbosity: only include tasks whose
+        # verbosity_level <= the requested display verbosity.
+        verbosity_levels = final.get("verbosity_level", [])
+        indices = [i for i, vl in enumerate(verbosity_levels) if vl <= verbosity]
+
+        if not indices:
+            return output
+
+        # Level 2 (-vv): endpoint summary for qualifying tasks.
+        paths = final.get("path", [])
+        verbs = final.get("verb", [])
+        output["api_paths"] = [paths[i] for i in indices]
+        output["api_verbs"] = [verbs[i] for i in indices]
+
+        # Level 3+ (-vvv): full controller detail for qualifying tasks.
+        if verbosity >= 3:
+            for key in ("response", "result", "diff", "metadata", "payload"):
+                values = final.get(key, [])
+                output["api_{0}".format(key)] = [values[i] for i in indices]
 
         return output
 

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -63,11 +63,8 @@ class NDOutput:
             return output
 
         # Build the final aggregated result if not already built.
-        try:
-            final = results.final_result
-        except ValueError:
-            results.build_final_result()
-            final = results.final_result
+        results.build_final_result()
+        final = results.final_result
 
         # Merge changed/failed from Results (API-level) with NDOutput (config-level).
         if final.get("changed"):

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -89,8 +89,7 @@ class NDOutput:
         # Level 3+ (-vvv): full controller detail for qualifying tasks.
         if verbosity >= 3:
             for key in ("response", "result", "diff", "metadata", "payload"):
-                values = final.get(key, [])
-                output["api_{0}".format(key)] = [values[i] for i in indices]
+                output["api_{0}".format(key)] = final.get(key, [])
 
         return output
 

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -16,6 +16,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
 
 
@@ -45,13 +46,17 @@ class NDStateMachine:
 
         # Operation tracking
         self.output = NDOutput(output_level=module.params.get("output_level", "normal"))
+        self.results = Results()
+        self.results.state = self.module.params.get("state", "")
+        self.results.check_mode = self.module.check_mode
 
         # Configuration
         # Accept either an orchestrator instance or a class.
         if isinstance(model_orchestrator, type) and issubclass(model_orchestrator, NDBaseOrchestrator):
-            self.model_orchestrator = model_orchestrator(rest_send=self.rest_send)
+            self.model_orchestrator = model_orchestrator(rest_send=self.rest_send, results=self.results)
         elif isinstance(model_orchestrator, NDBaseOrchestrator):
             self.model_orchestrator = model_orchestrator
+            self.model_orchestrator.results = self.results
         else:
             raise NDStateMachineError(f"model_orchestrator must be an NDBaseOrchestrator class or instance. Got: {type(model_orchestrator)}")
 

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -9,10 +9,11 @@ from typing import Any, ClassVar, Dict, Generic, List, Optional, Type, TypeVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict, model_validator
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
 ModelType = TypeVar("ModelType", bound=NDBaseModel)
 
@@ -57,8 +58,33 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
 
     # REST infrastructure
     rest_send: RestSend
+    results: Optional[Results] = None
 
-    def _request(self, path: str, verb: HttpVerbEnum, data: Optional[Dict[str, Any]] = None, not_found_ok: bool = False) -> ResponseType:
+    def _register_api_call(self, path: str, verb: HttpVerbEnum, operation_type: OperationType, payload: Optional[Dict[str, Any]] = None) -> None:
+        """Register the most recent REST call with Results for observability."""
+        if self.results is None:
+            return
+        self.results.action = operation_type.value
+        self.results.operation_type = operation_type
+        self.results.path_current = path
+        self.results.verb_current = verb
+        self.results.payload_current = payload
+        self.results.response_current = self.rest_send.response_current
+        self.results.result_current = self.rest_send.result_current
+        self.results.diff_current = {}
+        # Tag write operations as verbosity 2 (shown at -vv),
+        # read operations as verbosity 3 (shown at -vvv).
+        self.results.verbosity_level_current = 3 if operation_type == OperationType.QUERY else 2
+        self.results.register_api_call()
+
+    def _request(
+        self,
+        path: str,
+        verb: HttpVerbEnum,
+        data: Optional[Dict[str, Any]] = None,
+        not_found_ok: bool = False,
+        operation_type: OperationType = OperationType.QUERY,
+    ) -> ResponseType:
         """
         # Summary
 
@@ -77,6 +103,10 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
             self.rest_send.payload = data
         self.rest_send.commit()
 
+        # Register with Results before success/error checks so that
+        # both successful and failed calls are captured for troubleshooting.
+        self._register_api_call(path, verb, operation_type, self.rest_send.committed_payload)
+
         # Check not_found_ok before success because ResponseHandler treats
         # GET 404 as success=True (found=False).  Without this early return,
         # a GET 404 would fall through and return the raw 404 DATA body.
@@ -92,7 +122,7 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
         try:
             api_endpoint = self.create_endpoint()
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload(), operation_type=OperationType.CREATE)
         except Exception as e:
             raise Exception(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -100,7 +130,7 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.update_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload(), operation_type=OperationType.UPDATE)
         except Exception as e:
             raise Exception(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -108,7 +138,7 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.delete_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, operation_type=OperationType.DELETE)
         except Exception as e:
             raise Exception(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -116,14 +146,14 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.query_one_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, operation_type=OperationType.QUERY)
         except Exception as e:
             raise Exception(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
     def query_all(self, model_instance: Optional[ModelType] = None, **kwargs) -> ResponseType:
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True, operation_type=OperationType.QUERY)
             return result or []
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -146,14 +146,14 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.query_one_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, operation_type=OperationType.QUERY)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
         except Exception as e:
             raise Exception(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
     def query_all(self, model_instance: Optional[ModelType] = None, **kwargs) -> ResponseType:
         try:
             api_endpoint = self.query_all_endpoint()
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True, operation_type=OperationType.QUERY)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
             return result or []
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e

--- a/plugins/module_utils/rest/results.py
+++ b/plugins/module_utils/rest/results.py
@@ -605,6 +605,10 @@ class Results:
         msg += f"changed={self.changed}, failed={self.failed}"
         self.log.debug(msg)
 
+        # Idempotent check - if final result is already built, do nothing
+        if self._final_result is not None:
+            return
+
         # Aggregate data from all tasks
         diff_list = [task.diff for task in self._tasks]
         metadata_list = [task.metadata for task in self._tasks]

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -172,7 +172,6 @@ RETURN = r"""
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.utils.display import Display
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
@@ -200,7 +199,7 @@ def main():
         # Manage state
         nd_state_machine.manage_state()
 
-        verbosity = Display().verbosity
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
         module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except Exception as e:

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -172,6 +172,7 @@ RETURN = r"""
 """
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.utils.display import Display
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
@@ -199,7 +200,8 @@ def main():
         # Manage state
         nd_state_machine.manage_state()
 
-        module.exit_json(**nd_state_machine.output.format())
+        verbosity = Display().verbosity
+        module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except Exception as e:
         module.fail_json(msg=f"Module execution failed: {str(e)}", **nd_state_machine.output.format())

--- a/plugins/modules/nd_manage_fabric_ebgp.py
+++ b/plugins/modules/nd_manage_fabric_ebgp.py
@@ -1652,6 +1652,7 @@ RETURN = r"""
 """
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.utils.display import Display
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ebgp import FabricEbgpModel
@@ -1678,7 +1679,8 @@ def main():
         # Manage state
         nd_state_machine.manage_state()
 
-        module.exit_json(**nd_state_machine.output.format())
+        verbosity = Display().verbosity
+        module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except NDStateMachineError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/nd_manage_fabric_ebgp.py
+++ b/plugins/modules/nd_manage_fabric_ebgp.py
@@ -1652,7 +1652,6 @@ RETURN = r"""
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.utils.display import Display
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ebgp import FabricEbgpModel
@@ -1679,7 +1678,7 @@ def main():
         # Manage state
         nd_state_machine.manage_state()
 
-        verbosity = Display().verbosity
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
         module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except NDStateMachineError as e:

--- a/plugins/modules/nd_manage_fabric_external.py
+++ b/plugins/modules/nd_manage_fabric_external.py
@@ -742,6 +742,7 @@ RETURN = r"""
 """
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.utils.display import Display
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_external import FabricExternalConnectivityModel
@@ -768,7 +769,8 @@ def main():
         # Manage state
         nd_state_machine.manage_state()
 
-        module.exit_json(**nd_state_machine.output.format())
+        verbosity = Display().verbosity
+        module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except NDStateMachineError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/nd_manage_fabric_external.py
+++ b/plugins/modules/nd_manage_fabric_external.py
@@ -742,7 +742,6 @@ RETURN = r"""
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.utils.display import Display
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_external import FabricExternalConnectivityModel
@@ -769,7 +768,7 @@ def main():
         # Manage state
         nd_state_machine.manage_state()
 
-        verbosity = Display().verbosity
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
         module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except NDStateMachineError as e:

--- a/plugins/modules/nd_manage_fabric_ibgp.py
+++ b/plugins/modules/nd_manage_fabric_ibgp.py
@@ -1850,6 +1850,7 @@ RETURN = r"""
 """
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.utils.display import Display
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ibgp import FabricIbgpModel
@@ -1876,7 +1877,8 @@ def main():
         # Manage state
         nd_state_machine.manage_state()
 
-        module.exit_json(**nd_state_machine.output.format())
+        verbosity = Display().verbosity
+        module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except NDStateMachineError as e:
         module.fail_json(msg=str(e))

--- a/plugins/modules/nd_manage_fabric_ibgp.py
+++ b/plugins/modules/nd_manage_fabric_ibgp.py
@@ -1850,7 +1850,6 @@ RETURN = r"""
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.utils.display import Display
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ibgp import FabricIbgpModel
@@ -1877,7 +1876,7 @@ def main():
         # Manage state
         nd_state_machine.manage_state()
 
-        verbosity = Display().verbosity
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
         module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except NDStateMachineError as e:

--- a/tests/unit/module_utils/orchestrators/test_base_orchestrator.py
+++ b/tests/unit/module_utils/orchestrators/test_base_orchestrator.py
@@ -36,7 +36,6 @@ from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module im
 from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
-
 # =============================================================================
 # Test doubles: minimal concrete Endpoint and Model subclasses
 # =============================================================================
@@ -132,9 +131,9 @@ def _make_rest_send(response_dicts):
 
     Each dict in response_dicts should have RETURN_CODE, MESSAGE, DATA, etc.
     """
+
     def responses():
-        for resp in response_dicts:
-            yield resp
+        yield from response_dicts
 
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
@@ -489,11 +488,13 @@ class TestMultipleApiCalls:
 
     def test_sequential_calls_accumulate(self):
         """Multiple _request calls each register a separate task."""
-        rest_send = _make_rest_send([
-            _success_response(),
-            _success_response(),
-            _success_response(),
-        ])
+        rest_send = _make_rest_send(
+            [
+                _success_response(),
+                _success_response(),
+                _success_response(),
+            ]
+        )
         results = _make_results()
         orch = _make_orchestrator(rest_send, results)
 

--- a/tests/unit/module_utils/orchestrators/test_base_orchestrator.py
+++ b/tests/unit/module_utils/orchestrators/test_base_orchestrator.py
@@ -1,0 +1,560 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for orchestrators/base.py
+
+Tests the NDBaseOrchestrator class focusing on:
+- Results integration via _register_api_call()
+- Verbosity tagging (write=2, query=3)
+- CRUD operations passing correct operation_type to _request()
+- Graceful behaviour when results is None
+- Failed API calls captured before exception
+"""
+
+# pylint: disable=protected-access
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+from typing import ClassVar, Literal, Optional
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ConfigDict
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+# =============================================================================
+# Test doubles: minimal concrete Endpoint and Model subclasses
+# =============================================================================
+
+
+class StubGetEndpoint(NDEndpointBaseModel):
+    """Concrete GET endpoint for testing."""
+
+    class_name: Literal["StubGetEndpoint"] = "StubGetEndpoint"
+
+    @property
+    def path(self) -> str:
+        return "/api/v1/stub"
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.GET
+
+
+class StubPostEndpoint(NDEndpointBaseModel):
+    """Concrete POST endpoint for testing."""
+
+    class_name: Literal["StubPostEndpoint"] = "StubPostEndpoint"
+
+    @property
+    def path(self) -> str:
+        return "/api/v1/stub"
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.POST
+
+
+class StubPutEndpoint(NDEndpointBaseModel):
+    """Concrete PUT endpoint for testing."""
+
+    class_name: Literal["StubPutEndpoint"] = "StubPutEndpoint"
+    _path: str = "/api/v1/stub"
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.PUT
+
+    def set_identifiers(self, identifier=None) -> None:
+        if identifier is not None:
+            self._path = f"/api/v1/stub/{identifier}"
+
+
+class StubDeleteEndpoint(NDEndpointBaseModel):
+    """Concrete DELETE endpoint for testing."""
+
+    class_name: Literal["StubDeleteEndpoint"] = "StubDeleteEndpoint"
+    _path: str = "/api/v1/stub"
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.DELETE
+
+    def set_identifiers(self, identifier=None) -> None:
+        if identifier is not None:
+            self._path = f"/api/v1/stub/{identifier}"
+
+
+class StubModel(NDBaseModel):
+    """Minimal concrete model for testing."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    identifiers: ClassVar[list] = ["name"]
+    identifier_strategy: ClassVar[str] = "single"
+
+    name: str = "test_item"
+    description: Optional[str] = None
+
+
+# =============================================================================
+# Fixtures: RestSend wired with file-based Sender
+# =============================================================================
+
+
+def _make_rest_send(response_dicts):
+    """
+    Build a real RestSend instance backed by a file-based Sender
+    that yields the given response dicts in order.
+
+    Each dict in response_dicts should have RETURN_CODE, MESSAGE, DATA, etc.
+    """
+    def responses():
+        for resp in response_dicts:
+            yield resp
+
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = ResponseGenerator(responses())
+
+    rest_send = RestSend({"check_mode": False, "state": "merged"})
+    rest_send.sender = sender
+    rest_send.response_handler = ResponseHandler()
+    rest_send.unit_test = True
+    return rest_send
+
+
+def _success_response(data=None):
+    """Standard 200 OK response dict."""
+    return {
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/stub",
+        "MESSAGE": "OK",
+        "DATA": data or {},
+    }
+
+
+def _not_found_response():
+    """Standard 404 Not Found response dict."""
+    return {
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/stub",
+        "MESSAGE": "Not Found",
+        "DATA": {},
+    }
+
+
+def _error_response(code=500, message="Internal Server Error"):
+    """Standard error response dict."""
+    return {
+        "RETURN_CODE": code,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/stub",
+        "MESSAGE": message,
+        "DATA": {},
+    }
+
+
+def _make_orchestrator(rest_send, results=None):
+    """Create an NDBaseOrchestrator with stub endpoints and the given RestSend."""
+    return NDBaseOrchestrator(
+        create_endpoint=StubPostEndpoint,
+        update_endpoint=StubPutEndpoint,
+        delete_endpoint=StubDeleteEndpoint,
+        query_one_endpoint=StubGetEndpoint,
+        query_all_endpoint=StubGetEndpoint,
+        rest_send=rest_send,
+        results=results,
+    )
+
+
+def _make_results():
+    """Create a Results instance pre-configured for testing."""
+    r = Results()
+    r.state = "merged"
+    r.check_mode = False
+    return r
+
+
+# =============================================================================
+# Test: _register_api_call verbosity tagging
+# =============================================================================
+
+
+class TestRegisterApiCallVerbosityTagging:
+    """Tests that _register_api_call tags operations with correct verbosity_level."""
+
+    def test_query_tagged_at_verbosity_3(self):
+        """QUERY operations are tagged with verbosity_level=3."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+
+        assert len(results._tasks) == 1
+        assert results._tasks[0].verbosity_level == 3
+
+    def test_create_tagged_at_verbosity_2(self):
+        """CREATE operations are tagged with verbosity_level=2."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.POST, data={"name": "x"}, operation_type=OperationType.CREATE)
+
+        assert len(results._tasks) == 1
+        assert results._tasks[0].verbosity_level == 2
+
+    def test_update_tagged_at_verbosity_2(self):
+        """UPDATE operations are tagged with verbosity_level=2."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.PUT, data={"name": "x"}, operation_type=OperationType.UPDATE)
+
+        assert len(results._tasks) == 1
+        assert results._tasks[0].verbosity_level == 2
+
+    def test_delete_tagged_at_verbosity_2(self):
+        """DELETE operations are tagged with verbosity_level=2."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.DELETE, operation_type=OperationType.DELETE)
+
+        assert len(results._tasks) == 1
+        assert results._tasks[0].verbosity_level == 2
+
+
+# =============================================================================
+# Test: _register_api_call field population
+# =============================================================================
+
+
+class TestRegisterApiCallFieldPopulation:
+    """Tests that _register_api_call correctly populates Results fields."""
+
+    def test_path_and_verb_captured(self):
+        """Registered task stores path and verb from the API call."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/fabrics", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+
+        task = results._tasks[0]
+        assert task.path == "/api/v1/fabrics"
+        assert task.verb == "GET"
+
+    def test_payload_captured(self):
+        """Registered task stores the committed payload."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.POST, data={"name": "FAB1"}, operation_type=OperationType.CREATE)
+
+        task = results._tasks[0]
+        assert task.payload == {"name": "FAB1"}
+
+    def test_none_payload_for_get(self):
+        """GET requests register None payload."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+
+        task = results._tasks[0]
+        assert task.payload is None
+
+    def test_response_captured(self):
+        """Registered task stores the controller response."""
+        resp = _success_response(data={"id": "123"})
+        rest_send = _make_rest_send([resp])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+
+        task = results._tasks[0]
+        assert task.response["RETURN_CODE"] == 200
+
+    def test_result_captured(self):
+        """Registered task stores the handler result (success/found/changed)."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+
+        task = results._tasks[0]
+        assert task.result["success"] is True
+
+    def test_action_matches_operation_type(self):
+        """Registered task action matches the operation_type value."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.POST, data={"x": 1}, operation_type=OperationType.CREATE)
+
+        task = results._tasks[0]
+        assert task.metadata["action"] == "create"
+
+    def test_diff_is_empty_dict(self):
+        """Registered tasks always have an empty diff (orchestrator doesn't compute diffs)."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.POST, data={}, operation_type=OperationType.CREATE)
+
+        task = results._tasks[0]
+        # diff contains at least sequence_number added by register_api_call
+        assert task.diff.get("sequence_number") == 1
+
+
+# =============================================================================
+# Test: _request with results=None (graceful no-op)
+# =============================================================================
+
+
+class TestRequestWithoutResults:
+    """Tests that _request works correctly when results is None."""
+
+    def test_request_succeeds_without_results(self):
+        """_request completes normally when results is None."""
+        rest_send = _make_rest_send([_success_response(data={"key": "value"})])
+        orch = _make_orchestrator(rest_send, results=None)
+
+        result = orch._request("/api/v1/stub", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+
+        assert result == {"key": "value"}
+
+    def test_no_tasks_registered_when_results_none(self):
+        """No tasks are registered when results is None."""
+        rest_send = _make_rest_send([_success_response()])
+        orch = _make_orchestrator(rest_send, results=None)
+
+        orch._request("/api/v1/stub", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+
+        # results is None so nothing to check — just verify no exception
+
+
+# =============================================================================
+# Test: _request error handling with Results registration
+# =============================================================================
+
+
+class TestRequestErrorHandlingWithResults:
+    """Tests that failed API calls are registered before exceptions propagate."""
+
+    def test_failed_request_registered_before_exception(self):
+        """Failed API calls are captured in Results before the exception is raised."""
+        rest_send = _make_rest_send([_error_response(500, "Server Error")])
+        rest_send.timeout = 5
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        with pytest.raises(Exception, match="Request failed"):
+            orch._request("/api/v1/stub", HttpVerbEnum.POST, data={}, operation_type=OperationType.CREATE)
+
+        assert len(results._tasks) == 1
+        task = results._tasks[0]
+        assert task.verbosity_level == 2
+        assert task.path == "/api/v1/stub"
+
+    def test_404_not_found_ok_registered(self):
+        """404 with not_found_ok=True is registered and returns empty dict."""
+        rest_send = _make_rest_send([_not_found_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        result = orch._request("/api/v1/stub", HttpVerbEnum.GET, not_found_ok=True, operation_type=OperationType.QUERY)
+
+        assert result == {}
+        assert len(results._tasks) == 1
+
+
+# =============================================================================
+# Test: CRUD methods pass correct operation_type
+# =============================================================================
+
+
+class TestCrudOperationTypes:
+    """Tests that CRUD convenience methods pass the correct operation_type."""
+
+    def test_create_uses_create_operation_type(self):
+        """create() passes OperationType.CREATE to _request."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+        model = StubModel(name="new_item")
+
+        orch.create(model)
+
+        task = results._tasks[0]
+        assert task.metadata["action"] == "create"
+        assert task.verbosity_level == 2
+
+    def test_update_uses_update_operation_type(self):
+        """update() passes OperationType.UPDATE to _request."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+        model = StubModel(name="existing_item")
+
+        orch.update(model)
+
+        task = results._tasks[0]
+        assert task.metadata["action"] == "update"
+        assert task.verbosity_level == 2
+
+    def test_delete_uses_delete_operation_type(self):
+        """delete() passes OperationType.DELETE to _request."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+        model = StubModel(name="doomed_item")
+
+        orch.delete(model)
+
+        task = results._tasks[0]
+        assert task.metadata["action"] == "delete"
+        assert task.verbosity_level == 2
+        assert task.payload is None  # DELETE has no payload
+
+    def test_query_one_uses_query_operation_type(self):
+        """query_one() passes OperationType.QUERY to _request."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+        model = StubModel(name="some_item")
+
+        orch.query_one(model)
+
+        task = results._tasks[0]
+        assert task.metadata["action"] == "query"
+        assert task.verbosity_level == 3
+
+    def test_query_all_uses_query_operation_type(self):
+        """query_all() passes OperationType.QUERY to _request."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch.query_all()
+
+        task = results._tasks[0]
+        assert task.metadata["action"] == "query"
+        assert task.verbosity_level == 3
+
+
+# =============================================================================
+# Test: Multiple sequential API calls accumulate in Results
+# =============================================================================
+
+
+class TestMultipleApiCalls:
+    """Tests that multiple API calls accumulate correctly in Results."""
+
+    def test_sequential_calls_accumulate(self):
+        """Multiple _request calls each register a separate task."""
+        rest_send = _make_rest_send([
+            _success_response(),
+            _success_response(),
+            _success_response(),
+        ])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/a", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+        orch._request("/api/v1/b", HttpVerbEnum.POST, data={"x": 1}, operation_type=OperationType.CREATE)
+        orch._request("/api/v1/c", HttpVerbEnum.DELETE, operation_type=OperationType.DELETE)
+
+        assert len(results._tasks) == 3
+        assert results._tasks[0].path == "/api/v1/a"
+        assert results._tasks[0].verbosity_level == 3  # query
+        assert results._tasks[1].path == "/api/v1/b"
+        assert results._tasks[1].verbosity_level == 2  # create
+        assert results._tasks[2].path == "/api/v1/c"
+        assert results._tasks[2].verbosity_level == 2  # delete
+
+    def test_sequence_numbers_increment(self):
+        """Each registered task gets an incrementing sequence_number."""
+        rest_send = _make_rest_send([_success_response(), _success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/a", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+        orch._request("/api/v1/b", HttpVerbEnum.POST, data={}, operation_type=OperationType.CREATE)
+
+        assert results._tasks[0].sequence_number == 1
+        assert results._tasks[1].sequence_number == 2
+
+    def test_build_final_result_aggregates_all(self):
+        """build_final_result aggregates all registered tasks correctly."""
+        rest_send = _make_rest_send([_success_response(), _success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch._request("/api/v1/query", HttpVerbEnum.GET, operation_type=OperationType.QUERY)
+        orch._request("/api/v1/create", HttpVerbEnum.POST, data={"n": 1}, operation_type=OperationType.CREATE)
+
+        results.build_final_result()
+        final = results.final_result
+
+        assert final["path"] == ["/api/v1/query", "/api/v1/create"]
+        assert final["verb"] == ["GET", "POST"]
+        assert final["verbosity_level"] == [3, 2]
+
+
+# =============================================================================
+# Test: _request default operation_type
+# =============================================================================
+
+
+class TestRequestDefaultOperationType:
+    """Tests for the default operation_type parameter of _request."""
+
+    def test_default_is_query(self):
+        """_request defaults to OperationType.QUERY when operation_type is not specified."""
+        rest_send = _make_rest_send([_success_response()])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        # Call without explicit operation_type
+        orch._request("/api/v1/stub", HttpVerbEnum.GET)
+
+        task = results._tasks[0]
+        assert task.metadata["action"] == "query"
+        assert task.verbosity_level == 3

--- a/tests/unit/module_utils/test_nd_output.py
+++ b/tests/unit/module_utils/test_nd_output.py
@@ -21,7 +21,6 @@ from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
-
 # =============================================================================
 # Helpers
 # =============================================================================

--- a/tests/unit/module_utils/test_nd_output.py
+++ b/tests/unit/module_utils/test_nd_output.py
@@ -1,0 +1,446 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for nd_output.py
+
+Tests the NDOutput class for formatting module output, including
+verbosity-gated API call detail via format_with_verbosity().
+"""
+
+# pylint: disable=protected-access
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
+from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
+from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _register_task(
+    results,
+    path="/api/v1/test",
+    verb=HttpVerbEnum.POST,
+    payload=None,
+    verbosity_level=3,
+    operation_type=OperationType.CREATE,
+    success=True,
+    changed=True,
+):
+    """Register a single task in a Results instance with configurable fields."""
+    results.action = operation_type.value
+    results.operation_type = operation_type
+    results.path_current = path
+    results.verb_current = verb
+    results.payload_current = payload
+    results.verbosity_level_current = verbosity_level
+    results.response_current = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    results.result_current = {"success": success, "changed": changed}
+    results.diff_current = {"before": {}, "after": {"foo": "bar"}} if changed else {}
+    results.register_api_call()
+
+
+def _make_results_write_and_query():
+    """
+    Create a Results instance with two tasks:
+
+    1. Write operation (CREATE) tagged at verbosity_level=2
+    2. Query operation (QUERY) tagged at verbosity_level=3
+    """
+    r = Results()
+    r.state = "merged"
+    r.check_mode = False
+
+    # Task 1: write (verbosity 2 — shown at -vv)
+    _register_task(
+        r,
+        path="/api/v1/fabrics",
+        verb=HttpVerbEnum.POST,
+        payload={"name": "FAB1"},
+        verbosity_level=2,
+        operation_type=OperationType.CREATE,
+    )
+
+    # Task 2: query (verbosity 3 — shown at -vvv)
+    _register_task(
+        r,
+        path="/api/v1/fabrics",
+        verb=HttpVerbEnum.GET,
+        payload=None,
+        verbosity_level=3,
+        operation_type=OperationType.QUERY,
+        changed=False,
+    )
+
+    r.build_final_result()
+    return r
+
+
+# =============================================================================
+# Test: NDOutput.__init__
+# =============================================================================
+
+
+class TestNDOutputInit:
+    """Tests for NDOutput initialization."""
+
+    def test_init_normal(self):
+        """NDOutput initializes with output_level stored."""
+        output = NDOutput("normal")
+        assert output._output_level == "normal"
+        assert output._changed is False
+        assert output._logs == []
+        assert output._extra == {}
+
+    def test_init_debug(self):
+        """NDOutput accepts debug output_level."""
+        output = NDOutput("debug")
+        assert output._output_level == "debug"
+
+    def test_init_info(self):
+        """NDOutput accepts info output_level."""
+        output = NDOutput("info")
+        assert output._output_level == "info"
+
+
+# =============================================================================
+# Test: NDOutput.format (base output, no verbosity)
+# =============================================================================
+
+
+class TestNDOutputFormat:
+    """Tests for the base format() method."""
+
+    def test_format_normal_base_keys(self):
+        """Normal output_level includes output_level, changed, after, before, diff."""
+        output = NDOutput("normal")
+        result = output.format()
+        assert result["output_level"] == "normal"
+        assert result["changed"] is False
+        assert "after" in result
+        assert "before" in result
+        assert "diff" in result
+
+    def test_format_normal_excludes_proposed_and_logs(self):
+        """Normal output_level does NOT include proposed or logs."""
+        output = NDOutput("normal")
+        result = output.format()
+        assert "proposed" not in result
+        assert "logs" not in result
+
+    def test_format_info_includes_proposed(self):
+        """Info output_level includes proposed but not logs."""
+        output = NDOutput("info")
+        result = output.format()
+        assert "proposed" in result
+        assert "logs" not in result
+
+    def test_format_debug_includes_proposed_and_logs(self):
+        """Debug output_level includes both proposed and logs."""
+        output = NDOutput("debug")
+        result = output.format()
+        assert "proposed" in result
+        assert "logs" in result
+
+    def test_format_kwargs_merged(self):
+        """Extra kwargs passed to format() are included in output."""
+        output = NDOutput("normal")
+        result = output.format(custom_key="custom_value")
+        assert result["custom_key"] == "custom_value"
+
+    def test_format_extra_from_assign(self):
+        """Extra kwargs from assign() are included in output."""
+        output = NDOutput("normal")
+        output.assign(extra_field="extra_value")
+        result = output.format()
+        assert result["extra_field"] == "extra_value"
+
+    def test_format_lists_as_defaults(self):
+        """When no NDConfigCollection is assigned, lists are used as-is."""
+        output = NDOutput("normal")
+        result = output.format()
+        assert result["after"] == []
+        assert result["before"] == []
+        assert result["diff"] == []
+
+
+# =============================================================================
+# Test: NDOutput.assign
+# =============================================================================
+
+
+class TestNDOutputAssign:
+    """Tests for the assign() method."""
+
+    def test_assign_logs(self):
+        """assign() sets logs when a list is provided."""
+        output = NDOutput("debug")
+        output.assign(logs=["log1", "log2"])
+        assert output._logs == ["log1", "log2"]
+
+    def test_assign_logs_ignores_non_list(self):
+        """assign() ignores logs when a non-list is provided."""
+        output = NDOutput("debug")
+        output.assign(logs="not_a_list")
+        assert output._logs == []
+
+    def test_assign_none_values_ignored(self):
+        """assign() ignores None values for typed parameters."""
+        output = NDOutput("normal")
+        output.assign(after=None, before=None, diff=None, proposed=None, logs=None)
+        assert output._after == []
+        assert output._before == []
+
+    def test_assign_extra_kwargs(self):
+        """assign() stores extra kwargs in _extra."""
+        output = NDOutput("normal")
+        output.assign(custom="value1")
+        output.assign(another="value2")
+        assert output._extra["custom"] == "value1"
+        assert output._extra["another"] == "value2"
+
+
+# =============================================================================
+# Test: NDOutput.format_with_verbosity — verbosity 0 and 1
+# =============================================================================
+
+
+class TestFormatWithVerbosityLevel0And1:
+    """Tests for verbosity levels 0 and 1 (default / -v): no API detail."""
+
+    def test_verbosity_0_no_api_keys(self):
+        """Verbosity 0: output contains no api_* keys."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(0, results)
+        assert "api_paths" not in result
+        assert "api_verbs" not in result
+        assert "api_response" not in result
+
+    def test_verbosity_1_no_api_keys(self):
+        """Verbosity 1 (-v): output contains no api_* keys."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(1, results)
+        assert "api_paths" not in result
+        assert "api_verbs" not in result
+
+    def test_verbosity_0_preserves_base_format(self):
+        """Verbosity 0 still includes all base format() keys."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(0, results)
+        assert "output_level" in result
+        assert "changed" in result
+        assert "after" in result
+        assert "before" in result
+        assert "diff" in result
+
+
+# =============================================================================
+# Test: NDOutput.format_with_verbosity — verbosity 2 (-vv)
+# =============================================================================
+
+
+class TestFormatWithVerbosityLevel2:
+    """Tests for verbosity level 2 (-vv): API call summary for writes."""
+
+    def test_verbosity_2_includes_paths_and_verbs(self):
+        """Verbosity 2 includes api_paths and api_verbs."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(2, results)
+        assert "api_paths" in result
+        assert "api_verbs" in result
+
+    def test_verbosity_2_filters_to_writes_only(self):
+        """Verbosity 2 shows only tasks tagged verbosity_level <= 2 (writes)."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(2, results)
+        # Only the write task (POST, verbosity_level=2) should appear
+        assert result["api_paths"] == ["/api/v1/fabrics"]
+        assert result["api_verbs"] == ["POST"]
+
+    def test_verbosity_2_excludes_full_detail(self):
+        """Verbosity 2 does NOT include api_response, api_result, etc."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(2, results)
+        assert "api_response" not in result
+        assert "api_result" not in result
+        assert "api_diff" not in result
+        assert "api_metadata" not in result
+        assert "api_payload" not in result
+
+    def test_verbosity_2_propagates_changed_from_results(self):
+        """Results changed=True propagates into output at verbosity 2."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(2, results)
+        assert result["changed"] is True
+
+    def test_verbosity_2_propagates_failed_from_results(self):
+        """Results failed=True propagates into output at verbosity 2."""
+        output = NDOutput("normal")
+        r = Results()
+        r.state = "merged"
+        r.check_mode = False
+        _register_task(r, verbosity_level=2, success=False, changed=False)
+        r.build_final_result()
+        result = output.format_with_verbosity(2, r)
+        assert result.get("failed") is True
+
+
+# =============================================================================
+# Test: NDOutput.format_with_verbosity — verbosity 3+ (-vvv)
+# =============================================================================
+
+
+class TestFormatWithVerbosityLevel3:
+    """Tests for verbosity level 3+ (-vvv): full controller detail."""
+
+    def test_verbosity_3_includes_all_tasks(self):
+        """Verbosity 3 shows both write (vl=2) and query (vl=3) tasks."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(3, results)
+        assert len(result["api_paths"]) == 2
+        assert result["api_paths"] == ["/api/v1/fabrics", "/api/v1/fabrics"]
+        assert result["api_verbs"] == ["POST", "GET"]
+
+    def test_verbosity_3_includes_full_detail_keys(self):
+        """Verbosity 3 includes api_response, api_result, api_diff, api_metadata, api_payload."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(3, results)
+        assert "api_response" in result
+        assert "api_result" in result
+        assert "api_diff" in result
+        assert "api_metadata" in result
+        assert "api_payload" in result
+
+    def test_verbosity_3_detail_lists_match_task_count(self):
+        """All detail lists at verbosity 3 have the same length as task count."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(3, results)
+        for key in ("api_response", "api_result", "api_diff", "api_metadata", "api_payload"):
+            assert len(result[key]) == 2, f"{key} should have 2 entries"
+
+    def test_verbosity_3_payload_contains_correct_data(self):
+        """api_payload reflects registered payloads (dict for write, None for query)."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(3, results)
+        assert result["api_payload"][0] == {"name": "FAB1"}
+        assert result["api_payload"][1] is None
+
+    def test_verbosity_4_same_as_3(self):
+        """Verbosity 4+ behaves identically to 3 (all tasks, full detail)."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result_3 = output.format_with_verbosity(3, results)
+        result_4 = output.format_with_verbosity(4, results)
+        assert result_3["api_paths"] == result_4["api_paths"]
+        assert result_3["api_verbs"] == result_4["api_verbs"]
+        assert result_3.get("api_response") == result_4.get("api_response")
+
+
+# =============================================================================
+# Test: NDOutput.format_with_verbosity — edge cases
+# =============================================================================
+
+
+class TestFormatWithVerbosityEdgeCases:
+    """Edge case tests for format_with_verbosity."""
+
+    def test_none_results_returns_base_format(self):
+        """When results is None, returns base format() output without api_* keys."""
+        output = NDOutput("normal")
+        result = output.format_with_verbosity(3, None)
+        assert "api_paths" not in result
+        assert "changed" in result
+
+    def test_empty_results_no_api_keys(self):
+        """Results with no registered tasks produces no api_* keys."""
+        output = NDOutput("normal")
+        results = Results()
+        results.build_final_result()
+        result = output.format_with_verbosity(3, results)
+        assert "api_paths" not in result
+
+    def test_auto_builds_final_result(self):
+        """format_with_verbosity auto-calls build_final_result() if not yet built."""
+        output = NDOutput("normal")
+        r = Results()
+        r.state = "merged"
+        r.check_mode = False
+        _register_task(r, path="/api/v1/auto", verbosity_level=2)
+        # Do NOT call r.build_final_result() — let format_with_verbosity do it
+        result = output.format_with_verbosity(2, r)
+        assert result["api_paths"] == ["/api/v1/auto"]
+
+    def test_kwargs_forwarded_to_format(self):
+        """Extra kwargs are forwarded to the base format() call."""
+        output = NDOutput("normal")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(2, results, custom="val")
+        assert result["custom"] == "val"
+
+    def test_output_level_and_verbosity_independent(self):
+        """output_level and verbosity are independent — debug output_level with verbosity 0."""
+        output = NDOutput("debug")
+        results = _make_results_write_and_query()
+        result = output.format_with_verbosity(0, results)
+        # Debug output_level features present
+        assert "proposed" in result
+        assert "logs" in result
+        # But no api_* keys because verbosity < 2
+        assert "api_paths" not in result
+
+    def test_all_tasks_above_verbosity_threshold(self):
+        """When all tasks have verbosity_level > requested, no api_* keys appear."""
+        output = NDOutput("normal")
+        r = Results()
+        r.state = "merged"
+        r.check_mode = False
+        _register_task(r, verbosity_level=5)
+        r.build_final_result()
+        result = output.format_with_verbosity(2, r)
+        assert "api_paths" not in result
+
+    def test_multiple_write_tasks(self):
+        """Multiple write tasks all appear at verbosity 2."""
+        output = NDOutput("normal")
+        r = Results()
+        r.state = "merged"
+        r.check_mode = False
+        _register_task(r, path="/api/v1/a", verb=HttpVerbEnum.POST, verbosity_level=2)
+        _register_task(r, path="/api/v1/b", verb=HttpVerbEnum.PUT, verbosity_level=2)
+        _register_task(r, path="/api/v1/c", verb=HttpVerbEnum.DELETE, verbosity_level=2)
+        r.build_final_result()
+        result = output.format_with_verbosity(2, r)
+        assert result["api_paths"] == ["/api/v1/a", "/api/v1/b", "/api/v1/c"]
+        assert result["api_verbs"] == ["POST", "PUT", "DELETE"]
+
+    def test_changed_false_not_overwritten(self):
+        """If Results changed=False, output changed stays as-is from NDOutput."""
+        output = NDOutput("normal")
+        r = Results()
+        r.state = "merged"
+        r.check_mode = False
+        _register_task(r, verbosity_level=2, changed=False, success=True)
+        r.build_final_result()
+        result = output.format_with_verbosity(2, r)
+        assert result["changed"] is False


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Proposed Changes

### Verbosity-Gated API Call Results

This PR adds CLI verbosity-gated observability to all modules using the `NDStateMachine` pattern. When users increase Ansible CLI verbosity (`-vv`, `-vvv`), module output progressively includes API call details (endpoints, payloads, responses) without any new module parameters or Ansible dependencies.

#### Architecture

- **Tag at write-time, filter at read-time**: Each API call registered in `Results` is tagged with a `verbosity_level` (2 for write operations, 3 for queries). At output time, `format_with_verbosity()` filters tasks based on the CLI verbosity level.
- **No new dependencies**: Verbosity is read from `module._verbosity` (standard `AnsibleModule` attribute). No `Display()` import or new Ansible dependency is introduced in the orchestrator or REST layers.

#### Verbosity Tiers

| CLI Flag | Level | Additional Output |
|----------|-------|-------------------|
| (none) / `-v` | 0–1 | Standard output only (`changed`, `before`, `after`) |
| `-vv` | 2 | `api_paths`, `api_verbs` for write operations (CREATE/UPDATE/DELETE) |
| `-vvv` | 3+ | Full detail for all operations: `api_response`, `api_result`, `api_diff`, `api_metadata`, `api_payload` |

#### Files Changed

**Core infrastructure (3 files):**

- **`plugins/module_utils/orchestrators/base.py`**
  - Added `results: Optional[Results] = None` field to `NDBaseOrchestrator`.
  - Added `_register_api_call()` method that tags each REST call with action, path, verb, payload, response, result, and `verbosity_level` (2 for writes, 3 for queries).
  - Added `operation_type: OperationType = OperationType.QUERY` parameter to `_request()`.
  - All CRUD methods (`create`, `update`, `delete`, `query_one`, `query_all`) now pass the correct `OperationType` to `_request()`.
  - Registration happens **before** success/error checks so failed calls are captured for troubleshooting.

- **`plugins/module_utils/nd_output.py`**
  - Added `format_with_verbosity(verbosity: int, results: Optional[Results] = None, **kwargs)` method to `NDOutput`.
  - Builds final result from `Results` if not already built, filters tasks by `verbosity_level <= verbosity`.
  - At level 2: adds `api_paths` and `api_verbs` to output.
  - At level 3+: adds `api_response`, `api_result`, `api_diff`, `api_metadata`, `api_payload`.
  - Merges `changed`/`failed` from Results (API-level) with NDOutput (config-level).

- **`plugins/module_utils/nd_state_machine.py`**
  - Creates `self.results = Results()` with `state` and `check_mode` configured.
  - Passes `results=self.results` to orchestrator constructor (or sets it on existing instance).
  - Exposes `self.results` for module access at exit.

**Module files (4 files):**

- **`plugins/modules/nd_local_user.py`**
- **`plugins/modules/nd_manage_fabric_ibgp.py`**
- **`plugins/modules/nd_manage_fabric_external.py`**
- **`plugins/modules/nd_manage_fabric_ebgp.py`**

  All four modules updated identically:
  - Read verbosity from `module._verbosity` with safe fallback: `verbosity = module._verbosity if hasattr(module, "_verbosity") else 0`
  - Changed `exit_json` call from `output.format()` to `output.format_with_verbosity(verbosity, nd_state_machine.results)`.
  - `fail_json` calls still use `output.format()` (no verbosity filtering on failure — always emit standard output).

**Documentation (1 file):**

- **`plugins/doc_fragments/modules.py`**
  - Updated `output_level` option description to document the new CLI verbosity behavior:
    - `-vv` adds `api_paths` and `api_verbs`.
    - `-vvv` adds full controller detail including `api_response`, `api_result`, `api_diff`, `api_metadata`, and `api_payload`.

**Unit tests (2 files):**

- **`tests/unit/module_utils/test_nd_output.py`** — 29 tests across 7 classes:
  - `TestNDOutputInit` (3 tests): Constructor defaults.
  - `TestNDOutputFormat` (7 tests): Existing `format()` behavior preserved.
  - `TestNDOutputAssign` (4 tests): `assign()` method behavior.
  - `TestFormatWithVerbosityLevel0And1` (3 tests): No API detail at low verbosity.
  - `TestFormatWithVerbosityLevel2` (5 tests): Write-only summary at `-vv`.
  - `TestFormatWithVerbosityLevel3` (5 tests): Full detail at `-vvv`.
  - `TestFormatWithVerbosityEdgeCases` (8 tests): None results, empty tasks, mixed verbosity levels.

- **`tests/unit/module_utils/orchestrators/test_base_orchestrator.py`** — 21 tests across 7 classes:
  - `TestRegisterApiCallVerbosityTagging` (4 tests): Correct verbosity_level per operation type.
  - `TestRegisterApiCallFieldPopulation` (7 tests): Path, verb, payload, response, result, action, diff captured.
  - `TestRequestWithoutResults` (2 tests): Graceful no-op when `results=None`.
  - `TestRequestErrorHandlingWithResults` (2 tests): Failed calls registered before exception.
  - `TestCrudOperationTypes` (5 tests): CRUD methods pass correct `OperationType`.
  - `TestMultipleApiCalls` (3 tests): Sequential calls accumulate, sequence numbers increment, `build_final_result` aggregates.
  - `TestRequestDefaultOperationType` (1 test): Default is `OperationType.QUERY`.

  Uses real `RestSend` with file-based `Sender` (existing test pattern), concrete stub endpoint and model classes.

#### Subclass orchestrators unchanged

`LocalUserOrchestrator`, `ManageEbgpFabricOrchestrator`, `ManageExternalFabricOrchestrator`, and `ManageIbgpFabricOrchestrator` required no changes — they only override `query_all()` which calls `_request()` without explicit `operation_type`, correctly defaulting to `OperationType.QUERY` (verbosity=3).

## Test Notes

- Unit tests validate verbosity tagging, field population, output filtering at each tier, graceful degradation, and error capture.
- Existing tests (`test_results.py`, `test_rest_send.py`, `test_response_handler_nd.py`, `test_sender_nd.py`) should be re-run to confirm no regressions.
- Manual validation recommended: run any NDStateMachine-based module with `-vv` and `-vvv` against a live Nexus Dashboard to confirm API detail appears in output.

## Cisco Nexus Dashboard Version

- Developed against ND v4.2

## Related ND API Resource Category
<!-- Please select ND API resource category, please specify -->
* [ ] analyze
* [ ] infa
* [ ] manage
* [ ] onemanage
* [x] other

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
