### PR TITLE
nd_interface_svi

### DIFF
--- a/plugins/module_utils/models/interfaces/enums.py
+++ b/plugins/module_utils/models/interfaces/enums.py
@@ -143,3 +143,13 @@ class TrunkHostPolicyTypeEnum(str, Enum):
     """
 
     TRUNK_HOST = "trunkHost"
+
+
+class SviPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for SVI (switched virtual interface) interfaces.
+    """
+
+    SVI = "svi"

--- a/plugins/module_utils/models/interfaces/enums.py
+++ b/plugins/module_utils/models/interfaces/enums.py
@@ -163,3 +163,19 @@ class SubinterfaceManagedPolicyTypeEnum(str, Enum):
     """
 
     SUBINTERFACE = "subinterface"
+
+
+class SubinterfaceUnmanagedPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for unmanaged L3 subinterfaces (NX-OS).
+
+    The `userDefined` discriminator branch is intentionally excluded — out of scope for this module.
+
+    ## Raises
+
+    None
+    """
+
+    MONITOR_SUBINTERFACE = "monitorSubinterface"

--- a/plugins/module_utils/models/interfaces/enums.py
+++ b/plugins/module_utils/models/interfaces/enums.py
@@ -153,3 +153,13 @@ class SviPolicyTypeEnum(str, Enum):
     """
 
     SVI = "svi"
+
+
+class SubinterfaceManagedPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for managed L3 subinterfaces.
+    """
+
+    SUBINTERFACE = "subinterface"

--- a/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
+++ b/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
@@ -1,0 +1,347 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Managed L3 subinterface Pydantic models for Nexus Dashboard.
+
+This module defines nested Pydantic models that mirror the ND Manage Interfaces API payload structure for L3
+subinterfaces (`interfaceType: "subInterface"`, `policyType: "subinterface"`, `mode: "managed"`). The playbook config
+uses the same nesting so that `to_payload()` and `from_response()` work via standard Pydantic serialization with no
+custom wrapping or flattening.
+
+## Parents
+
+A subinterface is created on a physical Ethernet parent (e.g. `Ethernet1/3.2`) or on a Port-channel parent
+(e.g. `Port-channel10.5`). The parent type is encoded only in the `interface_name` string; the ND API does not require
+a separate parent reference. The `.<sub>` portion encodes the 802.1Q dot1q sub-id.
+
+## Model Hierarchy
+
+- `SubinterfaceManagedInterfaceModel` (top-level, `NDBaseModel`)
+    - `interface_name` (identifier, e.g. `Ethernet1/3.2`)
+    - `interface_type` (hardcoded: "subInterface")
+    - `config_data` -> `SubinterfaceManagedConfigDataModel`
+        - `mode` (hardcoded: "managed")
+        - `network_os` -> `SubinterfaceManagedNetworkOSModel`
+            - `network_os_type` (hardcoded: "nx-os")
+            - `policy` -> `SubinterfaceManagedPolicyModel`
+                - `policy_type` (hardcoded: SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE), `vlan_id`, L3 fields, PIM, Netflow
+
+## Field set
+
+Fields in `SubinterfaceManagedPolicyModel` mirror the `policyType: "subinterface"` schema in the ND Manage API
+(createInterfaceSubInterfaceNexusType) as observed on ND 4.2.1, covering vlan_id, VRF binding, IPv4/IPv6 addressing,
+routing tag, MTU, PIM, ip-redirects, admin-state, and netflow. The "unmanaged" subinterface variant
+(`policyType: "monitorSubinterface"`) is handled by a separate module.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    field_validator,
+    model_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceManagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+
+
+class SubinterfaceManagedPolicyModel(NDNestedModel):
+    """
+    # Summary
+
+    Policy fields for a managed L3 subinterface. Maps directly to the `configData.networkOS.policy` object in the
+    ND API.
+
+    `policy_type` is required by the API as a discriminator on both POST and PUT, so it carries a default of
+    `SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE` and is always serialized.
+
+    ## Raises
+
+    None
+    """
+
+    policy_type: SubinterfaceManagedPolicyTypeEnum = Field(
+        default=SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE,
+        alias="policyType",
+        frozen=True,
+        description="Interface policy type (hardcoded for this module)",
+    )
+    admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the subinterface")
+    description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Subinterface description")
+    extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the subinterface")
+    mtu: int | None = Field(default=None, alias="mtu", ge=576, le=9216, description="Subinterface MTU")
+    vlan_id: int | None = Field(default=None, alias="vlanId", ge=2, le=4094, description="802.1Q VLAN tag for the subinterface")
+    vrf_interface: str | None = Field(
+        default=None, alias="vrfInterface", min_length=1, max_length=32, description="Interface VRF name; use `default` for default VRF"
+    )
+    ip: str | None = Field(default=None, alias="ip", description="IPv4 address of the subinterface")
+    prefix: int | None = Field(default=None, alias="prefix", ge=8, le=31, description="IPv4 netmask length used with `ip`")
+    ipv6: str | None = Field(default=None, alias="ipv6", description="IPv6 address of the subinterface")
+    ipv6_prefix: int | None = Field(default=None, alias="ipv6Prefix", ge=1, le=127, description="IPv6 netmask length used with `ipv6`")
+    routing_tag: str | None = Field(default=None, alias="routingTag", description="Routing tag associated with the subinterface IP address")
+    ip_redirects: bool | None = Field(default=None, alias="ipRedirects", description="Disable both IPv4/IPv6 redirects on the interface")
+    pim_sparse: bool | None = Field(default=None, alias="pimSparse", description="Enable PIM sparse-mode on the subinterface")
+    pim_dr_priority: int | None = Field(
+        default=None, alias="pimDrPriority", ge=1, le=4294967295, description="Priority for PIM DR election on the subinterface"
+    )
+    netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the subinterface")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 3 Netflow monitor name (required when `netflow=true`)")
+    netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name (applicable to N7K only)")
+
+    # TODO(4.2.1) ND returns routingTag as int on GET despite OpenAPI declaring it string. Coerce so round-trip
+    # comparisons work. Lab-confirmed against the subinterface HAR; same wire quirk as nd_interface_svi.
+    @field_validator("routing_tag", mode="before")
+    @classmethod
+    def coerce_routing_tag_to_string(cls, value):
+        """
+        # Summary
+
+        Accept `routing_tag` as either string or integer. ND 4.2's API accepts string form on POST/PUT, but GET
+        responses return the value as an integer. Coerce ints to their decimal string form so round-trips and
+        idempotency comparisons work uniformly.
+
+        ## Raises
+
+        None
+        """
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+        return value
+
+    @model_validator(mode="after")
+    def _validate_netflow_monitor_present(self) -> SubinterfaceManagedPolicyModel:
+        """
+        # Summary
+
+        Reject enabling `netflow` without supplying a `netflow_monitor`.
+
+        The DOCUMENTATION and field description state that `netflow_monitor` is required when `netflow` is true. Enforcing it at the model layer
+        fails an incomplete policy early with a clear error instead of pushing a netflow config with no monitor and deferring the outcome to ND.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `netflow` is true and `netflow_monitor` is missing or empty.
+        """
+        if self.netflow is True and not self.netflow_monitor:
+            raise ValueError("netflow_monitor must be provided when netflow is true.")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_ip_prefix_paired(self) -> SubinterfaceManagedPolicyModel:
+        """
+        # Summary
+
+        Reject supplying only one half of an address/mask pair. `ip` requires `prefix` (and `ipv6` requires `ipv6_prefix`) and vice versa, so a
+        partial address is never serialized into a payload that ND would reject or apply ambiguously.
+
+        ## Raises
+
+        ### ValueError
+
+        - If exactly one of `ip` / `prefix` is set.
+        - If exactly one of `ipv6` / `ipv6_prefix` is set.
+        """
+        if (self.ip is None) != (self.prefix is None):
+            raise ValueError("ip and prefix are required together; set both or neither.")
+        if (self.ipv6 is None) != (self.ipv6_prefix is None):
+            raise ValueError("ipv6 and ipv6_prefix are required together; set both or neither.")
+        return self
+
+
+class SubinterfaceManagedNetworkOSModel(NDNestedModel):
+    """
+    # Summary
+
+    Network OS container for a managed subinterface. Maps to `configData.networkOS` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: SubinterfaceManagedPolicyModel | None = Field(default=None, alias="policy")
+
+
+class SubinterfaceManagedConfigDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Config data container for a managed subinterface. Maps to `configData` in the ND API. `mode` is always `"managed"`
+    for this module and is required by the API as a discriminator.
+
+    ## Raises
+
+    None
+    """
+
+    mode: Literal["managed"] = Field(default="managed", alias="mode", frozen=True)
+    network_os: SubinterfaceManagedNetworkOSModel = Field(alias="networkOS")
+
+
+class SubinterfaceManagedOperDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Operational state container returned by GET on a managed subinterface. Server-populated and read-only. Excluded
+    from payloads via `SubinterfaceManagedInterfaceModel.payload_exclude_fields`.
+
+    ## Raises
+
+    None
+    """
+
+    admin_status: str | None = Field(default=None, alias="adminStatus")
+    operational_description: str | None = Field(default=None, alias="operationalDescription")
+    operational_status: str | None = Field(default=None, alias="operationalStatus")
+    switch_name: str | None = Field(default=None, alias="switchName")
+
+
+class SubinterfaceManagedInterfaceModel(NDBaseModel):
+    """
+    # Summary
+
+    Managed L3 subinterface configuration for Nexus Dashboard.
+
+    Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
+    Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
+
+    `interface_type` is required by the ND API on both POST and PUT. The per-interface PUT (`updateInterface`) uses
+    `interfaceType` as the request-body discriminator (mapping `subInterface` -> `interfaceSubInterface`) and lists it
+    in `required`, so `to_payload()` always serializes it for both verbs (verified against the ND 4.2.1 OpenAPI spec).
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip", "oper_data"}
+
+    # --- Fields ---
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["subInterface"] = Field(default="subInterface", alias="interfaceType", frozen=True)
+    config_data: SubinterfaceManagedConfigDataModel | None = Field(default=None, alias="configData")
+    oper_data: SubinterfaceManagedOperDataModel | None = Field(default=None, alias="operData")
+
+    @field_validator("interface_name", mode="before")
+    @classmethod
+    def normalize_interface_name(cls, value):
+        """
+        # Summary
+
+        Validate that `interface_name` is a dotted subinterface form on either an Ethernet or Port-channel parent
+        (e.g. `Ethernet1/3.2`, `Port-channel10.5`). The parent kind is inferred from the prefix; no separate
+        `parent_interface` argument is needed. The sub-id portion (`.<n>`) is required.
+
+        Accepts any case for the parent prefix and normalizes to canonical capitalization (`Ethernet...`,
+        `Port-channel...`) so user input, POST payloads, and GET responses all compare equal.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `value` is a string without a `.<sub>` segment.
+        - If `value` does not start with `Ethernet` or `Port-channel` (case-insensitive).
+        """
+        if not isinstance(value, str) or not value:
+            return value
+        stripped = value.strip()
+        if "." not in stripped:
+            raise ValueError(f"interface_name must include a dot-separated subinterface id (e.g. 'Ethernet1/3.2'); got {value!r}")
+        parent, sub = stripped.rsplit(".", 1)
+        parent_lower = parent.lower()
+        # TODO(4.2.1) ND accepts canonical-case parents on POST (`Ethernet1/3.2`) but returns the same name lowercased
+        # on GET (`ethernet1/3.2`, `port-channel10.5`). Normalize both inputs to canonical case so idempotency
+        # comparisons work without re-implementing case-insensitive equality everywhere.
+        if parent_lower.startswith("ethernet"):
+            canonical_parent = "Ethernet" + parent[len("ethernet") :]
+        elif parent_lower.startswith("port-channel"):
+            canonical_parent = "Port-channel" + parent[len("port-channel") :]
+        else:
+            raise ValueError(f"interface_name parent must be 'Ethernet...' or 'Port-channel...'; got parent={parent!r}")
+        return f"{canonical_parent}.{sub}"
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_interface_subinterface_managed` module.
+
+        Each config item targets a single managed L3 subinterface identified by `interface_name`
+        (e.g. `Ethernet1/3.2`). To configure multiple subinterfaces in one task, list multiple config items.
+        Per-subinterface L3 settings (vlan_id, ip, vrf_interface, ...) live under `config_data.network_os.policy`
+        and apply to that one subinterface only.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    interface_name=dict(type="str", required=True),
+                    config_data=dict(
+                        type="dict",
+                        options=dict(
+                            network_os=dict(
+                                type="dict",
+                                options=dict(
+                                    policy=dict(
+                                        type="dict",
+                                        options=dict(
+                                            admin_state=dict(type="bool"),
+                                            description=dict(type="str"),
+                                            extra_config=dict(type="str"),
+                                            mtu=dict(type="int"),
+                                            vlan_id=dict(type="int"),
+                                            vrf_interface=dict(type="str"),
+                                            ip=dict(type="str"),
+                                            prefix=dict(type="int"),
+                                            ipv6=dict(type="str"),
+                                            ipv6_prefix=dict(type="int"),
+                                            routing_tag=dict(type="str"),
+                                            ip_redirects=dict(type="bool"),
+                                            pim_sparse=dict(type="bool"),
+                                            pim_dr_priority=dict(type="int"),
+                                            netflow=dict(type="bool"),
+                                            netflow_monitor=dict(type="str"),
+                                            netflow_sampler=dict(type="str"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/interfaces/subinterface_unmanaged_interface.py
+++ b/plugins/module_utils/models/interfaces/subinterface_unmanaged_interface.py
@@ -1,0 +1,218 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unmanaged L3 subinterface Pydantic models for Nexus Dashboard.
+
+This module defines nested Pydantic models that mirror the ND Manage Interfaces API payload structure for the
+unmanaged variant of L3 subinterfaces (`interfaceType: "subInterface"`, `mode: "unmanaged"`,
+`policyType: "monitorSubinterface"`). The policy body carries only the `policyType` discriminator; no L3 fields
+are configurable. All scaffolding fields are hardcoded via `Literal[...] + Field(frozen=True)` and excluded from
+the user-facing argument spec.
+
+The managed variant lives in `subinterface_managed_interface.py`.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    ConfigDict,
+    Field,
+    field_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceUnmanagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+
+
+class SubinterfaceUnmanagedPolicyModel(NDNestedModel):
+    """
+    # Summary
+
+    Policy fields for an unmanaged L3 subinterface. The body carries only the `policyType` discriminator. Extra
+    fields returned by ND on GET (for instance the `userDefined` discriminator branch's `templateName` /
+    `templateConfig`) are silently discarded via `extra="ignore"`.
+
+    ## Raises
+
+    None
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    policy_type: SubinterfaceUnmanagedPolicyTypeEnum = Field(
+        default=SubinterfaceUnmanagedPolicyTypeEnum.MONITOR_SUBINTERFACE,
+        alias="policyType",
+        frozen=True,
+        description="Interface policy type (hardcoded for this module)",
+    )
+
+
+class SubinterfaceUnmanagedNetworkOSModel(NDNestedModel):
+    """
+    # Summary
+
+    Network OS container for an unmanaged subinterface. Maps to `configData.networkOS` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: SubinterfaceUnmanagedPolicyModel = Field(default_factory=SubinterfaceUnmanagedPolicyModel, alias="policy")
+
+
+class SubinterfaceUnmanagedConfigDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Config data container for an unmanaged subinterface. Maps to `configData` in the ND API. `mode` is always
+    `"unmanaged"` for this module and is required by the API as a discriminator.
+
+    ## Raises
+
+    None
+    """
+
+    mode: Literal["unmanaged"] = Field(default="unmanaged", alias="mode", frozen=True)
+    network_os: SubinterfaceUnmanagedNetworkOSModel = Field(default_factory=SubinterfaceUnmanagedNetworkOSModel, alias="networkOS")
+
+
+class SubinterfaceUnmanagedOperDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Operational state container returned by GET on an unmanaged subinterface. Server-populated and read-only.
+    Excluded from payloads via `SubinterfaceUnmanagedInterfaceModel.payload_exclude_fields`.
+
+    ## Raises
+
+    None
+    """
+
+    admin_status: str | None = Field(default=None, alias="adminStatus")
+    operational_description: str | None = Field(default=None, alias="operationalDescription")
+    operational_status: str | None = Field(default=None, alias="operationalStatus")
+    switch_name: str | None = Field(default=None, alias="switchName")
+
+
+class SubinterfaceUnmanagedInterfaceModel(NDBaseModel):
+    """
+    # Summary
+
+    Unmanaged L3 subinterface configuration for Nexus Dashboard.
+
+    Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND
+    Manage Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic
+    serialization. The policy body carries only the `policyType` discriminator.
+
+    `interface_type` is required by the ND API on both POST and PUT. The per-interface PUT (`updateInterface`) uses
+    `interfaceType` as the request-body discriminator (mapping `subInterface` -> `interfaceSubInterface`) and lists it
+    in `required`, so `to_payload()` always serializes it for both verbs (verified against the ND 4.2.1 OpenAPI spec).
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip", "oper_data"}
+
+    # --- Fields ---
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["subInterface"] = Field(default="subInterface", alias="interfaceType", frozen=True)
+    config_data: SubinterfaceUnmanagedConfigDataModel = Field(default_factory=SubinterfaceUnmanagedConfigDataModel, alias="configData")
+    oper_data: SubinterfaceUnmanagedOperDataModel | None = Field(default=None, alias="operData")
+
+    @field_validator("interface_name", mode="before")
+    @classmethod
+    def normalize_interface_name(cls, value):
+        """
+        # Summary
+
+        Validate that `interface_name` is a dotted subinterface form on either an Ethernet or Port-channel
+        parent (e.g. `Ethernet1/3.2`, `Port-channel10.5`). The parent kind is inferred from the prefix; no
+        separate `parent_interface` argument is needed. The sub-id portion (`.<n>`) is required.
+
+        Accepts any case for the parent prefix and normalizes to canonical capitalization (`Ethernet...`,
+        `Port-channel...`) so user input, POST payloads, and GET responses all compare equal.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `value` is a string without a `.<sub>` segment.
+        - If the `.<sub>` segment is empty or non-numeric (e.g. `'Ethernet1/3.'`).
+        - If `value` does not start with `Ethernet` or `Port-channel` (case-insensitive).
+        - If the parent has no port/channel number after the prefix (e.g. `'ethernetfoo.1'`).
+        """
+        if not isinstance(value, str) or not value:
+            return value
+        stripped = value.strip()
+        if "." not in stripped:
+            raise ValueError(f"interface_name must include a dot-separated subinterface id (e.g. 'Ethernet1/3.2'); got {value!r}")
+        parent, sub = stripped.rsplit(".", 1)
+        if not sub.isdigit():
+            raise ValueError(f"interface_name subinterface id (after '.') must be a number (e.g. 'Ethernet1/3.2'); got {value!r}")
+        parent_lower = parent.lower()
+        # ND echoes interface names lowercased on GET; normalize to canonical case so idempotency comparisons work.
+        if parent_lower.startswith("ethernet"):
+            port_spec = parent[len("ethernet") :]
+            canonical_parent = "Ethernet" + port_spec
+        elif parent_lower.startswith("port-channel"):
+            port_spec = parent[len("port-channel") :]
+            canonical_parent = "Port-channel" + port_spec
+        else:
+            raise ValueError(f"interface_name parent must be 'Ethernet...' or 'Port-channel...'; got parent={parent!r}")
+        if not port_spec or not port_spec[0].isdigit():
+            raise ValueError(
+                f"interface_name parent {parent!r} is malformed; expected a port/channel number after the prefix (e.g. 'Ethernet1/3', 'Port-channel10')"
+            )
+        return f"{canonical_parent}.{sub}"
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_interface_subinterface_unmanaged` module.
+
+        The user supplies only `switch_ip` and `interface_name` per item. Every field under `config_data` is
+        hardcoded scaffolding (interface_type, mode, network_os_type, policy_type) and is intentionally hidden
+        from the arg spec.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    interface_name=dict(type="str", required=True),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -42,6 +42,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SviPolicyTypeEnum
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
 
 class SviPolicyModel(NDNestedModel):
@@ -60,7 +61,7 @@ class SviPolicyModel(NDNestedModel):
 
     policy_type: SviPolicyTypeEnum = Field(default=SviPolicyTypeEnum.SVI, alias="policyType", description="Interface policy type")
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
-    description: str | None = Field(default=None, alias="description", max_length=254, description="Interface description")
+    description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Interface description")
     extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the interface")
     mtu: int | None = Field(default=None, alias="mtu", ge=576, le=9216, description="Interface MTU")
     ip: str | None = Field(default=None, alias="ip", description="IPv4 address of the SVI")
@@ -79,34 +80,6 @@ class SviPolicyModel(NDNestedModel):
     netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
 
     # --- Validators ---
-
-    @field_validator("description")
-    @classmethod
-    def description_must_be_ascii(cls, value):
-        """
-        # Summary
-
-        Reject non-ASCII characters in `description`. Some NX-OS / ND backend code paths pipe interface descriptions
-        through CLI generators that do not handle UTF-8 cleanly and return a generic 500 ("unexpected error during
-        policy execution") instead of a meaningful validation error. Catching this client-side gives the user a clear
-        message instead of a confusing server fault. Remove or relax this check once Cisco fixes the backend.
-
-        ## Raises
-
-        ### ValueError
-
-        - If `value` contains any non-ASCII character.
-        """
-        if value is None:
-            return value
-        try:
-            value.encode("ascii")
-        except UnicodeEncodeError as e:
-            raise ValueError(
-                f"description must contain only ASCII characters; got non-ASCII at position {e.start}: {value[e.start]!r}. "
-                "The ND backend currently returns a generic 500 for non-ASCII descriptions."
-            ) from None
-        return value
 
     @field_validator("policy_type", mode="before")
     @classmethod

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -1,0 +1,356 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+SVI (switched virtual interface) Pydantic models for Nexus Dashboard.
+
+This module defines nested Pydantic models that mirror the ND Manage Interfaces API payload structure for SVI
+interfaces (`interfaceType: "svi"`, `policyType: "svi"`, `mode: "managed"`). The playbook config uses the same
+nesting so that `to_payload()` and `from_response()` work via standard Pydantic serialization with no custom
+wrapping or flattening.
+
+## Model Hierarchy
+
+- `SviInterfaceModel` (top-level, `NDBaseModel`)
+    - `interface_name` (identifier, e.g. `vlan333`)
+    - `interface_type` (default: "svi")
+    - `config_data` -> `SviConfigDataModel`
+        - `mode` (default: "managed")
+        - `network_os` -> `SviNetworkOSModel`
+            - `network_os_type` (default: "nx-os")
+            - `policy` -> `SviPolicyModel`
+                - `policy_type` (default: "svi"), `admin_state`, `ip`, `prefix`, etc.
+    - `oper_data` -> `SviOperDataModel` (read-only, returned on GET, excluded from payload)
+
+## Phase 1 field set
+
+The fields in `SviPolicyModel` cover the SVI options that the ND GUI sends on create. OSPF / ISIS / BFD /
+routing-protocol / replication-mode fields are deferred to phase 2 once their create/update flows have been
+captured from the GUI.
+"""
+
+import copy
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    FieldSerializationInfo,
+    field_serializer,
+    field_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SviPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+
+
+class SviPolicyModel(NDNestedModel):
+    """
+    # Summary
+
+    Policy fields for an SVI interface. Maps directly to the `configData.networkOS.policy` object in the ND API.
+
+    `policy_type` is required by the API as a discriminator on both POST and PUT, so it carries a default of
+    `SviPolicyTypeEnum.SVI` and is always serialized.
+
+    ## Raises
+
+    None
+    """
+
+    policy_type: SviPolicyTypeEnum = Field(default=SviPolicyTypeEnum.SVI, alias="policyType", description="Interface policy type")
+    admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
+    description: str | None = Field(default=None, alias="description", max_length=254, description="Interface description")
+    extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the interface")
+    mtu: int | None = Field(default=None, alias="mtu", ge=576, le=9216, description="Interface MTU")
+    ip: str | None = Field(default=None, alias="ip", description="IPv4 address of the SVI")
+    prefix: int | None = Field(default=None, alias="prefix", ge=1, le=31, description="IPv4 netmask length used with `ip`")
+    ipv6: str | None = Field(default=None, alias="ipv6", description="IPv6 address of the SVI")
+    v6prefix: int | None = Field(default=None, alias="v6prefix", ge=1, le=127, description="IPv6 netmask length used with `ipv6`")
+    ip_redirects: bool | None = Field(default=None, alias="ipRedirects", description="Disable both IPv4/IPv6 redirects on the interface")
+    pim_sparse: bool | None = Field(default=None, alias="pimSparse", description="Enable PIM sparse-mode on the interface")
+    pim_dr_priority: int | None = Field(default=None, alias="pimDrPriority", ge=1, le=4294967295, description="Priority for PIM DR election on the interface")
+    hsrp_group: int | None = Field(default=None, alias="hsrpGroup", description="HSRP group number")
+    hsrp_version: str | None = Field(default=None, alias="hsrpVersion", description="HSRP version")
+    preempt: bool | None = Field(default=None, alias="preempt", description="Enable HSRP preemption")
+    advertise_subnet_in_underlay: bool | None = Field(
+        default=None, alias="advertiseSubnetInUnderlay", description="Advertise the SVI subnet into the underlay routing protocol"
+    )
+    netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
+
+    # --- Validators ---
+
+    @field_validator("description")
+    @classmethod
+    def description_must_be_ascii(cls, value):
+        """
+        # Summary
+
+        Reject non-ASCII characters in `description`. Some NX-OS / ND backend code paths pipe interface descriptions
+        through CLI generators that do not handle UTF-8 cleanly and return a generic 500 ("unexpected error during
+        policy execution") instead of a meaningful validation error. Catching this client-side gives the user a clear
+        message instead of a confusing server fault. Remove or relax this check once Cisco fixes the backend.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `value` contains any non-ASCII character.
+        """
+        if value is None:
+            return value
+        try:
+            value.encode("ascii")
+        except UnicodeEncodeError as e:
+            raise ValueError(
+                f"description must contain only ASCII characters; got non-ASCII at position {e.start}: {value[e.start]!r}. "
+                "The ND backend currently returns a generic 500 for non-ASCII descriptions."
+            ) from None
+        return value
+
+    @field_validator("policy_type", mode="before")
+    @classmethod
+    def normalize_policy_type(cls, value):
+        """
+        # Summary
+
+        Accept `policy_type` in either Ansible (`svi`) or API (`svi`) format. They are identical for SVI so this is a
+        no-op today, but the validator is kept for symmetry with the ethernet policy models in case the API ever
+        diverges from the Ansible-side name.
+
+        ## Raises
+
+        None
+        """
+        if value is None:
+            return value
+        ansible_to_api = {e.name.lower(): e.value for e in SviPolicyTypeEnum}
+        return ansible_to_api.get(value, value)
+
+    # --- Serializers ---
+
+    @field_serializer("policy_type")
+    def serialize_policy_type(self, value: str | None, info: FieldSerializationInfo) -> str | None:
+        """
+        # Summary
+
+        Serialize `policy_type` to the API's value in payload mode, or the Ansible-friendly name in config mode. With
+        `use_enum_values=True`, the stored value is the enum's `.value` string (e.g. `"svi"`).
+
+        ## Raises
+
+        None
+        """
+        if value is None:
+            return None
+        mode = (info.context or {}).get("mode", "payload")
+        if mode == "config":
+            reverse = {e.value: e.name.lower() for e in SviPolicyTypeEnum}
+            return reverse.get(value, value)
+        return value
+
+
+class SviNetworkOSModel(NDNestedModel):
+    """
+    # Summary
+
+    Network OS container for an SVI interface. Maps to `configData.networkOS` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    network_os_type: str = Field(default="nx-os", alias="networkOSType")
+    policy: SviPolicyModel | None = Field(default=None, alias="policy")
+
+
+class SviConfigDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Config data container for an SVI interface. Maps to `configData` in the ND API. `mode` is always `"managed"` for
+    SVIs and is required by the API as a discriminator.
+
+    ## Raises
+
+    None
+    """
+
+    mode: str = Field(default="managed", alias="mode")
+    network_os: SviNetworkOSModel = Field(alias="networkOS")
+
+
+class SviOperDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Operational state container returned by GET on an SVI interface. Server-populated and read-only. Excluded from
+    payloads via `SviInterfaceModel.payload_exclude_fields`.
+
+    ## Raises
+
+    None
+    """
+
+    admin_status: str | None = Field(default=None, alias="adminStatus")
+    operational_description: str | None = Field(default=None, alias="operationalDescription")
+    operational_status: str | None = Field(default=None, alias="operationalStatus")
+    port_channel_id: int | None = Field(default=None, alias="portChannelId")
+    switch_name: str | None = Field(default=None, alias="switchName")
+    vlan_range: str | None = Field(default=None, alias="vlanRange")
+
+
+class SviInterfaceModel(NDBaseModel):
+    """
+    # Summary
+
+    SVI interface configuration for Nexus Dashboard.
+
+    Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
+    Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
+
+    `interface_type` is sent on POST but NOT on PUT (the API rejects it on PUT). The orchestrator's `update()` method
+    is responsible for popping it from the payload before sending.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip", "oper_data"}
+
+    # --- Fields ---
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: str = Field(default="svi", alias="interfaceType")
+    config_data: SviConfigDataModel | None = Field(default=None, alias="configData")
+    oper_data: SviOperDataModel | None = Field(default=None, alias="operData")
+
+    @classmethod
+    def from_response(cls, response: dict, **kwargs) -> "SviInterfaceModel":
+        """
+        # Summary
+
+        Build an `SviInterfaceModel` from an API GET response, stripping `hsrpVersion` before validation. ND's GET
+        returns `hsrpVersion: 1` (integer) as a server-side default even when HSRP is not configured, and re-emitting
+        that value (whether as integer `1` or string `"1"`) on a subsequent PUT causes the API to return a generic 500
+        ("unexpected error during policy execution"). The empty string `""` is the canonical "no HSRP version" form.
+
+        `hsrpGroup` is left intact — Bruno testing confirmed the API round-trips `hsrpGroup: 1` cleanly when other
+        HSRP fields are at their unconfigured defaults.
+
+        ## Raises
+
+        None
+        """
+        response = copy.deepcopy(response)
+        policy = response.get("configData", {}).get("networkOS", {}).get("policy")
+        if isinstance(policy, dict):
+            policy.pop("hsrpVersion", None)
+        return super().from_response(response, **kwargs)
+
+    @field_validator("interface_name", mode="before")
+    @classmethod
+    def normalize_interface_name(cls, value):
+        """
+        # Summary
+
+        Normalize SVI interface names to the ND API convention (lowercase `vlan` prefix, e.g. `Vlan333` -> `vlan333`,
+        `VLAN333` -> `vlan333`). Bare integers are accepted and prefixed with `vlan` (e.g. `333` -> `vlan333`).
+
+        ## Raises
+
+        None
+        """
+        if isinstance(value, int):
+            return f"vlan{value}"
+        if isinstance(value, str) and value:
+            stripped = value.strip()
+            if stripped.isdigit():
+                return f"vlan{stripped}"
+            if stripped.lower().startswith("vlan"):
+                return "vlan" + stripped[4:]
+        return value
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_interface_svi` module.
+
+        The module accepts `vlan_ids` (a list of integer VLAN IDs) which the module entry point expands into one flat
+        config item per ID (with `interface_name` set to `vlan<id>`). This mirrors the `interface_names` expansion in
+        the ethernet modules.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    vlan_ids=dict(type="list", elements="int", required=True),
+                    interface_type=dict(type="str", default="svi"),
+                    config_data=dict(
+                        type="dict",
+                        options=dict(
+                            mode=dict(type="str", default="managed"),
+                            network_os=dict(
+                                type="dict",
+                                options=dict(
+                                    network_os_type=dict(type="str", default="nx-os"),
+                                    policy=dict(
+                                        type="dict",
+                                        options=dict(
+                                            policy_type=dict(
+                                                type="str",
+                                                choices=[e.name.lower() for e in SviPolicyTypeEnum],
+                                                default="svi",
+                                            ),
+                                            admin_state=dict(type="bool"),
+                                            description=dict(type="str"),
+                                            extra_config=dict(type="str"),
+                                            mtu=dict(type="int"),
+                                            ip=dict(type="str"),
+                                            prefix=dict(type="int"),
+                                            ipv6=dict(type="str"),
+                                            v6prefix=dict(type="int"),
+                                            ip_redirects=dict(type="bool"),
+                                            pim_sparse=dict(type="bool"),
+                                            pim_dr_priority=dict(type="int"),
+                                            hsrp_group=dict(type="int"),
+                                            hsrp_version=dict(type="str"),
+                                            preempt=dict(type="bool"),
+                                            advertise_subnet_in_underlay=dict(type="bool"),
+                                            netflow=dict(type="bool"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -246,9 +246,9 @@ class SviInterfaceModel(NDBaseModel):
 
         Return the Ansible argument spec for the `nd_interface_svi` module.
 
-        The module accepts `vlan_ids` (a list of integer VLAN IDs) which the module entry point expands into one flat
-        config item per ID (with `interface_name` set to `vlan<id>`). This mirrors the `interface_names` expansion in
-        the ethernet modules.
+        Each config item targets a single SVI identified by `interface_name` (e.g. `vlan333`). To configure multiple SVIs
+        in one task, list multiple config items. Per-SVI L3 settings (ip, hsrp_*, vrf_interface, ...) live under
+        `config_data.network_os.policy` and apply to that one interface only.
 
         ## Raises
 
@@ -262,7 +262,7 @@ class SviInterfaceModel(NDBaseModel):
                 required=True,
                 options=dict(
                     switch_ip=dict(type="str", required=True),
-                    vlan_ids=dict(type="list", elements="int", required=True),
+                    interface_name=dict(type="str", required=True),
                     interface_type=dict(type="str", default="svi"),
                     config_data=dict(
                         type="dict",

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -57,7 +57,9 @@ class SviPolicyModel(NDNestedModel):
     None
     """
 
-    policy_type: SviPolicyTypeEnum = Field(default=SviPolicyTypeEnum.SVI, alias="policyType", frozen=True, description="Interface policy type (hardcoded for this module)")
+    policy_type: SviPolicyTypeEnum = Field(
+        default=SviPolicyTypeEnum.SVI, alias="policyType", frozen=True, description="Interface policy type (hardcoded for this module)"
+    )
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Interface description")
     extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the interface")

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -57,7 +57,7 @@ class SviPolicyModel(NDNestedModel):
     None
     """
 
-    policy_type: SviPolicyTypeEnum = Field(default=SviPolicyTypeEnum.SVI, alias="policyType", description="Interface policy type")
+    policy_type: SviPolicyTypeEnum = Field(default=SviPolicyTypeEnum.SVI, alias="policyType", frozen=True, description="Interface policy type (hardcoded for this module)")
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Interface description")
     extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the interface")
@@ -140,7 +140,7 @@ class SviNetworkOSModel(NDNestedModel):
     None
     """
 
-    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType")
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
     policy: SviPolicyModel | None = Field(default=None, alias="policy")
 
 
@@ -156,7 +156,7 @@ class SviConfigDataModel(NDNestedModel):
     None
     """
 
-    mode: Literal["managed"] = Field(default="managed", alias="mode")
+    mode: Literal["managed"] = Field(default="managed", alias="mode", frozen=True)
     network_os: SviNetworkOSModel = Field(alias="networkOS")
 
 
@@ -210,7 +210,7 @@ class SviInterfaceModel(NDBaseModel):
 
     switch_ip: str = Field(alias="switchIp")
     interface_name: str = Field(alias="interfaceName")
-    interface_type: Literal["svi"] = Field(default="svi", alias="interfaceType")
+    interface_type: Literal["svi"] = Field(default="svi", alias="interfaceType", frozen=True)
     config_data: SviConfigDataModel | None = Field(default=None, alias="configData")
     oper_data: SviOperDataModel | None = Field(default=None, alias="operData")
 

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -35,8 +35,6 @@ from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
-    FieldSerializationInfo,
-    field_serializer,
     field_validator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
@@ -128,47 +126,6 @@ class SviPolicyModel(NDNestedModel):
         """
         if isinstance(value, int) and not isinstance(value, bool):
             return str(value)
-        return value
-
-    @field_validator("policy_type", mode="before")
-    @classmethod
-    def normalize_policy_type(cls, value):
-        """
-        # Summary
-
-        Accept `policy_type` in either Ansible (`svi`) or API (`svi`) format. They are identical for SVI so this is a
-        no-op today, but the validator is kept for symmetry with the ethernet policy models in case the API ever
-        diverges from the Ansible-side name.
-
-        ## Raises
-
-        None
-        """
-        if value is None:
-            return value
-        ansible_to_api = {e.name.lower(): e.value for e in SviPolicyTypeEnum}
-        return ansible_to_api.get(value, value)
-
-    # --- Serializers ---
-
-    @field_serializer("policy_type")
-    def serialize_policy_type(self, value: str | None, info: FieldSerializationInfo) -> str | None:
-        """
-        # Summary
-
-        Serialize `policy_type` to the API's value in payload mode, or the Ansible-friendly name in config mode. With
-        `use_enum_values=True`, the stored value is the enum's `.value` string (e.g. `"svi"`).
-
-        ## Raises
-
-        None
-        """
-        if value is None:
-            return None
-        mode = (info.context or {}).get("mode", "payload")
-        if mode == "config":
-            reverse = {e.value: e.name.lower() for e in SviPolicyTypeEnum}
-            return reverse.get(value, value)
         return value
 
 
@@ -318,11 +275,6 @@ class SviInterfaceModel(NDBaseModel):
                                     policy=dict(
                                         type="dict",
                                         options=dict(
-                                            policy_type=dict(
-                                                type="str",
-                                                choices=[e.name.lower() for e in SviPolicyTypeEnum],
-                                                default="svi",
-                                            ),
                                             admin_state=dict(type="bool"),
                                             description=dict(type="str"),
                                             extra_config=dict(type="str"),

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -102,10 +102,9 @@ class SviPolicyModel(NDNestedModel):
 
     # --- Validators ---
 
-    # TODO(ND 4.3): remove this validator once ND 4.2 reaches end-of-support.
-    # ND 4.2 returns `routingTag` as an integer on GET despite the OpenAPI spec declaring it as string and accepting
-    # string on POST/PUT. Cisco has confirmed this is fixed in ND 4.3, so once 4.2 is deprecated this coercion is
-    # dead weight. Tracked in `project_svi_hsrp_phase2.md`.
+    # TODO(4.2.1) GET returns `routingTag` as an integer though the OpenAPI spec declares it as string and POST/PUT accept string.
+    # Remove this validator once ND 4.2 reaches end-of-support. Cisco has confirmed this is fixed in ND 4.3, so once 4.2 is
+    # deprecated this coercion is dead weight. Tracked in `project_svi_hsrp_phase2.md`.
     @field_validator("routing_tag", mode="before")
     @classmethod
     def coerce_routing_tag_to_string(cls, value):

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -269,19 +269,35 @@ class SviInterfaceModel(NDBaseModel):
         Normalize SVI interface names to the ND API convention (lowercase `vlan` prefix, e.g. `Vlan333` -> `vlan333`,
         `VLAN333` -> `vlan333`). Bare integers are accepted and prefixed with `vlan` (e.g. `333` -> `vlan333`).
 
+        When a numeric VLAN ID can be extracted from the input, it is range-checked against the controller-supported
+        SVI VLAN range (1-4094) so an out-of-range ID fails early with a clear error instead of being rejected by ND.
+
         ## Raises
 
-        None
+        ### ValueError
+
+        - If the extracted VLAN ID is outside the range 1-4094.
         """
+        normalized = value
+        vlan_id: int | None = None
+        if isinstance(value, bool):
+            return value
         if isinstance(value, int):
-            return f"vlan{value}"
-        if isinstance(value, str) and value:
+            vlan_id = value
+            normalized = f"vlan{value}"
+        elif isinstance(value, str) and value:
             stripped = value.strip()
             if stripped.isdigit():
-                return f"vlan{stripped}"
-            if stripped.lower().startswith("vlan"):
-                return "vlan" + stripped[4:]
-        return value
+                vlan_id = int(stripped)
+                normalized = f"vlan{stripped}"
+            elif stripped.lower().startswith("vlan"):
+                remainder = stripped[4:]
+                normalized = "vlan" + remainder
+                if remainder.isdigit():
+                    vlan_id = int(remainder)
+        if vlan_id is not None and not 1 <= vlan_id <= 4094:
+            raise ValueError(f"SVI VLAN ID must be in the range 1-4094, got {vlan_id}.")
+        return normalized
 
     # --- Argument Spec ---
 

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -14,13 +14,13 @@ wrapping or flattening.
 
 - `SviInterfaceModel` (top-level, `NDBaseModel`)
     - `interface_name` (identifier, e.g. `vlan333`)
-    - `interface_type` (default: "svi")
+    - `interface_type` (hardcoded: "svi")
     - `config_data` -> `SviConfigDataModel`
-        - `mode` (default: "managed")
+        - `mode` (hardcoded: "managed")
         - `network_os` -> `SviNetworkOSModel`
-            - `network_os_type` (default: "nx-os")
+            - `network_os_type` (hardcoded: "nx-os")
             - `policy` -> `SviPolicyModel`
-                - `policy_type` (default: "svi"), `admin_state`, `ip`, `prefix`, HSRP block, DHCP relay, etc.
+                - `policy_type` (hardcoded: SviPolicyTypeEnum.SVI), `admin_state`, `ip`, `prefix`, HSRP block, DHCP relay, etc.
     - `oper_data` -> `SviOperDataModel` (read-only, returned on GET, excluded from payload)
 
 ## Field set
@@ -140,7 +140,7 @@ class SviNetworkOSModel(NDNestedModel):
     None
     """
 
-    network_os_type: str = Field(default="nx-os", alias="networkOSType")
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType")
     policy: SviPolicyModel | None = Field(default=None, alias="policy")
 
 
@@ -156,7 +156,7 @@ class SviConfigDataModel(NDNestedModel):
     None
     """
 
-    mode: str = Field(default="managed", alias="mode")
+    mode: Literal["managed"] = Field(default="managed", alias="mode")
     network_os: SviNetworkOSModel = Field(alias="networkOS")
 
 
@@ -210,7 +210,7 @@ class SviInterfaceModel(NDBaseModel):
 
     switch_ip: str = Field(alias="switchIp")
     interface_name: str = Field(alias="interfaceName")
-    interface_type: str = Field(default="svi", alias="interfaceType")
+    interface_type: Literal["svi"] = Field(default="svi", alias="interfaceType")
     config_data: SviConfigDataModel | None = Field(default=None, alias="configData")
     oper_data: SviOperDataModel | None = Field(default=None, alias="operData")
 
@@ -263,15 +263,12 @@ class SviInterfaceModel(NDBaseModel):
                 options=dict(
                     switch_ip=dict(type="str", required=True),
                     interface_name=dict(type="str", required=True),
-                    interface_type=dict(type="str", default="svi"),
                     config_data=dict(
                         type="dict",
                         options=dict(
-                            mode=dict(type="str", default="managed"),
                             network_os=dict(
                                 type="dict",
                                 options=dict(
-                                    network_os_type=dict(type="str", default="nx-os"),
                                     policy=dict(
                                         type="dict",
                                         options=dict(

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -20,17 +20,17 @@ wrapping or flattening.
         - `network_os` -> `SviNetworkOSModel`
             - `network_os_type` (default: "nx-os")
             - `policy` -> `SviPolicyModel`
-                - `policy_type` (default: "svi"), `admin_state`, `ip`, `prefix`, etc.
+                - `policy_type` (default: "svi"), `admin_state`, `ip`, `prefix`, HSRP block, DHCP relay, etc.
     - `oper_data` -> `SviOperDataModel` (read-only, returned on GET, excluded from payload)
 
-## Phase 1 field set
+## Field set
 
-The fields in `SviPolicyModel` cover the SVI options that the ND GUI sends on create. OSPF / ISIS / BFD /
-routing-protocol / replication-mode fields are deferred to phase 2 once their create/update flows have been
-captured from the GUI.
+Fields in `SviPolicyModel` mirror the `policyType: "svi"` schema in the ND Manage API (createInterfaceSviManagedNexusType
+oneOf -> int_vlan.template), covering the full set of HSRP, DHCP relay, VRF, route tag, PIM, and Netflow options the
+ND GUI exposes for managed SVIs on Nexus. OSPF / ISIS / BFD / replication-mode fields belong to other policy types
+(e.g. `policyType: "vpcBackupSvi"` / int_fabric_vlan_11_1) and would be modelled as separate variants.
 """
 
-import copy
 from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -63,23 +63,72 @@ class SviPolicyModel(NDNestedModel):
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Interface description")
     extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the interface")
-    mtu: int | None = Field(default=None, alias="mtu", ge=576, le=9216, description="Interface MTU")
+    mtu: int | None = Field(default=None, alias="mtu", ge=68, le=9216, description="Interface MTU")
     ip: str | None = Field(default=None, alias="ip", description="IPv4 address of the SVI")
     prefix: int | None = Field(default=None, alias="prefix", ge=1, le=31, description="IPv4 netmask length used with `ip`")
     ipv6: str | None = Field(default=None, alias="ipv6", description="IPv6 address of the SVI")
-    v6prefix: int | None = Field(default=None, alias="v6prefix", ge=1, le=127, description="IPv6 netmask length used with `ipv6`")
+    prefixv6: int | None = Field(default=None, alias="prefixv6", ge=1, le=127, description="IPv6 netmask length used with `ipv6`")
     ip_redirects: bool | None = Field(default=None, alias="ipRedirects", description="Disable both IPv4/IPv6 redirects on the interface")
+    vrf_interface: str | None = Field(
+        default=None, alias="vrfInterface", min_length=1, max_length=32, description="Interface VRF name; use `default` for default VRF"
+    )
+    routing_tag: str | None = Field(default=None, alias="routingTag", description="Routing tag associated with the interface IP address")
     pim_sparse: bool | None = Field(default=None, alias="pimSparse", description="Enable PIM sparse-mode on the interface")
     pim_dr_priority: int | None = Field(default=None, alias="pimDrPriority", ge=1, le=4294967295, description="Priority for PIM DR election on the interface")
-    hsrp_group: int | None = Field(default=None, alias="hsrpGroup", description="HSRP group number")
-    hsrp_version: str | None = Field(default=None, alias="hsrpVersion", description="HSRP version")
-    preempt: bool | None = Field(default=None, alias="preempt", description="Enable HSRP preemption")
+
+    # --- HSRP block (gated by `hsrp=true`) ---
+    hsrp: bool | None = Field(default=None, alias="hsrp", description="Enable HSRP on the interface")
+    hsrp_vip: str | None = Field(default=None, alias="hsrpVip", description="HSRP IPv4 virtual IP; must match on active/standby device")
+    hsrp_vipv6: str | None = Field(default=None, alias="hsrpVipv6", description="HSRP IPv6 virtual IP; must match on active/standby device")
+    hsrp_group: int | None = Field(default=None, alias="hsrpGroup", ge=0, le=4095, description="HSRP group number")
+    hsrp_groupv6: int | None = Field(default=None, alias="hsrpGroupv6", ge=0, le=4095, description="HSRP IPv6 group number; if unset the IPv4 group is reused")
+    hsrp_version: Literal[1, 2] | None = Field(default=None, alias="hsrpVersion", description="HSRP version (1 or 2)")
+    hsrp_priority: int | None = Field(default=None, alias="hsrpPriority", ge=0, le=255, description="HSRP priority for election")
+    preempt: bool | None = Field(default=None, alias="preempt", description="Enable HSRP preemption (overthrow lower priority active routers)")
+    mac: str | None = Field(default=None, alias="mac", description="HSRP virtual MAC address override")
+
+    # --- DHCP relay block (up to 3 servers, each with optional VRF override) ---
+    dhcp_server_address1: str | None = Field(default=None, alias="dhcpServerAddress1", description="Primary DHCP relay server IP address")
+    dhcp_server_address2: str | None = Field(default=None, alias="dhcpServerAddress2", description="Secondary DHCP relay server IP address")
+    dhcp_server_address3: str | None = Field(default=None, alias="dhcpServerAddress3", description="Tertiary DHCP relay server IP address")
+    vrf_dhcp1: str | None = Field(default=None, alias="vrfDhcp1", description="VRF to reach DHCP server 1; `default` for default VRF, blank for interface VRF")
+    vrf_dhcp2: str | None = Field(default=None, alias="vrfDhcp2", description="VRF to reach DHCP server 2; `default` for default VRF, blank for interface VRF")
+    vrf_dhcp3: str | None = Field(default=None, alias="vrfDhcp3", description="VRF to reach DHCP server 3; `default` for default VRF, blank for interface VRF")
+
     advertise_subnet_in_underlay: bool | None = Field(
         default=None, alias="advertiseSubnetInUnderlay", description="Advertise the SVI subnet into the underlay routing protocol"
     )
     netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 3 Netflow monitor name (required when `netflow=true`)")
+    netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name (applicable to N7K only)")
 
     # --- Validators ---
+
+    # TODO(ND 4.3): remove this validator once ND 4.2 reaches end-of-support.
+    # ND 4.2 returns `routingTag` as an integer on GET despite the OpenAPI spec declaring it as string and accepting
+    # string on POST/PUT. Cisco has confirmed this is fixed in ND 4.3, so once 4.2 is deprecated this coercion is
+    # dead weight. Tracked in `project_svi_hsrp_phase2.md`.
+    @field_validator("routing_tag", mode="before")
+    @classmethod
+    def coerce_routing_tag_to_string(cls, value):
+        """
+        # Summary
+
+        Accept `routing_tag` as either string or integer. ND 4.2's API accepts string form on POST/PUT (matching
+        the OpenAPI spec which declares this as `string`), but GET responses return the value as an integer (e.g.
+        `12345` rather than `"12345"`). Coerce ints to their decimal string form so round-trips and idempotency
+        comparisons work uniformly. Lab-confirmed 2026-04-30 that PUT-back with the string form is accepted.
+
+        Cisco has confirmed the GET-side type drift is fixed in ND 4.3; this validator can be removed once ND 4.2
+        is deprecated.
+
+        ## Raises
+
+        None
+        """
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+        return value
 
     @field_validator("policy_type", mode="before")
     @classmethod
@@ -208,29 +257,6 @@ class SviInterfaceModel(NDBaseModel):
     config_data: SviConfigDataModel | None = Field(default=None, alias="configData")
     oper_data: SviOperDataModel | None = Field(default=None, alias="operData")
 
-    @classmethod
-    def from_response(cls, response: dict, **kwargs) -> "SviInterfaceModel":
-        """
-        # Summary
-
-        Build an `SviInterfaceModel` from an API GET response, stripping `hsrpVersion` before validation. ND's GET
-        returns `hsrpVersion: 1` (integer) as a server-side default even when HSRP is not configured, and re-emitting
-        that value (whether as integer `1` or string `"1"`) on a subsequent PUT causes the API to return a generic 500
-        ("unexpected error during policy execution"). The empty string `""` is the canonical "no HSRP version" form.
-
-        `hsrpGroup` is left intact — Bruno testing confirmed the API round-trips `hsrpGroup: 1` cleanly when other
-        HSRP fields are at their unconfigured defaults.
-
-        ## Raises
-
-        None
-        """
-        response = copy.deepcopy(response)
-        policy = response.get("configData", {}).get("networkOS", {}).get("policy")
-        if isinstance(policy, dict):
-            policy.pop("hsrpVersion", None)
-        return super().from_response(response, **kwargs)
-
     @field_validator("interface_name", mode="before")
     @classmethod
     def normalize_interface_name(cls, value):
@@ -304,15 +330,31 @@ class SviInterfaceModel(NDBaseModel):
                                             ip=dict(type="str"),
                                             prefix=dict(type="int"),
                                             ipv6=dict(type="str"),
-                                            v6prefix=dict(type="int"),
+                                            prefixv6=dict(type="int"),
                                             ip_redirects=dict(type="bool"),
+                                            vrf_interface=dict(type="str"),
+                                            routing_tag=dict(type="str"),
                                             pim_sparse=dict(type="bool"),
                                             pim_dr_priority=dict(type="int"),
+                                            hsrp=dict(type="bool"),
+                                            hsrp_vip=dict(type="str"),
+                                            hsrp_vipv6=dict(type="str"),
                                             hsrp_group=dict(type="int"),
-                                            hsrp_version=dict(type="str"),
+                                            hsrp_groupv6=dict(type="int"),
+                                            hsrp_version=dict(type="int", choices=[1, 2]),
+                                            hsrp_priority=dict(type="int"),
                                             preempt=dict(type="bool"),
+                                            mac=dict(type="str"),
+                                            dhcp_server_address1=dict(type="str"),
+                                            dhcp_server_address2=dict(type="str"),
+                                            dhcp_server_address3=dict(type="str"),
+                                            vrf_dhcp1=dict(type="str"),
+                                            vrf_dhcp2=dict(type="str"),
+                                            vrf_dhcp3=dict(type="str"),
                                             advertise_subnet_in_underlay=dict(type="bool"),
                                             netflow=dict(type="bool"),
+                                            netflow_monitor=dict(type="str"),
+                                            netflow_sampler=dict(type="str"),
                                         ),
                                     ),
                                 ),

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -190,8 +190,9 @@ class SviInterfaceModel(NDBaseModel):
     Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
     Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
 
-    `interface_type` is sent on POST but NOT on PUT (the API rejects it on PUT). The orchestrator's `update()` method
-    is responsible for popping it from the payload before sending.
+    `interface_type` is required by the ND API on both POST and PUT. The per-interface PUT (`updateInterface`) uses
+    `interfaceType` as the request-body discriminator (mapping `svi` -> `interfaceSvi`) and lists it in `required`, so
+    `to_payload()` always serializes it for both verbs (verified against the ND 4.2.1 OpenAPI spec).
 
     ## Raises
 

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -31,11 +31,14 @@ ND GUI exposes for managed SVIs on Nexus. OSPF / ISIS / BFD / replication-mode f
 (e.g. `policyType: "vpcBackupSvi"` / int_fabric_vlan_11_1) and would be modelled as separate variants.
 """
 
+from __future__ import annotations
+
 from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
     field_validator,
+    model_validator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SviPolicyTypeEnum
@@ -128,6 +131,47 @@ class SviPolicyModel(NDNestedModel):
         if isinstance(value, int) and not isinstance(value, bool):
             return str(value)
         return value
+
+    @model_validator(mode="after")
+    def _validate_netflow_monitor_present(self) -> SviPolicyModel:
+        """
+        # Summary
+
+        Reject enabling `netflow` without supplying a `netflow_monitor`.
+
+        The DOCUMENTATION and field description state that `netflow_monitor` is required when `netflow` is true. Enforcing it at the model layer
+        fails an incomplete policy early with a clear error instead of pushing a netflow config with no monitor and deferring the outcome to ND.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `netflow` is true and `netflow_monitor` is missing or empty.
+        """
+        if self.netflow is True and not self.netflow_monitor:
+            raise ValueError("netflow_monitor must be provided when netflow is true.")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_ip_prefix_paired(self) -> SviPolicyModel:
+        """
+        # Summary
+
+        Reject supplying only one half of an address/mask pair. `ip` requires `prefix` (and `ipv6` requires `prefixv6`) and vice versa, so a
+        partial address is never serialized into a payload that ND would reject or apply ambiguously.
+
+        ## Raises
+
+        ### ValueError
+
+        - If exactly one of `ip` / `prefix` is set.
+        - If exactly one of `ipv6` / `prefixv6` is set.
+        """
+        if (self.ip is None) != (self.prefix is None):
+            raise ValueError("ip and prefix are required together; set both or neither.")
+        if (self.ipv6 is None) != (self.prefixv6 is None):
+            raise ValueError("ipv6 and prefixv6 are required together; set both or neither.")
+        return self
 
 
 class SviNetworkOSModel(NDNestedModel):

--- a/plugins/module_utils/orchestrators/subinterface_managed_interface.py
+++ b/plugins/module_utils/orchestrators/subinterface_managed_interface.py
@@ -1,0 +1,291 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Managed L3 subinterface orchestrator for Nexus Dashboard.
+
+This module provides `SubinterfaceManagedInterfaceOrchestrator`, which implements CRUD operations for managed L3
+subinterfaces (`interfaceType: "subInterface"`, `policyType: "subinterface"`, `mode: "managed"`) via the ND Manage
+Interfaces API. Supports configuring subinterfaces across multiple switches in a single task.
+
+Each mutation operation (create, update, delete) is followed by a deploy call to persist changes to the switch.
+Deploy and remove operations are batched per-switch and executed in bulk after all mutations are complete.
+
+Subinterfaces are logical and support both `interfaceActions/remove` (bulk delete) and `interfaceActions/deploy`
+(bulk deploy), so `state: deleted` queues both and lets the standard `remove_pending` + `deploy_pending` flow
+handle the work (the same pattern used by `nd_interface_svi`, unlike physical ethernet which must use normalize).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+    EpManageInterfacesRemove,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceManagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import SubinterfaceManagedInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class SubinterfaceManagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[SubinterfaceManagedInterfaceModel]):
+    """
+    # Summary
+
+    Orchestrator for managed L3 subinterface CRUD operations on Nexus Dashboard.
+
+    Supports configuring subinterfaces across multiple switches in a single task. Each config item includes a
+    `switch_ip` that is resolved to a `switchId` via `FabricContext`.
+
+    Mutation methods (`create`, `update`) queue deploys instead of executing them immediately. Call `deploy_pending`
+    after all mutations are complete to deploy all changes in a single API call. `delete` queues subinterfaces for
+    bulk removal via `remove_pending`.
+
+    For `state: overridden`, `query_all` queries ALL switches in the fabric to enable fabric-wide convergence.
+
+    Uses `FabricContext` for pre-flight validation and switch resolution.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
+    - Via `create` if the create API request fails.
+    - Via `update` if the update API request fails.
+    - Via `remove_pending` if the bulk remove API request fails.
+    - Via `deploy_pending` if the bulk deploy API request fails.
+    - Via `query_one` if the query API request fails.
+    - Via `query_all` if the query API request fails.
+    """
+
+    model_class: ClassVar[type[NDBaseModel]] = SubinterfaceManagedInterfaceModel
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+
+    # TODO(4.2.1) ND returns HTTP 207 Multi-Status on subinterface POST with per-item `status: "failed"` when the parent
+    # interface is not in routed mode (or other policy validation fails). Our RestSend response_handler treats 207 as
+    # success and returns the body without raising, so without this check the orchestrator would silently report
+    # "changed" when nothing was actually created. Remove this workaround once CiscoDevNet/ansible-nd#295 lands the
+    # 207-aware response handling at the RestSend layer.
+    @staticmethod
+    def _raise_on_multi_status_failures(response: ResponseType) -> None:
+        """
+        # Summary
+
+        Inspect a 207 Multi-Status body and raise if any item carries `status: "failed"` or `status: "error"`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If `response["results"]` contains any item with `status` in `("failed", "error")`.
+        """
+        if not isinstance(response, dict):
+            return
+        results = response.get("results") or []
+        failed = [r for r in results if isinstance(r, dict) and r.get("status") in ("failed", "error")]
+        if failed:
+            summary = "; ".join(f"{r.get('name')}: {r.get('message')}" for r in failed)
+            raise RuntimeError(f"ND rejected {len(failed)} interface(s): {summary}")
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = NDEndpointBaseModel  # unused; delete() uses bulk remove
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesRemove
+
+    def create(self, model_instance: SubinterfaceManagedInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create a managed L3 subinterface. Resolves `switch_ip` from the model instance, injects `switchId`, and wraps
+        the payload in an `interfaces` array. Queues a deploy for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            request_body = {"interfaces": [payload]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+            self._raise_on_multi_status_failures(result)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: SubinterfaceManagedInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update a managed L3 subinterface. Resolves `switch_ip` from the model instance, injects `switchId` into the
+        payload. Queues a deploy for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: SubinterfaceManagedInterfaceModel, **kwargs) -> None:
+        """
+        # Summary
+
+        Queue a managed L3 subinterface for deferred bulk removal via `remove_pending` and bulk deploy via
+        `deploy_pending`. The remove deletes the subinterface from ND's config; the subsequent deploy pushes that
+        removal to the switch.
+
+        No API calls are made until `remove_pending` and `deploy_pending` are called after all mutations are complete.
+
+        ## Raises
+
+        None
+        """
+        switch_id = self._resolve_switch_id(model_instance.switch_ip)
+        self._queue_remove(model_instance.interface_name, switch_id)
+        self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def create_bulk(self, model_instances: list[SubinterfaceManagedInterfaceModel], **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create multiple managed L3 subinterfaces in bulk. Groups subinterfaces by switch and sends one POST per
+        switch with all subinterfaces in the `interfaces` array, reducing API calls from N to one-per-switch. Queues
+        deploys for all created subinterfaces for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create API request fails.
+        """
+        try:
+            groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+            for model_instance in model_instances:
+                switch_id = self._resolve_switch_id(model_instance.switch_ip)
+                payload = model_instance.to_payload()
+                payload["switchId"] = switch_id
+                groups[switch_id].append((model_instance.interface_name, payload))
+
+            results = []
+            for switch_id, items in groups.items():
+                api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
+                request_body = {"interfaces": [payload for interface_name, payload in items]}
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+                self._raise_on_multi_status_failures(result)
+                results.append(result)
+                for interface_name, payload in items:
+                    self._queue_deploy(interface_name, switch_id)
+            return results
+        except Exception as e:
+            raise RuntimeError(f"Bulk create failed: {e}") from e
+
+    def delete_bulk(self, model_instances: list[SubinterfaceManagedInterfaceModel], **kwargs) -> None:
+        """
+        # Summary
+
+        Queue multiple managed L3 subinterfaces for deferred bulk removal and deployment. No API calls are made until
+        `remove_pending` and `deploy_pending` are called after `manage_state` completes.
+
+        ## Raises
+
+        None
+        """
+        for model_instance in model_instances:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            self._queue_remove(model_instance.interface_name, switch_id)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def query_one(self, model_instance: SubinterfaceManagedInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Query a single managed L3 subinterface by name on a specific switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
+        subinterfaces with `interfaceType: "subInterface"` and `policyType: "subinterface"` (managed variant). The
+        unmanaged variant (`monitorSubinterface`) is managed by a separate orchestrator and is excluded here.
+
+        Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning
+        any data.
+
+        Each returned interface dict is enriched with a `switch_ip` field so that
+        `SubinterfaceManagedInterfaceModel` can be constructed with the composite identifier
+        `(switch_ip, interface_name)`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist on the target ND node.
+        - If the fabric is in deployment-freeze mode.
+        - If the query API request fails.
+        """
+        managed_policy_types = {e.value for e in SubinterfaceManagedPolicyTypeEnum}
+        try:
+            self.validate_prerequisites()
+            all_subifs = []
+            for switch_ip, switch_id in self.fabric_context.switch_map.items():
+                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                if not isinstance(result, dict):
+                    continue
+                interfaces = result.get("interfaces", []) or []
+                subifs = [iface for iface in interfaces if iface.get("interfaceType") == "subInterface"]
+                managed = [
+                    iface for iface in subifs if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_policy_types
+                ]
+                for iface in managed:
+                    iface["switchIp"] = switch_ip
+                all_subifs.extend(managed)
+            return all_subifs
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/subinterface_unmanaged_interface.py
+++ b/plugins/module_utils/orchestrators/subinterface_unmanaged_interface.py
@@ -1,0 +1,276 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unmanaged L3 subinterface orchestrator for Nexus Dashboard.
+
+Implements CRUD for the unmanaged variant of L3 subinterfaces
+(`interfaceType: "subInterface"`, `mode: "unmanaged"`, `policyType: "monitorSubinterface"`).
+
+Mirrors `SubinterfaceManagedInterfaceOrchestrator` in structure; differences:
+- `model_class` is `SubinterfaceUnmanagedInterfaceModel`
+- `query_all` filters for `policyType in {monitorSubinterface}`
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+    EpManageInterfacesRemove,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceUnmanagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_unmanaged_interface import SubinterfaceUnmanagedInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class SubinterfaceUnmanagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[SubinterfaceUnmanagedInterfaceModel]):
+    """
+    # Summary
+
+    Orchestrator for unmanaged L3 subinterface CRUD on Nexus Dashboard. See
+    `SubinterfaceManagedInterfaceOrchestrator` for the architectural notes; this is its sibling for the
+    `monitorSubinterface` policy.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - On any failed API request or 207 multi-status with a non-success per-item entry.
+    """
+
+    model_class: ClassVar[type[NDBaseModel]] = SubinterfaceUnmanagedInterfaceModel
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = NDEndpointBaseModel  # unused; delete() uses bulk remove
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesRemove
+
+    # TODO(4.2.1) multi-status-207-status-field-inconsistent
+    # ND returns HTTP 207 Multi-Status on subinterface POST with per-item `status: "failed"` when the parent
+    # interface is not in routed mode (or other policy validation fails). Our RestSend response_handler treats 207 as
+    # success and returns the body without raising, so without this check the orchestrator would silently report
+    # "changed" when nothing was actually created. Remove this workaround once CiscoDevNet/ansible-nd#295 lands the
+    # 207-aware response handling at the RestSend layer.
+    @staticmethod
+    def _raise_on_multi_status_failures(response: ResponseType) -> None:
+        """
+        # Summary
+
+        Inspect a 207 Multi-Status body and raise if any item carries `status: "failed"` or `status: "error"`. The
+        comparison is case-insensitive and whitespace-tolerant because ND is inconsistent about the casing of the
+        per-item `status` value across endpoints (see the `multi-status-207-status-field-inconsistent` vault note).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If `response["results"]` contains any item whose `status` is `"failed"` or `"error"` (any casing).
+        """
+        if not isinstance(response, dict):
+            return
+        results = response.get("results") or []
+        failed = [r for r in results if isinstance(r, dict) and str(r.get("status") or "").strip().lower() in ("failed", "error")]
+        if failed:
+            summary = "; ".join(f"{r.get('name')}: {r.get('message')}" for r in failed)
+            raise RuntimeError(f"ND rejected {len(failed)} interface(s): {summary}")
+
+    def create(self, model_instance: SubinterfaceUnmanagedInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create an unmanaged L3 subinterface. Resolves `switch_ip` from the model instance, injects `switchId`,
+        wraps the payload in an `interfaces` array, and queues a deploy for later bulk execution.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails.
+        - If the 207 response contains any per-item `status` of `failed` or `error`.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            request_body = {"interfaces": [payload]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+            self._raise_on_multi_status_failures(result)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: SubinterfaceUnmanagedInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update an unmanaged L3 subinterface. Resolves `switch_ip` from the model instance, injects `switchId` into the
+        payload. Queues a deploy for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: SubinterfaceUnmanagedInterfaceModel, **kwargs) -> None:
+        """
+        # Summary
+
+        Queue an unmanaged L3 subinterface for deferred bulk removal via `remove_pending` and bulk deploy via
+        `deploy_pending`. The remove deletes the subinterface from ND's config; the subsequent deploy pushes that
+        removal to the switch.
+
+        No API calls are made until `remove_pending` and `deploy_pending` are called after all mutations are complete.
+
+        ## Raises
+
+        None
+        """
+        switch_id = self._resolve_switch_id(model_instance.switch_ip)
+        self._queue_remove(model_instance.interface_name, switch_id)
+        self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def create_bulk(self, model_instances: list[SubinterfaceUnmanagedInterfaceModel], **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create multiple unmanaged L3 subinterfaces in bulk. Groups subinterfaces by switch and sends one POST per
+        switch with all subinterfaces in the `interfaces` array, reducing API calls from N to one-per-switch. Queues
+        deploys for all created subinterfaces for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create API request fails.
+        """
+        try:
+            groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+            for model_instance in model_instances:
+                switch_id = self._resolve_switch_id(model_instance.switch_ip)
+                payload = model_instance.to_payload()
+                payload["switchId"] = switch_id
+                groups[switch_id].append((model_instance.interface_name, payload))
+
+            results = []
+            for switch_id, items in groups.items():
+                api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
+                request_body = {"interfaces": [payload for interface_name, payload in items]}
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+                self._raise_on_multi_status_failures(result)
+                results.append(result)
+                for interface_name, payload in items:
+                    self._queue_deploy(interface_name, switch_id)
+            return results
+        except Exception as e:
+            raise RuntimeError(f"Bulk create failed: {e}") from e
+
+    def delete_bulk(self, model_instances: list[SubinterfaceUnmanagedInterfaceModel], **kwargs) -> None:
+        """
+        # Summary
+
+        Queue multiple unmanaged L3 subinterfaces for deferred bulk removal and deployment. No API calls are made
+        until `remove_pending` and `deploy_pending` are called after `manage_state` completes.
+
+        ## Raises
+
+        None
+        """
+        for model_instance in model_instances:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            self._queue_remove(model_instance.interface_name, switch_id)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def query_one(self, model_instance: SubinterfaceUnmanagedInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Query a single unmanaged L3 subinterface by name on a specific switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
+        subinterfaces with `interfaceType: "subInterface"` and `policyType` in the unmanaged set
+        (`monitorSubinterface`). The managed variant (`subinterface`) is managed by a separate orchestrator and is
+        excluded here.
+
+        Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning
+        any data.
+
+        Each returned interface dict is enriched with a `switchIp` field so that
+        `SubinterfaceUnmanagedInterfaceModel` can be constructed with the composite identifier
+        `(switch_ip, interface_name)`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist on the target ND node.
+        - If the fabric is in deployment-freeze mode.
+        - If the query API request fails.
+        """
+        unmanaged_policy_types = {e.value for e in SubinterfaceUnmanagedPolicyTypeEnum}
+        try:
+            self.validate_prerequisites()
+            all_subifs = []
+            for switch_ip, switch_id in self.fabric_context.switch_map.items():
+                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                if not isinstance(result, dict):
+                    continue
+                interfaces = result.get("interfaces", []) or []
+                subifs = [iface for iface in interfaces if iface.get("interfaceType") == "subInterface"]
+                unmanaged = [
+                    iface for iface in subifs if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in unmanaged_policy_types
+                ]
+                for iface in unmanaged:
+                    iface["switchIp"] = switch_ip
+                all_subifs.extend(unmanaged)
+            return all_subifs
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/svi_interface.py
+++ b/plugins/module_utils/orchestrators/svi_interface.py
@@ -1,0 +1,261 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+SVI (switched virtual interface) orchestrator for Nexus Dashboard.
+
+This module provides `SviInterfaceOrchestrator`, which implements CRUD operations for SVI interfaces via the ND
+Manage Interfaces API. Supports configuring SVIs across multiple switches in a single task.
+
+Each mutation operation (create, update, delete) is followed by a deploy call to persist changes to the switch.
+Deploy and remove operations are batched per-switch and executed in bulk after all mutations are complete.
+
+Unlike physical ethernet interfaces, SVIs support both `interfaceActions/remove` (bulk delete) and
+`interfaceActions/deploy` (bulk deploy), so `state: deleted` queues both and lets the standard
+`remove_pending` + `deploy_pending` flow handle the work.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+    EpManageInterfacesRemove,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SviPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.svi_interface import SviInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class SviInterfaceOrchestrator(NDBaseInterfaceOrchestrator[SviInterfaceModel]):
+    """
+    # Summary
+
+    Orchestrator for SVI interface CRUD operations on Nexus Dashboard.
+
+    Supports configuring SVIs across multiple switches in a single task. Each config item includes a `switch_ip`
+    that is resolved to a `switchId` via `FabricContext`.
+
+    Mutation methods (`create`, `update`) queue deploys instead of executing them immediately. Call `deploy_pending`
+    after all mutations are complete to deploy all changes in a single API call. `delete` queues interfaces for bulk
+    removal via `remove_pending`.
+
+    For `state: overridden`, `query_all` queries ALL switches in the fabric to enable fabric-wide convergence.
+
+    Uses `FabricContext` for pre-flight validation and switch resolution.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
+    - Via `create` if the create API request fails.
+    - Via `update` if the update API request fails.
+    - Via `remove_pending` if the bulk remove API request fails.
+    - Via `deploy_pending` if the bulk deploy API request fails.
+    - Via `query_one` if the query API request fails.
+    - Via `query_all` if the query API request fails.
+    """
+
+    model_class: ClassVar[type[NDBaseModel]] = SviInterfaceModel
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = NDEndpointBaseModel  # unused; delete() uses bulk remove
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesRemove
+
+    def create(self, model_instance: SviInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create an SVI interface. Resolves `switch_ip` from the model instance, injects `switchId`, and wraps the payload
+        in an `interfaces` array. Queues a deploy for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            request_body = {"interfaces": [payload]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: SviInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update an SVI interface. Resolves `switch_ip` from the model instance, injects `switchId` into the payload.
+        Queues a deploy for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: SviInterfaceModel, **kwargs) -> None:
+        """
+        # Summary
+
+        Queue an SVI interface for deferred bulk removal via `remove_pending` and bulk deploy via `deploy_pending`.
+        The remove deletes the interface from ND's config; the subsequent deploy pushes that removal to the switch.
+
+        No API calls are made until `remove_pending` and `deploy_pending` are called after all mutations are complete.
+
+        ## Raises
+
+        None
+        """
+        switch_id = self._resolve_switch_id(model_instance.switch_ip)
+        self._queue_remove(model_instance.interface_name, switch_id)
+        self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def create_bulk(self, model_instances: list[SviInterfaceModel], **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create multiple SVI interfaces in bulk. Groups interfaces by switch and sends one POST per switch with all
+        interfaces in the `interfaces` array, reducing API calls from N to one-per-switch. Queues deploys for all
+        created interfaces for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create API request fails.
+        """
+        try:
+            groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+            for model_instance in model_instances:
+                switch_id = self._resolve_switch_id(model_instance.switch_ip)
+                payload = model_instance.to_payload()
+                payload["switchId"] = switch_id
+                groups[switch_id].append((model_instance.interface_name, payload))
+
+            results = []
+            for switch_id, items in groups.items():
+                # Guarded at runtime by @requires_bulk_support("supports_bulk_create")
+                api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
+                request_body = {"interfaces": [payload for interface_name, payload in items]}
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+                results.append(result)
+                for interface_name, payload in items:
+                    self._queue_deploy(interface_name, switch_id)
+            return results
+        except Exception as e:
+            raise RuntimeError(f"Bulk create failed: {e}") from e
+
+    def delete_bulk(self, model_instances: list[SviInterfaceModel], **kwargs) -> None:
+        """
+        # Summary
+
+        Queue multiple SVI interfaces for deferred bulk removal and deployment. Each interface is queued for removal via
+        `remove_pending` and deployment via `deploy_pending`. No API calls are made until those methods are called after
+        `manage_state` completes.
+
+        ## Raises
+
+        None
+        """
+        for model_instance in model_instances:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            self._queue_remove(model_instance.interface_name, switch_id)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def query_one(self, model_instance: SviInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Query a single SVI interface by name on a specific switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for SVI
+        interfaces with `policyType: "svi"`. Other policy types (e.g. underlay-managed VLAN interfaces with different
+        policy types) are excluded so this orchestrator does not interfere with fabric-managed SVIs.
+
+        Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
+
+        Each returned interface dict is enriched with a `switch_ip` field so that `SviInterfaceModel` can be constructed
+        with the composite identifier `(switch_ip, interface_name)`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist on the target ND node.
+        - If the fabric is in deployment-freeze mode.
+        - If the query API request fails.
+        """
+        managed_policy_types = {e.value for e in SviPolicyTypeEnum}
+        try:
+            self.validate_prerequisites()
+            all_svis = []
+            for switch_ip, switch_id in self.fabric_context.switch_map.items():
+                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                if not result:
+                    continue
+                interfaces = result.get("interfaces", []) or []
+                svis = [iface for iface in interfaces if iface.get("interfaceType") == "svi"]
+                managed = [
+                    iface for iface in svis if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_policy_types
+                ]
+                for iface in managed:
+                    iface["switchIp"] = switch_ip
+                all_svis.extend(managed)
+            return all_svis
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/svi_interface.py
+++ b/plugins/module_utils/orchestrators/svi_interface.py
@@ -246,7 +246,7 @@ class SviInterfaceOrchestrator(NDBaseInterfaceOrchestrator[SviInterfaceModel]):
             for switch_ip, switch_id in self.fabric_context.switch_map.items():
                 api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
                 result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                if not result:
+                if not isinstance(result, dict):
                     continue
                 interfaces = result.get("interfaces", []) or []
                 svis = [iface for iface in interfaces if iface.get("interfaceType") == "svi"]

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -1,0 +1,471 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_interface_subinterface_managed
+version_added: "2.0.0"
+short_description: Manage L3 (managed) subinterfaces on Cisco Nexus Dashboard
+description:
+- Manage L3 subinterfaces (managed variant) on Cisco Nexus Dashboard.
+- A subinterface is created on an Ethernet or Port-channel parent interface; the parent type is encoded in the
+  O(config[].interface_name) value (e.g. C(Ethernet1/3.2) or C(Port-channel10.5)).
+- This module manages the managed variant only (C(policyType) C(subinterface)).
+  The unmanaged variant (C(policyType) C(monitorSubinterface)) is handled by C(nd_interface_subinterface_unmanaged).
+- It supports creating, updating, and deleting subinterface configurations on switches within a fabric.
+- Each config item targets a single subinterface identified by O(config[].interface_name).
+- Configure multiple subinterfaces in one task by listing multiple config items.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target switches.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of L3 subinterfaces to configure.
+    - Each item specifies the target switch, the subinterface name, and the policy configuration.
+    - Multiple subinterfaces and multiple switches can be configured in a single task by listing additional items.
+    - The structure mirrors the ND Manage Interfaces API payload.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of the switch on which to manage the subinterface.
+        - This is resolved to the switch serial number (switchId) internally.
+        type: str
+        required: true
+      interface_name:
+        description:
+        - The full subinterface name, including the dot-separated sub-id (e.g. C(Ethernet1/3.2), C(Port-channel10.5)).
+        - The parent kind is inferred from the prefix; only Ethernet and Port-channel parents are supported.
+        type: str
+        required: true
+      config_data:
+        description:
+        - The configuration data for this subinterface, following the ND API structure.
+        type: dict
+        suboptions:
+          network_os:
+            description:
+            - Network OS specific configuration.
+            type: dict
+            suboptions:
+              policy:
+                description:
+                - The policy configuration for the subinterface.
+                type: dict
+                suboptions:
+                  admin_state:
+                    description:
+                    - The administrative state of the subinterface.
+                    - Defaults to V(true) when unset during creation.
+                    type: bool
+                  description:
+                    description:
+                    - Subinterface description.
+                    - Maximum 254 characters.
+                    type: str
+                  extra_config:
+                    description:
+                    - Additional CLI configuration commands to apply to the subinterface.
+                    type: str
+                  mtu:
+                    description:
+                    - Subinterface MTU.
+                    - Valid range is 576-9216.
+                    type: int
+                  vlan_id:
+                    description:
+                    - 802.1Q VLAN tag for the subinterface.
+                    - Valid range is 2-4094.
+                    type: int
+                  vrf_interface:
+                    description:
+                    - VRF the subinterface is bound to.
+                    - Use V(default) for the default VRF.
+                    type: str
+                  ip:
+                    description:
+                    - IPv4 address of the subinterface.
+                    type: str
+                  prefix:
+                    description:
+                    - IPv4 netmask length used with O(config[].config_data.network_os.policy.ip).
+                    - Valid range is 8-31.
+                    type: int
+                  ipv6:
+                    description:
+                    - IPv6 address of the subinterface.
+                    type: str
+                  ipv6_prefix:
+                    description:
+                    - IPv6 netmask length used with O(config[].config_data.network_os.policy.ipv6).
+                    - Valid range is 1-127.
+                    type: int
+                  routing_tag:
+                    description:
+                    - Routing tag associated with the subinterface IP address.
+                    type: str
+                  ip_redirects:
+                    description:
+                    - Disable both IPv4/IPv6 redirects on the subinterface.
+                    type: bool
+                  pim_sparse:
+                    description:
+                    - Enable PIM sparse-mode on the subinterface.
+                    type: bool
+                  pim_dr_priority:
+                    description:
+                    - Priority for PIM DR election on the subinterface.
+                    - Valid range is 1-4294967295.
+                    type: int
+                  netflow:
+                    description:
+                    - Whether netflow is enabled on the subinterface.
+                    type: bool
+                  netflow_monitor:
+                    description:
+                    - Layer 3 Netflow monitor name.
+                    - Required when O(config[].config_data.network_os.policy.netflow=true).
+                    type: str
+                  netflow_sampler:
+                    description:
+                    - Netflow sampler name (applicable to N7K only).
+                    type: str
+  config_actions:
+    description:
+    - Controls deploy behavior after interface mutations are complete.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether to deploy interface changes after mutations are complete.
+        - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
+          execution via the C(interfaceActions/deploy) API. Only the subinterfaces modified by this task are deployed.
+        - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        type: bool
+        default: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the resources specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      The resources on ND will be modified to exactly match the configuration.
+      Any managed subinterface managed by this module that exists on ND but is not present in the configuration will be deleted.
+      Use with extra caution.
+    - Use O(state=deleted) to remove the specified subinterfaces via the C(interfaceActions/remove) API followed by a deploy.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This module manages NX-OS L3 subinterfaces only (interface_type C(subInterface), mode C(managed),
+  network_os_type C(nx-os), policy_type C(subinterface)). These values are hardcoded by the module and are not user-configurable.
+- The unmanaged variant (C(policyType) C(monitorSubinterface)) is handled by C(nd_interface_subinterface_unmanaged).
+- The parent interface must be in routed (L3) mode before a subinterface can be created on it.
+  ND rejects subinterface POST against L2 access/trunk parents with the message
+  "Sub-interface can be created only on routed physical or port-channel interfaces (discovered mode is not routed)".
+  In practice this blocks subinterfaces on typical vPC port-channels and peer-link port-channels, which are L2.
+  Change the parent's policy to a routed type (e.g. routedHost for Ethernet, l3PortChannel for Port-channel) before
+  using this module; the module does not auto-normalize the parent.
+"""
+
+EXAMPLES = r"""
+- name: Create a managed L3 subinterface on an Ethernet parent
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: "Tenant subinterface vlan 2"
+              vlan_id: 2
+              vrf_interface: VRF1
+              ip: 192.168.50.50
+              prefix: 24
+              ipv6: "2001:192:168:50::50"
+              ipv6_prefix: 64
+              routing_tag: "12345"
+              mtu: 9216
+              ip_redirects: true
+              pim_sparse: true
+              pim_dr_priority: 1
+              netflow: false
+    state: merged
+
+- name: Create multiple subinterfaces on different parents in one task
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.10
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 10
+              ip: 10.10.10.1
+              prefix: 24
+      - switch_ip: 192.168.1.1
+        interface_name: Port-channel10.20
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 20
+              ip: 10.10.20.1
+              prefix: 24
+    state: merged
+
+- name: Replace the configuration of a specific subinterface
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 2
+              ip: 10.20.30.40
+              prefix: 24
+              description: Reprovisioned subinterface Ethernet1/3.2
+    state: replaced
+
+# state=overridden is fabric-wide: every managed subinterface in the fabric that is managed by this module and is
+# NOT listed below is deleted. An empty config list deletes ALL such subinterfaces in the fabric. Use with caution.
+- name: Enforce subinterfaces fabric-wide, deleting all others managed by this module
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 2
+              ip: 10.10.10.1
+              prefix: 24
+              description: Subinterface to keep; all other managed subinterfaces deleted
+    state: overridden
+
+- name: Delete a subinterface
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+    state: deleted
+
+- name: Stage changes without deploying
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 2
+              ip: 192.168.50.50
+              prefix: 24
+    config_actions:
+      deploy: false
+    state: merged
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching interface configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.2
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          vlan_id: 2
+          vrf_interface: VRF1
+          ip: 192.168.50.50
+          prefix: 24
+after:
+  description:
+  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.2
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          vlan_id: 2
+          vrf_interface: VRF1
+          ip: 192.168.50.60
+          prefix: 24
+diff:
+  description: The per-interface difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.2
+    config_data:
+      network_os:
+        policy:
+          ip: 192.168.50.60
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.2
+    config_data:
+      network_os:
+        policy:
+          ip: 192.168.50.60
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing subinterface configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
+"""
+
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import SubinterfaceManagedInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_managed_interface import SubinterfaceManagedInterfaceOrchestrator
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_interface_subinterface_managed` Ansible module. Initializes the `NDStateMachine` with
+    `SubinterfaceManagedInterfaceOrchestrator` and executes the requested state operation.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(SubinterfaceManagedInterfaceModel.get_argument_spec())
+    argument_spec.update(
+        config_actions={
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_interface_subinterface_managed")
+    module_log.debug(
+        "config items=%d switches=%d",
+        len(module.params["config"]),
+        len({item.get("switch_ip") for item in module.params["config"]}),
+    )
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=SubinterfaceManagedInterfaceOrchestrator,
+        )
+        if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
+            raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        config_actions = module.params.get("config_actions") or {}
+        deploy = config_actions.get("deploy", True)
+        nd_state_machine.model_orchestrator.deploy = deploy
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            deploy,
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.remove_pending()
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_interface_subinterface_unmanaged.py
+++ b/plugins/modules/nd_interface_subinterface_unmanaged.py
@@ -1,0 +1,302 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_interface_subinterface_unmanaged
+version_added: "2.0.0"
+short_description: Manage L3 (unmanaged / monitor-mode) subinterfaces on Cisco Nexus Dashboard
+description:
+- Manage L3 subinterfaces (unmanaged variant) on Cisco Nexus Dashboard.
+- A subinterface is created on an Ethernet or Port-channel parent interface; the parent type is encoded in the
+  O(config[].interface_name) value (e.g. C(Ethernet1/3.20) or C(Port-channel10.20)).
+- This module manages the unmanaged variant only (C(policyType) C(monitorSubinterface)).
+  The managed variant (C(policyType) C(subinterface)) is handled by C(nd_interface_subinterface_managed).
+- The policy body for the unmanaged variant carries only the C(policyType) discriminator; no L3 configuration fields are exposed.
+- It supports creating, querying, and deleting subinterface configurations on switches within a fabric.
+- Each config item targets a single subinterface identified by O(config[].interface_name).
+- Configure multiple subinterfaces in one task by listing multiple config items.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target switches.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of L3 unmanaged (monitor-mode) subinterfaces to configure.
+    - Each item specifies the target switch and the subinterface name.
+    - Multiple subinterfaces and multiple switches can be configured in a single task by listing additional items.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of the switch on which to manage the subinterface.
+        - This is resolved to the switch serial number (switchId) internally.
+        type: str
+        required: true
+      interface_name:
+        description:
+        - The full subinterface name, including the dot-separated sub-id (e.g. C(Ethernet1/3.20), C(Port-channel10.20)).
+        - The parent kind is inferred from the prefix; only Ethernet and Port-channel parents are supported.
+        type: str
+        required: true
+  config_actions:
+    description:
+    - Controls deploy behavior after interface mutations are complete.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether to deploy interface changes after mutations are complete.
+        - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
+          execution via the C(interfaceActions/deploy) API. Only the subinterfaces modified by this task are deployed.
+        - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        type: bool
+        default: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new unmanaged subinterfaces and leave others unchanged.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the unmanaged subinterfaces specified in the configuration.
+      For unmanaged subinterfaces, replaced is effectively a no-op on existing subinterfaces because the policy body
+      carries only the C(policyType) discriminator with no user-configurable fields. It is still useful when the target
+      subinterface is missing, in which case it falls back to create.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth across the entire fabric.
+      Any unmanaged subinterface that exists on ND but is not present in the configuration will be deleted.
+      Use with extra caution.
+    - Use O(state=deleted) to remove the specified subinterfaces via the C(interfaceActions/remove) API followed by a deploy.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This module manages NX-OS L3 subinterfaces in unmanaged (monitor) mode (interface_type C(subInterface), mode C(unmanaged),
+  network_os_type C(nx-os), policy_type C(monitorSubinterface)). These values are hardcoded by the module and are not user-configurable.
+- The managed variant (C(policyType) C(subinterface)) is handled by C(nd_interface_subinterface_managed).
+- The parent interface must be in routed (L3) mode before a subinterface can be created on it.
+  ND rejects subinterface POST against L2 access/trunk parents with the message
+  "Sub-interface can be created only on routed physical or port-channel interfaces (discovered mode is not routed)".
+  In practice this blocks subinterfaces on typical vPC port-channels and peer-link port-channels, which are L2.
+  Change the parent's policy to a routed type (e.g. routedHost for Ethernet, l3PortChannel for Port-channel) before
+  using this module; the module does not auto-normalize the parent.
+"""
+
+EXAMPLES = r"""
+- name: Create an unmanaged L3 subinterface on an Ethernet parent
+  cisco.nd.nd_interface_subinterface_unmanaged:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.20
+    state: merged
+
+- name: Create multiple unmanaged subinterfaces on different parents in one task
+  cisco.nd.nd_interface_subinterface_unmanaged:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.20
+      - switch_ip: 192.168.1.1
+        interface_name: Port-channel10.20
+    state: merged
+
+# Note: For unmanaged subinterfaces, replaced is effectively a no-op on existing
+# subinterfaces - the policy body carries only policyType (no user-configurable fields).
+# replaced is still useful when the target subinterface is missing: it falls back to create.
+- name: Replace (or create if missing) an unmanaged subinterface
+  cisco.nd.nd_interface_subinterface_unmanaged:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.20
+    state: replaced
+
+- name: Override fabric-wide - delete any unmanaged subinterfaces not listed here
+  cisco.nd.nd_interface_subinterface_unmanaged:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.20
+    state: overridden
+
+- name: Delete an unmanaged subinterface
+  cisco.nd.nd_interface_subinterface_unmanaged:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.20
+    state: deleted
+
+- name: Stage an unmanaged subinterface without deploying
+  cisco.nd.nd_interface_subinterface_unmanaged:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Port-channel10.20
+    config_actions:
+      deploy: false
+    state: merged
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching interface configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample: []
+after:
+  description:
+  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.20
+diff:
+  description: The per-interface difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.20
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.20
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing unmanaged subinterface configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
+"""
+
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_unmanaged_interface import SubinterfaceUnmanagedInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_unmanaged_interface import SubinterfaceUnmanagedInterfaceOrchestrator
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_interface_subinterface_unmanaged` Ansible module. Initializes the `NDStateMachine` with
+    `SubinterfaceUnmanagedInterfaceOrchestrator` and executes the requested state operation.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(SubinterfaceUnmanagedInterfaceModel.get_argument_spec())
+    argument_spec.update(
+        config_actions={
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_interface_subinterface_unmanaged")
+    module_log.debug(
+        "config items=%d switches=%d",
+        len(module.params["config"]),
+        len({item.get("switch_ip") for item in module.params["config"]}),
+    )
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=SubinterfaceUnmanagedInterfaceOrchestrator,
+        )
+        if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
+            raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        config_actions = module.params.get("config_actions") or {}
+        deploy = config_actions.get("deploy", True)
+        nd_state_machine.model_orchestrator.deploy = deploy
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            deploy,
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.remove_pending()
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -1,0 +1,378 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_interface_svi
+version_added: "1.4.0"
+short_description: Manage SVI (switched virtual) interfaces on Cisco Nexus Dashboard
+description:
+- Manage SVI interfaces on Cisco Nexus Dashboard.
+- It supports creating, updating, querying, and deleting SVI interface configurations on switches within a fabric.
+- Multiple SVIs can share the same configuration via the O(config[].vlan_ids) list.
+- The interface name is derived from O(config[].vlan_ids) as C(vlan<id>) (e.g. V(333) -> C(vlan333)).
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target switches.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of SVI interface groups to configure.
+    - Each item specifies the target switch, a list of VLAN IDs, and a shared configuration.
+    - Multiple switches can be configured in a single task.
+    - The structure mirrors the ND Manage Interfaces API payload.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of the switch on which to manage the SVI interfaces.
+        - This is resolved to the switch serial number (switchId) internally.
+        type: str
+        required: true
+      vlan_ids:
+        description:
+        - The list of VLAN IDs for which to manage SVI interfaces.
+        - Each ID is expanded into a separate interface named C(vlan<id>).
+        type: list
+        elements: int
+        required: true
+      interface_type:
+        description:
+        - The type of the interface.
+        - Defaults to C(svi) for this module.
+        type: str
+        default: svi
+      config_data:
+        description:
+        - The configuration data shared by all SVIs in O(config[].vlan_ids), following the ND API structure.
+        type: dict
+        suboptions:
+          mode:
+            description:
+            - The interface operational mode.
+            - Defaults to C(managed) for SVIs. The ND API uses this as a discriminator
+              to select the SVI configuration schema.
+            type: str
+            default: managed
+          network_os:
+            description:
+            - Network OS specific configuration.
+            type: dict
+            suboptions:
+              network_os_type:
+                description:
+                - The network OS type of the switch.
+                type: str
+                default: nx-os
+              policy:
+                description:
+                - The policy configuration for the SVI.
+                type: dict
+                suboptions:
+                  policy_type:
+                    description:
+                    - The policy template type for the interface.
+                    type: str
+                    choices: [ svi ]
+                    default: svi
+                  admin_state:
+                    description:
+                    - The administrative state of the interface.
+                    - It defaults to C(true) when unset during creation.
+                    type: bool
+                  description:
+                    description:
+                    - The description of the interface.
+                    - Maximum 254 characters.
+                    type: str
+                  extra_config:
+                    description:
+                    - Additional CLI configuration commands to apply to the interface.
+                    type: str
+                  mtu:
+                    description:
+                    - The MTU setting for the interface.
+                    - Valid range is 576-9216.
+                    type: int
+                  ip:
+                    description:
+                    - The IPv4 address of the SVI.
+                    type: str
+                  prefix:
+                    description:
+                    - The IPv4 netmask length used with O(config[].config_data.network_os.policy.ip).
+                    - Valid range is 1-31.
+                    type: int
+                  ipv6:
+                    description:
+                    - The IPv6 address of the SVI.
+                    type: str
+                  v6prefix:
+                    description:
+                    - The IPv6 netmask length used with O(config[].config_data.network_os.policy.ipv6).
+                    - Valid range is 1-127.
+                    type: int
+                  ip_redirects:
+                    description:
+                    - Disable both IPv4/IPv6 redirects on the interface.
+                    type: bool
+                  pim_sparse:
+                    description:
+                    - Enable PIM sparse-mode on the interface.
+                    type: bool
+                  pim_dr_priority:
+                    description:
+                    - Priority for PIM DR election on the interface.
+                    - Valid range is 1-4294967295.
+                    type: int
+                  hsrp_group:
+                    description:
+                    - The HSRP group number for the interface.
+                    type: int
+                  hsrp_version:
+                    description:
+                    - The HSRP version.
+                    type: str
+                  preempt:
+                    description:
+                    - Enable HSRP preemption.
+                    type: bool
+                  advertise_subnet_in_underlay:
+                    description:
+                    - Advertise the SVI subnet into the underlay routing protocol.
+                    type: bool
+                  netflow:
+                    description:
+                    - Whether netflow is enabled on the interface.
+                    type: bool
+  deploy:
+    description:
+    - Whether to deploy interface changes after mutations are complete.
+    - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module execution
+      via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
+    - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+    - Setting O(deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+    type: bool
+    default: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the resources specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      The resources on ND will be modified to exactly match the configuration.
+      Any SVI managed by this module that exists on ND but is not present in the configuration will be deleted. Use with extra caution.
+    - Use O(state=deleted) to remove the specified SVIs via the C(interfaceActions/remove) API followed by a deploy.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This module manages NX-OS SVI interfaces only.
+- Phase 1 of this module supports the SVI options that the ND GUI sends on create. OSPF, ISIS, BFD, and underlay
+  routing-protocol options are not yet exposed and will be added in a follow-up release.
+"""
+
+EXAMPLES = r"""
+- name: Create three SVI interfaces with the same configuration
+  cisco.nd.nd_interface_svi:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        vlan_ids:
+          - 333
+          - 334
+          - 335
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 10.99.99.1
+              prefix: 24
+              description: Tenant SVI
+    state: merged
+  register: result
+
+- name: Create SVIs across multiple switches
+  cisco.nd.nd_interface_svi:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 10.99.99.1
+              prefix: 24
+      - switch_ip: 192.168.1.2
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 10.99.99.2
+              prefix: 24
+    state: merged
+
+- name: Delete SVI interfaces
+  cisco.nd.nd_interface_svi:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        vlan_ids:
+          - 333
+          - 334
+    state: deleted
+
+- name: Stage SVI changes without deploying (for batching)
+  cisco.nd.nd_interface_svi:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 10.99.99.1
+              prefix: 24
+    deploy: false
+    state: merged
+
+"""
+
+RETURN = r"""
+"""
+
+import copy
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.svi_interface import SviInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.svi_interface import SviInterfaceOrchestrator
+
+
+def expand_config(config_list):
+    """
+    # Summary
+
+    Expand grouped config items (with `vlan_ids` list) into flat config items (with singular `interface_name`). Each
+    group produces one flat item per VLAN ID, all sharing the same `config_data` and `switch_ip`. The `interface_name`
+    is set to `vlan<id>` (lowercase, matching the ND API convention).
+
+    ## Raises
+
+    None
+    """
+    expanded = []
+    for group in config_list:
+        vlan_ids = group.get("vlan_ids", []) or []
+        for vlan_id in vlan_ids:
+            item = copy.deepcopy(group)
+            item.pop("vlan_ids", None)
+            item["interface_name"] = f"vlan{vlan_id}"
+            expanded.append(item)
+    return expanded
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_interface_svi` Ansible module. Expands grouped config items, initializes the
+    `NDStateMachine` with `SviInterfaceOrchestrator`, and executes the requested state operation.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(SviInterfaceModel.get_argument_spec())
+    argument_spec.update(
+        deploy=dict(type="bool", default=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_interface_svi")
+
+    # Expand grouped config (vlan_ids list) into flat config items (interface_name singular)
+    module.params["config"] = expand_config(module.params["config"])
+    module_log.debug(
+        "expand_config done items=%d switches=%d",
+        len(module.params["config"]),
+        len({item.get("switch_ip") for item in module.params["config"]}),
+    )
+
+    nd_state_machine = None
+
+    try:
+        # Initialize StateMachine
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=SviInterfaceOrchestrator,
+        )
+        # Narrow type from NDBaseOrchestrator to NDBaseInterfaceOrchestrator so that
+        # interface-specific attributes (deploy, remove_pending, deploy_pending) are
+        # visible to Pylance and validated at runtime.
+        if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
+            raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        nd_state_machine.model_orchestrator.deploy = module.params["deploy"]
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            module.params["deploy"],
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        # Execute all queued bulk operations
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.remove_pending()
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -126,7 +126,8 @@ options:
                     description:
                     - Enable HSRP on the interface.
                     - When V(true), the other C(hsrp_*) and C(preempt)/C(mac) fields take effect.
-                    - No HSRP sub-options are strictly required; the controller applies defaults for any left unset (e.g. C(hsrp_group) and C(hsrp_version) default to C(1)).
+                    - No HSRP sub-options are strictly required; the controller applies defaults for any
+                      left unset (e.g. C(hsrp_group) and C(hsrp_version) default to C(1)).
                     type: bool
                   hsrp_vip:
                     description:
@@ -243,7 +244,8 @@ extends_documentation_fragment:
 - cisco.nd.check_mode
 notes:
 - This module is only supported on Nexus Dashboard.
-- This module manages NX-OS SVI interfaces only (interface_type C(svi), mode C(managed), network_os_type C(nx-os), policy_type C(svi)). These values are hardcoded by the module and are not user-configurable.
+- This module manages NX-OS SVI interfaces only (interface_type C(svi), mode C(managed), network_os_type C(nx-os), policy_type C(svi)).
+  These values are hardcoded by the module and are not user-configurable.
 - Other SVI policy types (e.g. policyType C(vpcBackupSvi) for fabric/underlay SVIs with OSPF, ISIS, BFD, and
   replication-mode options) are not yet exposed and will be added as separate variants in a follow-up release.
 """

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -418,7 +418,6 @@ EXAMPLES = r"""
               dhcp_server_address2: 10.10.10.11
               vrf_dhcp2: shared_services
     state: merged
-
 """
 
 RETURN = r"""

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -350,6 +350,27 @@ EXAMPLES = r"""
               mac: "0000.0c07.ac05"
     state: merged
 
+- name: Create an SVI with HSRP configured via extra_config (raw CLI)
+  cisco.nd.nd_interface_svi:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        vlan_ids:
+          - 10
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 192.0.2.2
+              prefix: 24
+              extra_config: |
+                hsrp 1
+                  preempt
+                  priority 110
+                  authentication md5 key-chain hsrp-keys
+                  track 1 decrement 20
+    state: merged
+
 - name: Create an SVI with DHCP relay servers
   cisco.nd.nd_interface_svi:
     fabric_name: my_fabric

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -125,6 +125,7 @@ options:
                     description:
                     - Enable HSRP on the interface.
                     - When V(true), the other C(hsrp_*) and C(preempt)/C(mac) fields take effect.
+                    - No HSRP sub-options are strictly required; the controller applies defaults for any left unset (e.g. C(hsrp_group) and C(hsrp_version) default to C(1)).
                     type: bool
                   hsrp_vip:
                     description:
@@ -138,6 +139,7 @@ options:
                     description:
                     - HSRP group number.
                     - Valid range is 0-4095.
+                    - The controller applies a default of C(1) when unset.
                     type: int
                   hsrp_groupv6:
                     description:
@@ -148,6 +150,7 @@ options:
                   hsrp_version:
                     description:
                     - HSRP protocol version.
+                    - The controller applies a default of C(1) when unset.
                     type: int
                     choices: [1, 2]
                   hsrp_priority:

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -14,8 +14,8 @@ short_description: Manage SVI (switched virtual) interfaces on Cisco Nexus Dashb
 description:
 - Manage SVI interfaces on Cisco Nexus Dashboard.
 - It supports creating, updating, querying, and deleting SVI interface configurations on switches within a fabric.
-- Multiple SVIs can share the same configuration via the O(config[].vlan_ids) list.
-- The interface name is derived from O(config[].vlan_ids) as C(vlan<id>) (e.g. V(333) -> C(vlan333)).
+- Each config item targets a single SVI identified by O(config[].interface_name) (e.g. C(vlan333)).
+- Configure multiple SVIs in one task by listing multiple config items.
 author:
 - Allen Robel (@allenrobel)
 options:
@@ -26,9 +26,9 @@ options:
     required: true
   config:
     description:
-    - The list of SVI interface groups to configure.
-    - Each item specifies the target switch, a list of VLAN IDs, and a shared configuration.
-    - Multiple switches can be configured in a single task.
+    - The list of SVI interfaces to configure.
+    - Each item specifies the target switch, the interface name, and the policy configuration.
+    - Multiple SVIs and multiple switches can be configured in a single task by listing additional items.
     - The structure mirrors the ND Manage Interfaces API payload.
     type: list
     elements: dict
@@ -36,16 +36,15 @@ options:
     suboptions:
       switch_ip:
         description:
-        - The management IP address of the switch on which to manage the SVI interfaces.
+        - The management IP address of the switch on which to manage the SVI interface.
         - This is resolved to the switch serial number (switchId) internally.
         type: str
         required: true
-      vlan_ids:
+      interface_name:
         description:
-        - The list of VLAN IDs for which to manage SVI interfaces.
-        - Each ID is expanded into a separate interface named C(vlan<id>).
-        type: list
-        elements: int
+        - The name of the SVI interface, in the form C(vlan<id>) (e.g. C(vlan333)).
+        - Each SVI is L3 and must have its own item with its own L3 settings (IP, VRF, HSRP, ...).
+        type: str
         required: true
       interface_type:
         description:
@@ -55,7 +54,7 @@ options:
         default: svi
       config_data:
         description:
-        - The configuration data shared by all SVIs in O(config[].vlan_ids), following the ND API structure.
+        - The configuration data for this SVI, following the ND API structure.
         type: dict
         suboptions:
           mode:
@@ -258,22 +257,37 @@ notes:
 """
 
 EXAMPLES = r"""
-- name: Create three SVI interfaces with the same configuration
+- name: Create three SVI interfaces, each with its own L3 settings
   cisco.nd.nd_interface_svi:
     fabric_name: my_fabric
     config:
       - switch_ip: 192.168.1.1
-        vlan_ids:
-          - 333
-          - 334
-          - 335
+        interface_name: vlan333
         config_data:
           network_os:
             policy:
               admin_state: true
               ip: 10.99.99.1
               prefix: 24
-              description: Tenant SVI
+              description: Tenant SVI 333
+      - switch_ip: 192.168.1.1
+        interface_name: vlan334
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 10.99.100.1
+              prefix: 24
+              description: Tenant SVI 334
+      - switch_ip: 192.168.1.1
+        interface_name: vlan335
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 10.99.101.1
+              prefix: 24
+              description: Tenant SVI 335
     state: merged
   register: result
 
@@ -282,8 +296,7 @@ EXAMPLES = r"""
     fabric_name: my_fabric
     config:
       - switch_ip: 192.168.1.1
-        vlan_ids:
-          - 333
+        interface_name: vlan333
         config_data:
           network_os:
             policy:
@@ -291,8 +304,7 @@ EXAMPLES = r"""
               ip: 10.99.99.1
               prefix: 24
       - switch_ip: 192.168.1.2
-        vlan_ids:
-          - 333
+        interface_name: vlan333
         config_data:
           network_os:
             policy:
@@ -306,9 +318,9 @@ EXAMPLES = r"""
     fabric_name: my_fabric
     config:
       - switch_ip: 192.168.1.1
-        vlan_ids:
-          - 333
-          - 334
+        interface_name: vlan333
+      - switch_ip: 192.168.1.1
+        interface_name: vlan334
     state: deleted
 
 - name: Stage SVI changes without deploying (for batching)
@@ -316,8 +328,7 @@ EXAMPLES = r"""
     fabric_name: my_fabric
     config:
       - switch_ip: 192.168.1.1
-        vlan_ids:
-          - 333
+        interface_name: vlan333
         config_data:
           network_os:
             policy:
@@ -332,8 +343,7 @@ EXAMPLES = r"""
     fabric_name: my_fabric
     config:
       - switch_ip: 192.168.1.1
-        vlan_ids:
-          - 500
+        interface_name: vlan500
         config_data:
           network_os:
             policy:
@@ -355,8 +365,7 @@ EXAMPLES = r"""
     fabric_name: my_fabric
     config:
       - switch_ip: 192.168.1.1
-        vlan_ids:
-          - 10
+        interface_name: vlan10
         config_data:
           network_os:
             policy:
@@ -376,8 +385,7 @@ EXAMPLES = r"""
     fabric_name: my_fabric
     config:
       - switch_ip: 192.168.1.1
-        vlan_ids:
-          - 600
+        interface_name: vlan600
         config_data:
           network_os:
             policy:
@@ -396,7 +404,6 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-import copy
 import logging
 import traceback
 
@@ -411,35 +418,12 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interf
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.svi_interface import SviInterfaceOrchestrator
 
 
-def expand_config(config_list):
-    """
-    # Summary
-
-    Expand grouped config items (with `vlan_ids` list) into flat config items (with singular `interface_name`). Each
-    group produces one flat item per VLAN ID, all sharing the same `config_data` and `switch_ip`. The `interface_name`
-    is set to `vlan<id>` (lowercase, matching the ND API convention).
-
-    ## Raises
-
-    None
-    """
-    expanded = []
-    for group in config_list:
-        vlan_ids = group.get("vlan_ids", []) or []
-        for vlan_id in vlan_ids:
-            item = copy.deepcopy(group)
-            item.pop("vlan_ids", None)
-            item["interface_name"] = f"vlan{vlan_id}"
-            expanded.append(item)
-    return expanded
-
-
 def main():
     """
     # Summary
 
-    Entry point for the `nd_interface_svi` Ansible module. Expands grouped config items, initializes the
-    `NDStateMachine` with `SviInterfaceOrchestrator`, and executes the requested state operation.
+    Entry point for the `nd_interface_svi` Ansible module. Initializes the `NDStateMachine` with
+    `SviInterfaceOrchestrator` and executes the requested state operation.
 
     ## Raises
 
@@ -458,11 +442,8 @@ def main():
     require_pydantic(module)
     setup_logging(module)
     module_log = logging.getLogger("nd.nd_interface_svi")
-
-    # Expand grouped config (vlan_ids list) into flat config items (interface_name singular)
-    module.params["config"] = expand_config(module.params["config"])
     module_log.debug(
-        "expand_config done items=%d switches=%d",
+        "config items=%d switches=%d",
         len(module.params["config"]),
         len({item.get("switch_ip") for item in module.params["config"]}),
     )

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -43,6 +43,7 @@ options:
       interface_name:
         description:
         - The name of the SVI interface, in the form C(vlan<id>) (e.g. C(vlan333)).
+        - A bare VLAN ID (e.g. C(333)) or a mixed-case prefix (e.g. C(Vlan333), C(VLAN333)) is also accepted and normalized to the C(vlan<id>) form.
         - Each SVI is L3 and must have its own item with its own L3 settings (IP, VRF, HSRP, ...).
         type: str
         required: true

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -9,7 +9,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_interface_svi
-version_added: "1.4.0"
+version_added: "2.0.0"
 short_description: Manage SVI (switched virtual) interfaces on Cisco Nexus Dashboard
 description:
 - Manage SVI interfaces on Cisco Nexus Dashboard.

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -80,12 +80,6 @@ options:
                 - The policy configuration for the SVI.
                 type: dict
                 suboptions:
-                  policy_type:
-                    description:
-                    - The policy template type for the interface.
-                    type: str
-                    choices: [ svi ]
-                    default: svi
                   admin_state:
                     description:
                     - The administrative state of the interface.

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -46,34 +46,16 @@ options:
         - Each SVI is L3 and must have its own item with its own L3 settings (IP, VRF, HSRP, ...).
         type: str
         required: true
-      interface_type:
-        description:
-        - The type of the interface.
-        - Defaults to C(svi) for this module.
-        type: str
-        default: svi
       config_data:
         description:
         - The configuration data for this SVI, following the ND API structure.
         type: dict
         suboptions:
-          mode:
-            description:
-            - The interface operational mode.
-            - Defaults to C(managed) for SVIs. The ND API uses this as a discriminator
-              to select the SVI configuration schema.
-            type: str
-            default: managed
           network_os:
             description:
             - Network OS specific configuration.
             type: dict
             suboptions:
-              network_os_type:
-                description:
-                - The network OS type of the switch.
-                type: str
-                default: nx-os
               policy:
                 description:
                 - The policy configuration for the SVI.
@@ -251,8 +233,8 @@ extends_documentation_fragment:
 - cisco.nd.check_mode
 notes:
 - This module is only supported on Nexus Dashboard.
-- This module manages NX-OS SVI interfaces with C(policyType: svi) only.
-- Other SVI policy types (e.g. C(policyType: vpcBackupSvi) for fabric/underlay SVIs with OSPF, ISIS, BFD, and
+- This module manages NX-OS SVI interfaces only (interface_type C(svi), mode C(managed), network_os_type C(nx-os), policy_type C(svi)). These values are hardcoded by the module and are not user-configurable.
+- Other SVI policy types (e.g. policyType C(vpcBackupSvi) for fabric/underlay SVIs with OSPF, ISIS, BFD, and
   replication-mode options) are not yet exposed and will be added as separate variants in a follow-up release.
 """
 

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -13,7 +13,7 @@ version_added: "2.0.0"
 short_description: Manage SVI (switched virtual) interfaces on Cisco Nexus Dashboard
 description:
 - Manage SVI interfaces on Cisco Nexus Dashboard.
-- It supports creating, updating, querying, and deleting SVI interface configurations on switches within a fabric.
+- It supports creating, updating, and deleting SVI interface configurations on switches within a fabric.
 - Each config item targets a single SVI identified by O(config[].interface_name) (e.g. C(vlan333)).
 - Configure multiple SVIs in one task by listing multiple config items.
 author:

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -103,7 +103,7 @@ options:
                   mtu:
                     description:
                     - The MTU setting for the interface.
-                    - Valid range is 576-9216.
+                    - Valid range is 68-9216.
                     type: int
                   ip:
                     description:
@@ -118,7 +118,7 @@ options:
                     description:
                     - The IPv6 address of the SVI.
                     type: str
-                  v6prefix:
+                  prefixv6:
                     description:
                     - The IPv6 netmask length used with O(config[].config_data.network_os.policy.ipv6).
                     - Valid range is 1-127.
@@ -127,6 +127,15 @@ options:
                     description:
                     - Disable both IPv4/IPv6 redirects on the interface.
                     type: bool
+                  vrf_interface:
+                    description:
+                    - The VRF the SVI is bound to.
+                    - Use V(default) for the default VRF.
+                    type: str
+                  routing_tag:
+                    description:
+                    - Routing tag associated with the interface IP address.
+                    type: str
                   pim_sparse:
                     description:
                     - Enable PIM sparse-mode on the interface.
@@ -136,18 +145,75 @@ options:
                     - Priority for PIM DR election on the interface.
                     - Valid range is 1-4294967295.
                     type: int
+                  hsrp:
+                    description:
+                    - Enable HSRP on the interface.
+                    - When V(true), the other C(hsrp_*) and C(preempt)/C(mac) fields take effect.
+                    type: bool
+                  hsrp_vip:
+                    description:
+                    - HSRP IPv4 virtual IP address; must match on active/standby devices.
+                    type: str
+                  hsrp_vipv6:
+                    description:
+                    - HSRP IPv6 virtual IP address; must match on active/standby devices.
+                    type: str
                   hsrp_group:
                     description:
-                    - The HSRP group number for the interface.
+                    - HSRP group number.
+                    - Valid range is 0-4095.
+                    type: int
+                  hsrp_groupv6:
+                    description:
+                    - HSRP IPv6 group number.
+                    - If unset, the IPv4 group number is reused for IPv6.
+                    - Valid range is 0-4095.
                     type: int
                   hsrp_version:
                     description:
-                    - The HSRP version.
-                    type: str
+                    - HSRP protocol version.
+                    type: int
+                    choices: [1, 2]
+                  hsrp_priority:
+                    description:
+                    - HSRP priority value used for active/standby election.
+                    - Valid range is 0-255.
+                    type: int
                   preempt:
                     description:
-                    - Enable HSRP preemption.
+                    - Enable HSRP preemption (overthrow lower-priority active routers).
                     type: bool
+                  mac:
+                    description:
+                    - HSRP virtual MAC address override.
+                    type: str
+                  dhcp_server_address1:
+                    description:
+                    - Primary DHCP relay server IP address.
+                    type: str
+                  dhcp_server_address2:
+                    description:
+                    - Secondary DHCP relay server IP address.
+                    type: str
+                  dhcp_server_address3:
+                    description:
+                    - Tertiary DHCP relay server IP address.
+                    type: str
+                  vrf_dhcp1:
+                    description:
+                    - VRF used to reach DHCP server 1.
+                    - Use V(default) for the default VRF; leave blank to use the interface VRF.
+                    type: str
+                  vrf_dhcp2:
+                    description:
+                    - VRF used to reach DHCP server 2.
+                    - Use V(default) for the default VRF; leave blank to use the interface VRF.
+                    type: str
+                  vrf_dhcp3:
+                    description:
+                    - VRF used to reach DHCP server 3.
+                    - Use V(default) for the default VRF; leave blank to use the interface VRF.
+                    type: str
                   advertise_subnet_in_underlay:
                     description:
                     - Advertise the SVI subnet into the underlay routing protocol.
@@ -156,6 +222,15 @@ options:
                     description:
                     - Whether netflow is enabled on the interface.
                     type: bool
+                  netflow_monitor:
+                    description:
+                    - Layer 3 netflow monitor name.
+                    - Required when O(config[].config_data.network_os.policy.netflow=true).
+                    type: str
+                  netflow_sampler:
+                    description:
+                    - Netflow sampler name (applicable to N7K only).
+                    type: str
   deploy:
     description:
     - Whether to deploy interface changes after mutations are complete.
@@ -183,9 +258,9 @@ extends_documentation_fragment:
 - cisco.nd.check_mode
 notes:
 - This module is only supported on Nexus Dashboard.
-- This module manages NX-OS SVI interfaces only.
-- Phase 1 of this module supports the SVI options that the ND GUI sends on create. OSPF, ISIS, BFD, and underlay
-  routing-protocol options are not yet exposed and will be added in a follow-up release.
+- This module manages NX-OS SVI interfaces with C(policyType: svi) only.
+- Other SVI policy types (e.g. C(policyType: vpcBackupSvi) for fabric/underlay SVIs with OSPF, ISIS, BFD, and
+  replication-mode options) are not yet exposed and will be added as separate variants in a follow-up release.
 """
 
 EXAMPLES = r"""
@@ -256,6 +331,49 @@ EXAMPLES = r"""
               ip: 10.99.99.1
               prefix: 24
     deploy: false
+    state: merged
+
+- name: Create an SVI with HSRP enabled
+  cisco.nd.nd_interface_svi:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        vlan_ids:
+          - 500
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vrf_interface: tenant_a
+              ip: 10.99.5.1
+              prefix: 24
+              hsrp: true
+              hsrp_group: 5
+              hsrp_version: 2
+              hsrp_vip: 10.99.5.254
+              hsrp_priority: 110
+              preempt: true
+              mac: "0000.0c07.ac05"
+    state: merged
+
+- name: Create an SVI with DHCP relay servers
+  cisco.nd.nd_interface_svi:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        vlan_ids:
+          - 600
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 10.99.6.1
+              prefix: 24
+              vrf_interface: tenant_b
+              dhcp_server_address1: 10.10.10.10
+              vrf_dhcp1: shared_services
+              dhcp_server_address2: 10.10.10.11
+              vrf_dhcp2: shared_services
     state: merged
 
 """

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -120,6 +120,7 @@ options:
                     description:
                     - Priority for PIM DR election on the interface.
                     - Valid range is 1-4294967295.
+                    - The controller applies a default of C(1) when unset.
                     type: int
                   hsrp:
                     description:

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -300,6 +300,38 @@ EXAMPLES = r"""
               prefix: 24
     state: merged
 
+- name: Replace the configuration of specific SVIs
+  cisco.nd.nd_interface_svi:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vlan333
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 10.99.99.10
+              prefix: 24
+              description: Reprovisioned tenant SVI 333
+    state: replaced
+
+# state=overridden is fabric-wide: every SVI in the fabric that is managed by this module and is NOT
+# listed below is deleted. An empty config list deletes ALL such SVIs in the fabric. Use with caution.
+- name: Enforce SVIs fabric-wide, deleting all others managed by this module
+  cisco.nd.nd_interface_svi:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vlan333
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 10.99.99.1
+              prefix: 24
+              description: SVI to keep; all other SVIs deleted
+    state: overridden
+
 - name: Delete SVI interfaces
   cisco.nd.nd_interface_svi:
     fabric_name: my_fabric

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -422,6 +422,84 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching interface configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vlan333
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          ip: 10.99.99.1
+          prefix: 24
+after:
+  description:
+  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vlan333
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          ip: 10.99.99.1
+          prefix: 25
+diff:
+  description: The per-interface difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vlan333
+    config_data:
+      network_os:
+        policy:
+          prefix: 25
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vlan333
+    config_data:
+      network_os:
+        policy:
+          prefix: 25
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing SVI interface configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
 """
 
 import logging

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -206,15 +206,20 @@ options:
                     description:
                     - Netflow sampler name (applicable to N7K only).
                     type: str
-  deploy:
+  config_actions:
     description:
-    - Whether to deploy interface changes after mutations are complete.
-    - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module execution
-      via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
-    - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
-    - Setting O(deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
-    type: bool
-    default: true
+    - Controls deploy behavior after interface mutations are complete.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether to deploy interface changes after mutations are complete.
+        - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
+          execution via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
+        - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        type: bool
+        default: true
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -317,7 +322,8 @@ EXAMPLES = r"""
               admin_state: true
               ip: 10.99.99.1
               prefix: 24
-    deploy: false
+    config_actions:
+      deploy: false
     state: merged
 
 - name: Create an SVI with HSRP enabled
@@ -414,7 +420,12 @@ def main():
     argument_spec = nd_argument_spec()
     argument_spec.update(SviInterfaceModel.get_argument_spec())
     argument_spec.update(
-        deploy=dict(type="bool", default=True),
+        config_actions={
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
     )
 
     module = AnsibleModule(
@@ -443,13 +454,15 @@ def main():
         # visible to Pylance and validated at runtime.
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
-        nd_state_machine.model_orchestrator.deploy = module.params["deploy"]
+        config_actions = module.params.get("config_actions") or {}
+        deploy = config_actions.get("deploy", True)
+        nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(
             "manage_state begin state=%s check_mode=%s deploy=%s",
             module.params.get("state"),
             module.check_mode,
-            module.params["deploy"],
+            deploy,
         )
         nd_state_machine.manage_state()
         module_log.debug("manage_state end")

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/deleted.yaml
@@ -1,0 +1,62 @@
+---
+# Deleted state tests for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# At this point Eth.2 and PC.5 exist (from overridden reduce). Delete actually
+# removes the subinterfaces from ND via interfaceActions/remove + deploy.
+
+- name: "DELETED: Delete Eth.2 (check mode)"
+  cisco.nd.nd_interface_subinterface_managed: &delete_eth_2
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: "{{ ethernet_parent }}.2"
+    state: deleted
+  check_mode: true
+  register: cm_deleted_eth_2
+
+- name: "DELETED: Delete Eth.2 (normal mode)"
+  cisco.nd.nd_interface_subinterface_managed: *delete_eth_2
+  register: nm_deleted_eth_2
+
+- name: "DELETED: Verify Eth.2 was removed"
+  vars:
+    eth_2_name: "{{ ethernet_parent }}.2"
+    eth_2_after: "{{ nm_deleted_eth_2.after | selectattr('interface_name', 'equalto', eth_2_name) | list }}"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_eth_2 is changed
+      - nm_deleted_eth_2 is changed
+      - eth_2_after | length == 0
+
+- name: "DELETED IDEMPOTENT: Delete Eth.2 again"
+  cisco.nd.nd_interface_subinterface_managed: *delete_eth_2
+  register: nm_deleted_eth_2_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change when subinterface already gone"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_eth_2_idem is not changed
+
+# --- DELETED: BULK CLEANUP (FINAL TEARDOWN) ---
+
+- name: "DELETED CLEANUP: Remove any remaining test subinterfaces"
+  cisco.nd.nd_interface_subinterface_managed:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config: "{{ cleanup_config }}"
+    state: deleted
+  register: nm_deleted_cleanup
+
+- name: "DELETED CLEANUP: Verify all test subinterfaces are gone"
+  vars:
+    remaining: >-
+      {{ nm_deleted_cleanup.after
+         | selectattr('interface_name', 'in', cleanup_config | map(attribute='interface_name') | list)
+         | list }}
+  ansible.builtin.assert:
+    that:
+      - remaining | length == 0

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/main.yaml
@@ -1,0 +1,49 @@
+---
+# Test code for the nd_interface_subinterface_managed module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#   ansible-test network-integration nd_interface_subinterface_managed
+#
+# --- Optional test variables ---
+#
+# Set the variables below in the [nd:vars] section of tests/integration/inventory.networking
+#
+# nd_logging_config (str, default: "")
+#   Path to a JSON file conforming to logging.config.dictConfig (see
+#   plugins/module_utils/common/log.py for an example). When set, the path is
+#   forwarded to the module subprocess via the ND_LOGGING_CONFIG environment
+#   variable.
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_interface_subinterface_managed state tests with optional logging env
+  block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/merged.yaml
@@ -1,0 +1,122 @@
+---
+# Merged state tests for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- MERGED CREATE: SINGLE SUBINTERFACE (ETHERNET PARENT) ---
+
+- name: "MERGED CREATE: Create Eth.2 subinterface (check mode)"
+  cisco.nd.nd_interface_subinterface_managed: &merge_eth_2
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_2 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_eth_2
+
+- name: "MERGED CREATE: Create Eth.2 subinterface (normal mode)"
+  cisco.nd.nd_interface_subinterface_managed: *merge_eth_2
+  register: nm_merged_create_eth_2
+
+- name: "MERGED CREATE: Verify Eth.2 creation"
+  vars:
+    expected_name: "{{ ethernet_parent }}.2"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_eth_2 is changed
+      - nm_merged_create_eth_2 is changed
+      - nm_merged_create_eth_2.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', expected_name) | list | length == 1
+
+# --- MERGED CREATE: MULTIPLE SUBINTERFACES IN ONE TASK ---
+
+- name: "MERGED CREATE: Create Eth.3 and Eth.4 in one task"
+  cisco.nd.nd_interface_subinterface_managed: &merge_eth_3_4
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_3 }}"
+      - "{{ subif_eth_4 }}"
+    state: merged
+  register: nm_merged_create_eth_3_4
+
+- name: "MERGED CREATE: Verify Eth.3 and Eth.4 creation"
+  vars:
+    eth_3_name: "{{ ethernet_parent }}.3"
+    eth_4_name: "{{ ethernet_parent }}.4"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_create_eth_3_4 is changed
+      - nm_merged_create_eth_3_4.after | selectattr('interface_name', 'equalto', eth_3_name) | list | length == 1
+      - nm_merged_create_eth_3_4.after | selectattr('interface_name', 'equalto', eth_4_name) | list | length == 1
+
+# --- MERGED CREATE: SUBINTERFACE ON PORT-CHANNEL PARENT ---
+
+- name: "MERGED CREATE: Create subinterface on Port-channel parent"
+  cisco.nd.nd_interface_subinterface_managed:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_pc_5 }}"
+    state: merged
+  register: nm_merged_create_pc_5
+
+- name: "MERGED CREATE: Verify Port-channel subinterface creation"
+  vars:
+    pc_5_name: "{{ port_channel_parent }}.5"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_create_pc_5 is changed
+      - nm_merged_create_pc_5.after | selectattr('interface_name', 'equalto', pc_5_name) | list | length == 1
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Re-apply Eth.2 (check mode)"
+  cisco.nd.nd_interface_subinterface_managed: *merge_eth_2
+  check_mode: true
+  register: cm_merged_idem_eth_2
+
+- name: "MERGED IDEMPOTENT: Re-apply Eth.2 (normal mode)"
+  cisco.nd.nd_interface_subinterface_managed: *merge_eth_2
+  register: nm_merged_idem_eth_2
+
+- name: "MERGED IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem_eth_2 is not changed
+      - nm_merged_idem_eth_2 is not changed
+
+# --- MERGED UPDATE ---
+
+- name: "MERGED UPDATE: Change description, ip, pim_sparse, pim_dr_priority on Eth.2"
+  cisco.nd.nd_interface_subinterface_managed: &merge_eth_2_updated
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_2_updated }}"
+    state: merged
+  register: nm_merged_update_eth_2
+
+- name: "MERGED UPDATE: Verify Eth.2 was updated"
+  vars:
+    eth_2_name: "{{ ethernet_parent }}.2"
+    eth_2_after: "{{ nm_merged_update_eth_2.after | selectattr('interface_name', 'equalto', eth_2_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_eth_2 is changed
+      - eth_2_after.config_data.network_os.policy.description == "Updated subif Eth.2"
+      - eth_2_after.config_data.network_os.policy.ip == "192.168.50.51"
+      - eth_2_after.config_data.network_os.policy.ip_redirects == false
+      - eth_2_after.config_data.network_os.policy.pim_sparse == true
+      - eth_2_after.config_data.network_os.policy.pim_dr_priority == 50
+      - eth_2_after.config_data.network_os.policy.routing_tag == "12345"
+
+- name: "MERGED UPDATE: Re-apply update for idempotency"
+  cisco.nd.nd_interface_subinterface_managed: *merge_eth_2_updated
+  register: nm_merged_update_eth_2_idem
+
+- name: "MERGED UPDATE: Verify idempotency after update"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_eth_2_idem is not changed

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/overridden.yaml
@@ -1,0 +1,60 @@
+---
+# Overridden state tests for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# At this point Eth.2, Eth.3, Eth.4, and PC.5 exist on the fabric. Override
+# reduces the set to only what is specified; any managed subinterface managed by
+# this module that is not in the config is removed.
+
+- name: "OVERRIDDEN: Reduce to only Eth.2 and PC.5"
+  cisco.nd.nd_interface_subinterface_managed: &override_eth_2_pc_5
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: "{{ ethernet_parent }}.2"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: "Overridden Eth.2"
+              vlan_id: 2
+              vrf_interface: default
+              ip: 10.99.200.1
+              prefix: 24
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: "{{ port_channel_parent }}.5"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: "Overridden PC.5"
+              vlan_id: 5
+              vrf_interface: default
+              ip: 10.99.205.1
+              prefix: 24
+    state: overridden
+  register: nm_overridden_reduce
+
+- name: "OVERRIDDEN: Verify reduce changed and removed entries are gone"
+  vars:
+    eth_3_name: "{{ ethernet_parent }}.3"
+    eth_4_name: "{{ ethernet_parent }}.4"
+    eth_3_after: "{{ nm_overridden_reduce.after | selectattr('interface_name', 'equalto', eth_3_name) | list }}"
+    eth_4_after: "{{ nm_overridden_reduce.after | selectattr('interface_name', 'equalto', eth_4_name) | list }}"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_reduce is changed
+      - eth_3_after | length == 0
+      - eth_4_after | length == 0
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply"
+  cisco.nd.nd_interface_subinterface_managed: *override_eth_2_pc_5
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_idem is not changed

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/replaced.yaml
@@ -1,0 +1,45 @@
+---
+# Replaced state tests for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# At this point Eth.2 (updated), Eth.3, Eth.4, and PC.5 exist from merged.yaml.
+
+- name: "REPLACED: Replace Eth.3 with a stripped-down config"
+  cisco.nd.nd_interface_subinterface_managed: &replace_eth_3
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: "{{ ethernet_parent }}.3"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: "Replaced Eth.3"
+              vlan_id: 3
+              vrf_interface: default
+              ip: 10.99.3.1
+              prefix: 24
+    state: replaced
+  register: nm_replaced_eth_3
+
+- name: "REPLACED: Verify Eth.3 was replaced"
+  vars:
+    eth_3_name: "{{ ethernet_parent }}.3"
+    eth_3_after: "{{ nm_replaced_eth_3.after | selectattr('interface_name', 'equalto', eth_3_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_eth_3 is changed
+      - eth_3_after.config_data.network_os.policy.description == "Replaced Eth.3"
+      - eth_3_after.config_data.network_os.policy.ip == "10.99.3.1"
+
+- name: "REPLACED IDEMPOTENT: Re-apply replace for Eth.3"
+  cisco.nd.nd_interface_subinterface_managed: *replace_eth_3
+  register: nm_replaced_eth_3_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_eth_3_idem is not changed

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/setup.yaml
@@ -1,0 +1,23 @@
+---
+# Pre-test cleanup for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Called from main.yaml before the merged/replaced/overridden/deleted state
+# blocks. Ensures no test subinterfaces exist on the target switch before the
+# state tests run.
+
+- name: "SETUP: Remove test subinterfaces before state tests"
+  cisco.nd.nd_interface_subinterface_managed:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config: "{{ cleanup_config }}"
+    state: deleted
+  register: setup_cleanup
+  tags: always
+
+- name: "DEBUG: Show cleanup result"
+  ansible.builtin.debug:
+    var: setup_cleanup
+  tags: always

--- a/tests/integration/targets/nd_interface_subinterface_managed/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/vars/main.yaml
@@ -1,0 +1,106 @@
+---
+# Variables for nd_interface_subinterface_managed integration tests.
+#
+# Override fabric_name, switch_ip, ethernet_parent and port_channel_parent in your
+# inventory or extra-vars to match a real ND 4.2 testbed.
+#
+# The parent interfaces must exist and (for Ethernet parents) must be free of any
+# L2 mode conflicts before subinterfaces can be created on them.
+
+test_fabric_name: "{{ nd_test_fabric_name | default('test_fabric') }}"
+test_switch_ip: "{{ nd_test_switch_ip | default('192.168.1.1') }}"
+ethernet_parent: "{{ nd_test_ethernet_parent | default('Ethernet1/3') }}"
+port_channel_parent: "{{ nd_test_port_channel_parent | default('Port-channel10') }}"
+
+# --- Base configs ---
+
+subif_eth_2:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.2"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Ansible integration test subif Eth.2"
+        vlan_id: 2
+        vrf_interface: default
+        ip: 192.168.50.50
+        prefix: 24
+        ipv6: "2001:192:168:50::50"
+        ipv6_prefix: 64
+        mtu: 9216
+        ip_redirects: true
+        pim_sparse: false
+        pim_dr_priority: 1
+        netflow: false
+
+subif_eth_3:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.3"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Ansible integration test subif Eth.3"
+        vlan_id: 3
+        vrf_interface: default
+        ip: 192.168.51.50
+        prefix: 24
+
+subif_eth_4:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.4"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Ansible integration test subif Eth.4"
+        vlan_id: 4
+        vrf_interface: default
+        ip: 192.168.52.50
+        prefix: 24
+
+subif_pc_5:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ port_channel_parent }}.5"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Ansible integration test subif PC.5"
+        vlan_id: 5
+        vrf_interface: default
+        ip: 192.168.55.1
+        prefix: 24
+
+# --- Updated configs for merge/replace tests ---
+
+subif_eth_2_updated:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.2"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Updated subif Eth.2"
+        vlan_id: 2
+        vrf_interface: default
+        ip: 192.168.50.51
+        prefix: 24
+        ip_redirects: false
+        pim_sparse: true
+        pim_dr_priority: 50
+        routing_tag: "12345"
+        netflow: false
+
+# --- Cleanup helper: all test subinterfaces to remove before tests run ---
+
+cleanup_config:
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.2"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.3"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.4"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ port_channel_parent }}.5"

--- a/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/deleted.yaml
@@ -1,0 +1,61 @@
+---
+# Deleted state tests for nd_interface_subinterface_unmanaged
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# At this point Eth.20 and PC.25 exist (from overridden reduce). Delete actually
+# removes the subinterfaces from ND via interfaceActions/remove + deploy.
+
+- name: "DELETED: Delete Eth.20 (check mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: &delete_eth_20
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_20 }}"
+    state: deleted
+  check_mode: true
+  register: cm_deleted_eth_20
+
+- name: "DELETED: Delete Eth.20 (normal mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: *delete_eth_20
+  register: nm_deleted_eth_20
+
+- name: "DELETED: Verify Eth.20 was removed"
+  vars:
+    eth_20_name: "{{ ethernet_parent }}.20"
+    eth_20_after: "{{ nm_deleted_eth_20.after | selectattr('interface_name', 'equalto', eth_20_name) | list }}"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_eth_20 is changed
+      - nm_deleted_eth_20 is changed
+      - eth_20_after | length == 0
+
+- name: "DELETED IDEMPOTENT: Delete Eth.20 again"
+  cisco.nd.nd_interface_subinterface_unmanaged: *delete_eth_20
+  register: nm_deleted_eth_20_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change when subinterface already gone"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_eth_20_idem is not changed
+
+# --- DELETED: BULK CLEANUP (FINAL TEARDOWN) ---
+
+- name: "DELETED CLEANUP: Remove any remaining test subinterfaces"
+  cisco.nd.nd_interface_subinterface_unmanaged:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config: "{{ cleanup_config }}"
+    state: deleted
+  register: nm_deleted_cleanup
+
+- name: "DELETED CLEANUP: Verify all test subinterfaces are gone"
+  vars:
+    remaining: >-
+      {{ nm_deleted_cleanup.after
+         | selectattr('interface_name', 'in', cleanup_config | map(attribute='interface_name') | list)
+         | list }}
+  ansible.builtin.assert:
+    that:
+      - remaining | length == 0

--- a/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/main.yaml
@@ -1,0 +1,49 @@
+---
+# Test code for the nd_interface_subinterface_unmanaged module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#   ansible-test network-integration nd_interface_subinterface_unmanaged
+#
+# --- Optional test variables ---
+#
+# Set the variables below in the [nd:vars] section of tests/integration/inventory.networking
+#
+# nd_logging_config (str, default: "")
+#   Path to a JSON file conforming to logging.config.dictConfig (see
+#   plugins/module_utils/common/log.py for an example). When set, the path is
+#   forwarded to the module subprocess via the ND_LOGGING_CONFIG environment
+#   variable.
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_interface_subinterface_unmanaged state tests with optional logging env
+  block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/merged.yaml
@@ -1,0 +1,96 @@
+---
+# Merged state tests for nd_interface_subinterface_unmanaged
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Unmanaged subinterfaces have no user-configurable policy fields, so this file
+# exercises only create paths and idempotency. There is no "update" phase because
+# the only fields the module accepts are the identifier (switch_ip + interface_name).
+
+# --- MERGED CREATE: SINGLE SUBINTERFACE (ETHERNET PARENT) ---
+
+- name: "MERGED CREATE: Create Eth.20 subinterface (check mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: &merge_eth_20
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_20 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_eth_20
+
+- name: "MERGED CREATE: Create Eth.20 subinterface (normal mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: *merge_eth_20
+  register: nm_merged_create_eth_20
+
+- name: "MERGED CREATE: Verify Eth.20 creation"
+  vars:
+    expected_name: "{{ ethernet_parent }}.20"
+    eth_20_after: "{{ nm_merged_create_eth_20.after | selectattr('interface_name', 'equalto', expected_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_eth_20 is changed
+      - nm_merged_create_eth_20 is changed
+      - nm_merged_create_eth_20.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', expected_name) | list | length == 1
+      - eth_20_after.config_data.network_os.policy.policy_type == "monitorSubinterface"
+
+# --- MERGED CREATE: MULTIPLE SUBINTERFACES IN ONE TASK ---
+
+- name: "MERGED CREATE: Create Eth.21 and Eth.22 in one task"
+  cisco.nd.nd_interface_subinterface_unmanaged: &merge_eth_21_22
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_21 }}"
+      - "{{ subif_eth_22 }}"
+    state: merged
+  register: nm_merged_create_eth_21_22
+
+- name: "MERGED CREATE: Verify Eth.21 and Eth.22 creation"
+  vars:
+    eth_21_name: "{{ ethernet_parent }}.21"
+    eth_22_name: "{{ ethernet_parent }}.22"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_create_eth_21_22 is changed
+      - nm_merged_create_eth_21_22.after | selectattr('interface_name', 'equalto', eth_21_name) | list | length == 1
+      - nm_merged_create_eth_21_22.after | selectattr('interface_name', 'equalto', eth_22_name) | list | length == 1
+
+# --- MERGED CREATE: SUBINTERFACE ON PORT-CHANNEL PARENT ---
+
+- name: "MERGED CREATE: Create subinterface on Port-channel parent"
+  cisco.nd.nd_interface_subinterface_unmanaged:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_pc_25 }}"
+    state: merged
+  register: nm_merged_create_pc_25
+
+- name: "MERGED CREATE: Verify Port-channel subinterface creation"
+  vars:
+    pc_25_name: "{{ port_channel_parent }}.25"
+    pc_25_after: "{{ nm_merged_create_pc_25.after | selectattr('interface_name', 'equalto', pc_25_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_create_pc_25 is changed
+      - nm_merged_create_pc_25.after | selectattr('interface_name', 'equalto', pc_25_name) | list | length == 1
+      - pc_25_after.config_data.network_os.policy.policy_type == "monitorSubinterface"
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Re-apply Eth.20 (check mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: *merge_eth_20
+  check_mode: true
+  register: cm_merged_idem_eth_20
+
+- name: "MERGED IDEMPOTENT: Re-apply Eth.20 (normal mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: *merge_eth_20
+  register: nm_merged_idem_eth_20
+
+- name: "MERGED IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem_eth_20 is not changed
+      - nm_merged_idem_eth_20 is not changed

--- a/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/overridden.yaml
@@ -1,0 +1,43 @@
+---
+# Overridden state tests for nd_interface_subinterface_unmanaged
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# At this point Eth.20, Eth.21, Eth.22, PC.25, and Eth.29 exist on the fabric.
+# Override reduces the set to only what is specified; any unmanaged subinterface
+# managed by this module that is not in the config is removed (fabric-wide scope).
+
+- name: "OVERRIDDEN: Reduce to only Eth.20 and PC.25"
+  cisco.nd.nd_interface_subinterface_unmanaged: &override_eth_20_pc_25
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_20 }}"
+      - "{{ subif_pc_25 }}"
+    state: overridden
+  register: nm_overridden_reduce
+
+- name: "OVERRIDDEN: Verify reduce changed and removed entries are gone"
+  vars:
+    eth_21_name: "{{ ethernet_parent }}.21"
+    eth_22_name: "{{ ethernet_parent }}.22"
+    eth_29_name: "{{ ethernet_parent }}.29"
+    eth_21_after: "{{ nm_overridden_reduce.after | selectattr('interface_name', 'equalto', eth_21_name) | list }}"
+    eth_22_after: "{{ nm_overridden_reduce.after | selectattr('interface_name', 'equalto', eth_22_name) | list }}"
+    eth_29_after: "{{ nm_overridden_reduce.after | selectattr('interface_name', 'equalto', eth_29_name) | list }}"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_reduce is changed
+      - eth_21_after | length == 0
+      - eth_22_after | length == 0
+      - eth_29_after | length == 0
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply"
+  cisco.nd.nd_interface_subinterface_unmanaged: *override_eth_20_pc_25
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_idem is not changed

--- a/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/replaced.yaml
@@ -1,0 +1,76 @@
+---
+# Replaced state tests for nd_interface_subinterface_unmanaged
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# At this point Eth.20, Eth.21, Eth.22, and PC.25 exist from merged.yaml.
+#
+# For unmanaged subinterfaces, `replaced` against an existing subinterface is
+# effectively a no-op because there are no user-configurable fields to overwrite.
+# Against a missing subinterface, `replaced` falls back to create. This file
+# exercises both paths.
+
+# --- REPLACED NO-OP: existing subinterface, no fields to change ---
+
+- name: "REPLACED NO-OP: Replace existing Eth.20 (check mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: &replace_eth_20
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_20 }}"
+    state: replaced
+  check_mode: true
+  register: cm_replaced_eth_20
+
+- name: "REPLACED NO-OP: Replace existing Eth.20 (normal mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: *replace_eth_20
+  register: nm_replaced_eth_20
+
+- name: "REPLACED NO-OP: Verify no change on existing subinterface"
+  vars:
+    eth_20_name: "{{ ethernet_parent }}.20"
+    eth_20_after: "{{ nm_replaced_eth_20.after | selectattr('interface_name', 'equalto', eth_20_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_eth_20 is not changed
+      - nm_replaced_eth_20 is not changed
+      - eth_20_after.config_data.network_os.policy.policy_type == "monitorSubinterface"
+
+# --- REPLACED FALL-BACK-TO-CREATE: missing subinterface, replaced creates it ---
+
+- name: "REPLACED CREATE: Replace missing Eth.29 (check mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: &replace_eth_29
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_29 }}"
+    state: replaced
+  check_mode: true
+  register: cm_replaced_eth_29
+
+- name: "REPLACED CREATE: Replace missing Eth.29 (normal mode)"
+  cisco.nd.nd_interface_subinterface_unmanaged: *replace_eth_29
+  register: nm_replaced_eth_29
+
+- name: "REPLACED CREATE: Verify Eth.29 created via replaced fall-back"
+  vars:
+    eth_29_name: "{{ ethernet_parent }}.29"
+    eth_29_after: "{{ nm_replaced_eth_29.after | selectattr('interface_name', 'equalto', eth_29_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_eth_29 is changed
+      - nm_replaced_eth_29 is changed
+      - nm_replaced_eth_29.after | selectattr('interface_name', 'equalto', eth_29_name) | list | length == 1
+      - eth_29_after.config_data.network_os.policy.policy_type == "monitorSubinterface"
+
+# --- REPLACED IDEMPOTENT: re-apply on Eth.29 (now existing) ---
+
+- name: "REPLACED IDEMPOTENT: Re-apply replaced for Eth.29"
+  cisco.nd.nd_interface_subinterface_unmanaged: *replace_eth_29
+  register: nm_replaced_eth_29_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_eth_29_idem is not changed

--- a/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_unmanaged/tasks/setup.yaml
@@ -1,0 +1,23 @@
+---
+# Pre-test cleanup for nd_interface_subinterface_unmanaged
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Called from main.yaml before the merged/replaced/overridden/deleted state
+# blocks. Ensures no test subinterfaces exist on the target switch before the
+# state tests run.
+
+- name: "SETUP: Remove test subinterfaces before state tests"
+  cisco.nd.nd_interface_subinterface_unmanaged:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config: "{{ cleanup_config }}"
+    state: deleted
+  register: setup_cleanup
+  tags: always
+
+- name: "DEBUG: Show cleanup result"
+  ansible.builtin.debug:
+    var: setup_cleanup
+  tags: always

--- a/tests/integration/targets/nd_interface_subinterface_unmanaged/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_unmanaged/vars/main.yaml
@@ -1,0 +1,62 @@
+---
+# Variables for nd_interface_subinterface_unmanaged integration tests.
+#
+# Override fabric_name, switch_ip, ethernet_parent and port_channel_parent in your
+# inventory or extra-vars to match a real ND 4.2 testbed.
+#
+# The parent interfaces must exist and (for Ethernet parents) must be in a routed
+# (L3) policy before unmanaged subinterfaces can be created on them. ND rejects
+# subinterface creation against L2 access/trunk parents with HTTP 207 status:failed
+# and message "Sub-interface can be created only on routed physical or port-channel
+# interfaces". The unmanaged variant follows the same rule as the managed variant.
+#
+# Sub-id range .20-.29 avoids collision with the managed target's .2-.5 range so
+# both targets can run on the same testbed without interference.
+
+test_fabric_name: "{{ nd_test_fabric_name | default('test_fabric') }}"
+test_switch_ip: "{{ nd_test_switch_ip | default('192.168.1.1') }}"
+ethernet_parent: "{{ nd_test_ethernet_parent | default('Ethernet1/3') }}"
+port_channel_parent: "{{ nd_test_port_channel_parent | default('Port-channel10') }}"
+
+# --- Base configs ---
+#
+# Unmanaged subinterfaces carry no user-configurable policy fields. Each config
+# item contains only switch_ip + interface_name; the module hard-codes
+# mode=unmanaged, network_os_type=nx-os, policy_type=monitorSubinterface.
+
+subif_eth_20:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.20"
+
+subif_eth_21:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.21"
+
+subif_eth_22:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.22"
+
+subif_pc_25:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ port_channel_parent }}.25"
+
+# Subinterface used to exercise the replaced fall-back-to-create case. NOT created
+# in merged.yaml; replaced.yaml is the first phase that touches it.
+
+subif_eth_29:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.29"
+
+# --- Cleanup helper: all test subinterfaces to remove before/after tests run ---
+
+cleanup_config:
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.20"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.21"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.22"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.29"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ port_channel_parent }}.25"

--- a/tests/integration/targets/nd_interface_svi/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/deleted.yaml
@@ -1,0 +1,119 @@
+---
+# Deleted state tests for nd_interface_svi
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point vlan333, vlan334, vlan335 exist (from overridden grow).
+# Unlike trunk_host (where deleted = reset to defaults), SVI delete actually
+# removes the SVI from ND via interfaceActions/remove + interfaceActions/deploy.
+
+# --- DELETED: SINGLE SVI ---
+
+- name: "DELETED: Delete vlan333 (check mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+    state: deleted
+  check_mode: true
+  register: cm_deleted_333
+
+- name: "DELETED: Delete vlan333 (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+    state: deleted
+  register: nm_deleted_333
+
+- name: "DELETED: Verify vlan333 was removed"
+  vars:
+    vlan333_after: "{{ nm_deleted_333.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan333') | list }}"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_333 is changed
+      - nm_deleted_333 is changed
+      - vlan333_after | length == 0
+
+# --- DELETED: IDEMPOTENCY ---
+
+- name: "DELETED IDEMPOTENT: Delete vlan333 again"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+    state: deleted
+  register: nm_deleted_333_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change when SVI already gone"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_333_idem is not changed
+
+# --- DELETED: FAN-OUT DELETE ---
+
+- name: "DELETED FAN-OUT: Delete vlan334 and vlan335 via fan-out (check mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 334
+          - 335
+    state: deleted
+  check_mode: true
+  register: cm_deleted_fanout
+
+- name: "DELETED FAN-OUT: Delete vlan334 and vlan335 via fan-out (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 334
+          - 335
+    state: deleted
+  register: nm_deleted_fanout
+
+- name: "DELETED FAN-OUT: Verify both SVIs removed"
+  vars:
+    vlan334_after: "{{ nm_deleted_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | list }}"
+    vlan335_after: "{{ nm_deleted_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | list }}"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_fanout is changed
+      - nm_deleted_fanout is changed
+      - vlan334_after | length == 0
+      - vlan335_after | length == 0
+
+# --- DELETED: BULK CLEANUP (FINAL TEARDOWN) ---
+
+- name: "DELETED CLEANUP: Remove any remaining test SVIs"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids: "{{ cleanup_vlan_ids }}"
+    state: deleted
+  register: nm_deleted_cleanup
+
+- name: "DELETED CLEANUP: Verify all test SVIs are gone"
+  vars:
+    remaining: "{{ nm_deleted_cleanup.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'in', ['vlan333', 'vlan334', 'vlan335', 'vlan336', 'vlan337', 'vlan338']) | list }}"
+  ansible.builtin.assert:
+    that:
+      - remaining | length == 0

--- a/tests/integration/targets/nd_interface_svi/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/deleted.yaml
@@ -12,7 +12,7 @@
 # --- DELETED: SINGLE SVI ---
 
 - name: "DELETED: Delete vlan333 (check mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &delete_vlan333
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -24,14 +24,7 @@
   register: cm_deleted_333
 
 - name: "DELETED: Delete vlan333 (normal mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
-    state: deleted
+  cisco.nd.nd_interface_svi: *delete_vlan333
   register: nm_deleted_333
 
 - name: "DELETED: Verify vlan333 was removed"
@@ -46,14 +39,7 @@
 # --- DELETED: IDEMPOTENCY ---
 
 - name: "DELETED IDEMPOTENT: Delete vlan333 again"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
-    state: deleted
+  cisco.nd.nd_interface_svi: *delete_vlan333
   register: nm_deleted_333_idem
 
 - name: "DELETED IDEMPOTENT: Verify no change when SVI already gone"
@@ -64,7 +50,7 @@
 # --- DELETED: FAN-OUT DELETE ---
 
 - name: "DELETED FAN-OUT: Delete vlan334 and vlan335 via fan-out (check mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &delete_vlan334_335
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -77,15 +63,7 @@
   register: cm_deleted_fanout
 
 - name: "DELETED FAN-OUT: Delete vlan334 and vlan335 via fan-out (normal mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 334
-          - 335
-    state: deleted
+  cisco.nd.nd_interface_svi: *delete_vlan334_335
   register: nm_deleted_fanout
 
 - name: "DELETED FAN-OUT: Verify both SVIs removed"

--- a/tests/integration/targets/nd_interface_svi/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/deleted.yaml
@@ -17,8 +17,7 @@
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
+        interface_name: vlan333
     state: deleted
   check_mode: true
   register: cm_deleted_333
@@ -47,33 +46,33 @@
     that:
       - nm_deleted_333_idem is not changed
 
-# --- DELETED: FAN-OUT DELETE ---
+# --- DELETED: MULTI-SVI DELETE ---
 
-- name: "DELETED FAN-OUT: Delete vlan334 and vlan335 via fan-out (check mode)"
+- name: "DELETED MULTI: Delete vlan334 and vlan335 in one task (check mode)"
   cisco.nd.nd_interface_svi: &delete_vlan334_335
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 334
-          - 335
+        interface_name: vlan334
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: vlan335
     state: deleted
   check_mode: true
-  register: cm_deleted_fanout
+  register: cm_deleted_multi
 
-- name: "DELETED FAN-OUT: Delete vlan334 and vlan335 via fan-out (normal mode)"
+- name: "DELETED MULTI: Delete vlan334 and vlan335 in one task (normal mode)"
   cisco.nd.nd_interface_svi: *delete_vlan334_335
-  register: nm_deleted_fanout
+  register: nm_deleted_multi
 
-- name: "DELETED FAN-OUT: Verify both SVIs removed"
+- name: "DELETED MULTI: Verify both SVIs removed"
   vars:
-    vlan334_after: "{{ nm_deleted_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | list }}"
-    vlan335_after: "{{ nm_deleted_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | list }}"
+    vlan334_after: "{{ nm_deleted_multi.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | list }}"
+    vlan335_after: "{{ nm_deleted_multi.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | list }}"
   ansible.builtin.assert:
     that:
-      - cm_deleted_fanout is changed
-      - nm_deleted_fanout is changed
+      - cm_deleted_multi is changed
+      - nm_deleted_multi is changed
       - vlan334_after | length == 0
       - vlan335_after | length == 0
 
@@ -83,9 +82,7 @@
   cisco.nd.nd_interface_svi:
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids: "{{ cleanup_vlan_ids }}"
+    config: "{{ cleanup_config }}"
     state: deleted
   register: nm_deleted_cleanup
 

--- a/tests/integration/targets/nd_interface_svi/tasks/hsrp_dhcp.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/hsrp_dhcp.yaml
@@ -1,0 +1,142 @@
+---
+# HSRP / DHCP-relay / VRF / route-tag tests for nd_interface_svi (phase 2 fields)
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- CLEANUP ---
+
+- name: "SETUP: Remove test SVIs before HSRP/DHCP tests"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 500
+          - 501
+    state: deleted
+  register: setup_cleanup_hsrp
+  tags: always
+
+- name: "DEBUG: Show HSRP/DHCP cleanup result"
+  ansible.builtin.debug:
+    var: setup_cleanup_hsrp
+  tags: always
+
+# --- HSRP CREATE ---
+
+- name: "MERGED CREATE: vlan500 with HSRP block (check mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_500_hsrp }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_hsrp
+
+- name: "MERGED CREATE: vlan500 with HSRP block (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_500_hsrp }}"
+    state: merged
+  register: nm_merged_create_hsrp
+
+- name: "DEBUG: HSRP create result"
+  ansible.builtin.debug:
+    var: nm_merged_create_hsrp
+
+- name: "MERGED CREATE: Verify HSRP fields persisted"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_hsrp is changed
+      - nm_merged_create_hsrp is changed
+      - >
+        nm_merged_create_hsrp.after
+          | selectattr('interface_name', 'equalto', 'vlan500')
+          | list | length == 1
+
+# --- HSRP IDEMPOTENCY (re-apply same config) ---
+
+- name: "MERGED IDEMPOTENT: re-apply vlan500 HSRP block"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_500_hsrp }}"
+    state: merged
+  register: nm_merged_idem_hsrp
+
+- name: "MERGED IDEMPOTENT: HSRP re-apply must not report changed"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_idem_hsrp is not changed
+
+# --- HSRP UPDATE (priority bump) ---
+
+- name: "MERGED UPDATE: change HSRP priority on vlan500"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_500_hsrp_updated }}"
+    state: merged
+  register: nm_merged_update_hsrp
+
+- name: "MERGED UPDATE: priority change reports changed"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_hsrp is changed
+
+# --- DHCP RELAY CREATE ---
+
+- name: "MERGED CREATE: vlan501 with DHCP relay block"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_501_dhcp }}"
+    state: merged
+  register: nm_merged_create_dhcp
+
+- name: "MERGED CREATE: DHCP relay create reports changed"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_create_dhcp is changed
+      - >
+        nm_merged_create_dhcp.after
+          | selectattr('interface_name', 'equalto', 'vlan501')
+          | list | length == 1
+
+# --- DHCP RELAY IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: re-apply DHCP relay vlan501"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_501_dhcp }}"
+    state: merged
+  register: nm_merged_idem_dhcp
+
+- name: "MERGED IDEMPOTENT: DHCP re-apply must not report changed"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_idem_dhcp is not changed
+
+# --- CLEANUP ---
+
+- name: "TEARDOWN: Remove HSRP/DHCP test SVIs"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 500
+          - 501
+    state: deleted
+  tags: always

--- a/tests/integration/targets/nd_interface_svi/tasks/hsrp_dhcp.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/hsrp_dhcp.yaml
@@ -12,9 +12,9 @@
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 500
-          - 501
+        interface_name: vlan500
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: vlan501
     state: deleted
   register: setup_cleanup_hsrp
   tags: always
@@ -120,8 +120,8 @@
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 500
-          - 501
+        interface_name: vlan500
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: vlan501
     state: deleted
   tags: always

--- a/tests/integration/targets/nd_interface_svi/tasks/hsrp_dhcp.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/hsrp_dhcp.yaml
@@ -27,7 +27,7 @@
 # --- HSRP CREATE ---
 
 - name: "MERGED CREATE: vlan500 with HSRP block (check mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &merge_vlan500_hsrp
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -37,12 +37,7 @@
   register: cm_merged_create_hsrp
 
 - name: "MERGED CREATE: vlan500 with HSRP block (normal mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_500_hsrp }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan500_hsrp
   register: nm_merged_create_hsrp
 
 - name: "DEBUG: HSRP create result"
@@ -62,12 +57,7 @@
 # --- HSRP IDEMPOTENCY (re-apply same config) ---
 
 - name: "MERGED IDEMPOTENT: re-apply vlan500 HSRP block"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_500_hsrp }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan500_hsrp
   register: nm_merged_idem_hsrp
 
 - name: "MERGED IDEMPOTENT: HSRP re-apply must not report changed"
@@ -94,7 +84,7 @@
 # --- DHCP RELAY CREATE ---
 
 - name: "MERGED CREATE: vlan501 with DHCP relay block"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &merge_vlan501_dhcp
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -114,12 +104,7 @@
 # --- DHCP RELAY IDEMPOTENCY ---
 
 - name: "MERGED IDEMPOTENT: re-apply DHCP relay vlan501"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_501_dhcp }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan501_dhcp
   register: nm_merged_idem_dhcp
 
 - name: "MERGED IDEMPOTENT: DHCP re-apply must not report changed"

--- a/tests/integration/targets/nd_interface_svi/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/main.yaml
@@ -1,0 +1,50 @@
+---
+# Test code for the nd_interface_svi module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#   ansible-test integration nd_interface_svi
+#
+# --- Optional test variables ---
+#
+# Set the variables below in the [nd:vars] section of tests/integration/inventory.networking
+#
+# nd_logging_config (str, default: "")
+#   Path to a JSON file conforming to logging.config.dictConfig (see
+#   plugins/module_utils/common/log.py for an example). When set, the path is
+#   forwarded to the module subprocess via the ND_LOGGING_CONFIG environment
+#   variable, enabling file-based logging from the nd collection. Empty (the
+#   default) disables logging. ansible-test strips the controller's shell env,
+#   so the variable cannot be inherited from the user's shell. Add to
+#   inventory.networking [nd:vars]:
+#     nd_logging_config=/absolute/path/to/logging_config.json
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_interface_svi state tests with optional logging env
+  block:
+    - name: Run nd_interface_svi merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run nd_interface_svi replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run nd_interface_svi overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run nd_interface_svi deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_svi/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/main.yaml
@@ -35,6 +35,9 @@
 
 - name: Run nd_interface_svi state tests with optional logging env
   block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
     - name: Run nd_interface_svi merged state tests
       ansible.builtin.include_tasks: merged.yaml
 

--- a/tests/integration/targets/nd_interface_svi/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/main.yaml
@@ -46,5 +46,8 @@
 
     - name: Run nd_interface_svi deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
+
+    - name: Run nd_interface_svi HSRP and DHCP-relay tests
+      ansible.builtin.include_tasks: hsrp_dhcp.yaml
   environment:
     ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
@@ -1,0 +1,329 @@
+---
+# Merged state tests for nd_interface_svi
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- CLEANUP ---
+
+- name: "SETUP: Remove test SVIs before merged tests"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids: "{{ cleanup_vlan_ids }}"
+    state: deleted
+  register: setup_cleanup
+  tags: always
+
+- name: "DEBUG: Show cleanup result"
+  ansible.builtin.debug:
+    var: setup_cleanup
+  tags: always
+
+# --- MERGED CREATE: SINGLE SVI ---
+
+- name: "MERGED CREATE: Create vlan333 with full config (check mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_333 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_333
+
+- name: "MERGED CREATE: Create vlan333 with full config (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_333 }}"
+    state: merged
+  register: nm_merged_create_333
+
+- name: "DEBUG: Show merged create result"
+  ansible.builtin.debug:
+    var: nm_merged_create_333
+
+- name: "MERGED CREATE: Verify vlan333 creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_333 is changed
+      - nm_merged_create_333 is changed
+      - nm_merged_create_333.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan333') | list | length == 1
+
+# --- MERGED CREATE: FAN-OUT (MULTIPLE VLANs, SINGLE CONFIG) ---
+
+- name: "MERGED CREATE: Create vlan334 and vlan335 via fan-out (check mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_334_335 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_fanout
+
+- name: "MERGED CREATE: Create vlan334 and vlan335 via fan-out (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_334_335 }}"
+    state: merged
+  register: nm_merged_create_fanout
+
+- name: "MERGED CREATE: Verify fan-out creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_fanout is changed
+      - nm_merged_create_fanout is changed
+      - nm_merged_create_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | list | length == 1
+      - nm_merged_create_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | list | length == 1
+
+# --- MERGED CREATE: SEPARATE CONFIG GROUP ---
+
+- name: "MERGED CREATE: Create vlan336 as a separate config group (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_336 }}"
+    state: merged
+  register: nm_merged_create_336
+
+- name: "MERGED CREATE: Verify vlan336 creation"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_create_336 is changed
+      - nm_merged_create_336.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan336') | list | length == 1
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Re-apply vlan333 creation (check mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_333 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_idem_333
+
+- name: "MERGED IDEMPOTENT: Re-apply vlan333 creation (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_333 }}"
+    state: merged
+  register: nm_merged_idem_333
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem_333 is not changed
+      - nm_merged_idem_333 is not changed
+
+- name: "MERGED IDEMPOTENT: Re-apply fan-out config for vlan334 and vlan335"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_334_335 }}"
+    state: merged
+  register: nm_merged_idem_fanout
+
+- name: "MERGED IDEMPOTENT: Verify fan-out idempotency"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_idem_fanout is not changed
+
+# --- MERGED UPDATE ---
+
+- name: "MERGED UPDATE: Update vlan333 description and other fields (check mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_333_updated }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_update_333
+
+- name: "MERGED UPDATE: Update vlan333 description and other fields (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_333_updated }}"
+    state: merged
+  register: nm_merged_update_333
+
+- name: "MERGED UPDATE: Verify vlan333 was updated"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_update_333 is changed
+      - nm_merged_update_333 is changed
+
+- name: "MERGED UPDATE: Verify updated values in after state"
+  vars:
+    vlan333_after: "{{ nm_merged_update_333.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan333') | first }}"
+  ansible.builtin.assert:
+    that:
+      - vlan333_after.config_data.network_os.policy.description == "Updated vlan333 description"
+      - vlan333_after.config_data.network_os.policy.ip == "10.99.99.2"
+      - vlan333_after.config_data.network_os.policy.ip_redirects == false
+      - vlan333_after.config_data.network_os.policy.pim_sparse == true
+      - vlan333_after.config_data.network_os.policy.pim_dr_priority == 50
+      - vlan333_after.config_data.network_os.policy.advertise_subnet_in_underlay == true
+
+- name: "MERGED UPDATE: Re-apply update for idempotency"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_333_updated }}"
+    state: merged
+  register: nm_merged_update_333_idem
+
+- name: "MERGED UPDATE: Verify idempotency after update"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_333_idem is not changed
+
+# --- MERGED UPDATE: FAN-OUT UPDATE ---
+
+- name: "MERGED UPDATE: Update vlan334 and vlan335 via fan-out"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_334_335_updated }}"
+    state: merged
+  register: nm_merged_update_fanout
+
+- name: "MERGED UPDATE: Verify fan-out update"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_fanout is changed
+
+- name: "MERGED UPDATE: Verify fan-out updated values"
+  vars:
+    vlan334_after: "{{ nm_merged_update_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | first }}"
+    vlan335_after: "{{ nm_merged_update_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | first }}"
+  ansible.builtin.assert:
+    that:
+      - vlan334_after.config_data.network_os.policy.description == "Updated fan-out description"
+      - vlan334_after.config_data.network_os.policy.admin_state == false
+      - vlan334_after.config_data.network_os.policy.ip == "10.99.100.2"
+      - vlan335_after.config_data.network_os.policy.description == "Updated fan-out description"
+      - vlan335_after.config_data.network_os.policy.admin_state == false
+      - vlan335_after.config_data.network_os.policy.ip == "10.99.100.2"
+
+# --- MERGED: ASCII VALIDATION (CLIENT-SIDE) ---
+
+- name: "MERGED ASCII: Reject non-ASCII description (em-dash)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              description: "non-ascii em — dash"
+    state: merged
+  register: nm_merged_ascii_fail
+  ignore_errors: true
+
+- name: "MERGED ASCII: Verify the module rejected non-ASCII before any API call"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_ascii_fail.failed
+      - "'description must contain only ASCII' in nm_merged_ascii_fail.msg"
+
+# --- MERGED WITH deploy: false ---
+
+- name: "MERGED NO-DEPLOY: Create vlan337 with deploy disabled"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 337
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "No-deploy test vlan337"
+              ip: 10.99.103.1
+              prefix: 24
+    deploy: false
+    state: merged
+  register: nm_merged_no_deploy
+
+- name: "MERGED NO-DEPLOY: Verify change was staged"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_no_deploy is changed
+
+# Clean up the no-deploy test interface for downstream tests
+- name: "CLEANUP: Remove vlan337"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 337
+    state: deleted
+
+# --- MERGED CREATE: LARGE FAN-OUT ---
+
+- name: "MERGED CREATE: Create vlan337 and vlan338 via fan-out (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_337_338 }}"
+    state: merged
+  register: nm_merged_create_large_fanout
+
+- name: "MERGED CREATE: Verify large fan-out creation"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_create_large_fanout is changed
+      - nm_merged_create_large_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan337') | list | length == 1
+      - nm_merged_create_large_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan338') | list | length == 1
+
+- name: "MERGED CREATE: Verify both fan-out interfaces have the same config"
+  vars:
+    vlan337_after: "{{ nm_merged_create_large_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan337') | first }}"
+    vlan338_after: "{{ nm_merged_create_large_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan338') | first }}"
+  ansible.builtin.assert:
+    that:
+      - vlan337_after.config_data.network_os.policy.description == "Fan-out test SVIs"
+      - vlan337_after.config_data.network_os.policy.ip == "10.99.102.1"
+      - vlan338_after.config_data.network_os.policy.description == "Fan-out test SVIs"
+      - vlan338_after.config_data.network_os.policy.ip == "10.99.102.1"
+
+- name: "MERGED IDEMPOTENT: Re-apply large fan-out"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ svi_337_338 }}"
+    state: merged
+  register: nm_merged_idem_large_fanout
+
+- name: "MERGED IDEMPOTENT: Verify large fan-out idempotency"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_idem_large_fanout is not changed

--- a/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
@@ -211,7 +211,8 @@
               description: "No-deploy test vlan337"
               ip: 10.99.103.1
               prefix: 24
-    deploy: false
+    config_actions:
+      deploy: false
     state: merged
   register: nm_merged_no_deploy
 

--- a/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
@@ -260,7 +260,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "No-deploy test vlan337"
               ip: 10.99.103.1

--- a/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
@@ -31,29 +31,30 @@
       - nm_merged_create_333 is changed
       - nm_merged_create_333.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan333') | list | length == 1
 
-# --- MERGED CREATE: FAN-OUT (MULTIPLE VLANs, SINGLE CONFIG) ---
+# --- MERGED CREATE: MULTIPLE SVIs IN ONE TASK ---
 
-- name: "MERGED CREATE: Create vlan334 and vlan335 via fan-out (check mode)"
+- name: "MERGED CREATE: Create vlan334 and vlan335 in one task (check mode)"
   cisco.nd.nd_interface_svi: &merge_vlan334_335
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
-      - "{{ svi_334_335 }}"
+      - "{{ svi_334 }}"
+      - "{{ svi_335 }}"
     state: merged
   check_mode: true
-  register: cm_merged_create_fanout
+  register: cm_merged_create_multi
 
-- name: "MERGED CREATE: Create vlan334 and vlan335 via fan-out (normal mode)"
+- name: "MERGED CREATE: Create vlan334 and vlan335 in one task (normal mode)"
   cisco.nd.nd_interface_svi: *merge_vlan334_335
-  register: nm_merged_create_fanout
+  register: nm_merged_create_multi
 
-- name: "MERGED CREATE: Verify fan-out creation"
+- name: "MERGED CREATE: Verify multi-SVI creation"
   ansible.builtin.assert:
     that:
-      - cm_merged_create_fanout is changed
-      - nm_merged_create_fanout is changed
-      - nm_merged_create_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | list | length == 1
-      - nm_merged_create_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | list | length == 1
+      - cm_merged_create_multi is changed
+      - nm_merged_create_multi is changed
+      - nm_merged_create_multi.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | list | length == 1
+      - nm_merged_create_multi.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | list | length == 1
 
 # --- MERGED CREATE: SEPARATE CONFIG GROUP ---
 
@@ -89,14 +90,14 @@
       - cm_merged_idem_333 is not changed
       - nm_merged_idem_333 is not changed
 
-- name: "MERGED IDEMPOTENT: Re-apply fan-out config for vlan334 and vlan335"
+- name: "MERGED IDEMPOTENT: Re-apply multi-SVI config for vlan334 and vlan335"
   cisco.nd.nd_interface_svi: *merge_vlan334_335
-  register: nm_merged_idem_fanout
+  register: nm_merged_idem_multi
 
-- name: "MERGED IDEMPOTENT: Verify fan-out idempotency"
+- name: "MERGED IDEMPOTENT: Verify multi-SVI idempotency"
   ansible.builtin.assert:
     that:
-      - nm_merged_idem_fanout is not changed
+      - nm_merged_idem_multi is not changed
 
 # --- MERGED UPDATE ---
 
@@ -141,34 +142,35 @@
     that:
       - nm_merged_update_333_idem is not changed
 
-# --- MERGED UPDATE: FAN-OUT UPDATE ---
+# --- MERGED UPDATE: MULTI-SVI UPDATE ---
 
-- name: "MERGED UPDATE: Update vlan334 and vlan335 via fan-out"
+- name: "MERGED UPDATE: Update vlan334 and vlan335 in one task"
   cisco.nd.nd_interface_svi:
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
-      - "{{ svi_334_335_updated }}"
+      - "{{ svi_334_updated }}"
+      - "{{ svi_335_updated }}"
     state: merged
-  register: nm_merged_update_fanout
+  register: nm_merged_update_multi
 
-- name: "MERGED UPDATE: Verify fan-out update"
+- name: "MERGED UPDATE: Verify multi-SVI update"
   ansible.builtin.assert:
     that:
-      - nm_merged_update_fanout is changed
+      - nm_merged_update_multi is changed
 
-- name: "MERGED UPDATE: Verify fan-out updated values"
+- name: "MERGED UPDATE: Verify multi-SVI updated values"
   vars:
-    vlan334_after: "{{ nm_merged_update_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | first }}"
-    vlan335_after: "{{ nm_merged_update_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | first }}"
+    vlan334_after: "{{ nm_merged_update_multi.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | first }}"
+    vlan335_after: "{{ nm_merged_update_multi.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | first }}"
   ansible.builtin.assert:
     that:
-      - vlan334_after.config_data.network_os.policy.description == "Updated fan-out description"
+      - vlan334_after.config_data.network_os.policy.description == "Updated vlan334 description"
       - vlan334_after.config_data.network_os.policy.admin_state == false
       - vlan334_after.config_data.network_os.policy.ip == "10.99.100.2"
-      - vlan335_after.config_data.network_os.policy.description == "Updated fan-out description"
+      - vlan335_after.config_data.network_os.policy.description == "Updated vlan335 description"
       - vlan335_after.config_data.network_os.policy.admin_state == false
-      - vlan335_after.config_data.network_os.policy.ip == "10.99.100.2"
+      - vlan335_after.config_data.network_os.policy.ip == "10.99.101.2"
 
 # --- MERGED: ASCII VALIDATION (CLIENT-SIDE) ---
 
@@ -178,8 +180,7 @@
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
+        interface_name: vlan333
         config_data:
           network_os:
             policy:
@@ -202,8 +203,7 @@
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 337
+        interface_name: vlan337
         config_data:
           network_os:
             policy:
@@ -227,44 +227,44 @@
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 337
+        interface_name: vlan337
     state: deleted
 
-# --- MERGED CREATE: LARGE FAN-OUT ---
+# --- MERGED CREATE: MULTI-SVI WITH UNIQUE L3 SETTINGS ---
 
-- name: "MERGED CREATE: Create vlan337 and vlan338 via fan-out (normal mode)"
+- name: "MERGED CREATE: Create vlan337 and vlan338 with unique IPs (normal mode)"
   cisco.nd.nd_interface_svi: &merge_vlan337_338
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
-      - "{{ svi_337_338 }}"
+      - "{{ svi_337 }}"
+      - "{{ svi_338 }}"
     state: merged
-  register: nm_merged_create_large_fanout
+  register: nm_merged_create_multi_337_338
 
-- name: "MERGED CREATE: Verify large fan-out creation"
+- name: "MERGED CREATE: Verify multi-SVI 337/338 creation"
   ansible.builtin.assert:
     that:
-      - nm_merged_create_large_fanout is changed
-      - nm_merged_create_large_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan337') | list | length == 1
-      - nm_merged_create_large_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan338') | list | length == 1
+      - nm_merged_create_multi_337_338 is changed
+      - nm_merged_create_multi_337_338.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan337') | list | length == 1
+      - nm_merged_create_multi_337_338.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan338') | list | length == 1
 
-- name: "MERGED CREATE: Verify both fan-out interfaces have the same config"
+- name: "MERGED CREATE: Verify each SVI has its own unique L3 config"
   vars:
-    vlan337_after: "{{ nm_merged_create_large_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan337') | first }}"
-    vlan338_after: "{{ nm_merged_create_large_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan338') | first }}"
+    vlan337_after: "{{ nm_merged_create_multi_337_338.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan337') | first }}"
+    vlan338_after: "{{ nm_merged_create_multi_337_338.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan338') | first }}"
   ansible.builtin.assert:
     that:
-      - vlan337_after.config_data.network_os.policy.description == "Fan-out test SVIs"
-      - vlan337_after.config_data.network_os.policy.ip == "10.99.102.1"
-      - vlan338_after.config_data.network_os.policy.description == "Fan-out test SVIs"
-      - vlan338_after.config_data.network_os.policy.ip == "10.99.102.1"
+      - vlan337_after.config_data.network_os.policy.description == "Multi-SVI test vlan337"
+      - vlan337_after.config_data.network_os.policy.ip == "10.99.103.1"
+      - vlan338_after.config_data.network_os.policy.description == "Multi-SVI test vlan338"
+      - vlan338_after.config_data.network_os.policy.ip == "10.99.104.1"
 
-- name: "MERGED IDEMPOTENT: Re-apply large fan-out"
+- name: "MERGED IDEMPOTENT: Re-apply multi-SVI 337/338"
   cisco.nd.nd_interface_svi: *merge_vlan337_338
-  register: nm_merged_idem_large_fanout
+  register: nm_merged_idem_multi_337_338
 
-- name: "MERGED IDEMPOTENT: Verify large fan-out idempotency"
+- name: "MERGED IDEMPOTENT: Verify multi-SVI 337/338 idempotency"
   ansible.builtin.assert:
     that:
-      - nm_merged_idem_large_fanout is not changed
+      - nm_merged_idem_multi_337_338 is not changed

--- a/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
@@ -4,24 +4,6 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# --- CLEANUP ---
-
-- name: "SETUP: Remove test SVIs before merged tests"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids: "{{ cleanup_vlan_ids }}"
-    state: deleted
-  register: setup_cleanup
-  tags: always
-
-- name: "DEBUG: Show cleanup result"
-  ansible.builtin.debug:
-    var: setup_cleanup
-  tags: always
-
 # --- MERGED CREATE: SINGLE SVI ---
 
 - name: "MERGED CREATE: Create vlan333 with full config (check mode)"

--- a/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/merged.yaml
@@ -25,7 +25,7 @@
 # --- MERGED CREATE: SINGLE SVI ---
 
 - name: "MERGED CREATE: Create vlan333 with full config (check mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &merge_vlan333
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -35,12 +35,7 @@
   register: cm_merged_create_333
 
 - name: "MERGED CREATE: Create vlan333 with full config (normal mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_333 }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan333
   register: nm_merged_create_333
 
 - name: "DEBUG: Show merged create result"
@@ -57,7 +52,7 @@
 # --- MERGED CREATE: FAN-OUT (MULTIPLE VLANs, SINGLE CONFIG) ---
 
 - name: "MERGED CREATE: Create vlan334 and vlan335 via fan-out (check mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &merge_vlan334_335
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -67,12 +62,7 @@
   register: cm_merged_create_fanout
 
 - name: "MERGED CREATE: Create vlan334 and vlan335 via fan-out (normal mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_334_335 }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan334_335
   register: nm_merged_create_fanout
 
 - name: "MERGED CREATE: Verify fan-out creation"
@@ -103,22 +93,12 @@
 # --- MERGED IDEMPOTENCY ---
 
 - name: "MERGED IDEMPOTENT: Re-apply vlan333 creation (check mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_333 }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan333
   check_mode: true
   register: cm_merged_idem_333
 
 - name: "MERGED IDEMPOTENT: Re-apply vlan333 creation (normal mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_333 }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan333
   register: nm_merged_idem_333
 
 - name: "MERGED IDEMPOTENT: Verify no change on second run"
@@ -128,12 +108,7 @@
       - nm_merged_idem_333 is not changed
 
 - name: "MERGED IDEMPOTENT: Re-apply fan-out config for vlan334 and vlan335"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_334_335 }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan334_335
   register: nm_merged_idem_fanout
 
 - name: "MERGED IDEMPOTENT: Verify fan-out idempotency"
@@ -144,7 +119,7 @@
 # --- MERGED UPDATE ---
 
 - name: "MERGED UPDATE: Update vlan333 description and other fields (check mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &merge_vlan333_updated
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -154,12 +129,7 @@
   register: cm_merged_update_333
 
 - name: "MERGED UPDATE: Update vlan333 description and other fields (normal mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_333_updated }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan333_updated
   register: nm_merged_update_333
 
 - name: "MERGED UPDATE: Verify vlan333 was updated"
@@ -181,12 +151,7 @@
       - vlan333_after.config_data.network_os.policy.advertise_subnet_in_underlay == true
 
 - name: "MERGED UPDATE: Re-apply update for idempotency"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_333_updated }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan333_updated
   register: nm_merged_update_333_idem
 
 - name: "MERGED UPDATE: Verify idempotency after update"
@@ -287,7 +252,7 @@
 # --- MERGED CREATE: LARGE FAN-OUT ---
 
 - name: "MERGED CREATE: Create vlan337 and vlan338 via fan-out (normal mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &merge_vlan337_338
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -314,12 +279,7 @@
       - vlan338_after.config_data.network_os.policy.ip == "10.99.102.1"
 
 - name: "MERGED IDEMPOTENT: Re-apply large fan-out"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ svi_337_338 }}"
-    state: merged
+  cisco.nd.nd_interface_svi: *merge_vlan337_338
   register: nm_merged_idem_large_fanout
 
 - name: "MERGED IDEMPOTENT: Verify large fan-out idempotency"

--- a/tests/integration/targets/nd_interface_svi/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/overridden.yaml
@@ -1,0 +1,195 @@
+---
+# Overridden state tests for nd_interface_svi
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point vlan333, vlan334, vlan335, vlan336, vlan337, vlan338 exist
+# from prior tests. Override will reduce the set to only what is specified.
+#
+# Unlike trunk_host (where deleted interfaces remain visible at fabric defaults),
+# SVIs that are removed by overridden are truly deleted from ND and disappear
+# from this module's query filter.
+
+# --- OVERRIDDEN: REDUCE TO TWO SVIs ---
+
+- name: "OVERRIDDEN: Override to only vlan333 and vlan334 (check mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Overridden vlan333"
+              ip: 10.99.200.1
+              prefix: 24
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 334
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Overridden vlan334"
+              ip: 10.99.201.1
+              prefix: 24
+    state: overridden
+  check_mode: true
+  register: cm_overridden_reduce
+
+- name: "OVERRIDDEN: Override to only vlan333 and vlan334 (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Overridden vlan333"
+              ip: 10.99.200.1
+              prefix: 24
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 334
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Overridden vlan334"
+              ip: 10.99.201.1
+              prefix: 24
+    state: overridden
+  register: nm_overridden_reduce
+
+- name: "OVERRIDDEN: Verify reduce changed and applied"
+  ansible.builtin.assert:
+    that:
+      - cm_overridden_reduce is changed
+      - nm_overridden_reduce is changed
+
+- name: "OVERRIDDEN: Verify vlan333 and vlan334 carry the overridden config"
+  vars:
+    vlan333_after: "{{ nm_overridden_reduce.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan333') | first }}"
+    vlan334_after: "{{ nm_overridden_reduce.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | first }}"
+  ansible.builtin.assert:
+    that:
+      - vlan333_after.config_data.network_os.policy.description == "Overridden vlan333"
+      - vlan333_after.config_data.network_os.policy.ip == "10.99.200.1"
+      - vlan334_after.config_data.network_os.policy.description == "Overridden vlan334"
+      - vlan334_after.config_data.network_os.policy.ip == "10.99.201.1"
+
+- name: "OVERRIDDEN: Verify removed SVIs are gone from after state"
+  vars:
+    vlan335_after: "{{ nm_overridden_reduce.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | list }}"
+    vlan336_after: "{{ nm_overridden_reduce.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan336') | list }}"
+    vlan337_after: "{{ nm_overridden_reduce.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan337') | list }}"
+    vlan338_after: "{{ nm_overridden_reduce.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan338') | list }}"
+  ansible.builtin.assert:
+    that:
+      - vlan335_after | length == 0
+      - vlan336_after | length == 0
+      - vlan337_after | length == 0
+      - vlan338_after | length == 0
+
+# --- OVERRIDDEN: IDEMPOTENCY ---
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply the same overridden config"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Overridden vlan333"
+              ip: 10.99.200.1
+              prefix: 24
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 334
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Overridden vlan334"
+              ip: 10.99.201.1
+              prefix: 24
+    state: overridden
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_idem is not changed
+
+# --- OVERRIDDEN: GROW THE SET BACK ---
+
+- name: "OVERRIDDEN: Re-add vlan335 by including it in the override set"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Overridden vlan333"
+              ip: 10.99.200.1
+              prefix: 24
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 334
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Overridden vlan334"
+              ip: 10.99.201.1
+              prefix: 24
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 335
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Overridden vlan335"
+              ip: 10.99.202.1
+              prefix: 24
+    state: overridden
+  register: nm_overridden_grow
+
+- name: "OVERRIDDEN: Verify grow changed and vlan335 is present"
+  vars:
+    vlan335_after: "{{ nm_overridden_grow.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | list }}"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_grow is changed
+      - vlan335_after | length == 1
+      - vlan335_after[0].config_data.network_os.policy.description == "Overridden vlan335"

--- a/tests/integration/targets/nd_interface_svi/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/overridden.yaml
@@ -25,7 +25,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Overridden vlan333"
               ip: 10.99.200.1
@@ -36,7 +35,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Overridden vlan334"
               ip: 10.99.201.1
@@ -56,7 +54,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Overridden vlan333"
               ip: 10.99.200.1
@@ -67,7 +64,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Overridden vlan334"
               ip: 10.99.201.1
@@ -118,7 +114,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Overridden vlan333"
               ip: 10.99.200.1
@@ -129,7 +124,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Overridden vlan334"
               ip: 10.99.201.1
@@ -155,7 +149,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Overridden vlan333"
               ip: 10.99.200.1
@@ -166,7 +159,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Overridden vlan334"
               ip: 10.99.201.1
@@ -177,7 +169,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Overridden vlan335"
               ip: 10.99.202.1

--- a/tests/integration/targets/nd_interface_svi/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/overridden.yaml
@@ -20,8 +20,7 @@
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
+        interface_name: vlan333
         config_data:
           network_os:
             policy:
@@ -30,8 +29,7 @@
               ip: 10.99.200.1
               prefix: 24
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 334
+        interface_name: vlan334
         config_data:
           network_os:
             policy:
@@ -96,8 +94,7 @@
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
+        interface_name: vlan333
         config_data:
           network_os:
             policy:
@@ -106,8 +103,7 @@
               ip: 10.99.200.1
               prefix: 24
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 334
+        interface_name: vlan334
         config_data:
           network_os:
             policy:
@@ -116,8 +112,7 @@
               ip: 10.99.201.1
               prefix: 24
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 335
+        interface_name: vlan335
         config_data:
           network_os:
             policy:

--- a/tests/integration/targets/nd_interface_svi/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/overridden.yaml
@@ -15,7 +15,7 @@
 # --- OVERRIDDEN: REDUCE TO TWO SVIs ---
 
 - name: "OVERRIDDEN: Override to only vlan333 and vlan334 (check mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &override_vlan333_334
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -44,31 +44,7 @@
   register: cm_overridden_reduce
 
 - name: "OVERRIDDEN: Override to only vlan333 and vlan334 (normal mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              description: "Overridden vlan333"
-              ip: 10.99.200.1
-              prefix: 24
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 334
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              description: "Overridden vlan334"
-              ip: 10.99.201.1
-              prefix: 24
-    state: overridden
+  cisco.nd.nd_interface_svi: *override_vlan333_334
   register: nm_overridden_reduce
 
 - name: "OVERRIDDEN: Verify reduce changed and applied"
@@ -104,31 +80,7 @@
 # --- OVERRIDDEN: IDEMPOTENCY ---
 
 - name: "OVERRIDDEN IDEMPOTENT: Re-apply the same overridden config"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              description: "Overridden vlan333"
-              ip: 10.99.200.1
-              prefix: 24
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 334
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              description: "Overridden vlan334"
-              ip: 10.99.201.1
-              prefix: 24
-    state: overridden
+  cisco.nd.nd_interface_svi: *override_vlan333_334
   register: nm_overridden_idem
 
 - name: "OVERRIDDEN IDEMPOTENT: Verify no change"

--- a/tests/integration/targets/nd_interface_svi/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/replaced.yaml
@@ -1,0 +1,143 @@
+---
+# Replaced state tests for nd_interface_svi
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point vlan333 (updated), vlan334-335 (updated), vlan336,
+# vlan337-338 exist from merged tests.
+
+# --- REPLACED: FULL REPLACE (SINGLE) ---
+
+- name: "REPLACED: Replace vlan333 config entirely (check mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Replaced vlan333"
+              ip: 10.99.150.1
+              prefix: 24
+    state: replaced
+  check_mode: true
+  register: cm_replaced_333
+
+- name: "REPLACED: Replace vlan333 config entirely (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Replaced vlan333"
+              ip: 10.99.150.1
+              prefix: 24
+    state: replaced
+  register: nm_replaced_333
+
+- name: "REPLACED: Verify vlan333 was replaced"
+  vars:
+    vlan333_after: "{{ nm_replaced_333.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan333') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_333 is changed
+      - nm_replaced_333 is changed
+      - vlan333_after.config_data.network_os.policy.description == "Replaced vlan333"
+      - vlan333_after.config_data.network_os.policy.ip == "10.99.150.1"
+
+- name: "REPLACED IDEMPOTENT: Re-apply replace for vlan333"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 333
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Replaced vlan333"
+              ip: 10.99.150.1
+              prefix: 24
+    state: replaced
+  register: nm_replaced_333_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_333_idem is not changed
+
+# --- REPLACED: FAN-OUT ---
+
+- name: "REPLACED: Replace vlan334 and vlan335 via fan-out (normal mode)"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 334
+          - 335
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Replaced fan-out"
+              ip: 10.99.151.1
+              prefix: 24
+    state: replaced
+  register: nm_replaced_fanout
+
+- name: "REPLACED: Verify fan-out replace"
+  vars:
+    vlan334_after: "{{ nm_replaced_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | first }}"
+    vlan335_after: "{{ nm_replaced_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_fanout is changed
+      - vlan334_after.config_data.network_os.policy.description == "Replaced fan-out"
+      - vlan334_after.config_data.network_os.policy.ip == "10.99.151.1"
+      - vlan335_after.config_data.network_os.policy.description == "Replaced fan-out"
+      - vlan335_after.config_data.network_os.policy.ip == "10.99.151.1"
+
+- name: "REPLACED IDEMPOTENT: Verify fan-out replace idempotency"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids:
+          - 334
+          - 335
+        config_data:
+          network_os:
+            policy:
+              policy_type: svi
+              admin_state: true
+              description: "Replaced fan-out"
+              ip: 10.99.151.1
+              prefix: 24
+    state: replaced
+  register: nm_replaced_fanout_idem
+
+- name: "REPLACED IDEMPOTENT: Verify fan-out idempotency"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_fanout_idem is not changed

--- a/tests/integration/targets/nd_interface_svi/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/replaced.yaml
@@ -11,7 +11,7 @@
 # --- REPLACED: FULL REPLACE (SINGLE) ---
 
 - name: "REPLACED: Replace vlan333 config entirely (check mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &replace_vlan333
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -30,21 +30,7 @@
   register: cm_replaced_333
 
 - name: "REPLACED: Replace vlan333 config entirely (normal mode)"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              description: "Replaced vlan333"
-              ip: 10.99.150.1
-              prefix: 24
-    state: replaced
+  cisco.nd.nd_interface_svi: *replace_vlan333
   register: nm_replaced_333
 
 - name: "REPLACED: Verify vlan333 was replaced"
@@ -58,21 +44,7 @@
       - vlan333_after.config_data.network_os.policy.ip == "10.99.150.1"
 
 - name: "REPLACED IDEMPOTENT: Re-apply replace for vlan333"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              description: "Replaced vlan333"
-              ip: 10.99.150.1
-              prefix: 24
-    state: replaced
+  cisco.nd.nd_interface_svi: *replace_vlan333
   register: nm_replaced_333_idem
 
 - name: "REPLACED IDEMPOTENT: Verify no change on second run"
@@ -83,7 +55,7 @@
 # --- REPLACED: FAN-OUT ---
 
 - name: "REPLACED: Replace vlan334 and vlan335 via fan-out (normal mode)"
-  cisco.nd.nd_interface_svi:
+  cisco.nd.nd_interface_svi: &replace_vlan334_335
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -114,22 +86,7 @@
       - vlan335_after.config_data.network_os.policy.ip == "10.99.151.1"
 
 - name: "REPLACED IDEMPOTENT: Verify fan-out replace idempotency"
-  cisco.nd.nd_interface_svi:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 334
-          - 335
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              description: "Replaced fan-out"
-              ip: 10.99.151.1
-              prefix: 24
-    state: replaced
+  cisco.nd.nd_interface_svi: *replace_vlan334_335
   register: nm_replaced_fanout_idem
 
 - name: "REPLACED IDEMPOTENT: Verify fan-out idempotency"

--- a/tests/integration/targets/nd_interface_svi/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/replaced.yaml
@@ -21,7 +21,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Replaced vlan333"
               ip: 10.99.150.1
@@ -41,7 +40,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Replaced vlan333"
               ip: 10.99.150.1
@@ -70,7 +68,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Replaced vlan333"
               ip: 10.99.150.1
@@ -97,7 +94,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Replaced fan-out"
               ip: 10.99.151.1
@@ -129,7 +125,6 @@
         config_data:
           network_os:
             policy:
-              policy_type: svi
               admin_state: true
               description: "Replaced fan-out"
               ip: 10.99.151.1

--- a/tests/integration/targets/nd_interface_svi/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/replaced.yaml
@@ -16,8 +16,7 @@
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 333
+        interface_name: vlan333
         config_data:
           network_os:
             policy:
@@ -52,44 +51,51 @@
     that:
       - nm_replaced_333_idem is not changed
 
-# --- REPLACED: FAN-OUT ---
+# --- REPLACED: MULTIPLE SVIs IN ONE TASK ---
 
-- name: "REPLACED: Replace vlan334 and vlan335 via fan-out (normal mode)"
+- name: "REPLACED: Replace vlan334 and vlan335 in one task (normal mode)"
   cisco.nd.nd_interface_svi: &replace_vlan334_335
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
       - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids:
-          - 334
-          - 335
+        interface_name: vlan334
         config_data:
           network_os:
             policy:
               admin_state: true
-              description: "Replaced fan-out"
+              description: "Replaced vlan334"
               ip: 10.99.151.1
               prefix: 24
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: vlan335
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: "Replaced vlan335"
+              ip: 10.99.152.1
+              prefix: 24
     state: replaced
-  register: nm_replaced_fanout
+  register: nm_replaced_multi
 
-- name: "REPLACED: Verify fan-out replace"
+- name: "REPLACED: Verify multi-SVI replace"
   vars:
-    vlan334_after: "{{ nm_replaced_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | first }}"
-    vlan335_after: "{{ nm_replaced_fanout.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | first }}"
+    vlan334_after: "{{ nm_replaced_multi.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan334') | first }}"
+    vlan335_after: "{{ nm_replaced_multi.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', 'vlan335') | first }}"
   ansible.builtin.assert:
     that:
-      - nm_replaced_fanout is changed
-      - vlan334_after.config_data.network_os.policy.description == "Replaced fan-out"
+      - nm_replaced_multi is changed
+      - vlan334_after.config_data.network_os.policy.description == "Replaced vlan334"
       - vlan334_after.config_data.network_os.policy.ip == "10.99.151.1"
-      - vlan335_after.config_data.network_os.policy.description == "Replaced fan-out"
-      - vlan335_after.config_data.network_os.policy.ip == "10.99.151.1"
+      - vlan335_after.config_data.network_os.policy.description == "Replaced vlan335"
+      - vlan335_after.config_data.network_os.policy.ip == "10.99.152.1"
 
-- name: "REPLACED IDEMPOTENT: Verify fan-out replace idempotency"
+- name: "REPLACED IDEMPOTENT: Re-apply multi-SVI replace"
   cisco.nd.nd_interface_svi: *replace_vlan334_335
-  register: nm_replaced_fanout_idem
+  register: nm_replaced_multi_idem
 
-- name: "REPLACED IDEMPOTENT: Verify fan-out idempotency"
+- name: "REPLACED IDEMPOTENT: Verify multi-SVI idempotency"
   ansible.builtin.assert:
     that:
-      - nm_replaced_fanout_idem is not changed
+      - nm_replaced_multi_idem is not changed

--- a/tests/integration/targets/nd_interface_svi/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/setup.yaml
@@ -12,9 +12,7 @@
   cisco.nd.nd_interface_svi:
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        vlan_ids: "{{ cleanup_vlan_ids }}"
+    config: "{{ cleanup_config }}"
     state: deleted
   register: setup_cleanup
   tags: always

--- a/tests/integration/targets/nd_interface_svi/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_svi/tasks/setup.yaml
@@ -1,0 +1,25 @@
+---
+# Pre-test cleanup for nd_interface_svi
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Called from main.yaml before the merged/replaced/overridden/deleted state
+# blocks. Ensures no test SVIs exist on the target switch before the state
+# tests run. The DEBUG task surfaces the cleanup result for triage.
+
+- name: "SETUP: Remove test SVIs before state tests"
+  cisco.nd.nd_interface_svi:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        vlan_ids: "{{ cleanup_vlan_ids }}"
+    state: deleted
+  register: setup_cleanup
+  tags: always
+
+- name: "DEBUG: Show cleanup result"
+  ansible.builtin.debug:
+    var: setup_cleanup
+  tags: always

--- a/tests/integration/targets/nd_interface_svi/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_svi/vars/main.yaml
@@ -1,0 +1,125 @@
+---
+# Variables for nd_interface_svi integration tests.
+#
+# Override fabric_name and switch_ip in your inventory or extra-vars
+# to match a real ND 4.2 testbed.
+
+test_fabric_name: "{{ nd_test_fabric_name | default('test_fabric') }}"
+test_switch_ip: "{{ nd_test_switch_ip | default('192.168.1.1') }}"
+
+# VLAN IDs reserved for these integration tests. The orchestrator expands each
+# ID into an interface named `vlan<id>`. These VLANs must NOT have SVIs already
+# configured at the start of the test run (cleanup is run first to ensure this).
+
+# --- Base configs ---
+
+svi_333:
+  switch_ip: "{{ test_switch_ip }}"
+  vlan_ids:
+    - 333
+  config_data:
+    network_os:
+      policy:
+        policy_type: svi
+        admin_state: true
+        description: "Ansible integration test vlan333"
+        ip: 10.99.99.1
+        prefix: 24
+        ip_redirects: true
+        pim_sparse: false
+        pim_dr_priority: 1
+        advertise_subnet_in_underlay: false
+        netflow: false
+
+svi_334_335:
+  switch_ip: "{{ test_switch_ip }}"
+  vlan_ids:
+    - 334
+    - 335
+  config_data:
+    network_os:
+      policy:
+        policy_type: svi
+        admin_state: true
+        description: "Ansible integration test fan-out"
+        ip: 10.99.100.1
+        prefix: 24
+        ip_redirects: true
+        pim_sparse: false
+        pim_dr_priority: 1
+        advertise_subnet_in_underlay: false
+        netflow: false
+
+svi_336:
+  switch_ip: "{{ test_switch_ip }}"
+  vlan_ids:
+    - 336
+  config_data:
+    network_os:
+      policy:
+        policy_type: svi
+        admin_state: true
+        description: "Ansible integration test vlan336"
+        ip: 10.99.101.1
+        prefix: 24
+
+# --- Updated configs for merge/replace tests ---
+
+svi_333_updated:
+  switch_ip: "{{ test_switch_ip }}"
+  vlan_ids:
+    - 333
+  config_data:
+    network_os:
+      policy:
+        policy_type: svi
+        admin_state: true
+        description: "Updated vlan333 description"
+        ip: 10.99.99.2
+        prefix: 24
+        ip_redirects: false
+        pim_sparse: true
+        pim_dr_priority: 50
+        advertise_subnet_in_underlay: true
+        netflow: false
+
+svi_334_335_updated:
+  switch_ip: "{{ test_switch_ip }}"
+  vlan_ids:
+    - 334
+    - 335
+  config_data:
+    network_os:
+      policy:
+        policy_type: svi
+        admin_state: false
+        description: "Updated fan-out description"
+        ip: 10.99.100.2
+        prefix: 24
+        ip_redirects: true
+
+# --- Fan-out config for large/multi tests ---
+
+svi_337_338:
+  switch_ip: "{{ test_switch_ip }}"
+  vlan_ids:
+    - 337
+    - 338
+  config_data:
+    network_os:
+      policy:
+        policy_type: svi
+        admin_state: true
+        description: "Fan-out test SVIs"
+        ip: 10.99.102.1
+        prefix: 24
+
+# --- Cleanup helper: all test VLAN IDs ---
+
+cleanup_vlan_ids:
+  - 333
+  - 334
+  - 335
+  - 336
+  - 337
+  - 338

--- a/tests/integration/targets/nd_interface_svi/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_svi/vars/main.yaml
@@ -7,16 +7,15 @@
 test_fabric_name: "{{ nd_test_fabric_name | default('test_fabric') }}"
 test_switch_ip: "{{ nd_test_switch_ip | default('192.168.1.1') }}"
 
-# VLAN IDs reserved for these integration tests. The orchestrator expands each
-# ID into an interface named `vlan<id>`. These VLANs must NOT have SVIs already
-# configured at the start of the test run (cleanup is run first to ensure this).
+# Each SVI is L3 and gets its own config item with its own IP. The interface_name
+# is `vlan<id>`. These VLANs must NOT have SVIs already configured at the start
+# of the test run (cleanup_config below is run first to ensure this).
 
 # --- Base configs ---
 
 svi_333:
   switch_ip: "{{ test_switch_ip }}"
-  vlan_ids:
-    - 333
+  interface_name: vlan333
   config_data:
     network_os:
       policy:
@@ -30,17 +29,31 @@ svi_333:
         advertise_subnet_in_underlay: false
         netflow: false
 
-svi_334_335:
+svi_334:
   switch_ip: "{{ test_switch_ip }}"
-  vlan_ids:
-    - 334
-    - 335
+  interface_name: vlan334
   config_data:
     network_os:
       policy:
         admin_state: true
-        description: "Ansible integration test fan-out"
+        description: "Ansible integration test vlan334"
         ip: 10.99.100.1
+        prefix: 24
+        ip_redirects: true
+        pim_sparse: false
+        pim_dr_priority: 1
+        advertise_subnet_in_underlay: false
+        netflow: false
+
+svi_335:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: vlan335
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Ansible integration test vlan335"
+        ip: 10.99.101.1
         prefix: 24
         ip_redirects: true
         pim_sparse: false
@@ -50,22 +63,20 @@ svi_334_335:
 
 svi_336:
   switch_ip: "{{ test_switch_ip }}"
-  vlan_ids:
-    - 336
+  interface_name: vlan336
   config_data:
     network_os:
       policy:
         admin_state: true
         description: "Ansible integration test vlan336"
-        ip: 10.99.101.1
+        ip: 10.99.102.1
         prefix: 24
 
 # --- Updated configs for merge/replace tests ---
 
 svi_333_updated:
   switch_ip: "{{ test_switch_ip }}"
-  vlan_ids:
-    - 333
+  interface_name: vlan333
   config_data:
     network_os:
       policy:
@@ -79,41 +90,59 @@ svi_333_updated:
         advertise_subnet_in_underlay: true
         netflow: false
 
-svi_334_335_updated:
+svi_334_updated:
   switch_ip: "{{ test_switch_ip }}"
-  vlan_ids:
-    - 334
-    - 335
+  interface_name: vlan334
   config_data:
     network_os:
       policy:
         admin_state: false
-        description: "Updated fan-out description"
+        description: "Updated vlan334 description"
         ip: 10.99.100.2
         prefix: 24
         ip_redirects: true
 
-# --- Fan-out config for large/multi tests ---
-
-svi_337_338:
+svi_335_updated:
   switch_ip: "{{ test_switch_ip }}"
-  vlan_ids:
-    - 337
-    - 338
+  interface_name: vlan335
+  config_data:
+    network_os:
+      policy:
+        admin_state: false
+        description: "Updated vlan335 description"
+        ip: 10.99.101.2
+        prefix: 24
+        ip_redirects: true
+
+# --- Multi-SVI configs for large/multi tests ---
+
+svi_337:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: vlan337
   config_data:
     network_os:
       policy:
         admin_state: true
-        description: "Fan-out test SVIs"
-        ip: 10.99.102.1
+        description: "Multi-SVI test vlan337"
+        ip: 10.99.103.1
+        prefix: 24
+
+svi_338:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: vlan338
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Multi-SVI test vlan338"
+        ip: 10.99.104.1
         prefix: 24
 
 # --- HSRP / DHCP-relay / VRF / route-tag scenarios (phase 2) ---
 
 svi_500_hsrp:
   switch_ip: "{{ test_switch_ip }}"
-  vlan_ids:
-    - 500
+  interface_name: vlan500
   config_data:
     network_os:
       policy:
@@ -133,8 +162,7 @@ svi_500_hsrp:
 
 svi_500_hsrp_updated:
   switch_ip: "{{ test_switch_ip }}"
-  vlan_ids:
-    - 500
+  interface_name: vlan500
   config_data:
     network_os:
       policy:
@@ -154,8 +182,7 @@ svi_500_hsrp_updated:
 
 svi_501_dhcp:
   switch_ip: "{{ test_switch_ip }}"
-  vlan_ids:
-    - 501
+  interface_name: vlan501
   config_data:
     network_os:
       policy:
@@ -169,14 +196,22 @@ svi_501_dhcp:
         dhcp_server_address2: 10.10.10.11
         vrf_dhcp2: default
 
-# --- Cleanup helper: all test VLAN IDs ---
+# --- Cleanup helper: all test SVIs to remove before tests run ---
 
-cleanup_vlan_ids:
-  - 333
-  - 334
-  - 335
-  - 336
-  - 337
-  - 338
-  - 500
-  - 501
+cleanup_config:
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: vlan333
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: vlan334
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: vlan335
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: vlan336
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: vlan337
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: vlan338
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: vlan500
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: vlan501

--- a/tests/integration/targets/nd_interface_svi/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_svi/vars/main.yaml
@@ -20,7 +20,6 @@ svi_333:
   config_data:
     network_os:
       policy:
-        policy_type: svi
         admin_state: true
         description: "Ansible integration test vlan333"
         ip: 10.99.99.1
@@ -39,7 +38,6 @@ svi_334_335:
   config_data:
     network_os:
       policy:
-        policy_type: svi
         admin_state: true
         description: "Ansible integration test fan-out"
         ip: 10.99.100.1
@@ -57,7 +55,6 @@ svi_336:
   config_data:
     network_os:
       policy:
-        policy_type: svi
         admin_state: true
         description: "Ansible integration test vlan336"
         ip: 10.99.101.1
@@ -72,7 +69,6 @@ svi_333_updated:
   config_data:
     network_os:
       policy:
-        policy_type: svi
         admin_state: true
         description: "Updated vlan333 description"
         ip: 10.99.99.2
@@ -91,7 +87,6 @@ svi_334_335_updated:
   config_data:
     network_os:
       policy:
-        policy_type: svi
         admin_state: false
         description: "Updated fan-out description"
         ip: 10.99.100.2
@@ -108,7 +103,6 @@ svi_337_338:
   config_data:
     network_os:
       policy:
-        policy_type: svi
         admin_state: true
         description: "Fan-out test SVIs"
         ip: 10.99.102.1
@@ -123,7 +117,6 @@ svi_500_hsrp:
   config_data:
     network_os:
       policy:
-        policy_type: svi
         admin_state: true
         description: "HSRP test vlan500"
         vrf_interface: default
@@ -145,7 +138,6 @@ svi_500_hsrp_updated:
   config_data:
     network_os:
       policy:
-        policy_type: svi
         admin_state: true
         description: "HSRP test vlan500 (updated priority)"
         vrf_interface: default
@@ -167,7 +159,6 @@ svi_501_dhcp:
   config_data:
     network_os:
       policy:
-        policy_type: svi
         admin_state: true
         description: "DHCP relay test vlan501"
         vrf_interface: default

--- a/tests/integration/targets/nd_interface_svi/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_svi/vars/main.yaml
@@ -114,6 +114,70 @@ svi_337_338:
         ip: 10.99.102.1
         prefix: 24
 
+# --- HSRP / DHCP-relay / VRF / route-tag scenarios (phase 2) ---
+
+svi_500_hsrp:
+  switch_ip: "{{ test_switch_ip }}"
+  vlan_ids:
+    - 500
+  config_data:
+    network_os:
+      policy:
+        policy_type: svi
+        admin_state: true
+        description: "HSRP test vlan500"
+        vrf_interface: default
+        ip: 10.99.150.1
+        prefix: 24
+        routing_tag: "12345"
+        hsrp: true
+        hsrp_group: 5
+        hsrp_version: 2
+        hsrp_vip: 10.99.150.254
+        hsrp_priority: 110
+        preempt: true
+        mac: "0000.0c07.ac05"
+
+svi_500_hsrp_updated:
+  switch_ip: "{{ test_switch_ip }}"
+  vlan_ids:
+    - 500
+  config_data:
+    network_os:
+      policy:
+        policy_type: svi
+        admin_state: true
+        description: "HSRP test vlan500 (updated priority)"
+        vrf_interface: default
+        ip: 10.99.150.1
+        prefix: 24
+        routing_tag: "12345"
+        hsrp: true
+        hsrp_group: 5
+        hsrp_version: 2
+        hsrp_vip: 10.99.150.254
+        hsrp_priority: 200
+        preempt: true
+        mac: "0000.0c07.ac05"
+
+svi_501_dhcp:
+  switch_ip: "{{ test_switch_ip }}"
+  vlan_ids:
+    - 501
+  config_data:
+    network_os:
+      policy:
+        policy_type: svi
+        admin_state: true
+        description: "DHCP relay test vlan501"
+        vrf_interface: default
+        ip: 10.99.151.1
+        prefix: 24
+        dhcp_server_address1: 10.10.10.10
+        vrf_dhcp1: default
+        dhcp_server_address2: 10.10.10.11
+        vrf_dhcp2: default
+
 # --- Cleanup helper: all test VLAN IDs ---
 
 cleanup_vlan_ids:
@@ -123,3 +187,5 @@ cleanup_vlan_ids:
   - 336
   - 337
   - 338
+  - 500
+  - 501

--- a/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_managed_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_managed_interface.json
@@ -1,0 +1,260 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py",
+        "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
+        "Simulates ND responses for:",
+        "  - GET /api/v1/manage/fabrics/{fabric}/summary  (fabric_summary)",
+        "  - GET /api/v1/manage/fabrics/{fabric}/switches (switch_map)",
+        "  - GET /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces (list)",
+        "  - GET /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces/{name} (one)",
+        "  - POST /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces (create)",
+        "  - PUT  /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces/{name} (update)",
+        "  - POST /api/v1/manage/fabrics/{fabric}/interfaceActions/remove",
+        "  - POST /api/v1/manage/fabrics/{fabric}/interfaceActions/deploy"
+    ],
+    "test_query_all_happy_path_00400a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_happy_path_00400b": {
+        "TEST_NOTES": ["Switch list: two switches"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400c": {
+        "TEST_NOTES": [
+            "Switch FDO11111AAA: one managed subinterface (kept), one ethernet (filtered out by interfaceType), one subinterface with unmanaged monitorSubinterface policy (filtered out by policyType)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Ethernet1/3.2",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "subinterface", "description": "kept"}}
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "accessHost"}}
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3.9",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "unmanaged",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "monitorSubinterface"}}
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400d": {
+        "TEST_NOTES": ["Switch FDO22222BBB: one managed subinterface on a Port-channel parent"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Port-channel10.5",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "subinterface", "description": "switch-2"}}
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_fabric_not_found_00420a": {
+        "TEST_NOTES": ["Fabric summary 404 — drives validate_for_mutation to raise"],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_query_one_happy_path_00500a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_query_one_happy_path_00500b": {
+        "TEST_NOTES": ["GET /interfaces/Ethernet1/3.2 — returns single managed subinterface"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/Ethernet1/3.2",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaceName": "Ethernet1/3.2",
+            "interfaceType": "subInterface",
+            "switchId": "FDO11111AAA",
+            "configData": {
+                "mode": "managed",
+                "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "subinterface", "description": "exists"}}
+            }
+        }
+    },
+    "test_create_happy_path_00600a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_happy_path_00600b": {
+        "TEST_NOTES": ["POST /interfaces — create response (all items success)"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.2", "status": "success", "message": "Interface added successfully"}
+            ]
+        }
+    },
+    "test_create_multi_status_failure_00610a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_multi_status_failure_00610b": {
+        "TEST_NOTES": ["POST /interfaces — 207 Multi-Status body with a per-item failure (parent not in routed mode)"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.2", "status": "failed", "message": "parent not in routed mode"}
+            ]
+        }
+    },
+    "test_update_happy_path_00700a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_update_happy_path_00700b": {
+        "TEST_NOTES": ["PUT /interfaces/Ethernet1/3.2 — update response"],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/Ethernet1/3.2",
+        "MESSAGE": "OK",
+        "DATA": {}
+    },
+    "test_delete_happy_path_00800a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_remove_pending_happy_path_00810a": {
+        "TEST_NOTES": ["POST /interfaceActions/remove — bulk remove response"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/remove",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"interfaceName": "Ethernet1/3.2", "status": "success", "message": "Interface removed", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_deploy_pending_happy_path_00820a": {
+        "TEST_NOTES": ["POST /interfaceActions/deploy — bulk deploy response"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/deploy",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"interfaceName": "Ethernet1/3.2", "status": "success", "message": "Interface deployed", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_bulk_happy_path_00900a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution (switch_map cached after first call)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_bulk_happy_path_00900b": {
+        "TEST_NOTES": ["POST /interfaces with two subinterfaces in the array"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.2", "status": "success"},
+                {"name": "Ethernet1/3.3", "status": "success"}
+            ]
+        }
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_unmanaged_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_unmanaged_interface.json
@@ -1,0 +1,470 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for test_subinterface_unmanaged_interface.py.",
+        "Keys follow the test_<module>_<NNNNN><a|b|c|...> convention from CLAUDE.md.",
+        "Suffix order matches the order RestSend.commit() will consume responses within each test.",
+        "Tests that resolve a switch IP consume one switches-list response first (FabricContext lazy fetch).",
+        "Tests that call validate_prerequisites consume one fabric-summary response first.",
+        "Switch A: fabricManagementIp=192.168.12.151, switchId=FDO12345ABC.",
+        "Switch B: fabricManagementIp=192.168.12.152, switchId=FDO12345ABD."
+    ],
+
+    "test_subinterface_unmanaged_interface_00100a": {
+        "TEST_NOTES": ["create happy path: switches list (1 switch)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00100b": {
+        "TEST_NOTES": ["create happy path: POST /interfaces (207 success)"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.20", "status": "success", "message": "Interface added successfully"}
+            ]
+        }
+    },
+
+    "test_subinterface_unmanaged_interface_00101a": {
+        "TEST_NOTES": ["create 207 failed: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00101b": {
+        "TEST_NOTES": ["create 207 failed: POST returns 207 with status=failed (parent not in routed mode)"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.20", "status": "failed", "message": "Parent interface Ethernet1/3 is not in routed mode"}
+            ]
+        }
+    },
+
+    "test_subinterface_unmanaged_interface_00102a": {
+        "TEST_NOTES": ["create _request failure: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00102b": {
+        "TEST_NOTES": ["create _request failure: POST returns 500"],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"error": "boom"}
+    },
+
+    "test_subinterface_unmanaged_interface_00200a": {
+        "TEST_NOTES": ["update happy path: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00200b": {
+        "TEST_NOTES": ["update happy path: PUT /interfaces/Ethernet1%2F3.20"],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces/Ethernet1%2F3.20",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_subinterface_unmanaged_interface_00201a": {
+        "TEST_NOTES": ["update _request failure: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00201b": {
+        "TEST_NOTES": ["update _request failure: PUT returns 500"],
+        "RETURN_CODE": 500,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces/Ethernet1%2F3.20",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"error": "boom"}
+    },
+
+    "test_subinterface_unmanaged_interface_00300a": {
+        "TEST_NOTES": ["delete: only switches list consumed (no API call by delete itself)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+
+    "test_subinterface_unmanaged_interface_00301a": {
+        "TEST_NOTES": ["delete unknown switch: switches list has a DIFFERENT IP"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "10.0.0.99", "switchId": "FDO99999XYZ"}
+            ]
+        }
+    },
+
+    "test_subinterface_unmanaged_interface_00400a": {
+        "TEST_NOTES": ["create_bulk: switches list with 2 switches"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"},
+                {"fabricManagementIp": "192.168.12.152", "switchId": "FDO12345ABD"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00400b": {
+        "TEST_NOTES": ["create_bulk: POST switch A (Ethernet1/3.20 + Ethernet1/3.21) — 207 success"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.20", "status": "success", "message": "Interface added successfully"},
+                {"name": "Ethernet1/3.21", "status": "success", "message": "Interface added successfully"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00400c": {
+        "TEST_NOTES": ["create_bulk: POST switch B (Ethernet1/3.20) — 207 success"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABD/interfaces",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.20", "status": "success", "message": "Interface added successfully"}
+            ]
+        }
+    },
+
+    "test_subinterface_unmanaged_interface_00401a": {
+        "TEST_NOTES": ["create_bulk failure: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"},
+                {"fabricManagementIp": "192.168.12.152", "switchId": "FDO12345ABD"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00401b": {
+        "TEST_NOTES": ["create_bulk failure: POST switch A succeeds"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.20", "status": "success", "message": "Interface added successfully"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00401c": {
+        "TEST_NOTES": ["create_bulk failure: POST switch B fails"],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABD/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"error": "boom"}
+    },
+
+    "test_subinterface_unmanaged_interface_00500a": {
+        "TEST_NOTES": ["delete_bulk: only switches list consumed (no API calls by delete_bulk itself)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"},
+                {"fabricManagementIp": "192.168.12.152", "switchId": "FDO12345ABD"}
+            ]
+        }
+    },
+
+    "test_subinterface_unmanaged_interface_00600a": {
+        "TEST_NOTES": ["query_one happy: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00600b": {
+        "TEST_NOTES": ["query_one happy: GET /interfaces/Ethernet1%2F3.20"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces/Ethernet1%2F3.20",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaceName": "Ethernet1/3.20",
+            "interfaceType": "subInterface",
+            "configData": {
+                "mode": "unmanaged",
+                "networkOS": {
+                    "networkOSType": "nx-os",
+                    "policy": {
+                        "policyType": "monitorSubinterface"
+                    }
+                }
+            }
+        }
+    },
+
+    "test_subinterface_unmanaged_interface_00601a": {
+        "TEST_NOTES": ["query_one failure: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00601b": {
+        "TEST_NOTES": ["query_one failure: GET returns 500"],
+        "RETURN_CODE": 500,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces/Ethernet1%2F3.20",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"error": "boom"}
+    },
+
+    "test_subinterface_unmanaged_interface_00700a": {
+        "TEST_NOTES": ["query_all happy: fabric summary (local + default)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a",
+            "local": true,
+            "fabricStatus": "default"
+        }
+    },
+    "test_subinterface_unmanaged_interface_00700b": {
+        "TEST_NOTES": ["query_all happy: switches list (2 switches)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"},
+                {"fabricManagementIp": "192.168.12.152", "switchId": "FDO12345ABD"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00700c": {
+        "TEST_NOTES": [
+            "query_all happy: switch A interfaces — mixed managed (policyType=subinterface) + unmanaged (policyType=monitorSubinterface)",
+            "Only the monitorSubinterface entry should pass the filter."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Ethernet1/3.20",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "unmanaged",
+                        "networkOS": {"policy": {"policyType": "monitorSubinterface"}}
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3.2",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"policy": {"policyType": "subinterface"}}
+                    }
+                },
+                {
+                    "interfaceName": "ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {"networkOS": {"policy": {"policyType": "int_access_host"}}}
+                }
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00700d": {
+        "TEST_NOTES": ["query_all happy: switch B interfaces — only managed subinterface (must be excluded)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABD/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Ethernet1/3.2",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"policy": {"policyType": "subinterface"}}
+                    }
+                }
+            ]
+        }
+    },
+
+    "test_subinterface_unmanaged_interface_00701a": {
+        "TEST_NOTES": ["query_all empty fabric: fabric summary"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "local": true, "fabricStatus": "default"}
+    },
+    "test_subinterface_unmanaged_interface_00701b": {
+        "TEST_NOTES": ["query_all empty fabric: switches list returns no switches"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": []}
+    },
+
+    "test_subinterface_unmanaged_interface_00702a": {
+        "TEST_NOTES": ["query_all frozen fabric: fabric summary returns fabricStatus=frozen"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "local": true,
+            "fabricStatus": "frozen"
+        }
+    },
+
+    "test_subinterface_unmanaged_interface_00703a": {
+        "TEST_NOTES": ["query_all no subifs: fabric summary"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "local": true, "fabricStatus": "default"}
+    },
+    "test_subinterface_unmanaged_interface_00703b": {
+        "TEST_NOTES": ["query_all no subifs: switches list (1 switch)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00703c": {
+        "TEST_NOTES": ["query_all no subifs: only ethernet interfaces (must all be filtered out)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {"networkOS": {"policy": {"policyType": "int_access_host"}}}
+                }
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00704a": {
+        "TEST_NOTES": ["query_all non-dict DATA: fabric summary"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "local": true, "fabricStatus": "default"}
+    },
+    "test_subinterface_unmanaged_interface_00704b": {
+        "TEST_NOTES": ["query_all non-dict DATA: switches list (1 switch)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00704c": {
+        "TEST_NOTES": [
+            "query_all non-dict DATA: ND returns a bare JSON array instead of {'interfaces': [...]}.",
+            "The isinstance(result, dict) guard must skip this switch rather than raising AttributeError on .get()."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "OK",
+        "DATA": []
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_svi_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_svi_interface.json
@@ -1,0 +1,236 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for tests/unit/module_utils/orchestrators/test_svi_interface.py",
+        "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
+        "Simulates ND responses for:",
+        "  - GET /api/v1/manage/fabrics/{fabric}/summary  (fabric_summary)",
+        "  - GET /api/v1/manage/fabrics/{fabric}/switches (switch_map)",
+        "  - GET /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces (list)",
+        "  - GET /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces/{name} (one)",
+        "  - POST /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces (create)",
+        "  - PUT  /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces/{name} (update)",
+        "  - POST /api/v1/manage/fabrics/{fabric}/interfaceActions/remove",
+        "  - POST /api/v1/manage/fabrics/{fabric}/interfaceActions/deploy"
+    ],
+    "test_query_all_happy_path_00400a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_happy_path_00400b": {
+        "TEST_NOTES": ["Switch list: two switches"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400c": {
+        "TEST_NOTES": [
+            "Switch FDO11111AAA: one SVI (kept), one ethernet (filtered out by interfaceType), one VLAN with non-svi policy (filtered out by policyType)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vlan100",
+                    "interfaceType": "svi",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "svi", "description": "kept"}}
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "accessHost"}}
+                    }
+                },
+                {
+                    "interfaceName": "vlan999",
+                    "interfaceType": "svi",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "underlaySvi"}}
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400d": {
+        "TEST_NOTES": ["Switch FDO22222BBB: one SVI"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vlan200",
+                    "interfaceType": "svi",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "svi", "description": "switch-2"}}
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_fabric_not_found_00420a": {
+        "TEST_NOTES": ["Fabric summary 404 — drives validate_for_mutation to raise"],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_query_one_happy_path_00500a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_query_one_happy_path_00500b": {
+        "TEST_NOTES": ["GET /interfaces/vlan333 — returns single SVI"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vlan333",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaceName": "vlan333",
+            "interfaceType": "svi",
+            "switchId": "FDO11111AAA",
+            "configData": {
+                "mode": "managed",
+                "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "svi", "description": "exists"}}
+            }
+        }
+    },
+    "test_create_happy_path_00600a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_happy_path_00600b": {
+        "TEST_NOTES": ["POST /interfaces — create response"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"name": "vlan333", "status": "success", "message": "Interface added successfully"}
+            ]
+        }
+    },
+    "test_update_happy_path_00700a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_update_happy_path_00700b": {
+        "TEST_NOTES": ["PUT /interfaces/vlan333 — update response"],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vlan333",
+        "MESSAGE": "OK",
+        "DATA": {}
+    },
+    "test_delete_happy_path_00800a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_remove_pending_happy_path_00810a": {
+        "TEST_NOTES": ["POST /interfaceActions/remove — bulk remove response"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/remove",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"interfaceName": "vlan333", "status": "success", "message": "Interface removed", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_deploy_pending_happy_path_00820a": {
+        "TEST_NOTES": ["POST /interfaceActions/deploy — bulk deploy response"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/deploy",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"interfaceName": "vlan333", "status": "success", "message": "Interface deployed", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_bulk_happy_path_00900a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution (called once for each model in the bulk)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_bulk_happy_path_00900b": {
+        "TEST_NOTES": ["POST /interfaces with two SVIs in the array"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"name": "vlan333", "status": "success"},
+                {"name": "vlan334", "status": "success"}
+            ]
+        }
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_svi_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_svi_interface.json
@@ -23,6 +23,16 @@
             "ownerCluster": "cluster_a"
         }
     },
+    "test_query_all_happy_path_00400_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
     "test_query_all_happy_path_00400b": {
         "TEST_NOTES": ["Switch list: two switches"],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/models/test_subinterface_managed_interface.py
+++ b/tests/unit/module_utils/models/test_subinterface_managed_interface.py
@@ -1,0 +1,995 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for subinterface_managed_interface.py
+
+Tests the managed L3 subinterface Pydantic model classes.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceManagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import (
+    SubinterfaceManagedConfigDataModel,
+    SubinterfaceManagedInterfaceModel,
+    SubinterfaceManagedNetworkOSModel,
+    SubinterfaceManagedOperDataModel,
+    SubinterfaceManagedPolicyModel,
+)
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test data constants
+# =============================================================================
+
+SAMPLE_API_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "Ethernet1/3.2",
+    "interfaceType": "subInterface",
+    "switchId": "FDO11111AAA",
+    "configData": {
+        "mode": "managed",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "policyType": "subinterface",
+                "adminState": True,
+                "description": "Sample subinterface",
+                "vlanId": 2,
+                "ip": "10.20.30.40",
+                "ipRedirects": True,
+                "netflow": False,
+                "pimDrPriority": 1,
+                "pimSparse": False,
+                "prefix": 24,
+            },
+        },
+    },
+    "operData": {
+        "adminStatus": "up",
+        "operationalDescription": "subinterface is down",
+        "operationalStatus": "down",
+        "switchName": "LE1",
+    },
+}
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "Ethernet1/3.2",
+    "interface_type": "subInterface",
+    "config_data": {
+        "mode": "managed",
+        "network_os": {
+            "network_os_type": "nx-os",
+            "policy": {
+                "policy_type": "subinterface",
+                "admin_state": True,
+                "description": "Sample subinterface",
+                "vlan_id": 2,
+                "ip": "10.20.30.40",
+                "ip_redirects": True,
+                "netflow": False,
+                "pim_dr_priority": 1,
+                "pim_sparse": False,
+                "prefix": 24,
+            },
+        },
+    },
+}
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — initialization and defaults
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00100():
+    """
+    # Summary
+
+    Verify every policy field defaults to None except `policy_type` which defaults to
+    `SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE`.
+
+    ## Test
+
+    - Instantiate with no arguments
+    - All optional fields are None
+    - policy_type defaults to "subinterface"
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SubinterfaceManagedPolicyModel()
+    assert instance.policy_type == SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE
+    assert instance.policy_type == "subinterface"
+    assert instance.admin_state is None
+    assert instance.description is None
+    assert instance.extra_config is None
+    assert instance.mtu is None
+    assert instance.vlan_id is None
+    assert instance.vrf_interface is None
+    assert instance.ip is None
+    assert instance.prefix is None
+    assert instance.ipv6 is None
+    assert instance.ipv6_prefix is None
+    assert instance.routing_tag is None
+    assert instance.ip_redirects is None
+    assert instance.pim_sparse is None
+    assert instance.pim_dr_priority is None
+    assert instance.netflow is None
+    assert instance.netflow_monitor is None
+    assert instance.netflow_sampler is None
+
+
+def test_subinterface_managed_interface_00110():
+    """
+    # Summary
+
+    Verify construction with snake_case field names.
+
+    ## Test
+
+    - Construct with Python field names
+    - Values accessible
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SubinterfaceManagedPolicyModel(
+            admin_state=True,
+            description="test",
+            vlan_id=10,
+            ip="10.0.0.1",
+            prefix=24,
+            mtu=9216,
+        )
+    assert instance.admin_state is True
+    assert instance.description == "test"
+    assert instance.vlan_id == 10
+    assert instance.ip == "10.0.0.1"
+    assert instance.prefix == 24
+    assert instance.mtu == 9216
+    # Hardcoded model default; user no longer supplies this field.
+    assert instance.policy_type == "subinterface"
+
+
+def test_subinterface_managed_interface_00120():
+    """
+    # Summary
+
+    Verify construction with camelCase aliases.
+
+    ## Test
+
+    - Construct with API alias names
+    - Values accessible by Python names
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SubinterfaceManagedPolicyModel(
+            adminState=True,
+            ipRedirects=True,
+            pimDrPriority=5,
+            vlanId=20,
+            policyType="subinterface",
+        )
+    assert instance.admin_state is True
+    assert instance.ip_redirects is True
+    assert instance.pim_dr_priority == 5
+    assert instance.vlan_id == 20
+    assert instance.policy_type == "subinterface"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — description ASCII validator
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,should_raise",
+    [
+        ("plain ASCII", False),
+        ("with-hyphen and 123", False),
+        ("", False),
+        (None, False),
+        ("em — dash", True),
+        ("smart “quotes”", True),
+        ("emoji \U0001f600", True),
+        ("latin-1 \xe9", True),
+    ],
+    ids=[
+        "ascii_ok",
+        "ascii_punct_digits",
+        "empty_string",
+        "none_passthrough",
+        "em_dash_rejected",
+        "smart_quotes_rejected",
+        "emoji_rejected",
+        "latin1_rejected",
+    ],
+)
+def test_subinterface_managed_interface_00130(value, should_raise):
+    """
+    # Summary
+
+    Verify `description` (typed `AsciiDescription`) rejects any non-ASCII character.
+
+    Cisco backend pipes interface descriptions through CLI generators that 500 on UTF-8. Catching this client-side
+    gives users a clear error instead of a generic "unexpected error during policy execution" 500.
+
+    ## Test
+
+    - ASCII strings (including empty and None) accepted
+    - Any non-ASCII character (em-dash, smart quotes, emoji, latin-1) raises
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    - models.types.ascii_only()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError, match="description must contain only ASCII"):
+            SubinterfaceManagedPolicyModel(description=value)
+    else:
+        with does_not_raise():
+            instance = SubinterfaceManagedPolicyModel(description=value)
+        assert instance.description == value
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — range validation
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "field,value,should_raise",
+    [
+        ("mtu", 576, False),
+        ("mtu", 9216, False),
+        ("mtu", 575, True),
+        ("mtu", 9217, True),
+        ("vlan_id", 2, False),
+        ("vlan_id", 4094, False),
+        ("vlan_id", 1, True),
+        ("vlan_id", 4095, True),
+        ("prefix", 8, False),
+        ("prefix", 31, False),
+        ("prefix", 7, True),
+        ("prefix", 32, True),
+        ("ipv6_prefix", 1, False),
+        ("ipv6_prefix", 127, False),
+        ("ipv6_prefix", 0, True),
+        ("ipv6_prefix", 128, True),
+        ("pim_dr_priority", 1, False),
+        ("pim_dr_priority", 4294967295, False),
+        ("pim_dr_priority", 0, True),
+        ("pim_dr_priority", 4294967296, True),
+    ],
+    ids=lambda v: str(v) if not isinstance(v, bool) else ("raise" if v else "ok"),
+)
+def test_subinterface_managed_interface_00220(field, value, should_raise):
+    """
+    # Summary
+
+    Verify ge/le constraints on every numeric policy field.
+
+    ## Test
+
+    - At-min and at-max values accepted
+    - Below-min and above-max values rejected with ValidationError
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    # `prefix`/`ipv6_prefix` are required-together with `ip`/`ipv6` (see `_validate_ip_prefix_paired`), so supply
+    # the paired address when range-testing the mask length in isolation.
+    kwargs = {field: value}
+    if field == "prefix":
+        kwargs.setdefault("ip", "10.1.1.1")
+    elif field == "ipv6_prefix":
+        kwargs.setdefault("ipv6", "2001:db8::1")
+    if should_raise:
+        with pytest.raises(ValidationError):
+            SubinterfaceManagedPolicyModel(**kwargs)
+    else:
+        with does_not_raise():
+            instance = SubinterfaceManagedPolicyModel(**kwargs)
+        assert getattr(instance, field) == value
+
+
+def test_subinterface_managed_interface_00230():
+    """
+    # Summary
+
+    Verify `description` max_length=254.
+
+    ## Test
+
+    - 254 characters accepted
+    - 255 characters rejected
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        SubinterfaceManagedPolicyModel(description="a" * 254)
+    with pytest.raises(ValidationError):
+        SubinterfaceManagedPolicyModel(description="a" * 255)
+
+
+def test_subinterface_managed_interface_00240():
+    """
+    # Summary
+
+    Verify `vrf_interface` length constraints (min_length=1, max_length=32).
+
+    ## Test
+
+    - 1 and 32 character strings accepted
+    - empty string and 33 character string rejected
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        SubinterfaceManagedPolicyModel(vrf_interface="a")
+        SubinterfaceManagedPolicyModel(vrf_interface="a" * 32)
+    with pytest.raises(ValidationError):
+        SubinterfaceManagedPolicyModel(vrf_interface="")
+    with pytest.raises(ValidationError):
+        SubinterfaceManagedPolicyModel(vrf_interface="a" * 33)
+
+
+def test_subinterface_managed_interface_00250():
+    """
+    # Summary
+
+    Verify `_validate_netflow_monitor_present`: `netflow_monitor` is required when `netflow` is true.
+
+    ## Test
+
+    - `netflow=True` without `netflow_monitor` is rejected
+    - `netflow=True` with `netflow_monitor` is accepted
+    - `netflow=False` (or unset) without `netflow_monitor` is accepted
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel._validate_netflow_monitor_present()
+    """
+    with pytest.raises(ValidationError, match="netflow_monitor must be provided when netflow is true"):
+        SubinterfaceManagedPolicyModel(netflow=True)
+    with does_not_raise():
+        SubinterfaceManagedPolicyModel(netflow=True, netflow_monitor="MONITOR-1")
+        SubinterfaceManagedPolicyModel(netflow=False)
+        SubinterfaceManagedPolicyModel()
+
+
+def test_subinterface_managed_interface_00260():
+    """
+    # Summary
+
+    Verify `_validate_ip_prefix_paired`: `ip`/`prefix` (and `ipv6`/`ipv6_prefix`) are required together.
+
+    ## Test
+
+    - `ip` without `prefix` is rejected; `prefix` without `ip` is rejected
+    - `ipv6` without `ipv6_prefix` is rejected; `ipv6_prefix` without `ipv6` is rejected
+    - Both halves of a pair, or neither, is accepted
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel._validate_ip_prefix_paired()
+    """
+    with pytest.raises(ValidationError, match="ip and prefix are required together"):
+        SubinterfaceManagedPolicyModel(ip="10.1.1.1")
+    with pytest.raises(ValidationError, match="ip and prefix are required together"):
+        SubinterfaceManagedPolicyModel(prefix=24)
+    with pytest.raises(ValidationError, match="ipv6 and ipv6_prefix are required together"):
+        SubinterfaceManagedPolicyModel(ipv6="2001:db8::1")
+    with pytest.raises(ValidationError, match="ipv6 and ipv6_prefix are required together"):
+        SubinterfaceManagedPolicyModel(ipv6_prefix=64)
+    with does_not_raise():
+        SubinterfaceManagedPolicyModel(ip="10.1.1.1", prefix=24)
+        SubinterfaceManagedPolicyModel(ipv6="2001:db8::1", ipv6_prefix=64)
+        SubinterfaceManagedPolicyModel()
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — payload / config serialization
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00300():
+    """
+    # Summary
+
+    Verify `to_payload`-style serialization (model_dump with aliases, exclude_none) emits camelCase keys.
+
+    ## Test
+
+    - Construct with snake_case
+    - Dump with by_alias=True
+    - Output uses API camelCase keys
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.model_dump()
+    """
+    instance = SubinterfaceManagedPolicyModel(
+        admin_state=True,
+        description="payload",
+        vlan_id=30,
+        ip_redirects=True,
+        pim_dr_priority=2,
+    )
+    data = instance.model_dump(by_alias=True, exclude_none=True)
+    assert data["adminState"] is True
+    assert data["description"] == "payload"
+    assert data["vlanId"] == 30
+    assert data["ipRedirects"] is True
+    assert data["pimDrPriority"] == 2
+    assert "admin_state" not in data
+    assert "ip_redirects" not in data
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — routing_tag int->str coercion
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("12345", "12345"),
+        (12345, "12345"),
+        (0, "0"),
+        (None, None),
+    ],
+    ids=["string_passthrough", "int_coerced", "zero_int_coerced", "none_passthrough"],
+)
+def test_subinterface_managed_interface_00310(value, expected):
+    """
+    # Summary
+
+    Verify `routing_tag` accepts both strings (Ansible playbook side / POST/PUT request side) and integers (ND
+    GET response side). ND coerces input to int internally and returns int on GET even though OpenAPI declares
+    the field as string; the model normalizes to string for clean round-trips.
+
+    ## Test
+
+    - String values pass through unchanged
+    - Integer values are coerced to their decimal string form
+    - None passes through
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.coerce_routing_tag_to_string()
+    """
+    instance = SubinterfaceManagedPolicyModel(routing_tag=value)
+    assert instance.routing_tag == expected
+
+
+# =============================================================================
+# Test: SubinterfaceManagedNetworkOSModel
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00400():
+    """
+    # Summary
+
+    Verify default values for SubinterfaceManagedNetworkOSModel.
+
+    ## Test
+
+    - network_os_type defaults to "nx-os"
+    - policy defaults to None
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedNetworkOSModel.__init__()
+    """
+    instance = SubinterfaceManagedNetworkOSModel()
+    assert instance.network_os_type == "nx-os"
+    assert instance.policy is None
+
+
+def test_subinterface_managed_interface_00410():
+    """
+    # Summary
+
+    Verify SubinterfaceManagedNetworkOSModel accepts a SubinterfaceManagedPolicyModel as the `policy` field.
+
+    ## Test
+
+    - Pass a populated policy
+    - Access through the network OS container
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedNetworkOSModel.__init__()
+    """
+    policy = SubinterfaceManagedPolicyModel(admin_state=True, description="net-os")
+    instance = SubinterfaceManagedNetworkOSModel(policy=policy)
+    assert instance.policy is not None
+    assert instance.policy.admin_state is True
+    assert instance.policy.description == "net-os"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedConfigDataModel
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00500():
+    """
+    # Summary
+
+    Verify SubinterfaceManagedConfigDataModel defaults — `mode` is "managed" and `network_os` is required.
+
+    ## Test
+
+    - Construct with only network_os
+    - mode defaults to "managed"
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedConfigDataModel.__init__()
+    """
+    nos = SubinterfaceManagedNetworkOSModel(policy=SubinterfaceManagedPolicyModel(admin_state=True))
+    instance = SubinterfaceManagedConfigDataModel(network_os=nos)
+    assert instance.mode == "managed"
+    assert instance.network_os is not None
+
+
+def test_subinterface_managed_interface_00510():
+    """
+    # Summary
+
+    Verify SubinterfaceManagedConfigDataModel rejects construction without network_os.
+
+    ## Test
+
+    - Construct with no network_os
+    - ValidationError raised
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedConfigDataModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        SubinterfaceManagedConfigDataModel()  # network_os is required
+
+
+# =============================================================================
+# Test: SubinterfaceManagedOperDataModel — read-only operational data
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00600():
+    """
+    # Summary
+
+    Verify SubinterfaceManagedOperDataModel parses GET-side aliases.
+
+    ## Test
+
+    - Construct with camelCase aliases
+    - Access by snake_case fields
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedOperDataModel.__init__()
+    """
+    instance = SubinterfaceManagedOperDataModel(
+        adminStatus="up",
+        operationalDescription="subinterface is down",
+        operationalStatus="down",
+        switchName="LE1",
+    )
+    assert instance.admin_status == "up"
+    assert instance.operational_description == "subinterface is down"
+    assert instance.operational_status == "down"
+    assert instance.switch_name == "LE1"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — interface_name normalization
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("Ethernet1/3.2", "Ethernet1/3.2"),
+        ("ethernet1/3.2", "Ethernet1/3.2"),
+        ("ETHERNET1/3.2", "Ethernet1/3.2"),
+        ("eThErNeT1/3.2", "Ethernet1/3.2"),
+        ("Port-channel10.5", "Port-channel10.5"),
+        ("port-channel10.5", "Port-channel10.5"),
+        ("PORT-CHANNEL10.5", "Port-channel10.5"),
+        ("  Ethernet1/3.2  ", "Ethernet1/3.2"),
+    ],
+    ids=[
+        "ethernet_canonical_passthrough",
+        "ethernet_lowercase",
+        "ethernet_uppercase",
+        "ethernet_mixed_case",
+        "portchannel_canonical_passthrough",
+        "portchannel_lowercase",
+        "portchannel_uppercase",
+        "ethernet_padded",
+    ],
+)
+def test_subinterface_managed_interface_00700(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` canonicalizes the parent prefix capitalization while preserving the
+    dot-separated sub-id (e.g. `ethernet1/3.2` -> `Ethernet1/3.2`, `port-channel10.5` -> `Port-channel10.5`).
+
+    ## Test
+
+    - Any-cased Ethernet/Port-channel parents normalize to canonical capitalization
+    - Surrounding whitespace is stripped
+    - The `.<sub>` segment is preserved
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.normalize_interface_name()
+    """
+    instance = SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+    assert instance.interface_name == expected
+
+
+def test_subinterface_managed_interface_00710():
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects a name without a dot-separated sub-id.
+
+    ## Test
+
+    - A parent-only name (no `.<sub>`) raises ValidationError mentioning the dot-separated requirement
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match="must include a dot-separated subinterface id"):
+        SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name="Ethernet1/3")
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["Loopback0.1", "Vlan10.2", "mgmt0.3", "Tunnel1.4"],
+    ids=["loopback", "vlan", "mgmt", "tunnel"],
+)
+def test_subinterface_managed_interface_00720(value):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects parents that are neither Ethernet nor Port-channel.
+
+    ## Test
+
+    - A dotted name on a non-Ethernet/Port-channel parent raises ValidationError mentioning the allowed parents
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match="parent must be 'Ethernet...' or 'Port-channel...'"):
+        SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — composite identifier
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00800():
+    """
+    # Summary
+
+    Verify identifier configuration: composite `(switch_ip, interface_name)`.
+
+    ## Test
+
+    - identifier_strategy is "composite"
+    - identifiers is ["switch_ip", "interface_name"]
+    - get_identifier_value returns the tuple
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel — class attributes
+    - SubinterfaceManagedInterfaceModel.get_identifier_value()
+    """
+    assert SubinterfaceManagedInterfaceModel.identifier_strategy == "composite"
+    assert SubinterfaceManagedInterfaceModel.identifiers == ["switch_ip", "interface_name"]
+    instance = SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name="Ethernet1/3.2")
+    assert instance.get_identifier_value() == ("1.2.3.4", "Ethernet1/3.2")
+
+
+def test_subinterface_managed_interface_00810():
+    """
+    # Summary
+
+    Verify `payload_exclude_fields` excludes `switch_ip` and `oper_data` from `to_payload`.
+
+    ## Test
+
+    - Construct from a full GET response
+    - to_payload omits switchIp and operData
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.to_payload()
+    """
+    instance = SubinterfaceManagedInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+    assert "switchIp" not in payload
+    assert "operData" not in payload
+    # Verify the remaining top-level shape
+    assert payload["interfaceName"] == "Ethernet1/3.2"
+    assert payload["interfaceType"] == "subInterface"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — from_response robustness
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00900():
+    """
+    # Summary
+
+    Verify `from_response` is robust to missing nested structures.
+
+    ## Test
+
+    - Response with no configData
+    - Response with configData but no policy
+    - Both return a valid model without raising
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.from_response()
+    """
+    minimal = {
+        "switchIp": "1.2.3.4",
+        "interfaceName": "Ethernet1/3.2",
+        "switchId": "X",
+    }
+    with does_not_raise():
+        SubinterfaceManagedInterfaceModel.from_response(minimal)
+
+    no_policy = copy.deepcopy(minimal)
+    no_policy["configData"] = {"mode": "managed", "networkOS": {"networkOSType": "nx-os"}}
+    with does_not_raise():
+        SubinterfaceManagedInterfaceModel.from_response(no_policy)
+
+
+def test_subinterface_managed_interface_00910():
+    """
+    # Summary
+
+    Verify a populated policy round-trips through `from_response` -> `to_payload` with all fields preserved.
+
+    ## Test
+
+    - Response includes vlan_id, ip, prefix, PIM, netflow fields
+    - After from_response, every field is reachable on the model
+    - to_payload re-emits every field with API names
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.from_response()
+    - SubinterfaceManagedInterfaceModel.to_payload()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    response["configData"]["networkOS"]["policy"].update(
+        {
+            "mtu": 9216,
+            "vrfInterface": "tenant_a",
+            "ipv6": "2001:db8::1",
+            "ipv6Prefix": 64,
+            "routingTag": "12345",
+            "netflow": True,
+            "netflowMonitor": "MON1",
+        }
+    )
+
+    instance = SubinterfaceManagedInterfaceModel.from_response(response)
+    policy = instance.config_data.network_os.policy
+    assert policy.mtu == 9216
+    assert policy.vrf_interface == "tenant_a"
+    assert policy.ipv6 == "2001:db8::1"
+    assert policy.ipv6_prefix == 64
+    assert policy.routing_tag == "12345"
+    assert policy.netflow is True
+    assert policy.netflow_monitor == "MON1"
+
+    payload_policy = instance.to_payload()["configData"]["networkOS"]["policy"]
+    assert payload_policy["mtu"] == 9216
+    assert payload_policy["vrfInterface"] == "tenant_a"
+    assert payload_policy["ipv6"] == "2001:db8::1"
+    assert payload_policy["ipv6Prefix"] == 64
+    assert payload_policy["routingTag"] == "12345"
+    assert payload_policy["netflow"] is True
+    assert payload_policy["netflowMonitor"] == "MON1"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — round-trip from_response -> to_payload
+# =============================================================================
+
+
+def test_subinterface_managed_interface_01000():
+    """
+    # Summary
+
+    Verify a full GET response round-trips through from_response and to_payload, producing the same shape minus
+    excluded fields. All fields present in SAMPLE_API_RESPONSE must round-trip cleanly with their API aliases.
+
+    ## Test
+
+    - Build model from SAMPLE_API_RESPONSE
+    - to_payload result matches expected
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.from_response()
+    - SubinterfaceManagedInterfaceModel.to_payload()
+    """
+    instance = SubinterfaceManagedInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+
+    expected_policy_keys = set(SAMPLE_API_RESPONSE["configData"]["networkOS"]["policy"].keys())
+    assert set(payload["configData"]["networkOS"]["policy"].keys()) == expected_policy_keys
+    assert payload["interfaceName"] == "Ethernet1/3.2"
+    assert payload["interfaceType"] == "subInterface"
+    assert payload["configData"]["mode"] == "managed"
+    assert payload["configData"]["networkOS"]["networkOSType"] == "nx-os"
+
+
+def test_subinterface_managed_interface_01010():
+    """
+    # Summary
+
+    Verify from_config (Ansible-side snake_case) produces an equivalent model to from_response (API-side camelCase).
+
+    ## Test
+
+    - Build model A from SAMPLE_API_RESPONSE
+    - Build model B from SAMPLE_ANSIBLE_CONFIG
+    - to_payload outputs match
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.from_response()
+    - SubinterfaceManagedInterfaceModel.from_config()
+    """
+    a = SubinterfaceManagedInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    b = SubinterfaceManagedInterfaceModel.from_config(SAMPLE_ANSIBLE_CONFIG)
+    # b has no oper_data so payloads should match (oper_data excluded from payload anyway)
+    assert a.to_payload() == b.to_payload()
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — get_argument_spec
+# =============================================================================
+
+
+def test_subinterface_managed_interface_01100():
+    """
+    # Summary
+
+    Verify the argument spec exposes the expected top-level keys and required structure.
+
+    ## Test
+
+    - fabric_name is required str
+    - config is required list-of-dict
+    - state is enum with merged/replaced/overridden/deleted
+    - policy options include the writable fields and exclude the hardcoded discriminators
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.get_argument_spec()
+    """
+    spec = SubinterfaceManagedInterfaceModel.get_argument_spec()
+    assert spec["fabric_name"]["type"] == "str"
+    assert spec["fabric_name"]["required"] is True
+    assert spec["config"]["type"] == "list"
+    assert spec["config"]["required"] is True
+    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert spec["state"]["default"] == "merged"
+
+    config_options = spec["config"]["options"]
+    assert config_options["switch_ip"]["required"] is True
+    assert config_options["interface_name"]["type"] == "str"
+    assert config_options["interface_name"]["required"] is True
+    # interface_type, mode, and network_os_type are hardcoded in the Pydantic model
+    # and intentionally absent from the user-facing argument spec.
+    assert "interface_type" not in config_options
+    assert "mode" not in config_options["config_data"]["options"]
+    assert "network_os_type" not in config_options["config_data"]["options"]["network_os"]["options"]
+
+    policy_options = config_options["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    expected_policy_fields = {
+        "admin_state",
+        "description",
+        "extra_config",
+        "mtu",
+        "vlan_id",
+        "vrf_interface",
+        "ip",
+        "prefix",
+        "ipv6",
+        "ipv6_prefix",
+        "routing_tag",
+        "ip_redirects",
+        "pim_sparse",
+        "pim_dr_priority",
+        "netflow",
+        "netflow_monitor",
+        "netflow_sampler",
+    }
+    assert set(policy_options.keys()) == expected_policy_fields
+    assert "policy_type" not in policy_options
+    assert policy_options["vlan_id"]["type"] == "int"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — interface_type default
+# =============================================================================
+
+
+def test_subinterface_managed_interface_01200():
+    """
+    # Summary
+
+    Verify `interface_type` defaults to "subInterface".
+
+    ## Test
+
+    - Construct without interface_type
+    - Field equals "subInterface"
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.__init__()
+    """
+    instance = SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name="Ethernet1/3.2")
+    assert instance.interface_type == "subInterface"

--- a/tests/unit/module_utils/models/test_subinterface_managed_interface.py
+++ b/tests/unit/module_utils/models/test_subinterface_managed_interface.py
@@ -220,7 +220,7 @@ def test_subinterface_managed_interface_00120():
         ("", False),
         (None, False),
         ("em — dash", True),
-        ("smart “quotes”", True),
+        ("smart \u201cquotes\u201d", True),
         ("emoji \U0001f600", True),
         ("latin-1 \xe9", True),
     ],

--- a/tests/unit/module_utils/models/test_subinterface_unmanaged_interface.py
+++ b/tests/unit/module_utils/models/test_subinterface_unmanaged_interface.py
@@ -1,0 +1,625 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for subinterface_unmanaged_interface.py
+
+Tests the unmanaged (monitor-mode) L3 subinterface Pydantic model classes. The unmanaged variant carries only the
+`policyType` discriminator in its policy body; no L3 fields are configurable, so the focus here is the
+`interface_name` normalizer, the hardcoded scaffolding fields, and `extra="ignore"` tolerance on read.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceUnmanagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_unmanaged_interface import (
+    SubinterfaceUnmanagedConfigDataModel,
+    SubinterfaceUnmanagedInterfaceModel,
+    SubinterfaceUnmanagedNetworkOSModel,
+    SubinterfaceUnmanagedOperDataModel,
+    SubinterfaceUnmanagedPolicyModel,
+)
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test data constants
+# =============================================================================
+
+SAMPLE_API_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "Ethernet1/3.20",
+    "interfaceType": "subInterface",
+    "switchId": "FDO11111AAA",
+    "configData": {
+        "mode": "unmanaged",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "policyType": "monitorSubinterface",
+            },
+        },
+    },
+    "operData": {
+        "adminStatus": "up",
+        "operationalDescription": "subinterface is down",
+        "operationalStatus": "down",
+        "switchName": "LE1",
+    },
+}
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "Ethernet1/3.20",
+}
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedPolicyModel — initialization and defaults
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00100():
+    """
+    # Summary
+
+    Verify the unmanaged policy body carries only the `policy_type` discriminator, defaulting to
+    `SubinterfaceUnmanagedPolicyTypeEnum.MONITOR_SUBINTERFACE`.
+
+    ## Test
+
+    - Instantiate with no arguments
+    - policy_type defaults to "monitorSubinterface"
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SubinterfaceUnmanagedPolicyModel()
+    assert instance.policy_type == SubinterfaceUnmanagedPolicyTypeEnum.MONITOR_SUBINTERFACE
+    assert instance.policy_type == "monitorSubinterface"
+
+
+def test_subinterface_unmanaged_interface_00110():
+    """
+    # Summary
+
+    Verify `extra="ignore"` silently discards fields ND returns on GET that are not part of the unmanaged policy
+    body (e.g. the `userDefined` discriminator branch's `templateName` / `templateConfig`).
+
+    ## Test
+
+    - Construct with unknown extra keys plus the policy_type alias
+    - Construction succeeds and the extras are not attached to the model
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SubinterfaceUnmanagedPolicyModel(
+            policyType="monitorSubinterface",
+            templateName="int_subif_unmanaged",
+            templateConfig={"foo": "bar"},
+        )
+    assert instance.policy_type == "monitorSubinterface"
+    assert not hasattr(instance, "templateName")
+    assert not hasattr(instance, "templateConfig")
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedNetworkOSModel
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00400():
+    """
+    # Summary
+
+    Verify default values for SubinterfaceUnmanagedNetworkOSModel — `network_os_type` is "nx-os" and `policy` is
+    populated via default_factory (never None).
+
+    ## Test
+
+    - Construct with no arguments
+    - network_os_type defaults to "nx-os"
+    - policy is a SubinterfaceUnmanagedPolicyModel with the monitor discriminator
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedNetworkOSModel.__init__()
+    """
+    instance = SubinterfaceUnmanagedNetworkOSModel()
+    assert instance.network_os_type == "nx-os"
+    assert isinstance(instance.policy, SubinterfaceUnmanagedPolicyModel)
+    assert instance.policy.policy_type == "monitorSubinterface"
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedConfigDataModel
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00500():
+    """
+    # Summary
+
+    Verify SubinterfaceUnmanagedConfigDataModel defaults — `mode` is "unmanaged" and `network_os` is populated via
+    default_factory, so the container constructs with no arguments (unlike the managed variant, where network_os is
+    required).
+
+    ## Test
+
+    - Construct with no arguments
+    - mode defaults to "unmanaged"
+    - network_os is present
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedConfigDataModel.__init__()
+    """
+    instance = SubinterfaceUnmanagedConfigDataModel()
+    assert instance.mode == "unmanaged"
+    assert isinstance(instance.network_os, SubinterfaceUnmanagedNetworkOSModel)
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedOperDataModel — read-only operational data
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00600():
+    """
+    # Summary
+
+    Verify SubinterfaceUnmanagedOperDataModel parses GET-side aliases.
+
+    ## Test
+
+    - Construct with camelCase aliases
+    - Access by snake_case fields
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedOperDataModel.__init__()
+    """
+    instance = SubinterfaceUnmanagedOperDataModel(
+        adminStatus="up",
+        operationalDescription="subinterface is down",
+        operationalStatus="down",
+        switchName="LE1",
+    )
+    assert instance.admin_status == "up"
+    assert instance.operational_description == "subinterface is down"
+    assert instance.operational_status == "down"
+    assert instance.switch_name == "LE1"
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedInterfaceModel — interface_name normalization
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("Ethernet1/3.20", "Ethernet1/3.20"),
+        ("ethernet1/3.20", "Ethernet1/3.20"),
+        ("ETHERNET1/3.20", "Ethernet1/3.20"),
+        ("eThErNeT1/3.20", "Ethernet1/3.20"),
+        ("Port-channel10.20", "Port-channel10.20"),
+        ("port-channel10.20", "Port-channel10.20"),
+        ("PORT-CHANNEL10.20", "Port-channel10.20"),
+        ("  Ethernet1/3.20  ", "Ethernet1/3.20"),
+    ],
+    ids=[
+        "ethernet_canonical_passthrough",
+        "ethernet_lowercase",
+        "ethernet_uppercase",
+        "ethernet_mixed_case",
+        "portchannel_canonical_passthrough",
+        "portchannel_lowercase",
+        "portchannel_uppercase",
+        "ethernet_padded",
+    ],
+)
+def test_subinterface_unmanaged_interface_00700(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` canonicalizes the parent prefix capitalization while preserving the
+    dot-separated sub-id (e.g. `ethernet1/3.20` -> `Ethernet1/3.20`, `port-channel10.20` -> `Port-channel10.20`).
+    This is the same lowercase-on-GET normalization needed for idempotency.
+
+    ## Test
+
+    - Any-cased Ethernet/Port-channel parents normalize to canonical capitalization
+    - Surrounding whitespace is stripped
+    - The `.<sub>` segment is preserved
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.normalize_interface_name()
+    """
+    instance = SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+    assert instance.interface_name == expected
+
+
+def test_subinterface_unmanaged_interface_00710():
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects a name without a dot-separated sub-id.
+
+    ## Test
+
+    - A parent-only name (no `.<sub>`) raises ValidationError mentioning the dot-separated requirement
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match="must include a dot-separated subinterface id"):
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name="Ethernet1/3")
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["Loopback0.1", "Vlan10.2", "mgmt0.3", "Tunnel1.4"],
+    ids=["loopback", "vlan", "mgmt", "tunnel"],
+)
+def test_subinterface_unmanaged_interface_00720(value):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects parents that are neither Ethernet nor Port-channel.
+
+    ## Test
+
+    - A dotted name on a non-Ethernet/Port-channel parent raises ValidationError mentioning the allowed parents
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match="parent must be 'Ethernet...' or 'Port-channel...'"):
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+
+
+def test_subinterface_unmanaged_interface_00730():
+    """
+    # Summary
+
+    Verify `normalize_interface_name` passes an empty string through its guard unchanged (no normalization, no
+    "missing dot" ValueError) — the `not value` guard defers to the field's own type handling.
+
+    ## Test
+
+    - An empty `interface_name` constructs without raising and is preserved as ""
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.normalize_interface_name()
+    """
+    with does_not_raise():
+        instance = SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name="")
+    assert instance.interface_name == ""
+
+
+def test_subinterface_unmanaged_interface_00740():
+    """
+    # Summary
+
+    Verify a non-string `interface_name` is passed through the normalizer's guard unchanged (it does not raise the
+    validator's own ValueError) and is then rejected by the field's `str` type validation.
+
+    ## Test
+
+    - A None `interface_name` raises ValidationError, but not the normalizer's dot/parent messages
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name=None)
+    message = str(exc_info.value)
+    assert "must include a dot-separated subinterface id" not in message
+    assert "parent must be" not in message
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["Ethernet1/3.", "Port-channel10."],
+    ids=["ethernet_trailing_dot", "portchannel_trailing_dot"],
+)
+def test_subinterface_unmanaged_interface_00750(value):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects a trailing-dot name with an empty sub-id (e.g. `Ethernet1/3.`).
+
+    ## Test
+
+    - A name whose `.<sub>` segment is empty raises ValidationError mentioning the numeric sub-id requirement
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match="subinterface id .* must be a number"):
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["Ethernet1/3.abc", "Port-channel10.2a"],
+    ids=["ethernet_alpha_sub", "portchannel_alphanumeric_sub"],
+)
+def test_subinterface_unmanaged_interface_00760(value):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects a non-numeric sub-id (e.g. `Ethernet1/3.abc`).
+
+    ## Test
+
+    - A name whose `.<sub>` segment is not all-digits raises ValidationError mentioning the numeric sub-id requirement
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match="subinterface id .* must be a number"):
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["ethernetfoo.1", "port-channelbar.2"],
+    ids=["ethernet_no_port", "portchannel_no_number"],
+)
+def test_subinterface_unmanaged_interface_00770(value):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects a parent that carries the right prefix but no port/channel number
+    after it (e.g. `ethernetfoo.1`), rather than silently canonicalizing the malformed parent.
+
+    ## Test
+
+    - A name whose parent has a non-numeric first character after the `Ethernet`/`Port-channel` prefix raises
+      ValidationError mentioning the malformed parent
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match="is malformed"):
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedInterfaceModel — composite identifier
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00800():
+    """
+    # Summary
+
+    Verify identifier configuration: composite `(switch_ip, interface_name)`.
+
+    ## Test
+
+    - identifier_strategy is "composite"
+    - identifiers is ["switch_ip", "interface_name"]
+    - get_identifier_value returns the tuple
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel — class attributes
+    - SubinterfaceUnmanagedInterfaceModel.get_identifier_value()
+    """
+    assert SubinterfaceUnmanagedInterfaceModel.identifier_strategy == "composite"
+    assert SubinterfaceUnmanagedInterfaceModel.identifiers == ["switch_ip", "interface_name"]
+    instance = SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name="Ethernet1/3.20")
+    assert instance.get_identifier_value() == ("1.2.3.4", "Ethernet1/3.20")
+
+
+def test_subinterface_unmanaged_interface_00810():
+    """
+    # Summary
+
+    Verify `payload_exclude_fields` excludes `switch_ip` and `oper_data` from `to_payload`.
+
+    ## Test
+
+    - Construct from a full GET response
+    - to_payload omits switchIp and operData
+    - to_payload retains the hardcoded interfaceName / interfaceType
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.to_payload()
+    """
+    instance = SubinterfaceUnmanagedInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+    assert "switchIp" not in payload
+    assert "operData" not in payload
+    assert payload["interfaceName"] == "Ethernet1/3.20"
+    assert payload["interfaceType"] == "subInterface"
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedInterfaceModel — from_response robustness
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00900():
+    """
+    # Summary
+
+    Verify `from_response` is robust to missing nested structures and to extra policy fields ND may return.
+
+    ## Test
+
+    - Response with no configData constructs without raising (scaffolding defaults fill in)
+    - Response whose policy carries unexpected extra keys is accepted (extra="ignore")
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.from_response()
+    """
+    minimal = {
+        "switchIp": "1.2.3.4",
+        "interfaceName": "Ethernet1/3.20",
+        "switchId": "X",
+    }
+    with does_not_raise():
+        SubinterfaceUnmanagedInterfaceModel.from_response(minimal)
+
+    extra_policy = copy.deepcopy(SAMPLE_API_RESPONSE)
+    extra_policy["configData"]["networkOS"]["policy"]["templateName"] = "int_subif_unmanaged"
+    with does_not_raise():
+        instance = SubinterfaceUnmanagedInterfaceModel.from_response(extra_policy)
+    assert instance.config_data.network_os.policy.policy_type == "monitorSubinterface"
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedInterfaceModel — round-trip + fixed hidden fields
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_01000():
+    """
+    # Summary
+
+    Verify a full GET response round-trips through from_response and to_payload, re-emitting every hardcoded
+    scaffolding field with its API alias: interfaceType, mode, networkOSType, and policyType.
+
+    ## Test
+
+    - Build model from SAMPLE_API_RESPONSE
+    - to_payload re-emits the fixed discriminator fields
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.from_response()
+    - SubinterfaceUnmanagedInterfaceModel.to_payload()
+    """
+    instance = SubinterfaceUnmanagedInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+    assert payload["interfaceName"] == "Ethernet1/3.20"
+    assert payload["interfaceType"] == "subInterface"
+    assert payload["configData"]["mode"] == "unmanaged"
+    assert payload["configData"]["networkOS"]["networkOSType"] == "nx-os"
+    assert payload["configData"]["networkOS"]["policy"]["policyType"] == "monitorSubinterface"
+
+
+def test_subinterface_unmanaged_interface_01010():
+    """
+    # Summary
+
+    Verify from_config (Ansible-side, only switch_ip + interface_name) produces a model whose payload matches the
+    one built from a full API response — the hardcoded scaffolding is filled in identically either way.
+
+    ## Test
+
+    - Build model A from SAMPLE_API_RESPONSE
+    - Build model B from SAMPLE_ANSIBLE_CONFIG
+    - to_payload outputs match
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.from_response()
+    - SubinterfaceUnmanagedInterfaceModel.from_config()
+    """
+    a = SubinterfaceUnmanagedInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    b = SubinterfaceUnmanagedInterfaceModel.from_config(SAMPLE_ANSIBLE_CONFIG)
+    assert a.to_payload() == b.to_payload()
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedInterfaceModel — get_argument_spec
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_01100():
+    """
+    # Summary
+
+    Verify the argument spec exposes only `switch_ip` and `interface_name` per config item — every config_data
+    field is hardcoded scaffolding and intentionally hidden.
+
+    ## Test
+
+    - fabric_name is required str
+    - config is required list-of-dict with only switch_ip and interface_name options
+    - config_data is absent from the config options
+    - state is enum with merged/replaced/overridden/deleted
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.get_argument_spec()
+    """
+    spec = SubinterfaceUnmanagedInterfaceModel.get_argument_spec()
+    assert spec["fabric_name"]["type"] == "str"
+    assert spec["fabric_name"]["required"] is True
+    assert spec["config"]["type"] == "list"
+    assert spec["config"]["required"] is True
+    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert spec["state"]["default"] == "merged"
+
+    config_options = spec["config"]["options"]
+    assert set(config_options.keys()) == {"switch_ip", "interface_name"}
+    assert config_options["switch_ip"]["required"] is True
+    assert config_options["interface_name"]["type"] == "str"
+    assert config_options["interface_name"]["required"] is True
+    # Every config_data field (interface_type, mode, network_os_type, policy_type) is hardcoded in the
+    # Pydantic model and intentionally absent from the user-facing argument spec.
+    assert "config_data" not in config_options
+    assert "interface_type" not in config_options
+
+
+# =============================================================================
+# Test: SubinterfaceUnmanagedInterfaceModel — interface_type default
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_01200():
+    """
+    # Summary
+
+    Verify `interface_type` defaults to "subInterface".
+
+    ## Test
+
+    - Construct without interface_type
+    - Field equals "subInterface"
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceModel.__init__()
+    """
+    instance = SubinterfaceUnmanagedInterfaceModel(switch_ip="1.2.3.4", interface_name="Ethernet1/3.20")
+    assert instance.interface_type == "subInterface"

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -1,0 +1,941 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for svi_interface.py
+
+Tests the SVI (switched virtual interface) Pydantic model classes.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.svi_interface import (
+    SviConfigDataModel,
+    SviInterfaceModel,
+    SviNetworkOSModel,
+    SviOperDataModel,
+    SviPolicyModel,
+)
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test data constants
+# =============================================================================
+
+SAMPLE_API_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "vlan333",
+    "interfaceType": "svi",
+    "switchId": "9NIE7U0ZXHZ",
+    "configData": {
+        "mode": "managed",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "policyType": "svi",
+                "adminState": True,
+                "advertiseSubnetInUnderlay": False,
+                "description": "Sample SVI",
+                "hsrpGroup": 1,
+                "ip": "10.99.99.1",
+                "ipRedirects": True,
+                "netflow": False,
+                "pimDrPriority": 1,
+                "pimSparse": False,
+                "preempt": False,
+                "prefix": 24,
+            },
+        },
+    },
+    "operData": {
+        "adminStatus": "up",
+        "operationalDescription": "VLAN/BD is down",
+        "operationalStatus": "down",
+        "portChannelId": -1,
+        "switchName": "LE1",
+        "vlanRange": "-1",
+    },
+}
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "vlan333",
+    "interface_type": "svi",
+    "config_data": {
+        "mode": "managed",
+        "network_os": {
+            "network_os_type": "nx-os",
+            "policy": {
+                "policy_type": "svi",
+                "admin_state": True,
+                "advertise_subnet_in_underlay": False,
+                "description": "Sample SVI",
+                "hsrp_group": 1,
+                "ip": "10.99.99.1",
+                "ip_redirects": True,
+                "netflow": False,
+                "pim_dr_priority": 1,
+                "pim_sparse": False,
+                "preempt": False,
+                "prefix": 24,
+            },
+        },
+    },
+}
+
+
+# =============================================================================
+# Test: SviPolicyModel — initialization and defaults
+# =============================================================================
+
+
+def test_svi_interface_00100():
+    """
+    # Summary
+
+    Verify every policy field defaults to None except `policy_type` which defaults to `SviPolicyTypeEnum.SVI`.
+
+    ## Test
+
+    - Instantiate with no arguments
+    - All optional fields are None
+    - policy_type defaults to "svi"
+
+    ## Classes and Methods
+
+    - SviPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SviPolicyModel()
+    assert instance.policy_type == "svi"
+    assert instance.admin_state is None
+    assert instance.description is None
+    assert instance.extra_config is None
+    assert instance.mtu is None
+    assert instance.ip is None
+    assert instance.prefix is None
+    assert instance.ipv6 is None
+    assert instance.v6prefix is None
+    assert instance.ip_redirects is None
+    assert instance.pim_sparse is None
+    assert instance.pim_dr_priority is None
+    assert instance.hsrp_group is None
+    assert instance.hsrp_version is None
+    assert instance.preempt is None
+    assert instance.advertise_subnet_in_underlay is None
+    assert instance.netflow is None
+
+
+def test_svi_interface_00110():
+    """
+    # Summary
+
+    Verify construction with snake_case field names.
+
+    ## Test
+
+    - Construct with Python field names
+    - Values accessible
+
+    ## Classes and Methods
+
+    - SviPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SviPolicyModel(
+            admin_state=True,
+            description="test",
+            ip="10.0.0.1",
+            prefix=24,
+            mtu=9216,
+            policy_type="svi",
+        )
+    assert instance.admin_state is True
+    assert instance.description == "test"
+    assert instance.ip == "10.0.0.1"
+    assert instance.prefix == 24
+    assert instance.mtu == 9216
+    assert instance.policy_type == "svi"
+
+
+def test_svi_interface_00120():
+    """
+    # Summary
+
+    Verify construction with camelCase aliases.
+
+    ## Test
+
+    - Construct with API alias names
+    - Values accessible by Python names
+
+    ## Classes and Methods
+
+    - SviPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SviPolicyModel(
+            adminState=True,
+            ipRedirects=True,
+            pimDrPriority=5,
+            advertiseSubnetInUnderlay=True,
+            policyType="svi",
+        )
+    assert instance.admin_state is True
+    assert instance.ip_redirects is True
+    assert instance.pim_dr_priority == 5
+    assert instance.advertise_subnet_in_underlay is True
+    assert instance.policy_type == "svi"
+
+
+# =============================================================================
+# Test: SviPolicyModel — description ASCII validator
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,should_raise",
+    [
+        ("plain ASCII", False),
+        ("with-hyphen and 123", False),
+        ("", False),  # max_length lower bound 0 acceptable here, validator only checks ASCII
+        (None, False),
+        ("em — dash", True),
+        ("smart “quotes”", True),
+        ("emoji \U0001f600", True),
+        ("latin-1 \xe9", True),
+    ],
+    ids=[
+        "ascii_ok",
+        "ascii_punct_digits",
+        "empty_string",
+        "none_passthrough",
+        "em_dash_rejected",
+        "smart_quotes_rejected",
+        "emoji_rejected",
+        "latin1_rejected",
+    ],
+)
+def test_svi_interface_00130(value, should_raise):
+    """
+    # Summary
+
+    Verify the `description_must_be_ascii` validator rejects any non-ASCII character.
+
+    Cisco backend pipes interface descriptions through CLI generators that 500 on UTF-8. Catching this client-side
+    gives users a clear error instead of a generic "unexpected error during policy execution" 500.
+
+    ## Test
+
+    - ASCII strings (including empty and None) accepted
+    - Any non-ASCII character (em-dash, smart quotes, emoji, latin-1) raises
+
+    ## Classes and Methods
+
+    - SviPolicyModel.description_must_be_ascii()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError, match="description must contain only ASCII"):
+            SviPolicyModel(description=value)
+    else:
+        with does_not_raise():
+            instance = SviPolicyModel(description=value)
+        assert instance.description == value
+
+
+# =============================================================================
+# Test: SviPolicyModel — policy_type normalize and serialize
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected,raises",
+    [
+        ("svi", "svi", False),
+        ("unknown_value", None, True),
+        (None, None, True),
+    ],
+    ids=[
+        "ansible_name_passthrough",
+        "unknown_rejected_by_enum",
+        "none_rejected_field_required_with_default",
+    ],
+)
+def test_svi_interface_00170(value, expected, raises):
+    """
+    # Summary
+
+    Verify `normalize_policy_type` accepts the Ansible/API name and rejects unknown values. `None` is also rejected
+    because `policy_type` is a non-optional field carrying a default — the API requires it on every PUT/POST.
+
+    ## Test
+
+    - "svi" passes through
+    - Unknown values fail enum validation
+    - None is rejected (field is required-with-default, not Optional)
+
+    ## Classes and Methods
+
+    - SviPolicyModel.normalize_policy_type()
+    """
+    if raises:
+        with pytest.raises(ValidationError):
+            SviPolicyModel(policy_type=value)
+    else:
+        with does_not_raise():
+            instance = SviPolicyModel(policy_type=value)
+        assert instance.policy_type == expected
+
+
+@pytest.mark.parametrize(
+    "stored_value,mode,expected",
+    [
+        ("svi", "payload", "svi"),
+        ("svi", "config", "svi"),
+        ("svi", None, "svi"),
+        (None, "payload", None),
+    ],
+    ids=[
+        "payload_mode",
+        "config_mode",
+        "default_mode_payload",
+        "none_value",
+    ],
+)
+def test_svi_interface_00180(stored_value, mode, expected):
+    """
+    # Summary
+
+    Verify `serialize_policy_type` returns the API value in payload mode and the Ansible name in config mode. For SVI
+    these happen to be identical, but the validator-serializer pair is preserved for symmetry with ethernet models.
+
+    ## Test
+
+    - payload mode returns API value
+    - config mode returns Ansible name
+    - None passes through
+
+    ## Classes and Methods
+
+    - SviPolicyModel.serialize_policy_type()
+    """
+    instance = SviPolicyModel(policy_type=stored_value) if stored_value else SviPolicyModel()
+    if stored_value is None:
+        # field default kicks in; result is "svi" not None — adjust expectation
+        if mode == "payload":
+            data = instance.model_dump(by_alias=True, context={"mode": "payload"})
+        else:
+            data = instance.model_dump(by_alias=False, context={"mode": "config"})
+        assert data.get("policyType" if mode == "payload" else "policy_type") == "svi"
+        return
+    if mode == "payload":
+        data = instance.model_dump(by_alias=True, context={"mode": "payload"})
+        assert data["policyType"] == expected
+    elif mode == "config":
+        data = instance.model_dump(by_alias=False, context={"mode": "config"})
+        assert data["policy_type"] == expected
+    else:
+        data = instance.model_dump(by_alias=True)
+        assert data["policyType"] == expected
+
+
+# =============================================================================
+# Test: SviPolicyModel — range validation
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "field,value,should_raise",
+    [
+        ("mtu", 576, False),
+        ("mtu", 9216, False),
+        ("mtu", 575, True),
+        ("mtu", 9217, True),
+        ("prefix", 1, False),
+        ("prefix", 31, False),
+        ("prefix", 0, True),
+        ("prefix", 32, True),
+        ("v6prefix", 1, False),
+        ("v6prefix", 127, False),
+        ("v6prefix", 0, True),
+        ("v6prefix", 128, True),
+        ("pim_dr_priority", 1, False),
+        ("pim_dr_priority", 4294967295, False),
+        ("pim_dr_priority", 0, True),
+        ("pim_dr_priority", 4294967296, True),
+    ],
+    ids=lambda v: str(v) if not isinstance(v, bool) else ("raise" if v else "ok"),
+)
+def test_svi_interface_00220(field, value, should_raise):
+    """
+    # Summary
+
+    Verify ge/le constraints on every numeric policy field.
+
+    ## Test
+
+    - At-min and at-max values accepted
+    - Below-min and above-max values rejected with ValidationError
+
+    ## Classes and Methods
+
+    - SviPolicyModel.__init__()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError):
+            SviPolicyModel(**{field: value})
+    else:
+        with does_not_raise():
+            instance = SviPolicyModel(**{field: value})
+        assert getattr(instance, field) == value
+
+
+def test_svi_interface_00230():
+    """
+    # Summary
+
+    Verify `description` max_length=254.
+
+    ## Test
+
+    - 254 characters accepted
+    - 255 characters rejected
+
+    ## Classes and Methods
+
+    - SviPolicyModel.__init__()
+    """
+    with does_not_raise():
+        SviPolicyModel(description="a" * 254)
+    with pytest.raises(ValidationError):
+        SviPolicyModel(description="a" * 255)
+
+
+# =============================================================================
+# Test: SviPolicyModel — payload / config serialization
+# =============================================================================
+
+
+def test_svi_interface_00300():
+    """
+    # Summary
+
+    Verify `to_payload`-style serialization (model_dump with aliases, exclude_none) emits camelCase keys.
+
+    ## Test
+
+    - Construct with snake_case
+    - Dump with by_alias=True
+    - Output uses API camelCase keys
+
+    ## Classes and Methods
+
+    - SviPolicyModel.model_dump()
+    """
+    instance = SviPolicyModel(
+        admin_state=True,
+        description="payload",
+        ip_redirects=True,
+        pim_dr_priority=2,
+        advertise_subnet_in_underlay=True,
+    )
+    data = instance.model_dump(by_alias=True, exclude_none=True)
+    assert data["adminState"] is True
+    assert data["description"] == "payload"
+    assert data["ipRedirects"] is True
+    assert data["pimDrPriority"] == 2
+    assert data["advertiseSubnetInUnderlay"] is True
+    assert "admin_state" not in data
+    assert "ip_redirects" not in data
+
+
+# =============================================================================
+# Test: SviNetworkOSModel
+# =============================================================================
+
+
+def test_svi_interface_00400():
+    """
+    # Summary
+
+    Verify default values for SviNetworkOSModel.
+
+    ## Test
+
+    - network_os_type defaults to "nx-os"
+    - policy defaults to None
+
+    ## Classes and Methods
+
+    - SviNetworkOSModel.__init__()
+    """
+    instance = SviNetworkOSModel()
+    assert instance.network_os_type == "nx-os"
+    assert instance.policy is None
+
+
+def test_svi_interface_00410():
+    """
+    # Summary
+
+    Verify SviNetworkOSModel accepts a SviPolicyModel as the `policy` field.
+
+    ## Test
+
+    - Pass a populated policy
+    - Access through the network OS container
+
+    ## Classes and Methods
+
+    - SviNetworkOSModel.__init__()
+    """
+    policy = SviPolicyModel(admin_state=True, description="net-os")
+    instance = SviNetworkOSModel(policy=policy)
+    assert instance.policy is not None
+    assert instance.policy.admin_state is True
+    assert instance.policy.description == "net-os"
+
+
+# =============================================================================
+# Test: SviConfigDataModel
+# =============================================================================
+
+
+def test_svi_interface_00500():
+    """
+    # Summary
+
+    Verify SviConfigDataModel defaults — `mode` is "managed" and `network_os` is required.
+
+    ## Test
+
+    - Construct with only network_os
+    - mode defaults to "managed"
+
+    ## Classes and Methods
+
+    - SviConfigDataModel.__init__()
+    """
+    nos = SviNetworkOSModel(policy=SviPolicyModel(admin_state=True))
+    instance = SviConfigDataModel(network_os=nos)
+    assert instance.mode == "managed"
+    assert instance.network_os is not None
+
+
+def test_svi_interface_00510():
+    """
+    # Summary
+
+    Verify SviConfigDataModel rejects construction without network_os.
+
+    ## Test
+
+    - Construct with no network_os
+    - ValidationError raised
+
+    ## Classes and Methods
+
+    - SviConfigDataModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        SviConfigDataModel()  # network_os is required
+
+
+# =============================================================================
+# Test: SviOperDataModel — read-only operational data
+# =============================================================================
+
+
+def test_svi_interface_00600():
+    """
+    # Summary
+
+    Verify SviOperDataModel parses GET-side aliases.
+
+    ## Test
+
+    - Construct with camelCase aliases
+    - Access by snake_case fields
+
+    ## Classes and Methods
+
+    - SviOperDataModel.__init__()
+    """
+    instance = SviOperDataModel(
+        adminStatus="up",
+        operationalDescription="VLAN/BD is down",
+        operationalStatus="down",
+        portChannelId=-1,
+        switchName="LE1",
+        vlanRange="-1",
+    )
+    assert instance.admin_status == "up"
+    assert instance.operational_description == "VLAN/BD is down"
+    assert instance.operational_status == "down"
+    assert instance.port_channel_id == -1
+    assert instance.switch_name == "LE1"
+    assert instance.vlan_range == "-1"
+
+
+# =============================================================================
+# Test: SviInterfaceModel — interface_name normalization
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("vlan333", "vlan333"),
+        ("Vlan333", "vlan333"),
+        ("VLAN333", "vlan333"),
+        ("vLaN333", "vlan333"),
+        ("333", "vlan333"),
+        (333, "vlan333"),
+        ("  333  ", "vlan333"),
+    ],
+    ids=[
+        "lowercase_passthrough",
+        "title_case",
+        "all_caps",
+        "mixed_case",
+        "bare_digit_string",
+        "bare_int",
+        "padded_digit_string",
+    ],
+)
+def test_svi_interface_00700(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` converts all common forms to the lowercase API form `vlan<id>`.
+
+    ## Test
+
+    - Title / mixed / all-caps cased forms normalize to lowercase `vlan<id>`
+    - Bare integer (or its string form) is prefixed with `vlan`
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.normalize_interface_name()
+    """
+    instance = SviInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+    assert instance.interface_name == expected
+
+
+# =============================================================================
+# Test: SviInterfaceModel — composite identifier
+# =============================================================================
+
+
+def test_svi_interface_00800():
+    """
+    # Summary
+
+    Verify identifier configuration: composite `(switch_ip, interface_name)`.
+
+    ## Test
+
+    - identifier_strategy is "composite"
+    - identifiers is ["switch_ip", "interface_name"]
+    - get_identifier_value returns the tuple
+
+    ## Classes and Methods
+
+    - SviInterfaceModel — class attributes
+    - SviInterfaceModel.get_identifier_value()
+    """
+    assert SviInterfaceModel.identifier_strategy == "composite"
+    assert SviInterfaceModel.identifiers == ["switch_ip", "interface_name"]
+    instance = SviInterfaceModel(switch_ip="1.2.3.4", interface_name="vlan333")
+    assert instance.get_identifier_value() == ("1.2.3.4", "vlan333")
+
+
+def test_svi_interface_00810():
+    """
+    # Summary
+
+    Verify `payload_exclude_fields` excludes `switch_ip` and `oper_data` from `to_payload`.
+
+    ## Test
+
+    - Construct with all top-level fields
+    - to_payload omits switch_ip and operData
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.to_payload()
+    """
+    instance = SviInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+    assert "switchIp" not in payload
+    assert "operData" not in payload
+    # Verify the remaining top-level shape
+    assert payload["interfaceName"] == "vlan333"
+    assert payload["interfaceType"] == "svi"
+
+
+# =============================================================================
+# Test: SviInterfaceModel — from_response strips hsrpVersion
+# =============================================================================
+
+
+def test_svi_interface_00900():
+    """
+    # Summary
+
+    Verify `from_response` strips `hsrpVersion` (poison field) and preserves `hsrpGroup` (round-trips fine).
+
+    ND's GET returns `hsrpVersion: 1` (integer) as a server-side default even when HSRP is unconfigured. Re-emitting
+    that on PUT triggers a generic 500. `hsrpGroup: 1` is benign on round-trip.
+
+    ## Test
+
+    - Response with hsrpGroup=1 and hsrpVersion=1
+    - Model has hsrp_group=1 and hsrp_version=None
+    - to_payload() includes hsrpGroup but not hsrpVersion
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.from_response()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    response["configData"]["networkOS"]["policy"]["hsrpVersion"] = 1
+    response["configData"]["networkOS"]["policy"]["hsrpGroup"] = 1
+
+    instance = SviInterfaceModel.from_response(response)
+    policy = instance.config_data.network_os.policy
+    assert policy.hsrp_group == 1
+    assert policy.hsrp_version is None
+
+    payload = instance.to_payload()
+    policy_payload = payload["configData"]["networkOS"]["policy"]
+    assert policy_payload["hsrpGroup"] == 1
+    assert "hsrpVersion" not in policy_payload
+
+
+def test_svi_interface_00910():
+    """
+    # Summary
+
+    Verify `from_response` does not mutate the caller's input dict.
+
+    ## Test
+
+    - Response includes hsrpVersion
+    - After from_response, response still includes hsrpVersion
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.from_response()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    response["configData"]["networkOS"]["policy"]["hsrpVersion"] = 1
+
+    SviInterfaceModel.from_response(response)
+    # Caller's dict must be untouched
+    assert response["configData"]["networkOS"]["policy"]["hsrpVersion"] == 1
+
+
+def test_svi_interface_00920():
+    """
+    # Summary
+
+    Verify `from_response` is robust to missing nested structures.
+
+    ## Test
+
+    - Response with no configData
+    - Response with configData but no networkOS
+    - Response with networkOS but no policy
+    - All return a valid model without raising
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.from_response()
+    """
+    minimal = {
+        "switchIp": "1.2.3.4",
+        "interfaceName": "vlan333",
+        "switchId": "X",
+    }
+    with does_not_raise():
+        SviInterfaceModel.from_response(minimal)
+
+    no_policy = copy.deepcopy(minimal)
+    no_policy["configData"] = {"mode": "managed", "networkOS": {"networkOSType": "nx-os"}}
+    with does_not_raise():
+        SviInterfaceModel.from_response(no_policy)
+
+
+# =============================================================================
+# Test: SviInterfaceModel — round-trip from_response -> to_payload
+# =============================================================================
+
+
+def test_svi_interface_01000():
+    """
+    # Summary
+
+    Verify a full GET response round-trips through from_response and to_payload, producing the same shape minus
+    excluded fields and stripped hsrpVersion.
+
+    ## Test
+
+    - Build model from SAMPLE_API_RESPONSE
+    - to_payload result matches expected
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.from_response()
+    - SviInterfaceModel.to_payload()
+    """
+    instance = SviInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+
+    expected_policy_keys = {
+        "policyType",
+        "adminState",
+        "advertiseSubnetInUnderlay",
+        "description",
+        "hsrpGroup",
+        "ip",
+        "ipRedirects",
+        "netflow",
+        "pimDrPriority",
+        "pimSparse",
+        "preempt",
+        "prefix",
+    }
+    assert set(payload["configData"]["networkOS"]["policy"].keys()) == expected_policy_keys
+    assert payload["interfaceName"] == "vlan333"
+    assert payload["interfaceType"] == "svi"
+    assert payload["configData"]["mode"] == "managed"
+    assert payload["configData"]["networkOS"]["networkOSType"] == "nx-os"
+
+
+def test_svi_interface_01010():
+    """
+    # Summary
+
+    Verify from_config (Ansible-side snake_case) produces an equivalent model to from_response (API-side camelCase).
+
+    ## Test
+
+    - Build model A from SAMPLE_API_RESPONSE
+    - Build model B from SAMPLE_ANSIBLE_CONFIG
+    - to_payload outputs match
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.from_response()
+    - SviInterfaceModel.from_config()
+    """
+    a = SviInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    b = SviInterfaceModel.from_config(SAMPLE_ANSIBLE_CONFIG)
+    # b has no oper_data so payloads should match (oper_data excluded from payload anyway)
+    assert a.to_payload() == b.to_payload()
+
+
+# =============================================================================
+# Test: SviInterfaceModel — get_argument_spec
+# =============================================================================
+
+
+def test_svi_interface_01100():
+    """
+    # Summary
+
+    Verify the argument spec exposes the expected top-level keys and required structure.
+
+    ## Test
+
+    - fabric_name is required str
+    - config is required list-of-dict
+    - state is enum with merged/replaced/overridden/deleted
+    - policy options include the phase 1 writable fields
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.get_argument_spec()
+    """
+    spec = SviInterfaceModel.get_argument_spec()
+    assert spec["fabric_name"]["type"] == "str"
+    assert spec["fabric_name"]["required"] is True
+    assert spec["config"]["type"] == "list"
+    assert spec["config"]["required"] is True
+    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert spec["state"]["default"] == "merged"
+
+    config_options = spec["config"]["options"]
+    assert config_options["switch_ip"]["required"] is True
+    assert config_options["vlan_ids"]["type"] == "list"
+    assert config_options["vlan_ids"]["elements"] == "int"
+    assert config_options["vlan_ids"]["required"] is True
+    assert config_options["interface_type"]["default"] == "svi"
+
+    policy_options = config_options["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    expected_policy_fields = {
+        "policy_type",
+        "admin_state",
+        "description",
+        "extra_config",
+        "mtu",
+        "ip",
+        "prefix",
+        "ipv6",
+        "v6prefix",
+        "ip_redirects",
+        "pim_sparse",
+        "pim_dr_priority",
+        "hsrp_group",
+        "hsrp_version",
+        "preempt",
+        "advertise_subnet_in_underlay",
+        "netflow",
+    }
+    assert set(policy_options.keys()) == expected_policy_fields
+    assert policy_options["policy_type"]["choices"] == ["svi"]
+    assert policy_options["policy_type"]["default"] == "svi"
+
+
+# =============================================================================
+# Test: SviInterfaceModel — interface_type default
+# =============================================================================
+
+
+def test_svi_interface_01200():
+    """
+    # Summary
+
+    Verify `interface_type` defaults to "svi".
+
+    ## Test
+
+    - Construct without interface_type
+    - Field equals "svi"
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.__init__()
+    """
+    instance = SviInterfaceModel(switch_ip="1.2.3.4", interface_name="vlan333")
+    assert instance.interface_type == "svi"

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -239,7 +239,7 @@ def test_svi_interface_00130(value, should_raise):
     """
     # Summary
 
-    Verify the `description_must_be_ascii` validator rejects any non-ASCII character.
+    Verify `description` (typed `AsciiDescription`) rejects any non-ASCII character.
 
     Cisco backend pipes interface descriptions through CLI generators that 500 on UTF-8. Catching this client-side
     gives users a clear error instead of a generic "unexpected error during policy execution" 500.
@@ -251,7 +251,8 @@ def test_svi_interface_00130(value, should_raise):
 
     ## Classes and Methods
 
-    - SviPolicyModel.description_must_be_ascii()
+    - SviPolicyModel.__init__()
+    - models.types.ascii_only()
     """
     if should_raise:
         with pytest.raises(ValidationError, match="description must contain only ASCII"):

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -333,12 +333,19 @@ def test_svi_interface_00220(field, value, should_raise):
 
     - SviPolicyModel.__init__()
     """
+    # `prefix`/`prefixv6` are required-together with `ip`/`ipv6` (see `_validate_ip_prefix_paired`), so supply
+    # the paired address when range-testing the mask length in isolation.
+    kwargs = {field: value}
+    if field == "prefix":
+        kwargs.setdefault("ip", "10.1.1.1")
+    elif field == "prefixv6":
+        kwargs.setdefault("ipv6", "2001:db8::1")
     if should_raise:
         with pytest.raises(ValidationError):
-            SviPolicyModel(**{field: value})
+            SviPolicyModel(**kwargs)
     else:
         with does_not_raise():
-            instance = SviPolicyModel(**{field: value})
+            instance = SviPolicyModel(**kwargs)
         assert getattr(instance, field) == value
 
 
@@ -361,6 +368,60 @@ def test_svi_interface_00230():
         SviPolicyModel(description="a" * 254)
     with pytest.raises(ValidationError):
         SviPolicyModel(description="a" * 255)
+
+
+def test_svi_interface_00240():
+    """
+    # Summary
+
+    Verify `_validate_netflow_monitor_present`: `netflow_monitor` is required when `netflow` is true.
+
+    ## Test
+
+    - `netflow=True` without `netflow_monitor` is rejected
+    - `netflow=True` with `netflow_monitor` is accepted
+    - `netflow=False` (or unset) without `netflow_monitor` is accepted
+
+    ## Classes and Methods
+
+    - SviPolicyModel._validate_netflow_monitor_present()
+    """
+    with pytest.raises(ValidationError, match="netflow_monitor must be provided when netflow is true"):
+        SviPolicyModel(netflow=True)
+    with does_not_raise():
+        SviPolicyModel(netflow=True, netflow_monitor="MONITOR-1")
+        SviPolicyModel(netflow=False)
+        SviPolicyModel()
+
+
+def test_svi_interface_00250():
+    """
+    # Summary
+
+    Verify `_validate_ip_prefix_paired`: `ip`/`prefix` (and `ipv6`/`prefixv6`) are required together.
+
+    ## Test
+
+    - `ip` without `prefix` is rejected; `prefix` without `ip` is rejected
+    - `ipv6` without `prefixv6` is rejected; `prefixv6` without `ipv6` is rejected
+    - Both halves of a pair, or neither, is accepted
+
+    ## Classes and Methods
+
+    - SviPolicyModel._validate_ip_prefix_paired()
+    """
+    with pytest.raises(ValidationError, match="ip and prefix are required together"):
+        SviPolicyModel(ip="10.1.1.1")
+    with pytest.raises(ValidationError, match="ip and prefix are required together"):
+        SviPolicyModel(prefix=24)
+    with pytest.raises(ValidationError, match="ipv6 and prefixv6 are required together"):
+        SviPolicyModel(ipv6="2001:db8::1")
+    with pytest.raises(ValidationError, match="ipv6 and prefixv6 are required together"):
+        SviPolicyModel(prefixv6=64)
+    with does_not_raise():
+        SviPolicyModel(ip="10.1.1.1", prefix=24)
+        SviPolicyModel(ipv6="2001:db8::1", prefixv6=64)
+        SviPolicyModel()
 
 
 # =============================================================================

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -949,9 +949,8 @@ def test_svi_interface_01100():
 
     config_options = spec["config"]["options"]
     assert config_options["switch_ip"]["required"] is True
-    assert config_options["vlan_ids"]["type"] == "list"
-    assert config_options["vlan_ids"]["elements"] == "int"
-    assert config_options["vlan_ids"]["required"] is True
+    assert config_options["interface_name"]["type"] == "str"
+    assert config_options["interface_name"]["required"] is True
     assert config_options["interface_type"]["default"] == "svi"
 
     policy_options = config_options["config_data"]["options"]["network_os"]["options"]["policy"]["options"]

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -134,15 +134,31 @@ def test_svi_interface_00100():
     assert instance.ip is None
     assert instance.prefix is None
     assert instance.ipv6 is None
-    assert instance.v6prefix is None
+    assert instance.prefixv6 is None
     assert instance.ip_redirects is None
+    assert instance.vrf_interface is None
+    assert instance.routing_tag is None
     assert instance.pim_sparse is None
     assert instance.pim_dr_priority is None
+    assert instance.hsrp is None
+    assert instance.hsrp_vip is None
+    assert instance.hsrp_vipv6 is None
     assert instance.hsrp_group is None
+    assert instance.hsrp_groupv6 is None
     assert instance.hsrp_version is None
+    assert instance.hsrp_priority is None
     assert instance.preempt is None
+    assert instance.mac is None
+    assert instance.dhcp_server_address1 is None
+    assert instance.dhcp_server_address2 is None
+    assert instance.dhcp_server_address3 is None
+    assert instance.vrf_dhcp1 is None
+    assert instance.vrf_dhcp2 is None
+    assert instance.vrf_dhcp3 is None
     assert instance.advertise_subnet_in_underlay is None
     assert instance.netflow is None
+    assert instance.netflow_monitor is None
+    assert instance.netflow_sampler is None
 
 
 def test_svi_interface_00110():
@@ -367,22 +383,34 @@ def test_svi_interface_00180(stored_value, mode, expected):
 @pytest.mark.parametrize(
     "field,value,should_raise",
     [
-        ("mtu", 576, False),
+        ("mtu", 68, False),
         ("mtu", 9216, False),
-        ("mtu", 575, True),
+        ("mtu", 67, True),
         ("mtu", 9217, True),
         ("prefix", 1, False),
         ("prefix", 31, False),
         ("prefix", 0, True),
         ("prefix", 32, True),
-        ("v6prefix", 1, False),
-        ("v6prefix", 127, False),
-        ("v6prefix", 0, True),
-        ("v6prefix", 128, True),
+        ("prefixv6", 1, False),
+        ("prefixv6", 127, False),
+        ("prefixv6", 0, True),
+        ("prefixv6", 128, True),
         ("pim_dr_priority", 1, False),
         ("pim_dr_priority", 4294967295, False),
         ("pim_dr_priority", 0, True),
         ("pim_dr_priority", 4294967296, True),
+        ("hsrp_group", 0, False),
+        ("hsrp_group", 4095, False),
+        ("hsrp_group", -1, True),
+        ("hsrp_group", 4096, True),
+        ("hsrp_groupv6", 0, False),
+        ("hsrp_groupv6", 4095, False),
+        ("hsrp_groupv6", -1, True),
+        ("hsrp_groupv6", 4096, True),
+        ("hsrp_priority", 0, False),
+        ("hsrp_priority", 255, False),
+        ("hsrp_priority", -1, True),
+        ("hsrp_priority", 256, True),
     ],
     ids=lambda v: str(v) if not isinstance(v, bool) else ("raise" if v else "ok"),
 )
@@ -695,7 +723,7 @@ def test_svi_interface_00810():
 
 
 # =============================================================================
-# Test: SviInterfaceModel — from_response strips hsrpVersion
+# Test: SviInterfaceModel — from_response round-trips hsrpVersion as int
 # =============================================================================
 
 
@@ -703,20 +731,21 @@ def test_svi_interface_00900():
     """
     # Summary
 
-    Verify `from_response` strips `hsrpVersion` (poison field) and preserves `hsrpGroup` (round-trips fine).
+    Verify `from_response` round-trips `hsrpVersion` as integer through `to_payload`.
 
-    ND's GET returns `hsrpVersion: 1` (integer) as a server-side default even when HSRP is unconfigured. Re-emitting
-    that on PUT triggers a generic 500. `hsrpGroup: 1` is benign on round-trip.
+    Lab-verified 2026-04-30: ND accepts `hsrpVersion: 1` (integer) on PUT cleanly even when `hsrp` is not set, so
+    no GET-side stripping is needed. The phase-1 strip workaround has been removed.
 
     ## Test
 
     - Response with hsrpGroup=1 and hsrpVersion=1
-    - Model has hsrp_group=1 and hsrp_version=None
-    - to_payload() includes hsrpGroup but not hsrpVersion
+    - Model has hsrp_group=1 and hsrp_version=1
+    - to_payload() includes both as integers
 
     ## Classes and Methods
 
     - SviInterfaceModel.from_response()
+    - SviInterfaceModel.to_payload()
     """
     response = copy.deepcopy(SAMPLE_API_RESPONSE)
     response["configData"]["networkOS"]["policy"]["hsrpVersion"] = 1
@@ -725,35 +754,48 @@ def test_svi_interface_00900():
     instance = SviInterfaceModel.from_response(response)
     policy = instance.config_data.network_os.policy
     assert policy.hsrp_group == 1
-    assert policy.hsrp_version is None
+    assert policy.hsrp_version == 1
 
     payload = instance.to_payload()
     policy_payload = payload["configData"]["networkOS"]["policy"]
     assert policy_payload["hsrpGroup"] == 1
-    assert "hsrpVersion" not in policy_payload
+    assert policy_payload["hsrpVersion"] == 1
 
 
-def test_svi_interface_00910():
+@pytest.mark.parametrize(
+    "value,should_raise",
+    [
+        (1, False),
+        (2, False),
+        (0, True),
+        (3, True),
+        ("1", True),  # API requires int, string-form must be rejected client-side
+    ],
+    ids=["v1_ok", "v2_ok", "below_min_rejected", "above_max_rejected", "string_rejected"],
+)
+def test_svi_interface_00910(value, should_raise):
     """
     # Summary
 
-    Verify `from_response` does not mutate the caller's input dict.
+    Verify `hsrp_version` is `Literal[1, 2]`. Strings are rejected to keep the wire format aligned with the OpenAPI
+    schema, which declares `hsrpVersion` as integer.
 
     ## Test
 
-    - Response includes hsrpVersion
-    - After from_response, response still includes hsrpVersion
+    - Integers 1 and 2 accepted
+    - Other integers and string `"1"` rejected by Pydantic
 
     ## Classes and Methods
 
-    - SviInterfaceModel.from_response()
+    - SviPolicyModel.__init__()
     """
-    response = copy.deepcopy(SAMPLE_API_RESPONSE)
-    response["configData"]["networkOS"]["policy"]["hsrpVersion"] = 1
-
-    SviInterfaceModel.from_response(response)
-    # Caller's dict must be untouched
-    assert response["configData"]["networkOS"]["policy"]["hsrpVersion"] == 1
+    if should_raise:
+        with pytest.raises(ValidationError):
+            SviPolicyModel(hsrp_version=value)
+    else:
+        with does_not_raise():
+            instance = SviPolicyModel(hsrp_version=value)
+        assert instance.hsrp_version == value
 
 
 def test_svi_interface_00920():
@@ -787,6 +829,134 @@ def test_svi_interface_00920():
         SviInterfaceModel.from_response(no_policy)
 
 
+def test_svi_interface_00930():
+    """
+    # Summary
+
+    Verify a full HSRP block round-trips through `from_response` -> `to_payload` with all fields preserved.
+
+    Mirrors the lab-verified shape: `hsrp: true` plus `hsrpGroup`, `hsrpVersion` (int), `hsrpVip`, `hsrpPriority`,
+    `preempt`, and `mac` all flow through unchanged.
+
+    ## Test
+
+    - Response includes a full HSRP block
+    - After from_response, every HSRP field is reachable on the model
+    - to_payload re-emits every HSRP field with API names
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.from_response()
+    - SviInterfaceModel.to_payload()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    response["configData"]["networkOS"]["policy"].update(
+        {
+            "hsrp": True,
+            "hsrpGroup": 5,
+            "hsrpVersion": 2,
+            "hsrpVip": "10.99.99.254",
+            "hsrpPriority": 110,
+            "preempt": True,
+            "mac": "0000.0c07.ac05",
+        }
+    )
+
+    instance = SviInterfaceModel.from_response(response)
+    policy = instance.config_data.network_os.policy
+    assert policy.hsrp is True
+    assert policy.hsrp_group == 5
+    assert policy.hsrp_version == 2
+    assert policy.hsrp_vip == "10.99.99.254"
+    assert policy.hsrp_priority == 110
+    assert policy.preempt is True
+    assert policy.mac == "0000.0c07.ac05"
+
+    payload_policy = instance.to_payload()["configData"]["networkOS"]["policy"]
+    assert payload_policy["hsrp"] is True
+    assert payload_policy["hsrpGroup"] == 5
+    assert payload_policy["hsrpVersion"] == 2
+    assert payload_policy["hsrpVip"] == "10.99.99.254"
+    assert payload_policy["hsrpPriority"] == 110
+    assert payload_policy["preempt"] is True
+    assert payload_policy["mac"] == "0000.0c07.ac05"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("12345", "12345"),
+        (12345, "12345"),
+        (0, "0"),
+        (None, None),
+    ],
+    ids=["string_passthrough", "int_coerced", "zero_int_coerced", "none_passthrough"],
+)
+def test_svi_interface_00935(value, expected):
+    """
+    # Summary
+
+    Verify `routing_tag` accepts both strings (Ansible playbook side / POST/PUT request side) and integers (ND
+    GET response side). ND coerces input to int internally and returns int on GET even though OpenAPI declares
+    the field as string; the model normalizes to string for clean round-trips.
+
+    ## Test
+
+    - String values pass through unchanged
+    - Integer values are coerced to their decimal string form
+    - None passes through
+
+    ## Classes and Methods
+
+    - SviPolicyModel.coerce_routing_tag_to_string()
+    """
+    instance = SviPolicyModel(routing_tag=value)
+    assert instance.routing_tag == expected
+
+
+def test_svi_interface_00940():
+    """
+    # Summary
+
+    Verify the DHCP relay fields round-trip through `from_response` -> `to_payload` for all 3 server slots and
+    their corresponding VRF overrides.
+
+    ## Test
+
+    - Response includes dhcpServerAddress1/2/3 and vrfDhcp1/2/3
+    - Model preserves all six fields
+    - to_payload re-emits them with API aliases
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.from_response()
+    - SviInterfaceModel.to_payload()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    response["configData"]["networkOS"]["policy"].update(
+        {
+            "dhcpServerAddress1": "10.10.10.10",
+            "vrfDhcp1": "shared",
+            "dhcpServerAddress2": "10.10.10.11",
+            "vrfDhcp2": "default",
+            "dhcpServerAddress3": "10.10.10.12",
+            "vrfDhcp3": "mgmt",
+        }
+    )
+
+    instance = SviInterfaceModel.from_response(response)
+    policy = instance.config_data.network_os.policy
+    assert policy.dhcp_server_address1 == "10.10.10.10"
+    assert policy.vrf_dhcp1 == "shared"
+    assert policy.dhcp_server_address3 == "10.10.10.12"
+
+    payload_policy = instance.to_payload()["configData"]["networkOS"]["policy"]
+    assert payload_policy["dhcpServerAddress1"] == "10.10.10.10"
+    assert payload_policy["vrfDhcp1"] == "shared"
+    assert payload_policy["dhcpServerAddress3"] == "10.10.10.12"
+    assert payload_policy["vrfDhcp3"] == "mgmt"
+
+
 # =============================================================================
 # Test: SviInterfaceModel — round-trip from_response -> to_payload
 # =============================================================================
@@ -797,7 +967,7 @@ def test_svi_interface_01000():
     # Summary
 
     Verify a full GET response round-trips through from_response and to_payload, producing the same shape minus
-    excluded fields and stripped hsrpVersion.
+    excluded fields. All fields present in SAMPLE_API_RESPONSE must round-trip cleanly with their API aliases.
 
     ## Test
 
@@ -812,20 +982,7 @@ def test_svi_interface_01000():
     instance = SviInterfaceModel.from_response(SAMPLE_API_RESPONSE)
     payload = instance.to_payload()
 
-    expected_policy_keys = {
-        "policyType",
-        "adminState",
-        "advertiseSubnetInUnderlay",
-        "description",
-        "hsrpGroup",
-        "ip",
-        "ipRedirects",
-        "netflow",
-        "pimDrPriority",
-        "pimSparse",
-        "preempt",
-        "prefix",
-    }
+    expected_policy_keys = set(SAMPLE_API_RESPONSE["configData"]["networkOS"]["policy"].keys())
     assert set(payload["configData"]["networkOS"]["policy"].keys()) == expected_policy_keys
     assert payload["interfaceName"] == "vlan333"
     assert payload["interfaceType"] == "svi"
@@ -903,19 +1060,37 @@ def test_svi_interface_01100():
         "ip",
         "prefix",
         "ipv6",
-        "v6prefix",
+        "prefixv6",
         "ip_redirects",
+        "vrf_interface",
+        "routing_tag",
         "pim_sparse",
         "pim_dr_priority",
+        "hsrp",
+        "hsrp_vip",
+        "hsrp_vipv6",
         "hsrp_group",
+        "hsrp_groupv6",
         "hsrp_version",
+        "hsrp_priority",
         "preempt",
+        "mac",
+        "dhcp_server_address1",
+        "dhcp_server_address2",
+        "dhcp_server_address3",
+        "vrf_dhcp1",
+        "vrf_dhcp2",
+        "vrf_dhcp3",
         "advertise_subnet_in_underlay",
         "netflow",
+        "netflow_monitor",
+        "netflow_sampler",
     }
     assert set(policy_options.keys()) == expected_policy_fields
     assert policy_options["policy_type"]["choices"] == ["svi"]
     assert policy_options["policy_type"]["default"] == "svi"
+    assert policy_options["hsrp_version"]["type"] == "int"
+    assert policy_options["hsrp_version"]["choices"] == [1, 2]
 
 
 # =============================================================================

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -183,13 +183,13 @@ def test_svi_interface_00110():
             ip="10.0.0.1",
             prefix=24,
             mtu=9216,
-            policy_type="svi",
         )
     assert instance.admin_state is True
     assert instance.description == "test"
     assert instance.ip == "10.0.0.1"
     assert instance.prefix == 24
     assert instance.mtu == 9216
+    # Hardcoded model default; user no longer supplies this field.
     assert instance.policy_type == "svi"
 
 
@@ -277,102 +277,6 @@ def test_svi_interface_00130(value, should_raise):
         with does_not_raise():
             instance = SviPolicyModel(description=value)
         assert instance.description == value
-
-
-# =============================================================================
-# Test: SviPolicyModel — policy_type normalize and serialize
-# =============================================================================
-
-
-@pytest.mark.parametrize(
-    "value,expected,raises",
-    [
-        ("svi", "svi", False),
-        ("unknown_value", None, True),
-        (None, None, True),
-    ],
-    ids=[
-        "ansible_name_passthrough",
-        "unknown_rejected_by_enum",
-        "none_rejected_field_required_with_default",
-    ],
-)
-def test_svi_interface_00170(value, expected, raises):
-    """
-    # Summary
-
-    Verify `normalize_policy_type` accepts the Ansible/API name and rejects unknown values. `None` is also rejected
-    because `policy_type` is a non-optional field carrying a default — the API requires it on every PUT/POST.
-
-    ## Test
-
-    - "svi" passes through
-    - Unknown values fail enum validation
-    - None is rejected (field is required-with-default, not Optional)
-
-    ## Classes and Methods
-
-    - SviPolicyModel.normalize_policy_type()
-    """
-    if raises:
-        with pytest.raises(ValidationError):
-            SviPolicyModel(policy_type=value)
-    else:
-        with does_not_raise():
-            instance = SviPolicyModel(policy_type=value)
-        assert instance.policy_type == expected
-
-
-@pytest.mark.parametrize(
-    "stored_value,mode,expected",
-    [
-        ("svi", "payload", "svi"),
-        ("svi", "config", "svi"),
-        ("svi", None, "svi"),
-        (None, "payload", None),
-    ],
-    ids=[
-        "payload_mode",
-        "config_mode",
-        "default_mode_payload",
-        "none_value",
-    ],
-)
-def test_svi_interface_00180(stored_value, mode, expected):
-    """
-    # Summary
-
-    Verify `serialize_policy_type` returns the API value in payload mode and the Ansible name in config mode. For SVI
-    these happen to be identical, but the validator-serializer pair is preserved for symmetry with ethernet models.
-
-    ## Test
-
-    - payload mode returns API value
-    - config mode returns Ansible name
-    - None passes through
-
-    ## Classes and Methods
-
-    - SviPolicyModel.serialize_policy_type()
-    """
-    instance = SviPolicyModel(policy_type=stored_value) if stored_value else SviPolicyModel()
-    if stored_value is None:
-        # field default kicks in; result is "svi" not None — adjust expectation
-        if mode == "payload":
-            data = instance.model_dump(by_alias=True, context={"mode": "payload"})
-        else:
-            data = instance.model_dump(by_alias=False, context={"mode": "config"})
-        assert data.get("policyType" if mode == "payload" else "policy_type") == "svi"
-        return
-    if mode == "payload":
-        data = instance.model_dump(by_alias=True, context={"mode": "payload"})
-        assert data["policyType"] == expected
-    elif mode == "config":
-        data = instance.model_dump(by_alias=False, context={"mode": "config"})
-        assert data["policy_type"] == expected
-    else:
-        data = instance.model_dump(by_alias=True)
-        assert data["policyType"] == expected
 
 
 # =============================================================================
@@ -1052,7 +956,6 @@ def test_svi_interface_01100():
 
     policy_options = config_options["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
     expected_policy_fields = {
-        "policy_type",
         "admin_state",
         "description",
         "extra_config",
@@ -1087,8 +990,7 @@ def test_svi_interface_01100():
         "netflow_sampler",
     }
     assert set(policy_options.keys()) == expected_policy_fields
-    assert policy_options["policy_type"]["choices"] == ["svi"]
-    assert policy_options["policy_type"]["default"] == "svi"
+    assert "policy_type" not in policy_options
     assert policy_options["hsrp_version"]["type"] == "int"
     assert policy_options["hsrp_version"]["choices"] == [1, 2]
 

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -236,7 +236,7 @@ def test_svi_interface_00120():
         ("", False),  # max_length lower bound 0 acceptable here, validator only checks ASCII
         (None, False),
         ("em — dash", True),
-        ("smart “quotes”", True),
+        ("smart \u201cquotes\u201d", True),
         ("emoji \U0001f600", True),
         ("latin-1 \xe9", True),
     ],

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -635,6 +635,52 @@ def test_svi_interface_00700(value, expected):
     assert instance.interface_name == expected
 
 
+@pytest.mark.parametrize(
+    "value",
+    [0, 4095, "0", "9999", "vlan0", "vlan4095", "VLAN9999"],
+    ids=["int_zero", "int_above_max", "str_zero", "str_above_max", "prefixed_zero", "prefixed_above_max", "caps_above_max"],
+)
+def test_svi_interface_00710(value):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects a VLAN ID outside the controller-supported range 1-4094.
+
+    ## Test
+
+    - An extractable VLAN ID below 1 or above 4094 raises ValidationError
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match=r"SVI VLAN ID must be in the range 1-4094"):
+        SviInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(1, "vlan1"), (4094, "vlan4094"), ("vlan4094", "vlan4094")],
+    ids=["min_boundary", "max_boundary", "prefixed_max_boundary"],
+)
+def test_svi_interface_00711(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` accepts the VLAN ID range boundaries 1 and 4094.
+
+    ## Test
+
+    - VLAN IDs 1 and 4094 are accepted and normalized to `vlan<id>`
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.normalize_interface_name()
+    """
+    instance = SviInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+    assert instance.interface_name == expected
+
+
 # =============================================================================
 # Test: SviInterfaceModel — composite identifier
 # =============================================================================

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -951,7 +951,11 @@ def test_svi_interface_01100():
     assert config_options["switch_ip"]["required"] is True
     assert config_options["interface_name"]["type"] == "str"
     assert config_options["interface_name"]["required"] is True
-    assert config_options["interface_type"]["default"] == "svi"
+    # interface_type, mode, and network_os_type are hardcoded in the Pydantic model
+    # and intentionally absent from the user-facing argument spec.
+    assert "interface_type" not in config_options
+    assert "mode" not in config_options["config_data"]["options"]
+    assert "network_os_type" not in config_options["config_data"]["options"]["network_os"]["options"]
 
     policy_options = config_options["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
     expected_policy_fields = {

--- a/tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py
@@ -1,0 +1,589 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for subinterface_managed_interface orchestrator.
+
+Verifies that `SubinterfaceManagedInterfaceOrchestrator` correctly:
+- declares the right `model_class` and bulk-support flags
+- filters `query_all` results down to interfaceType=subInterface + managed policyType=subinterface
+- builds correct POST/PUT payloads on create/update
+- queues remove + deploy on delete (no immediate API call)
+- groups create_bulk by switch
+- raises on 207 Multi-Status bodies that carry per-item failures
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as the `sender` injected into a real
+`RestSend`. Responses are read from
+`tests/unit/module_utils/fixtures/fixture_data/test_subinterface_managed_interface.json`.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import SubinterfaceManagedInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_managed_interface import SubinterfaceManagedInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_subif(key: str):
+    """Load fixture data for the orchestrator's test_subinterface_managed_interface.json file."""
+    return load_fixture("test_subinterface_managed_interface")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> SubinterfaceManagedInterfaceOrchestrator:
+    """Construct an orchestrator with the file-based RestSend injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    return SubinterfaceManagedInterfaceOrchestrator(rest_send=rest_send)
+
+
+def _build_model(switch_ip: str = "192.168.1.1", interface_name: str = "Ethernet1/3.2", **policy_kwargs) -> SubinterfaceManagedInterfaceModel:
+    """Build a SubinterfaceManagedInterfaceModel with optional policy fields populated."""
+    config_data = None
+    if policy_kwargs:
+        config_data = {"mode": "managed", "network_os": {"network_os_type": "nx-os", "policy": policy_kwargs}}
+    return SubinterfaceManagedInterfaceModel.from_config(
+        {"switch_ip": switch_ip, "interface_name": interface_name, "interface_type": "subInterface", "config_data": config_data}
+    )
+
+
+# =============================================================================
+# Test: ClassVar / model_class
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00010() -> None:
+    """
+    # Summary
+
+    Verify `model_class` points to `SubinterfaceManagedInterfaceModel`.
+
+    ## Test
+
+    - model_class is SubinterfaceManagedInterfaceModel
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.model_class
+    """
+    assert SubinterfaceManagedInterfaceOrchestrator.model_class is SubinterfaceManagedInterfaceModel
+
+
+def test_subinterface_managed_orchestrator_00020() -> None:
+    """
+    # Summary
+
+    Verify bulk-support flags are enabled.
+
+    ## Test
+
+    - supports_bulk_create is True
+    - supports_bulk_delete is True
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator
+    """
+    assert SubinterfaceManagedInterfaceOrchestrator.supports_bulk_create is True
+    assert SubinterfaceManagedInterfaceOrchestrator.supports_bulk_delete is True
+
+
+# =============================================================================
+# Test: _raise_on_multi_status_failures — 207 Multi-Status handling
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        "not a dict",
+        {},
+        {"results": []},
+        {"results": [{"name": "Ethernet1/3.2", "status": "success"}]},
+    ],
+    ids=["none", "non_dict", "empty_dict", "empty_results", "all_success"],
+)
+def test_subinterface_managed_orchestrator_00100(response) -> None:
+    """
+    # Summary
+
+    Verify `_raise_on_multi_status_failures` does NOT raise for non-dict bodies, missing/empty results, or
+    all-success results.
+
+    ## Test
+
+    - None / non-dict / empty results / all-success bodies do not raise
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures()
+    """
+    with does_not_raise():
+        SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures(response)
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["failed", "error"],
+    ids=["failed", "error"],
+)
+def test_subinterface_managed_orchestrator_00110(status) -> None:
+    """
+    # Summary
+
+    Verify `_raise_on_multi_status_failures` raises `RuntimeError` when any result item carries
+    `status: "failed"` or `status: "error"`, surfacing the per-item name and message.
+
+    ND returns HTTP 207 Multi-Status on subinterface POST with per-item failures (e.g. parent not in routed mode)
+    that the RestSend layer treats as success; this guard converts those into a hard failure.
+
+    ## Test
+
+    - A results body with one failed item raises RuntimeError mentioning the count and message
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures()
+    """
+    response = {
+        "results": [
+            {"name": "Ethernet1/3.2", "status": "success"},
+            {"name": "Ethernet1/3.3", "status": status, "message": "parent not in routed mode"},
+        ]
+    }
+    with pytest.raises(RuntimeError, match=r"ND rejected 1 interface\(s\).*parent not in routed mode"):
+        SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures(response)
+
+
+# =============================================================================
+# Test: query_all — happy path with filtering
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00400() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=subInterface AND
+    managed policyType=subinterface, and injects `switchIp` onto each kept interface.
+
+    ## Test
+
+    - Fabric summary returns 200
+    - Two switches in the switch list
+    - Switch 1 returns: managed subinterface (kept), ethernet (filtered by interfaceType),
+      unmanaged subinterface with policyType=monitorSubinterface (filtered by policyType)
+    - Switch 2 returns: managed subinterface (kept)
+    - Result contains exactly two subinterfaces with switchIp injected
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_subif("test_query_all_happy_path_00400a")
+        yield responses_subif("test_query_all_happy_path_00400b")
+        yield responses_subif("test_query_all_happy_path_00400c")
+        yield responses_subif("test_query_all_happy_path_00400d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    by_name = {iface["interfaceName"]: iface for iface in result}
+    assert set(by_name) == {"Ethernet1/3.2", "Port-channel10.5"}
+
+    assert by_name["Ethernet1/3.2"]["switchIp"] == "192.168.1.1"
+    assert by_name["Port-channel10.5"]["switchIp"] == "192.168.1.2"
+
+    # Filtered out: ethernet (interfaceType) and monitorSubinterface (policyType)
+    assert "Ethernet1/1" not in by_name
+    assert "Ethernet1/3.9" not in by_name
+
+
+def test_subinterface_managed_orchestrator_00420() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - query_all raises RuntimeError mentioning the fabric name
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.query_all()
+    - FabricContext.validate_for_mutation()
+    """
+
+    def responses():
+        yield responses_subif("test_query_all_fabric_not_found_00420a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        orchestrator.query_all()
+
+
+# =============================================================================
+# Test: query_one — happy path
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00500() -> None:
+    """
+    # Summary
+
+    Verify `query_one` resolves the switch_ip and issues a GET on the interface.
+
+    ## Test
+
+    - Switch list returns one switch
+    - Interface GET returns the subinterface body
+    - query_one returns the response DATA
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.query_one()
+    """
+
+    def responses():
+        yield responses_subif("test_query_one_happy_path_00500a")
+        yield responses_subif("test_query_one_happy_path_00500b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="Ethernet1/3.2")
+        result = orchestrator.query_one(model)
+
+    assert result["interfaceName"] == "Ethernet1/3.2"
+    assert result["interfaceType"] == "subInterface"
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "subinterface"
+
+
+# =============================================================================
+# Test: create — happy path; payload inspection
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00600() -> None:
+    """
+    # Summary
+
+    Verify `create` resolves switch_ip, issues a POST wrapping the payload in `interfaces[]`, injects `switchId`, and
+    queues a deploy.
+
+    ## Test
+
+    - Switch list returns one switch
+    - POST returns success
+    - After create, the interface is queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.create()
+    """
+
+    def responses():
+        yield responses_subif("test_create_happy_path_00600a")
+        yield responses_subif("test_create_happy_path_00600b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="Ethernet1/3.2", admin_state=True, vlan_id=2, ip="10.20.30.40", prefix=24)
+        orchestrator.create(model)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+def test_subinterface_managed_orchestrator_00610() -> None:
+    """
+    # Summary
+
+    Verify `create` raises `RuntimeError` when the POST returns a 207 Multi-Status body with a per-item failure,
+    rather than silently reporting success and queuing a deploy.
+
+    ## Test
+
+    - Switch list returns one switch
+    - POST returns a results body containing one item with status "failed"
+    - create raises RuntimeError mentioning the create failure
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.create()
+    - SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures()
+    """
+
+    def responses():
+        yield responses_subif("test_create_multi_status_failure_00610a")
+        yield responses_subif("test_create_multi_status_failure_00610b")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    model = _build_model(interface_name="Ethernet1/3.2", admin_state=True, vlan_id=2, ip="10.20.30.40", prefix=24)
+
+    with pytest.raises(RuntimeError, match=r"Create failed.*parent not in routed mode"):
+        orchestrator.create(model)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") not in orchestrator._pending_deploys
+
+
+# =============================================================================
+# Test: update — happy path
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00700() -> None:
+    """
+    # Summary
+
+    Verify `update` resolves switch_ip, issues a PUT on the interface, and queues a deploy.
+
+    ## Test
+
+    - Switch list returns one switch
+    - PUT returns 200
+    - After update, the interface is queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.update()
+    """
+
+    def responses():
+        yield responses_subif("test_update_happy_path_00700a")
+        yield responses_subif("test_update_happy_path_00700b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="Ethernet1/3.2", description="updated description")
+        orchestrator.update(model)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+# =============================================================================
+# Test: delete — queues remove + deploy, no immediate API call
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00800() -> None:
+    """
+    # Summary
+
+    Verify `delete` queues both a remove and a deploy without making any API call beyond the switch_id resolution.
+    The actual remove/deploy happens later via `remove_pending` / `deploy_pending`.
+
+    ## Test
+
+    - Switch list returns one switch
+    - delete() makes only the switch_map GET (one fixture consumed)
+    - After delete, the interface is queued in both `_pending_removes` and `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.delete()
+    """
+
+    def responses():
+        yield responses_subif("test_delete_happy_path_00800a")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="Ethernet1/3.2")
+        orchestrator.delete(model)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_removes
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+def test_subinterface_managed_orchestrator_00810() -> None:
+    """
+    # Summary
+
+    Verify `remove_pending` issues `interfaceActions/remove` with all queued interfaces and clears the queue.
+
+    ## Test
+
+    - Queue one interface manually (no preceding switch_map GET needed)
+    - Call remove_pending
+    - Queue is empty after success
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.remove_pending()
+    """
+
+    def responses():
+        yield responses_subif("test_remove_pending_happy_path_00810a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    orchestrator._queue_remove("Ethernet1/3.2", "FDO11111AAA")
+
+    with does_not_raise():
+        orchestrator.remove_pending()
+
+    assert orchestrator._pending_removes == []
+
+
+def test_subinterface_managed_orchestrator_00820() -> None:
+    """
+    # Summary
+
+    Verify `deploy_pending` issues `interfaceActions/deploy` with all queued interfaces and clears the queue.
+
+    ## Test
+
+    - Queue one interface manually
+    - Call deploy_pending
+    - Queue is empty after success
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.deploy_pending()
+    """
+
+    def responses():
+        yield responses_subif("test_deploy_pending_happy_path_00820a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    orchestrator._queue_deploy("Ethernet1/3.2", "FDO11111AAA")
+
+    with does_not_raise():
+        orchestrator.deploy_pending()
+
+    assert orchestrator._pending_deploys == []
+
+
+# =============================================================================
+# Test: create_bulk — multiple subinterfaces grouped per switch
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00900() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` groups interfaces by switch and sends one POST per switch with all subinterfaces in the
+    `interfaces` array. Both interfaces are queued for deploy.
+
+    ## Test
+
+    - Two subinterfaces on the same switch
+    - One POST issued (one switch group)
+    - Both interfaces queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.create_bulk()
+    """
+
+    def responses():
+        yield responses_subif("test_create_bulk_happy_path_00900a")
+        yield responses_subif("test_create_bulk_happy_path_00900b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        models = [
+            _build_model(interface_name="Ethernet1/3.2", admin_state=True, vlan_id=2, ip="10.20.30.40", prefix=24),
+            _build_model(interface_name="Ethernet1/3.3", admin_state=True, vlan_id=3, ip="10.20.31.40", prefix=24),
+        ]
+        orchestrator.create_bulk(models)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_deploys
+    assert ("Ethernet1/3.3", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+# =============================================================================
+# Test: payload shape — verify the nested PUT body shape
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_01000() -> None:
+    """
+    # Summary
+
+    Verify the in-memory payload built by `to_payload` for a subinterface is shaped correctly for the PUT API:
+    nested `configData.networkOS.policy` block, no `switch_ip` or `oper_data` at top level. (Wire dispatch is
+    exercised elsewhere; this asserts the payload shape on a model the orchestrator would send unmodified.)
+
+    ## Test
+
+    - Build a partial-update model (description-only)
+    - to_payload produces the canonical nested shape
+    - switchId injection done by orchestrator is not in to_payload
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.to_payload()
+    - SubinterfaceManagedInterfaceOrchestrator.update() — payload assembly
+    """
+    model = _build_model(interface_name="Ethernet1/3.2", description="just description")
+    payload = model.to_payload()
+
+    assert payload["interfaceName"] == "Ethernet1/3.2"
+    assert payload["interfaceType"] == "subInterface"
+    assert "switchIp" not in payload
+    assert "operData" not in payload
+    assert "switchId" not in payload  # injected by orchestrator, not by model
+
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert policy["policyType"] == "subinterface"
+    assert policy["description"] == "just description"

--- a/tests/unit/module_utils/orchestrators/test_subinterface_unmanaged_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_subinterface_unmanaged_interface.py
@@ -1,0 +1,790 @@
+# pylint: disable=unused-import
+# pylint: disable=redefined-outer-name
+# pylint: disable=protected-access
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=invalid-name
+# pylint: disable=line-too-long
+# pylint: disable=too-many-lines
+
+"""Unit tests for SubinterfaceUnmanagedInterfaceOrchestrator."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_unmanaged_interface import SubinterfaceUnmanagedInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_unmanaged_interface import (
+    SubinterfaceUnmanagedInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_subinterface_unmanaged_interface(key: str):
+    """Load fixture data for test_subinterface_unmanaged_interface tests."""
+    return load_fixture("test_subinterface_unmanaged_interface")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator) -> RestSend:
+    """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": "fabric_1"})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+# =============================================================================
+# Test: _raise_on_multi_status_failures
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "payload, expected_raise",
+    [
+        ({"results": [{"name": "Ethernet1/3.20", "status": "success", "message": "ok"}]}, False),
+        ({"results": [{"name": "Ethernet1/3.20", "status": "failed", "message": "parent not routed"}]}, True),
+        ({"results": [{"name": "Ethernet1/3.20", "status": "error", "message": "validation"}]}, True),
+        ({"results": [{"name": "Ethernet1/3.20", "status": "Failed", "message": "parent not routed"}]}, True),
+        ({"results": [{"name": "Ethernet1/3.20", "status": " ERROR ", "message": "validation"}]}, True),
+        ({"results": [{"name": "Ethernet1/3.20", "status": None, "message": "no status key"}]}, False),
+        ({"results": []}, False),
+        ({}, False),
+        (None, False),
+        ("not a dict", False),
+    ],
+    ids=[
+        "success",
+        "failed-raises",
+        "error-raises",
+        "failed-mixed-case-raises",
+        "error-padded-uppercase-raises",
+        "none-status-no-raise",
+        "empty-results",
+        "missing-results",
+        "none-input",
+        "non-dict-input",
+    ],
+)
+def test_subinterface_unmanaged_interface_00010(payload, expected_raise) -> None:
+    """
+    # Summary
+
+    Verify `_raise_on_multi_status_failures` behavior across the matrix.
+
+    ## Test
+
+    - Various 207-body shapes are passed
+    - `RuntimeError` is raised iff any item carries `status` of `"failed"`/`"error"` (case-insensitive, whitespace-tolerant)
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator._raise_on_multi_status_failures()
+    """
+    if expected_raise:
+        with pytest.raises(RuntimeError, match=r"ND rejected"):
+            SubinterfaceUnmanagedInterfaceOrchestrator._raise_on_multi_status_failures(payload)
+    else:
+        with does_not_raise():
+            SubinterfaceUnmanagedInterfaceOrchestrator._raise_on_multi_status_failures(payload)
+
+
+# =============================================================================
+# Test: create
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00100(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `create` resolves the switch IP, wraps the payload in `{"interfaces": [...]}`, injects `switchId`, and queues a deploy.
+
+    ## Test
+
+    - First call to `_resolve_switch_id` triggers switches-list fetch
+    - POST is issued against `/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces`
+    - Request body is `{"interfaces": [{...payload..., "switchId": "FDO12345ABC"}]}`
+    - `_pending_deploys` contains a single `(interface_name, switch_id)` pair
+    - Result carries `results[0].status == "success"`
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.create()
+    - NDBaseInterfaceOrchestrator._resolve_switch_id()
+    - NDBaseInterfaceOrchestrator._queue_deploy()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
+
+    with does_not_raise():
+        result = orchestrator.create(model)
+
+    assert result["results"][0]["status"] == "success"
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert "interfaces" in body
+    assert len(body["interfaces"]) == 1
+    payload_item = body["interfaces"][0]
+    assert payload_item["interfaceName"] == "Ethernet1/3.20"
+    assert payload_item["interfaceType"] == "subInterface"
+    assert payload_item["switchId"] == "FDO12345ABC"
+    assert "switchIp" not in payload_item
+    assert ("Ethernet1/3.20", "FDO12345ABC") in orchestrator._pending_deploys
+
+
+def test_subinterface_unmanaged_interface_00101(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `create` raises when the 207 response carries `status: failed`.
+
+    ## Test
+
+    - POST returns 207 with `results[0].status = "failed"`
+    - `_raise_on_multi_status_failures` raises; `create` wraps it in a `RuntimeError` matching `Create failed.*ND rejected`
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.create()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
+
+    with pytest.raises(RuntimeError, match=r"Create failed.*ND rejected"):
+        orchestrator.create(model)
+
+    assert orchestrator._pending_deploys == []
+
+
+def test_subinterface_unmanaged_interface_00102(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `create` wraps a `_request` failure (non-2xx) in `RuntimeError` mentioning the identifier.
+
+    ## Test
+
+    - switches-list returns 200
+    - POST returns 500
+    - `RuntimeError` matches `Create failed for .*Ethernet1/3.20`
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.create()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
+
+    match = r"Create failed for .*Ethernet1/3\.20"
+    with pytest.raises(RuntimeError, match=match):
+        orchestrator.create(model)
+
+    assert orchestrator._pending_deploys == []
+
+
+# =============================================================================
+# Test: update
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00200(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `update` issues a PUT against the per-interface URL, injects `switchId` into the payload, and queues a deploy.
+
+    ## Test
+
+    - switches-list fetched on first switch_id resolution
+    - PUT is issued against `/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces/Ethernet1%2F3.20`
+    - `switchId` is present in the payload
+    - `_pending_deploys` contains the `(Ethernet1/3.20, FDO12345ABC)` pair
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
+
+    with does_not_raise():
+        orchestrator.update(model)
+
+    assert rest_send.verb == HttpVerbEnum.PUT.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert body["interfaceName"] == "Ethernet1/3.20"
+    assert body["switchId"] == "FDO12345ABC"
+    assert "switchIp" not in body
+    assert ("Ethernet1/3.20", "FDO12345ABC") in orchestrator._pending_deploys
+
+
+def test_subinterface_unmanaged_interface_00201(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `update` wraps a `_request` failure in `RuntimeError` mentioning the identifier.
+
+    ## Test
+
+    - PUT returns 500
+    - `RuntimeError` matches `Update failed for .*Ethernet1/3.20`
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
+
+    match = r"Update failed for .*Ethernet1/3\.20"
+    with pytest.raises(RuntimeError, match=match):
+        orchestrator.update(model)
+
+    assert orchestrator._pending_deploys == []
+
+
+# =============================================================================
+# Test: delete
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00300(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `delete` queues a remove + deploy without making any API call beyond the switches-list fetch.
+
+    ## Test
+
+    - Only the switches-list response is consumed (one HTTP call to resolve switch_id)
+    - `_pending_removes` contains `(Ethernet1/3.20, FDO12345ABC)`
+    - `_pending_deploys` contains `(Ethernet1/3.20, FDO12345ABC)`
+    - `delete` returns None
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.delete()
+    - NDBaseInterfaceOrchestrator._queue_remove()
+    - NDBaseInterfaceOrchestrator._queue_deploy()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "deleted"})
+    model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
+
+    with does_not_raise():
+        result = orchestrator.delete(model)
+
+    assert result is None
+    assert ("Ethernet1/3.20", "FDO12345ABC") in orchestrator._pending_removes
+    assert ("Ethernet1/3.20", "FDO12345ABC") in orchestrator._pending_deploys
+
+
+def test_subinterface_unmanaged_interface_00301(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `delete` propagates the raw `RuntimeError` from `_resolve_switch_id` when the IP is unknown.
+
+    ## Test
+
+    - switches-list returns a different IP
+    - `RuntimeError` matches `No switch found with fabricManagementIp '192\\.168\\.12\\.151'`
+    - No queues are populated
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.delete()
+    - NDBaseInterfaceOrchestrator._resolve_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "deleted"})
+    model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
+
+    match = r"No switch found with fabricManagementIp '192\.168\.12\.151'"
+    with pytest.raises(RuntimeError, match=match):
+        orchestrator.delete(model)
+
+    assert orchestrator._pending_removes == []
+    assert orchestrator._pending_deploys == []
+
+
+# =============================================================================
+# Test: create_bulk
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00400(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` groups interfaces by switch and issues one POST per switch with the per-switch subset
+    wrapped in `{"interfaces": [...]}`.
+
+    ## Test
+
+    - Three interfaces split across two switches: Ethernet1/3.20 + Ethernet1/3.21 on switch A, Ethernet1/3.20 on switch B
+    - Two POSTs are issued (one per switch)
+    - All three pairs are queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}c")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    models = [
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20"),
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.21"),
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.152", interface_name="Ethernet1/3.20"),
+    ]
+
+    with does_not_raise():
+        orchestrator.create_bulk(models)
+
+    assert rest_send.path in (
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABD/interfaces",
+    )
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert sorted(orchestrator._pending_deploys) == sorted(
+        [
+            ("Ethernet1/3.20", "FDO12345ABC"),
+            ("Ethernet1/3.21", "FDO12345ABC"),
+            ("Ethernet1/3.20", "FDO12345ABD"),
+        ]
+    )
+
+
+def test_subinterface_unmanaged_interface_00401(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` wraps a per-switch `_request` failure in `RuntimeError` matching `Bulk create failed`.
+
+    ## Test
+
+    - switches-list succeeds
+    - First per-switch POST succeeds, second returns 500
+    - `RuntimeError` matches `Bulk create failed`
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}c")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    models = [
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20"),
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.152", interface_name="Ethernet1/3.20"),
+    ]
+
+    match = r"Bulk create failed"
+    with pytest.raises(RuntimeError, match=match):
+        orchestrator.create_bulk(models)
+
+
+# =============================================================================
+# Test: delete_bulk
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00500(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `delete_bulk` queues remove + deploy entries for each instance without issuing any API call beyond the
+    switches-list fetch.
+
+    ## Test
+
+    - Two interfaces on two switches
+    - Only switches-list response is consumed
+    - `_pending_removes` and `_pending_deploys` each contain both pairs
+    - `delete_bulk` returns None
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.delete_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "deleted"})
+    models = [
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20"),
+        SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.152", interface_name="Ethernet1/3.20"),
+    ]
+
+    with does_not_raise():
+        result = orchestrator.delete_bulk(models)
+
+    assert result is None
+    expected = [("Ethernet1/3.20", "FDO12345ABC"), ("Ethernet1/3.20", "FDO12345ABD")]
+    assert sorted(orchestrator._pending_removes) == sorted(expected)
+    assert sorted(orchestrator._pending_deploys) == sorted(expected)
+
+
+# =============================================================================
+# Test: query_one
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00600(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `query_one` issues a GET against the per-interface URL and returns the DATA dict.
+
+    ## Test
+
+    - switches-list fetched on first switch_id resolution
+    - GET hits `/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces/Ethernet1%2F3.20`
+    - Returned DATA matches the fixture (policyType: monitorSubinterface)
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
+
+    with does_not_raise():
+        result = orchestrator.query_one(model)
+
+    assert rest_send.verb == HttpVerbEnum.GET.value
+    assert result["interfaceName"] == "Ethernet1/3.20"
+    assert result["interfaceType"] == "subInterface"
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "monitorSubinterface"
+
+
+def test_subinterface_unmanaged_interface_00601(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `query_one` wraps a `_request` failure in `RuntimeError` mentioning the identifier.
+
+    ## Test
+
+    - switches-list succeeds, GET returns 500
+    - `RuntimeError` matches `Query failed for .*Ethernet1/3.20`
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
+
+    match = r"Query failed for .*Ethernet1/3\.20"
+    with pytest.raises(RuntimeError, match=match):
+        orchestrator.query_one(model)
+
+
+# =============================================================================
+# Test: query_all
+# =============================================================================
+
+
+def test_subinterface_unmanaged_interface_00700(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates prerequisites, iterates all switches, filters for `monitorSubinterface` policyType,
+    and enriches each result with `switchIp`.
+
+    ## Test
+
+    - Fabric summary fetched once (validate_prerequisites)
+    - Switches-list fetched once (switch_map)
+    - Switch A returns a mix: one managed subinterface (policyType=subinterface) + one unmanaged (policyType=monitorSubinterface)
+    - Switch B returns only a managed subinterface
+    - Result contains only the unmanaged entry from switch A, enriched with `switchIp`
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.query_all()
+    - NDBaseInterfaceOrchestrator.validate_prerequisites()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}c")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}d")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+
+    with does_not_raise():
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "Ethernet1/3.20"
+    assert result[0]["configData"]["networkOS"]["policy"]["policyType"] == "monitorSubinterface"
+    assert result[0]["switchIp"] == "192.168.12.151"
+    # Verify the managed entry was excluded
+    assert all(item["configData"]["networkOS"]["policy"]["policyType"] == "monitorSubinterface" for item in result)
+
+
+def test_subinterface_unmanaged_interface_00701(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty list when the fabric has no switches.
+
+    ## Test
+
+    - Fabric summary returns valid (local, default)
+    - Switches list returns no switches
+    - `query_all` returns []
+    - No per-switch interface fetches occur
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+
+    with does_not_raise():
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_subinterface_unmanaged_interface_00702(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `query_all` surfaces a `RuntimeError` (wrapped as `Query all failed: ...`) when the fabric is in
+    deployment-freeze mode.
+
+    ## Test
+
+    - Fabric summary returns `fabricStatus: frozen`
+    - `query_all` raises `RuntimeError` with `Query all failed.*deployment freeze`
+    - No per-switch fetches occur
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.query_all()
+    - NDBaseInterfaceOrchestrator.validate_prerequisites()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+
+    match = r"Query all failed.*deployment freeze"
+    with pytest.raises(RuntimeError, match=match):
+        orchestrator.query_all()
+
+
+def test_subinterface_unmanaged_interface_00703(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty list when no switch has any subInterface entries.
+
+    ## Test
+
+    - One switch with only ethernet interfaces
+    - `query_all` returns []
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}c")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+
+    with does_not_raise():
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_subinterface_unmanaged_interface_00704(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `query_all` skips a switch whose interface-list DATA is a non-dict (e.g. ND returns a bare JSON array
+    instead of `{"interfaces": [...]}`) instead of raising `AttributeError` on `.get()`.
+
+    ## Test
+
+    - Fabric summary returns valid (local, default)
+    - Switches list returns one switch
+    - That switch's interfaces GET returns a bare list as DATA
+    - `query_all` returns [] without raising
+
+    ## Classes and Methods
+
+    - SubinterfaceUnmanagedInterfaceOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}c")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen)
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+
+    with does_not_raise():
+        result = orchestrator.query_all()
+
+    assert result == []

--- a/tests/unit/module_utils/orchestrators/test_svi_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_svi_interface.py
@@ -145,6 +145,7 @@ def test_svi_orchestrator_00400() -> None:
 
     def responses():
         yield responses_svi("test_query_all_happy_path_00400a")
+        yield responses_svi("test_query_all_happy_path_00400_freeze")
         yield responses_svi("test_query_all_happy_path_00400b")
         yield responses_svi("test_query_all_happy_path_00400c")
         yield responses_svi("test_query_all_happy_path_00400d")

--- a/tests/unit/module_utils/orchestrators/test_svi_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_svi_interface.py
@@ -1,0 +1,485 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for svi_interface orchestrator.
+
+Verifies that `SviInterfaceOrchestrator` correctly:
+- declares the right `model_class` and bulk-support flags
+- filters `query_all` results down to interfaceType=svi + policyType=svi
+- builds correct POST/PUT payloads on create/update
+- queues remove + deploy on delete (no immediate API call)
+- preserves `interfaceType` on PUT (matches the GUI's canonical PUT body)
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as the `sender` injected into a real
+`RestSend`. Responses are read from
+`tests/unit/module_utils/fixtures/fixture_data/test_svi_interface.json`.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.svi_interface import SviInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.svi_interface import SviInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_svi(key: str):
+    """Load fixture data for the orchestrator's test_svi_interface.json file."""
+    return load_fixture("test_svi_interface")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> SviInterfaceOrchestrator:
+    """Construct an orchestrator with the file-based RestSend injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    return SviInterfaceOrchestrator(rest_send=rest_send)
+
+
+def _build_model(switch_ip: str = "192.168.1.1", interface_name: str = "vlan333", **policy_kwargs) -> SviInterfaceModel:
+    """Build an SviInterfaceModel with optional policy fields populated."""
+    config_data = None
+    if policy_kwargs:
+        config_data = {"mode": "managed", "network_os": {"network_os_type": "nx-os", "policy": policy_kwargs}}
+    return SviInterfaceModel.from_config({"switch_ip": switch_ip, "interface_name": interface_name, "interface_type": "svi", "config_data": config_data})
+
+
+# =============================================================================
+# Test: ClassVar / model_class
+# =============================================================================
+
+
+def test_svi_orchestrator_00010() -> None:
+    """
+    # Summary
+
+    Verify `model_class` points to `SviInterfaceModel`.
+
+    ## Test
+
+    - model_class is SviInterfaceModel
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.model_class
+    """
+    assert SviInterfaceOrchestrator.model_class is SviInterfaceModel
+
+
+def test_svi_orchestrator_00020() -> None:
+    """
+    # Summary
+
+    Verify bulk-support flags are enabled.
+
+    ## Test
+
+    - supports_bulk_create is True
+    - supports_bulk_delete is True
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator
+    """
+    assert SviInterfaceOrchestrator.supports_bulk_create is True
+    assert SviInterfaceOrchestrator.supports_bulk_delete is True
+
+
+# =============================================================================
+# Test: query_all — happy path with filtering
+# =============================================================================
+
+
+def test_svi_orchestrator_00400() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=svi AND policyType=svi,
+    and injects `switchIp` onto each kept interface.
+
+    ## Test
+
+    - Fabric summary returns 200
+    - Two switches in the switch list
+    - Switch 1 returns: SVI (kept), ethernet (filtered by interfaceType), SVI with policyType=underlaySvi (filtered by policyType)
+    - Switch 2 returns: SVI (kept)
+    - Result contains exactly two SVIs with switchIp injected
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_svi("test_query_all_happy_path_00400a")
+        yield responses_svi("test_query_all_happy_path_00400b")
+        yield responses_svi("test_query_all_happy_path_00400c")
+        yield responses_svi("test_query_all_happy_path_00400d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    by_name = {iface["interfaceName"]: iface for iface in result}
+    assert set(by_name) == {"vlan100", "vlan200"}
+
+    assert by_name["vlan100"]["switchIp"] == "192.168.1.1"
+    assert by_name["vlan200"]["switchIp"] == "192.168.1.2"
+
+    # Filtered out: ethernet and underlaySvi
+    assert "Ethernet1/1" not in by_name
+    assert "vlan999" not in by_name
+
+
+def test_svi_orchestrator_00420() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - query_all raises RuntimeError mentioning the fabric name
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.query_all()
+    - FabricContext.validate_for_mutation()
+    """
+
+    def responses():
+        yield responses_svi("test_query_all_fabric_not_found_00420a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        orchestrator.query_all()
+
+
+# =============================================================================
+# Test: query_one — happy path
+# =============================================================================
+
+
+def test_svi_orchestrator_00500() -> None:
+    """
+    # Summary
+
+    Verify `query_one` resolves the switch_ip and issues a GET on the interface.
+
+    ## Test
+
+    - Switch list returns one switch
+    - Interface GET returns the SVI body
+    - query_one returns the response DATA
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.query_one()
+    """
+
+    def responses():
+        yield responses_svi("test_query_one_happy_path_00500a")
+        yield responses_svi("test_query_one_happy_path_00500b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="vlan333")
+        result = orchestrator.query_one(model)
+
+    assert result["interfaceName"] == "vlan333"
+    assert result["interfaceType"] == "svi"
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "svi"
+
+
+# =============================================================================
+# Test: create — happy path; payload inspection
+# =============================================================================
+
+
+def test_svi_orchestrator_00600() -> None:
+    """
+    # Summary
+
+    Verify `create` resolves switch_ip, issues a POST wrapping the payload in `interfaces[]`, injects `switchId`, and
+    queues a deploy.
+
+    ## Test
+
+    - Switch list returns one switch
+    - POST returns success
+    - After create, the interface is queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.create()
+    """
+
+    def responses():
+        yield responses_svi("test_create_happy_path_00600a")
+        yield responses_svi("test_create_happy_path_00600b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="vlan333", admin_state=True, ip="10.99.99.1", prefix=24)
+        orchestrator.create(model)
+
+    assert ("vlan333", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+# =============================================================================
+# Test: update — happy path
+# =============================================================================
+
+
+def test_svi_orchestrator_00700() -> None:
+    """
+    # Summary
+
+    Verify `update` resolves switch_ip, issues a PUT on the interface, and queues a deploy.
+
+    ## Test
+
+    - Switch list returns one switch
+    - PUT returns 200
+    - After update, the interface is queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.update()
+    """
+
+    def responses():
+        yield responses_svi("test_update_happy_path_00700a")
+        yield responses_svi("test_update_happy_path_00700b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="vlan333", description="updated description")
+        orchestrator.update(model)
+
+    assert ("vlan333", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+# =============================================================================
+# Test: delete — queues remove + deploy, no immediate API call
+# =============================================================================
+
+
+def test_svi_orchestrator_00800() -> None:
+    """
+    # Summary
+
+    Verify `delete` queues both a remove and a deploy without making any API call beyond the switch_id resolution.
+    The actual remove/deploy happens later via `remove_pending` / `deploy_pending`.
+
+    ## Test
+
+    - Switch list returns one switch
+    - delete() makes only the switch_map GET (one fixture consumed)
+    - After delete, the interface is queued in both `_pending_removes` and `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.delete()
+    """
+
+    def responses():
+        yield responses_svi("test_delete_happy_path_00800a")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="vlan333")
+        orchestrator.delete(model)
+
+    assert ("vlan333", "FDO11111AAA") in orchestrator._pending_removes
+    assert ("vlan333", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+def test_svi_orchestrator_00810() -> None:
+    """
+    # Summary
+
+    Verify `remove_pending` issues `interfaceActions/remove` with all queued interfaces and clears the queue.
+
+    ## Test
+
+    - Queue one interface manually (no preceding switch_map GET needed)
+    - Call remove_pending
+    - Queue is empty after success
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.remove_pending()
+    """
+
+    def responses():
+        yield responses_svi("test_remove_pending_happy_path_00810a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    orchestrator._queue_remove("vlan333", "FDO11111AAA")
+
+    with does_not_raise():
+        orchestrator.remove_pending()
+
+    assert orchestrator._pending_removes == []
+
+
+def test_svi_orchestrator_00820() -> None:
+    """
+    # Summary
+
+    Verify `deploy_pending` issues `interfaceActions/deploy` with all queued interfaces and clears the queue.
+
+    ## Test
+
+    - Queue one interface manually
+    - Call deploy_pending
+    - Queue is empty after success
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.deploy_pending()
+    """
+
+    def responses():
+        yield responses_svi("test_deploy_pending_happy_path_00820a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    orchestrator._queue_deploy("vlan333", "FDO11111AAA")
+
+    with does_not_raise():
+        orchestrator.deploy_pending()
+
+    assert orchestrator._pending_deploys == []
+
+
+# =============================================================================
+# Test: create_bulk — multiple SVIs grouped per switch
+# =============================================================================
+
+
+def test_svi_orchestrator_00900() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` groups interfaces by switch and sends one POST per switch with all SVIs in the
+    `interfaces` array. Both interfaces are queued for deploy.
+
+    ## Test
+
+    - Two SVIs on the same switch
+    - One POST issued (one switch group)
+    - Both interfaces queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SviInterfaceOrchestrator.create_bulk()
+    """
+
+    def responses():
+        yield responses_svi("test_create_bulk_happy_path_00900a")
+        yield responses_svi("test_create_bulk_happy_path_00900b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        models = [
+            _build_model(interface_name="vlan333", admin_state=True, ip="10.99.99.1", prefix=24),
+            _build_model(interface_name="vlan334", admin_state=True, ip="10.99.99.2", prefix=24),
+        ]
+        orchestrator.create_bulk(models)
+
+    assert ("vlan333", "FDO11111AAA") in orchestrator._pending_deploys
+    assert ("vlan334", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+# =============================================================================
+# Test: payload shape — verify update strips no extra fields and PUT works on partial body
+# =============================================================================
+
+
+def test_svi_orchestrator_01000() -> None:
+    """
+    # Summary
+
+    Verify the in-memory payload built by `to_payload` for an SVI is shaped correctly for the PUT API: nested
+    `configData.networkOS.policy` block, no `switch_ip` or `oper_data` at top level. (Wire dispatch is exercised
+    elsewhere; this asserts the payload shape on a model the orchestrator would send unmodified.)
+
+    ## Test
+
+    - Build a partial-update model (description-only)
+    - to_payload produces the canonical nested shape
+    - switchId injection done by orchestrator is not in to_payload
+    - hsrpVersion absent (model defaults; from_response strip irrelevant here)
+
+    ## Classes and Methods
+
+    - SviInterfaceModel.to_payload()
+    - SviInterfaceOrchestrator.update() — payload assembly
+    """
+    model = _build_model(interface_name="vlan333", description="just description")
+    payload = model.to_payload()
+
+    assert payload["interfaceName"] == "vlan333"
+    assert payload["interfaceType"] == "svi"
+    assert "switchIp" not in payload
+    assert "operData" not in payload
+    assert "switchId" not in payload  # injected by orchestrator, not by model
+
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert policy["policyType"] == "svi"
+    assert policy["description"] == "just description"
+    assert "hsrpVersion" not in policy

--- a/tests/unit/module_utils/orchestrators/test_svi_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_svi_interface.py
@@ -145,7 +145,6 @@ def test_svi_orchestrator_00400() -> None:
 
     def responses():
         yield responses_svi("test_query_all_happy_path_00400a")
-        yield responses_svi("test_query_all_happy_path_00400_freeze")
         yield responses_svi("test_query_all_happy_path_00400b")
         yield responses_svi("test_query_all_happy_path_00400c")
         yield responses_svi("test_query_all_happy_path_00400d")


### PR DESCRIPTION
## Related Issue(s)

- CiscoDevNet/ansible-nd#319

### Deferred follow-ups (tracked)

- #349 — query_all per-switch fan-out / no fabric-wide interface endpoint (cross-cutting)
- #352 — SVI phase 2: HSRP sub-block modeling + OSPF/ISIS/BFD interface fields

## Proposed Changes

Adds `nd_interface_svi` to manage SVI (switched virtual interface) configurations on Cisco Nexus Dashboard via the Manage Interfaces API.

- `plugins/module_utils/models/interfaces/svi_interface.py` — `SviInterfaceModel` plus nested `SviPolicyModel`, `SviNetworkOSModel`, `SviConfigDataModel`, `SviOperDataModel`. Composite identifier `(switch_ip, interface_name)` where `interface_name` is normalized to lowercase `vlan<id>`.
- `plugins/module_utils/orchestrators/svi_interface.py` — `SviInterfaceOrchestrator` inheriting from `NDBaseInterfaceOrchestrator` (not the ethernet base; SVIs have no port-channel concerns and support real DELETE via `interfaceActions/remove` + `interfaceActions/deploy`).
- `plugins/modules/nd_interface_svi.py` — module entry point. Each config item targets a single SVI via `interface_name` (e.g. `vlan333`); to configure multiple SVIs, list multiple config items.
- `plugins/module_utils/models/interfaces/enums.py` — adds `SviPolicyTypeEnum.SVI = "svi"`.

Phase 1 exposes the policy fields the ND GUI sends on create: `admin_state`, `description`, `ip`/`prefix`, `ipv6`/`v6prefix`, `ip_redirects`, `pim_sparse`, `pim_dr_priority`, `hsrp_group`, `hsrp_version`, `preempt`, `advertise_subnet_in_underlay`, `mtu`, `extra_config`, `netflow`. OSPF / ISIS / BFD / proper HSRP sub-block modeling deferred to a follow-up release.

One SVI-specific deviation from the loopback / ethernet-access pattern, validated by Bruno testing against a live testbed:

1. `from_response()` strips `hsrpVersion`. ND's GET returns `hsrpVersion: 1` (integer) as a server-side default even when HSRP is unconfigured; re-emitting that on PUT — as either int `1` or string `"1"` — triggers a generic 500 ("unexpected error during policy execution"). `hsrpGroup: 1` round-trips fine, so only `hsrpVersion` is poisoned. Proper HSRP sub-block modeling is deferred to phase 2.

## Test Notes

Full create / update / query / idempotency / delete lifecycle verified against an ND 4.2 testbed (`fabric_1`, switch `LE1` at `192.168.12.151`, VLANs 333/334/335).

- Unit tests: `tests/unit/.../test_svi_interface*.py` (commit `434b221`).
- Integration tests: `tests/integration/targets/nd_interface_svi/` (commit `f8b2223`).
- POST: 201 with single and multi-VLAN config items.
- PUT: 200 on partial body (only `description` + `policyType`) — server merges.
- GET: round-trips through model with `oper_data` populated.
- Idempotency: second-run reports `changed: false` with empty diff.
- DELETE: `interfaceActions/remove` (204) followed by `interfaceActions/deploy` confirmed via post-delete check_mode query (`before: []`).

## Cisco Nexus Dashboard Version

4.2

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved (this branch is stacked on `nd_interface_ethernet_trunk_host`; rebase will follow that branch's merge to develop)
* [x] New or updates to documentation has been made accordingly (module DOCUMENTATION + EXAMPLES populated)
* [ ] Assigned the proper reviewers


