### PR TITLE
nd_interface_port_channel_access

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -283,7 +283,7 @@ class EpManageInterfacesDelete(_EpManageInterfacesBase):
     """
     # Summary
 
-    Delete a specific interface configuration.
+    Delete a specific interface via the per-interface endpoint.
 
     - Path: `/api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/interfaces/{interface_name}`
     - Verb: DELETE
@@ -293,6 +293,10 @@ class EpManageInterfacesDelete(_EpManageInterfacesBase):
 
     To reset physical interfaces to their default state, see `EpManageInterfacesNormalize` and set the payload to an
     appropriate default config (for example `module_utils/models/interfaces/interface_default_config.py`).
+
+    Also used by vPC interface orchestrators because the `interfaceActions/remove` bulk endpoint returns
+    `Invalid Interface` for vPC entries on ND 4.2.1 (lab-verified). The per-interface DELETE returns 204
+    on success and a subsequent GET returns 404.
 
     ## Raises
 

--- a/plugins/module_utils/models/interfaces/enums.py
+++ b/plugins/module_utils/models/interfaces/enums.py
@@ -5,10 +5,10 @@
 """
 # Summary
 
-Shared enum definitions for ethernet interface models.
+Shared enum definitions for interface models.
 
-These enums are derived from ND config templates (e.g. `int_access_host`, `int_trunk_host`) and constrain policy
-fields across multiple interface types. Each enum's member values match the API's expected strings exactly.
+These enums are derived from ND interface config templates and constrain policy fields across multiple interface types.
+Each enum's member values match the API's expected strings exactly.
 """
 
 from __future__ import annotations
@@ -24,6 +24,16 @@ class AccessHostPolicyTypeEnum(str, Enum):
     """
 
     ACCESS_HOST = "accessHost"
+
+
+class AccessPoHostPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for port-channel access host interfaces.
+    """
+
+    ACCESS_PO_HOST = "accessPoHost"
 
 
 class BpduFilterEnum(str, Enum):
@@ -77,6 +87,17 @@ class FecEnum(str, Enum):
     RS_IEEE = "rsIEEE"
 
 
+class LacpRateEnum(str, Enum):
+    """
+    # Summary
+
+    LACP rate (PDU transmit interval).
+    """
+
+    NORMAL = "normal"
+    FAST = "fast"
+
+
 class LinkTypeEnum(str, Enum):
     """
     # Summary
@@ -98,6 +119,18 @@ class MtuEnum(str, Enum):
 
     DEFAULT = "default"
     JUMBO = "jumbo"
+
+
+class PortChannelModeEnum(str, Enum):
+    """
+    # Summary
+
+    Port-channel mode.
+    """
+
+    ON = "on"
+    ACTIVE = "active"
+    PASSIVE = "passive"
 
 
 class SpeedEnum(str, Enum):

--- a/plugins/module_utils/models/interfaces/enums.py
+++ b/plugins/module_utils/models/interfaces/enums.py
@@ -1,0 +1,132 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+# Summary
+
+Shared enum definitions for interface models.
+
+These enums are derived from ND config templates (e.g. `int_port_channel_access_host`,
+`int_port_channel_trunk_host`) and constrain policy fields across multiple interface types.
+Each enum's member values match the API's expected strings exactly.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class AccessPoHostPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for port-channel access host interfaces.
+    """
+
+    ACCESS_PO_HOST = "accessPoHost"
+
+
+class BpduFilterEnum(str, Enum):
+    """
+    # Summary
+
+    Spanning-tree BPDU filter settings.
+    """
+
+    ENABLE = "enable"
+    DISABLE = "disable"
+    DEFAULT = "default"
+
+
+class BpduGuardEnum(str, Enum):
+    """
+    # Summary
+
+    Spanning-tree BPDU guard settings.
+    """
+
+    ENABLE = "enable"
+    DISABLE = "disable"
+    DEFAULT = "default"
+
+
+class DuplexModeEnum(str, Enum):
+    """
+    # Summary
+
+    Port duplex mode settings.
+    """
+
+    AUTO = "auto"
+    FULL = "full"
+    HALF = "half"
+
+
+class LacpRateEnum(str, Enum):
+    """
+    # Summary
+
+    LACP rate (PDU transmit interval).
+    """
+
+    NORMAL = "normal"
+    FAST = "fast"
+
+
+class MtuEnum(str, Enum):
+    """
+    # Summary
+
+    Interface MTU setting.
+    """
+
+    DEFAULT = "default"
+    JUMBO = "jumbo"
+
+
+class PortChannelModeEnum(str, Enum):
+    """
+    # Summary
+
+    Port-channel mode.
+    """
+
+    ON = "on"
+    ACTIVE = "active"
+    PASSIVE = "passive"
+
+
+class SpeedEnum(str, Enum):
+    """
+    # Summary
+
+    Interface speed setting.
+    """
+
+    AUTO = "auto"
+    TEN_MB = "10Mb"
+    HUNDRED_MB = "100Mb"
+    ONE_GB = "1Gb"
+    TWO_POINT_FIVE_GB = "2.5Gb"
+    FIVE_GB = "5Gb"
+    TEN_GB = "10Gb"
+    TWENTY_FIVE_GB = "25Gb"
+    FORTY_GB = "40Gb"
+    FIFTY_GB = "50Gb"
+    HUNDRED_GB = "100Gb"
+    TWO_HUNDRED_GB = "200Gb"
+    FOUR_HUNDRED_GB = "400Gb"
+    EIGHT_HUNDRED_GB = "800Gb"
+
+
+class StormControlActionEnum(str, Enum):
+    """
+    # Summary
+
+    Storm control action on threshold violation.
+    """
+
+    SHUTDOWN = "shutdown"
+    TRAP = "trap"
+    DEFAULT = "default"

--- a/plugins/module_utils/models/interfaces/enums.py
+++ b/plugins/module_utils/models/interfaces/enums.py
@@ -36,6 +36,36 @@ class AccessPoHostPolicyTypeEnum(str, Enum):
     ACCESS_PO_HOST = "accessPoHost"
 
 
+class TrunkPoHostPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for port-channel trunk host interfaces.
+    """
+
+    TRUNK_PO_HOST = "trunkPoHost"
+
+
+class AccessVpcHostPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for vPC access host interfaces (`int_vpc_access_host` template).
+    """
+
+    ACCESS_VPC_HOST = "accessVpcHost"
+
+
+class TrunkVpcHostPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for vPC trunk host interfaces (`int_vpc_trunk_host` template).
+    """
+
+    TRUNK_VPC_HOST = "trunkVpcHost"
+
+
 class BpduFilterEnum(str, Enum):
     """
     # Summary

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -30,6 +30,7 @@ interfaces inherit access-mode settings from the port-channel; users do not pre-
 
 from __future__ import annotations
 
+import re
 from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -52,6 +53,14 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+
+# Splits an interface name into its leading alphabetic prefix and the rest (digits/separators).
+_INTERFACE_NAME_PREFIX_RE = re.compile(r"^([A-Za-z]+)(.*)$")
+
+# Member interfaces of a port-channel are always physical ethernet ports, so the canonical wire prefix
+# is always "Ethernet". Any case-insensitive NX-OS abbreviation (e.g. "e", "eth", "ether") expands to the
+# full form so user input matches the wire key and idempotency holds.
+_CANONICAL_MEMBER_TYPE = "Ethernet"
 
 
 class PortChannelAccessPolicyModel(NDNestedModel):
@@ -151,23 +160,50 @@ class PortChannelAccessPolicyModel(NDNestedModel):
         """
         # Summary
 
-        Normalize each member interface name to ND API convention (e.g. `ethernet1/1` -> `Ethernet1/1`).
+        Normalize each member interface name to ND's canonical `Ethernet` form so that any user-supplied casing or
+        NX-OS abbreviation round-trips against the wire form. Members are always physical ethernet ports. Examples:
+
+        - `ethernet1/1` -> `Ethernet1/1`
+        - `ETHERNET1/1` -> `Ethernet1/1`
+        - `eth1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `e1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `Ethernet1/1` -> `Ethernet1/1` (idempotent)
+
+        Because the wire key is matched exactly, an abbreviated prefix that is not expanded would never match ND's
+        `Ethernet...` form, silently breaking idempotency (the port-channel re-deploys on every run). Any
+        case-insensitive prefix of `Ethernet` (`e`, `et`, `eth`, ...) is therefore expanded to the full canonical
+        name; an unrecognized prefix falls back to Title case so it still round-trips. Only the leading alphabetic
+        run is rewritten; digits and separators are preserved verbatim.
 
         ## Raises
 
         None
         """
-        if value is None:
-            return value
         if not isinstance(value, list):
             return value
-        normalized = []
-        for name in value:
-            if isinstance(name, str) and name:
-                normalized.append(name[0].upper() + name[1:])
-            else:
-                normalized.append(name)
-        return normalized
+        return [cls._normalize_member_name(name) for name in value]
+
+    @staticmethod
+    def _normalize_member_name(name):
+        """
+        # Summary
+
+        Normalize a single member interface name to ND's canonical `Ethernet` form (see `normalize_ports`).
+        Non-string or empty values are returned unchanged.
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(name, str) or not name:
+            return name
+        match = _INTERFACE_NAME_PREFIX_RE.match(name)
+        if not match:
+            return name
+        prefix, rest = match.groups()
+        if _CANONICAL_MEMBER_TYPE.lower().startswith(prefix.lower()):
+            return _CANONICAL_MEMBER_TYPE + rest
+        return prefix[0].upper() + prefix[1:].lower() + rest
 
     @model_serializer(mode="wrap")
     def _strip_policy_type_in_config(self, handler, info: SerializationInfo):

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -1,0 +1,379 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Port-channel access (accessPoHost) interface Pydantic models for Nexus Dashboard.
+
+This module defines nested Pydantic models that mirror the ND Manage Interfaces API payload
+structure for port-channel accessPoHost interfaces. The playbook config uses the same nesting
+so that `to_payload()` and `from_response()` work via standard Pydantic serialization with no
+custom wrapping or flattening.
+
+The port-channel policy is the single source of truth for member configuration. Member ethernet
+interfaces inherit access-mode settings from the port-channel; users do not pre-configure members.
+
+## Model Hierarchy
+
+- `PortChannelAccessInterfaceModel` (top-level, `NDBaseModel`)
+    - `switch_ip` (composite identifier)
+    - `interface_name` (composite identifier; e.g. `port-channel501`)
+    - `interface_type` (default: "portChannel")
+    - `config_data` -> `PortChannelAccessConfigDataModel`
+        - `mode` (default: "access")
+        - `network_os` -> `PortChannelAccessNetworkOSModel`
+            - `network_os_type` (default: "nx-os")
+            - `policy` -> `PortChannelAccessPolicyModel`
+                - `admin_state`, `access_vlan`, `ports`, `port_channel_mode`,
+                  `lacp_rate`, `bpdu_guard`, `description`, `policy_type`, etc.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    FieldSerializationInfo,
+    field_serializer,
+    field_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    AccessPoHostPolicyTypeEnum,
+    BpduFilterEnum,
+    BpduGuardEnum,
+    DuplexModeEnum,
+    LacpRateEnum,
+    MtuEnum,
+    PortChannelModeEnum,
+    SpeedEnum,
+    StormControlActionEnum,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+
+
+class PortChannelAccessPolicyModel(NDNestedModel):
+    """
+    # Summary
+
+    Policy fields for a port-channel accessPoHost interface. Maps directly to the `configData.networkOS.policy`
+    object in the ND API.
+
+    The `ports` field carries the list of member interface names (e.g. `Ethernet1/1`). Member interfaces inherit
+    access-mode configuration from this policy; modifying a member's standalone configuration while it is a
+    port-channel member is restricted by the ethernet orchestrators.
+
+    ## Raises
+
+    None
+    """
+
+    admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
+    access_vlan: int | None = Field(default=None, alias="accessVlan", ge=1, le=4094, description="VLAN for this access port-channel")
+    bpdu_filter: BpduFilterEnum | None = Field(default=None, alias="bpduFilter", description="Configure spanning-tree BPDU filter")
+    bpdu_guard: BpduGuardEnum | None = Field(default=None, alias="bpduGuard", description="Enable spanning-tree BPDU guard")
+    cdp: bool | None = Field(default=None, alias="cdp", description="Enable CDP on the interface")
+    copy_description: bool | None = Field(
+        default=None, alias="copyDescription", description="Propagate the port-channel description to all member interfaces"
+    )
+    description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Interface description")
+    duplex_mode: DuplexModeEnum | None = Field(default=None, alias="duplexMode", description="Port duplex mode")
+    extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the interface")
+    lacp_port_priority: int | None = Field(
+        default=None, alias="lacpPortPriority", ge=1, le=65535, description="LACP port priority (1-65535, default 32768)"
+    )
+    lacp_rate: LacpRateEnum | None = Field(default=None, alias="lacpRate", description="LACP rate (normal=30s, fast=1s)")
+    lacp_suspend: bool | None = Field(default=None, alias="lacpSuspend", description="Suspend port if LACP PDUs not received")
+    monitor: bool | None = Field(default=None, alias="monitor", description="Enable switchport monitor for SPAN/ERSPAN")
+    mtu: MtuEnum | None = Field(default=None, alias="mtu", description="Interface MTU")
+    netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name")
+    netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name")
+    policy_type: AccessPoHostPolicyTypeEnum | None = Field(default=None, alias="policyType", description="Interface policy type")
+    port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode (on/active/passive)")
+    ports: list[str] | None = Field(default=None, alias="ports", description="Member interface names (e.g. ['Ethernet1/1', 'Ethernet1/2'])")
+    qos: bool | None = Field(default=None, alias="qos", description="Enable QoS configuration for this interface")
+    qos_policy: str | None = Field(default=None, alias="qosPolicy", description="Custom QoS policy name")
+    queuing_policy: str | None = Field(default=None, alias="queuingPolicy", description="Custom queuing policy name")
+    speed: SpeedEnum | None = Field(default=None, alias="speed", description="Interface speed")
+    storm_control: bool | None = Field(default=None, alias="stormControl", description="Enable traffic storm control")
+    storm_control_action: StormControlActionEnum | None = Field(
+        default=None, alias="stormControlAction", description="Storm control action on threshold violation"
+    )
+    storm_control_broadcast_level: float | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Broadcast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_broadcast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Broadcast storm control level in packets per second",
+    )
+    storm_control_multicast_level: float | None = Field(
+        default=None,
+        alias="stormControlMulticastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Multicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_multicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlMulticastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Multicast storm control level in packets per second",
+    )
+    storm_control_unicast_level: float | None = Field(
+        default=None,
+        alias="stormControlUnicastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Unicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_unicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlUnicastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Unicast storm control level in packets per second",
+    )
+
+    # --- Validators ---
+
+    @field_validator("policy_type", mode="before")
+    @classmethod
+    def normalize_policy_type(cls, value):
+        """
+        # Summary
+
+        Accept `policy_type` in either Ansible (`access_po_host`) or API (`accessPoHost`) format, normalizing to the
+        API value for enum validation.
+
+        ## Raises
+
+        None
+        """
+        if value is None:
+            return value
+        ansible_to_api = {e.name.lower(): e.value for e in AccessPoHostPolicyTypeEnum}
+        return ansible_to_api.get(value, value)
+
+    @field_validator("ports", mode="before")
+    @classmethod
+    def normalize_ports(cls, value):
+        """
+        # Summary
+
+        Normalize each member interface name to ND API convention (e.g. `ethernet1/1` -> `Ethernet1/1`).
+
+        ## Raises
+
+        None
+        """
+        if value is None:
+            return value
+        if not isinstance(value, list):
+            return value
+        normalized = []
+        for name in value:
+            if isinstance(name, str) and name:
+                normalized.append(name[0].upper() + name[1:])
+            else:
+                normalized.append(name)
+        return normalized
+
+    # --- Serializers ---
+
+    @field_serializer("policy_type")
+    def serialize_policy_type(self, value: str | None, info: FieldSerializationInfo) -> str | None:
+        """
+        # Summary
+
+        Serialize `policy_type` to the API's camelCase value in payload mode, or the Ansible-friendly name in config mode.
+
+        With `use_enum_values=True`, the stored value is the enum's `.value` string (e.g. `"accessPoHost"`).
+
+        ## Raises
+
+        None
+        """
+        if value is None:
+            return None
+        mode = (info.context or {}).get("mode", "payload")
+        if mode == "config":
+            reverse = {e.value: e.name.lower() for e in AccessPoHostPolicyTypeEnum}
+            return reverse.get(value, value)
+        return value
+
+
+class PortChannelAccessNetworkOSModel(NDNestedModel):
+    """
+    # Summary
+
+    Network OS container for a port-channel accessPoHost interface. Maps to `configData.networkOS` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    network_os_type: str = Field(default="nx-os", alias="networkOSType")
+    policy: PortChannelAccessPolicyModel | None = Field(default=None, alias="policy")
+
+
+class PortChannelAccessConfigDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Config data container for a port-channel accessPoHost interface. Maps to `configData` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    mode: str = Field(default="access", alias="mode")
+    network_os: PortChannelAccessNetworkOSModel = Field(alias="networkOS")
+
+
+class PortChannelAccessInterfaceModel(NDBaseModel):
+    """
+    # Summary
+
+    Port-channel accessPoHost interface configuration for Nexus Dashboard.
+
+    Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
+    Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
+
+    The `interface_name` is the port-channel's own name (e.g. `port-channel501`), not a member interface. Member
+    interfaces are listed in `config_data.network_os.policy.ports`.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
+
+    # --- Fields ---
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: str = Field(default="portChannel", alias="interfaceType")
+    config_data: PortChannelAccessConfigDataModel | None = Field(default=None, alias="configData")
+
+    @field_validator("interface_name", mode="before")
+    @classmethod
+    def normalize_interface_name(cls, value):
+        """
+        # Summary
+
+        Normalize the port-channel interface name to lowercase to match ND API convention (e.g. `Port-Channel501` ->
+        `port-channel501`).
+
+        ## Raises
+
+        None
+        """
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_interface_port_channel_access` module.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    interface_name=dict(type="str", required=True),
+                    interface_type=dict(type="str", default="portChannel"),
+                    config_data=dict(
+                        type="dict",
+                        options=dict(
+                            mode=dict(type="str", default="access"),
+                            network_os=dict(
+                                type="dict",
+                                options=dict(
+                                    network_os_type=dict(type="str", default="nx-os"),
+                                    policy=dict(
+                                        type="dict",
+                                        options=dict(
+                                            admin_state=dict(type="bool"),
+                                            access_vlan=dict(type="int"),
+                                            bpdu_filter=dict(type="str", choices=[e.value for e in BpduFilterEnum]),
+                                            bpdu_guard=dict(type="str", choices=[e.value for e in BpduGuardEnum]),
+                                            cdp=dict(type="bool"),
+                                            copy_description=dict(type="bool"),
+                                            description=dict(type="str"),
+                                            duplex_mode=dict(type="str", choices=[e.value for e in DuplexModeEnum]),
+                                            extra_config=dict(type="str"),
+                                            lacp_port_priority=dict(type="int"),
+                                            lacp_rate=dict(type="str", choices=[e.value for e in LacpRateEnum]),
+                                            lacp_suspend=dict(type="bool"),
+                                            monitor=dict(type="bool"),
+                                            mtu=dict(type="str", choices=[e.value for e in MtuEnum]),
+                                            netflow=dict(type="bool"),
+                                            netflow_monitor=dict(type="str"),
+                                            netflow_sampler=dict(type="str"),
+                                            policy_type=dict(
+                                                type="str",
+                                                choices=[e.name.lower() for e in AccessPoHostPolicyTypeEnum],
+                                                default="access_po_host",
+                                            ),
+                                            port_channel_mode=dict(type="str", choices=[e.value for e in PortChannelModeEnum]),
+                                            ports=dict(type="list", elements="str"),
+                                            qos=dict(type="bool"),
+                                            qos_policy=dict(type="str"),
+                                            queuing_policy=dict(type="str"),
+                                            speed=dict(type="str", choices=[e.value for e in SpeedEnum]),
+                                            storm_control=dict(type="bool"),
+                                            storm_control_action=dict(type="str", choices=[e.value for e in StormControlActionEnum]),
+                                            storm_control_broadcast_level=dict(type="float"),
+                                            storm_control_broadcast_level_pps=dict(type="int"),
+                                            storm_control_multicast_level=dict(type="float"),
+                                            storm_control_multicast_level_pps=dict(type="int"),
+                                            storm_control_unicast_level=dict(type="float"),
+                                            storm_control_unicast_level_pps=dict(type="int"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -34,8 +34,6 @@ from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
-    FieldSerializationInfo,
-    field_serializer,
     field_validator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
@@ -91,7 +89,9 @@ class PortChannelAccessPolicyModel(NDNestedModel):
     netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
     netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name")
     netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name")
-    policy_type: AccessPoHostPolicyTypeEnum | None = Field(default=None, alias="policyType", description="Interface policy type")
+    policy_type: AccessPoHostPolicyTypeEnum = Field(
+        default=AccessPoHostPolicyTypeEnum.ACCESS_PO_HOST, alias="policyType", description="Interface policy type"
+    )
     port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode (on/active/passive)")
     ports: list[str] | None = Field(default=None, alias="ports", description="Member interface names (e.g. ['Ethernet1/1', 'Ethernet1/2'])")
     qos: bool | None = Field(default=None, alias="qos", description="Enable QoS configuration for this interface")
@@ -147,24 +147,6 @@ class PortChannelAccessPolicyModel(NDNestedModel):
 
     # --- Validators ---
 
-    @field_validator("policy_type", mode="before")
-    @classmethod
-    def normalize_policy_type(cls, value):
-        """
-        # Summary
-
-        Accept `policy_type` in either Ansible (`access_po_host`) or API (`accessPoHost`) format, normalizing to the
-        API value for enum validation.
-
-        ## Raises
-
-        None
-        """
-        if value is None:
-            return value
-        ansible_to_api = {e.name.lower(): e.value for e in AccessPoHostPolicyTypeEnum}
-        return ansible_to_api.get(value, value)
-
     @field_validator("ports", mode="before")
     @classmethod
     def normalize_ports(cls, value):
@@ -188,29 +170,6 @@ class PortChannelAccessPolicyModel(NDNestedModel):
             else:
                 normalized.append(name)
         return normalized
-
-    # --- Serializers ---
-
-    @field_serializer("policy_type")
-    def serialize_policy_type(self, value: str | None, info: FieldSerializationInfo) -> str | None:
-        """
-        # Summary
-
-        Serialize `policy_type` to the API's camelCase value in payload mode, or the Ansible-friendly name in config mode.
-
-        With `use_enum_values=True`, the stored value is the enum's `.value` string (e.g. `"accessPoHost"`).
-
-        ## Raises
-
-        None
-        """
-        if value is None:
-            return None
-        mode = (info.context or {}).get("mode", "payload")
-        if mode == "config":
-            reverse = {e.value: e.name.lower() for e in AccessPoHostPolicyTypeEnum}
-            return reverse.get(value, value)
-        return value
 
 
 class PortChannelAccessNetworkOSModel(NDNestedModel):
@@ -344,11 +303,6 @@ class PortChannelAccessInterfaceModel(NDBaseModel):
                                             netflow=dict(type="bool"),
                                             netflow_monitor=dict(type="str"),
                                             netflow_sampler=dict(type="str"),
-                                            policy_type=dict(
-                                                type="str",
-                                                choices=[e.name.lower() for e in AccessPoHostPolicyTypeEnum],
-                                                default="access_po_host",
-                                            ),
                                             port_channel_mode=dict(type="str", choices=[e.value for e in PortChannelModeEnum]),
                                             ports=dict(type="list", elements="str"),
                                             qos=dict(type="bool"),

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -90,7 +90,7 @@ class PortChannelAccessPolicyModel(NDNestedModel):
     netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name")
     netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name")
     policy_type: AccessPoHostPolicyTypeEnum = Field(
-        default=AccessPoHostPolicyTypeEnum.ACCESS_PO_HOST, alias="policyType", description="Interface policy type"
+        default=AccessPoHostPolicyTypeEnum.ACCESS_PO_HOST, alias="policyType", frozen=True, description="Interface policy type (hardcoded for this module)"
     )
     port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode (on/active/passive)")
     ports: list[str] | None = Field(default=None, alias="ports", description="Member interface names (e.g. ['Ethernet1/1', 'Ethernet1/2'])")
@@ -183,7 +183,7 @@ class PortChannelAccessNetworkOSModel(NDNestedModel):
     None
     """
 
-    network_os_type: str = Field(default="nx-os", alias="networkOSType")
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
     policy: PortChannelAccessPolicyModel | None = Field(default=None, alias="policy")
 
 
@@ -198,7 +198,7 @@ class PortChannelAccessConfigDataModel(NDNestedModel):
     None
     """
 
-    mode: str = Field(default="access", alias="mode")
+    mode: Literal["access"] = Field(default="access", alias="mode", frozen=True)
     network_os: PortChannelAccessNetworkOSModel = Field(alias="networkOS")
 
 
@@ -232,7 +232,7 @@ class PortChannelAccessInterfaceModel(NDBaseModel):
 
     switch_ip: str = Field(alias="switchIp")
     interface_name: str = Field(alias="interfaceName")
-    interface_type: str = Field(default="portChannel", alias="interfaceType")
+    interface_type: Literal["portChannel"] = Field(default="portChannel", alias="interfaceType", frozen=True)
     config_data: PortChannelAccessConfigDataModel | None = Field(default=None, alias="configData")
 
     @field_validator("interface_name", mode="before")
@@ -274,15 +274,12 @@ class PortChannelAccessInterfaceModel(NDBaseModel):
                 options=dict(
                     switch_ip=dict(type="str", required=True),
                     interface_name=dict(type="str", required=True),
-                    interface_type=dict(type="str", default="portChannel"),
                     config_data=dict(
                         type="dict",
                         options=dict(
-                            mode=dict(type="str", default="access"),
                             network_os=dict(
                                 type="dict",
                                 options=dict(
-                                    network_os_type=dict(type="str", default="nx-os"),
                                     policy=dict(
                                         type="dict",
                                         options=dict(

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -25,7 +25,7 @@ interfaces inherit access-mode settings from the port-channel; users do not pre-
             - `network_os_type` (default: "nx-os")
             - `policy` -> `PortChannelAccessPolicyModel`
                 - `admin_state`, `access_vlan`, `ports`, `port_channel_mode`,
-                  `lacp_rate`, `bpdu_guard`, `description`, `policy_type`, etc.
+                  `lacp_rate`, `bpdu_guard`, `description`, etc.
 """
 
 from __future__ import annotations
@@ -34,7 +34,9 @@ from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
+    SerializationInfo,
     field_validator,
+    model_serializer,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
@@ -167,6 +169,41 @@ class PortChannelAccessPolicyModel(NDNestedModel):
                 normalized.append(name)
         return normalized
 
+    @model_serializer(mode="wrap")
+    def _strip_policy_type_in_config(self, handler, info: SerializationInfo):
+        """
+        # Summary
+
+        Omit `policy_type` from `to_config()` output while leaving payload and diff modes untouched.
+
+        The field is hardcoded by the model (frozen at `AccessPoHostPolicyTypeEnum.ACCESS_PO_HOST`), is excluded
+        from the Ansible argspec, and is therefore not something the user supplies or needs surfaced back.
+        The wire form `"accessPoHost"` would otherwise appear under the `policy_type` key in
+        `before`/`after`/`gathered` output and confuse playbooks that compare against the Ansible
+        snake_case convention. Payload and diff serialization still emit the wire value so the POST/PUT
+        body and the round-trip diff comparison line up with what ND returns.
+
+        Implemented as a wrap-mode model serializer because `exclude_none=True` on `to_config()` evaluates
+        the field value before serialization runs — returning None from a field_serializer is too late to
+        drop the key.
+
+        ## Raises
+
+        ### AssertionError
+
+        - If the wrapped handler returns a non-`dict`. A model-level serializer always serializes to a `dict`,
+          so this is an invariant check that fails loudly rather than silently leaving `policy_type` in the
+          config output.
+        """
+        result = handler(self)
+        if not isinstance(result, dict):
+            raise AssertionError(f"Expected dict from model serialization, got {type(result).__name__}")
+        mode = (info.context or {}).get("mode", "payload")
+        if mode == "config":
+            result.pop("policy_type", None)
+            result.pop("policyType", None)
+        return result
+
 
 class PortChannelAccessNetworkOSModel(NDNestedModel):
     """
@@ -195,7 +232,7 @@ class PortChannelAccessConfigDataModel(NDNestedModel):
     """
 
     mode: Literal["access"] = Field(default="access", alias="mode", frozen=True)
-    network_os: PortChannelAccessNetworkOSModel = Field(alias="networkOS")
+    network_os: PortChannelAccessNetworkOSModel = Field(default_factory=PortChannelAccessNetworkOSModel, alias="networkOS")
 
 
 class PortChannelAccessInterfaceModel(NDBaseModel):

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -73,15 +73,11 @@ class PortChannelAccessPolicyModel(NDNestedModel):
     bpdu_filter: BpduFilterEnum | None = Field(default=None, alias="bpduFilter", description="Configure spanning-tree BPDU filter")
     bpdu_guard: BpduGuardEnum | None = Field(default=None, alias="bpduGuard", description="Enable spanning-tree BPDU guard")
     cdp: bool | None = Field(default=None, alias="cdp", description="Enable CDP on the interface")
-    copy_description: bool | None = Field(
-        default=None, alias="copyDescription", description="Propagate the port-channel description to all member interfaces"
-    )
+    copy_description: bool | None = Field(default=None, alias="copyDescription", description="Propagate the port-channel description to all member interfaces")
     description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Interface description")
     duplex_mode: DuplexModeEnum | None = Field(default=None, alias="duplexMode", description="Port duplex mode")
     extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the interface")
-    lacp_port_priority: int | None = Field(
-        default=None, alias="lacpPortPriority", ge=1, le=65535, description="LACP port priority (1-65535, default 32768)"
-    )
+    lacp_port_priority: int | None = Field(default=None, alias="lacpPortPriority", ge=1, le=65535, description="LACP port priority (1-65535, default 32768)")
     lacp_rate: LacpRateEnum | None = Field(default=None, alias="lacpRate", description="LACP rate (normal=30s, fast=1s)")
     lacp_suspend: bool | None = Field(default=None, alias="lacpSuspend", description="Suspend port if LACP PDUs not received")
     monitor: bool | None = Field(default=None, alias="monitor", description="Enable switchport monitor for SPAN/ERSPAN")

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -1,0 +1,590 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Port-channel trunk host (trunkPoHost) interface Pydantic models for Nexus Dashboard.
+
+This module defines nested Pydantic models that mirror the ND Manage Interfaces API payload
+structure for port-channel trunkPoHost interfaces. The playbook config uses the same nesting
+so that `to_payload()` and `from_response()` work via standard Pydantic serialization with no
+custom wrapping or flattening.
+
+The port-channel policy is the single source of truth for member configuration. Member ethernet
+interfaces inherit trunk-mode settings from the port-channel; users do not pre-configure members.
+
+## Model Hierarchy
+
+- `PortChannelTrunkHostInterfaceModel` (top-level, `NDBaseModel`)
+    - `switch_ip` (composite identifier)
+    - `interface_name` (composite identifier; e.g. `port-channel501`)
+    - `interface_type` (default: "portChannel")
+    - `config_data` -> `PortChannelTrunkHostConfigDataModel`
+        - `mode` (default: "trunk")
+        - `network_os` -> `PortChannelTrunkHostNetworkOSModel`
+            - `network_os_type` (default: "nx-os")
+            - `policy` -> `PortChannelTrunkHostPolicyModel`
+                - `admin_state`, `allowed_vlans`, `native_vlan`, `ports`, `port_channel_mode`,
+                  `lacp_rate`, `bpdu_guard`, `description`, `policy_type`, `vlan_mapping`,
+                  `vlan_mapping_entries`, etc.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated, ClassVar, Literal, Optional  # Optional needed for Annotated runtime expr (see types.py)
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    BeforeValidator,
+    Field,
+    SerializationInfo,
+    field_validator,
+    model_serializer,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    BpduFilterEnum,
+    BpduGuardEnum,
+    DuplexModeEnum,
+    LacpRateEnum,
+    LinkTypeEnum,
+    MtuEnum,
+    PortChannelModeEnum,
+    SpeedEnum,
+    StormControlActionEnum,
+    TrunkPoHostPolicyTypeEnum,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+
+# Shape regex: "none", "all", or comma-separated VLAN ids/ranges. Range bounds are validated separately.
+_ALLOWED_VLANS_SHAPE = re.compile(r"^(none|all|(\d+(-\d+)?)(,\d+(-\d+)?)*)$")
+# Single VLAN id or range token (e.g. "100" or "100-200"). Range bounds are validated separately.
+_VLAN_ID_OR_RANGE_SHAPE = re.compile(r"^\d+(-\d+)?$")
+
+# Splits an interface name into its leading alphabetic prefix and the rest (digits/separators).
+_INTERFACE_NAME_PREFIX_RE = re.compile(r"^([A-Za-z]+)(.*)$")
+
+# Member interfaces of a port-channel are always physical ethernet ports, so the canonical wire prefix
+# is always "Ethernet". Any case-insensitive NX-OS abbreviation (e.g. "e", "eth", "ether") expands to the
+# full form so user input matches the wire key and idempotency holds.
+_CANONICAL_MEMBER_TYPE = "Ethernet"
+
+
+def _validate_vlan_id_or_range(token: str, field_name: str) -> None:
+    """
+    # Summary
+
+    Validate a single VLAN id or range token (e.g. `"100"` or `"100-200"`) and confirm every id is in 1..4094 and any range has start <= end.
+
+    Shared helper used by `_validate_allowed_vlans` (per comma-split token) and `_validate_customer_vlan_id_list` (per list element).
+    `field_name` is interpolated into error messages so callers see which field surfaced the failure.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `token` does not match `\\d+(-\\d+)?`.
+    - If any VLAN id is outside 1..4094.
+    - If a range has start greater than end.
+    """
+    if not _VLAN_ID_OR_RANGE_SHAPE.match(token):
+        raise ValueError(f"{field_name} entry {token!r} must be a VLAN id or range (e.g. '100' or '100-200')")
+    if "-" in token:
+        start_str, end_str = token.split("-", 1)
+        start, end = int(start_str), int(end_str)
+        if not 1 <= start <= 4094 or not 1 <= end <= 4094:
+            raise ValueError(f"{field_name} range {token!r} is out of bounds; VLAN ids must be in 1..4094")
+        if start > end:
+            raise ValueError(f"{field_name} range {token!r} has start greater than end")
+    else:
+        vid = int(token)
+        if not 1 <= vid <= 4094:
+            raise ValueError(f"{field_name} id {vid} is out of bounds; VLAN ids must be in 1..4094")
+
+
+def _validate_allowed_vlans(value):
+    """
+    # Summary
+
+    Validate `allowed_vlans` matches `"none"`, `"all"`, or a comma-separated list of VLAN ids/ranges where every id is in 1..4094 and every range start <= end.
+    ND returns single-id values as JSON ints (e.g. `250`) but accepts both forms on input; this validator coerces int -> str so round-trips and idempotency
+    comparisons are stable.
+
+    Used as the `BeforeValidator` payload for the `AllowedVlans` Annotated type.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `value` is a non-empty string that does not match the expected shape.
+    - If any VLAN id is outside 1..4094.
+    - If any range has start greater than end.
+    """
+    if value is None or value == "":
+        return value
+    # TODO(4.2.1) interface-get-field-normalization
+    # ND echoes a single-id allowed_vlans as a JSON int (e.g. 250) on GET even though POST/PUT accept (and the
+    # spec types it as) a string. We coerce int -> str here so a GET response round-trips against the str the
+    # user supplied and idempotency comparisons stay stable. Remove when the GET-side retype is fixed.
+    if isinstance(value, int) and not isinstance(value, bool):
+        value = str(value)
+    if not isinstance(value, str):
+        return value
+    if value in ("none", "all"):
+        return value
+    if not _ALLOWED_VLANS_SHAPE.match(value):
+        raise ValueError(f"allowed_vlans must be 'none', 'all', or a comma-separated list of VLAN ids/ranges (e.g. '1-200,500-2000,3000'); got {value!r}")
+    for token in value.split(","):
+        _validate_vlan_id_or_range(token, "allowed_vlans")
+    return value
+
+
+def _validate_customer_vlan_id_list(value):
+    """
+    # Summary
+
+    Validate `customer_vlan_id` is a list of non-empty VLAN id or range strings where every id is in 1..4094 and every range start <= end.
+    Used in `vlanMappingEntries` to identify which customer VLAN ids map to a provider VLAN id.
+
+    Used as the `BeforeValidator` payload for the `CustomerVlanIdList` Annotated type.
+
+    ## Raises
+
+    ### ValueError
+
+    - If any list entry is not a non-empty string.
+    - If any entry is not a VLAN id or range, has an id outside 1..4094, or has a reversed range.
+    """
+    if value is None:
+        return value
+    if not isinstance(value, list):
+        return value
+    for entry in value:
+        if not isinstance(entry, str) or not entry:
+            raise ValueError(f"customer_vlan_id entries must be non-empty strings (VLAN id or range); got {entry!r}")
+        _validate_vlan_id_or_range(entry, "customer_vlan_id")
+    return value
+
+
+# TODO: After all per-policy interface modules (ethernet_trunk_host, svi, ...) merge to develop, consolidate
+# AllowedVlans, CustomerVlanIdList, and the _validate_vlan_id_or_range helper into models/types.py so the
+# sibling modules can share a single source of truth. Also introduce a shared `VlanId` type (1..4094) in the
+# same PR and replace per-field `Field(ge=1, le=4094)` constraints (native_vlan, customer_inner_vlan_id,
+# provider_vlan_id, access_vlan, ...) — the constraint is already enforced today, this is cosmetic/consistency
+# cleanup. Each branch currently carries its own copy of the validators because adding VLAN-specific code to the
+# loopback base branch (where types.py lives) is out of that branch's scope. Tracked in CiscoDevNet/ansible-nd#347.
+# See AsciiDescription comment in models/types.py for why Optional[...] is used at runtime instead of `... | None`.
+AllowedVlans = Annotated[Optional[str], BeforeValidator(_validate_allowed_vlans)]
+"""Trunk allowed-VLANs spec (`str | None`): 'none', 'all', or comma-separated VLAN ids/ranges in 1..4094."""
+
+CustomerVlanIdList = Annotated[Optional[list[str]], BeforeValidator(_validate_customer_vlan_id_list)]
+"""Customer VLAN id list (`list[str] | None`): each entry is a VLAN id or range in 1..4094 (e.g. `['100', '200-300']`)."""
+
+
+class PortChannelTrunkHostVlanMappingEntryModel(NDNestedModel):
+    """
+    # Summary
+
+    A single VLAN mapping entry for a trunk port-channel. Maps to one element of `policy.vlanMappingEntries`
+    in the ND API. Use entries to translate customer VLAN ids to provider VLAN ids, optionally with selective
+    dot1q-tunnel mode.
+
+    ## Raises
+
+    None
+    """
+
+    customer_inner_vlan_id: int | None = Field(
+        default=None, alias="customerInnerVlanId", ge=1, le=4094, description="Inner customer VLAN id (selective dot1q-tunnel only)"
+    )
+    customer_vlan_id: CustomerVlanIdList = Field(
+        default=None,
+        alias="customerVlanId",
+        description="Customer VLAN id list; each entry is a VLAN id or range string in 1..4094 (e.g. ['100', '200-300'])",
+    )
+    dot1q_tunnel: bool | None = Field(default=None, alias="dot1qTunnel", description="Use selective dot1q-tunnel mode for this entry")
+    provider_vlan_id: int | None = Field(default=None, alias="providerVlanId", ge=1, le=4094, description="Provider VLAN id")
+
+
+class PortChannelTrunkHostPolicyModel(NDNestedModel):
+    """
+    # Summary
+
+    Policy fields for a port-channel trunkPoHost interface. Maps directly to the `configData.networkOS.policy`
+    object in the ND API.
+
+    The `ports` field carries the list of member interface names (e.g. `Ethernet1/1`). Member interfaces inherit
+    trunk-mode configuration from this policy; modifying a member's standalone configuration while it is a
+    port-channel member is restricted by the ethernet orchestrators.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `allowed_vlans` is set and does not match `none`, `all`, or comma-separated VLAN ranges.
+
+    ### AssertionError
+
+    - If the wrapped model serializer receives a non-`dict` from the handler (see `_strip_policy_type_in_config`).
+    """
+
+    admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
+    allowed_vlans: AllowedVlans = Field(
+        default=None,
+        alias="allowedVlans",
+        description="Trunk allowed VLANs ('none', 'all', or comma-separated VLAN ids/ranges in 1..4094, e.g. '100-200,300')",
+    )
+    bandwidth: int | None = Field(default=None, alias="bandwidth", ge=1, le=100000000, description="Interface bandwidth in kilobits per second")
+    bpdu_filter: BpduFilterEnum | None = Field(default=None, alias="bpduFilter", description="Configure spanning-tree BPDU filter")
+    bpdu_guard: BpduGuardEnum | None = Field(default=None, alias="bpduGuard", description="Enable spanning-tree BPDU guard")
+    cdp: bool | None = Field(default=None, alias="cdp", description="Enable CDP on the interface")
+    copy_description: bool | None = Field(default=None, alias="copyDescription", description="Propagate the port-channel description to all member interfaces")
+    description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Interface description")
+    duplex_mode: DuplexModeEnum | None = Field(default=None, alias="duplexMode", description="Port duplex mode")
+    extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the interface")
+    inherit_bandwidth: int | None = Field(
+        default=None, alias="inheritBandwidth", ge=1, le=100000000, description="Inherited interface bandwidth in kilobits per second"
+    )
+    lacp_port_priority: int | None = Field(default=None, alias="lacpPortPriority", ge=1, le=65535, description="LACP port priority (1-65535, default 32768)")
+    lacp_rate: LacpRateEnum | None = Field(default=None, alias="lacpRate", description="LACP rate (normal=30s, fast=1s)")
+    lacp_suspend: bool | None = Field(default=None, alias="lacpSuspend", description="Suspend port if LACP PDUs not received")
+    link_type: LinkTypeEnum | None = Field(default=None, alias="linkType", description="Spanning-tree link type")
+    monitor: bool | None = Field(default=None, alias="monitor", description="Enable switchport monitor for SPAN/ERSPAN")
+    mtu: MtuEnum | None = Field(default=None, alias="mtu", description="Interface MTU")
+    native_vlan: int | None = Field(default=None, alias="nativeVlan", ge=1, le=4094, description="Trunk native VLAN id")
+    negotiate_auto: bool | None = Field(default=None, alias="negotiateAuto", description="Enable link auto-negotiation")
+    netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name")
+    netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name")
+    orphan_port: bool | None = Field(
+        default=None, alias="orphanPort", description="Configure as a vPC orphan port (suspended by secondary peer on vPC failure)"
+    )
+    pfc: bool | None = Field(default=None, alias="pfc", description="Enable Priority Flow Control")
+    policy_type: TrunkPoHostPolicyTypeEnum = Field(
+        default=TrunkPoHostPolicyTypeEnum.TRUNK_PO_HOST, alias="policyType", frozen=True, description="Interface policy type (hardcoded for this module)"
+    )
+    port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode (on/active/passive)")
+    port_type_edge_trunk: bool | None = Field(default=None, alias="portTypeEdgeTrunk", description="Configure as edge trunk port (PortFast on trunk)")
+    ports: list[str] | None = Field(default=None, alias="ports", description="Member interface names (e.g. ['Ethernet1/1', 'Ethernet1/2'])")
+    ptp: bool | None = Field(default=None, alias="ptp", description="Enable Precision Time Protocol on the interface")
+    qos: bool | None = Field(default=None, alias="qos", description="Enable QoS configuration for this interface")
+    qos_policy: str | None = Field(default=None, alias="qosPolicy", description="Custom QoS policy name")
+    queuing_policy: str | None = Field(default=None, alias="queuingPolicy", description="Custom queuing policy name")
+    speed: SpeedEnum | None = Field(default=None, alias="speed", description="Interface speed")
+    storm_control: bool | None = Field(default=None, alias="stormControl", description="Enable traffic storm control")
+    storm_control_action: StormControlActionEnum | None = Field(
+        default=None, alias="stormControlAction", description="Storm control action on threshold violation"
+    )
+    storm_control_broadcast_level: float | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Broadcast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_broadcast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Broadcast storm control level in packets per second",
+    )
+    storm_control_multicast_level: float | None = Field(
+        default=None,
+        alias="stormControlMulticastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Multicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_multicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlMulticastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Multicast storm control level in packets per second",
+    )
+    storm_control_unicast_level: float | None = Field(
+        default=None,
+        alias="stormControlUnicastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Unicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_unicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlUnicastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Unicast storm control level in packets per second",
+    )
+    vlan_mapping: bool | None = Field(default=None, alias="vlanMapping", description="Enable VLAN mapping on the trunk")
+    vlan_mapping_entries: list[PortChannelTrunkHostVlanMappingEntryModel] | None = Field(
+        default=None, alias="vlanMappingEntries", description="VLAN mapping entries (used when vlan_mapping is enabled)"
+    )
+
+    # --- Validators ---
+
+    @field_validator("ports", mode="before")
+    @classmethod
+    def normalize_ports(cls, value):
+        """
+        # Summary
+
+        Normalize each member interface name to ND's canonical `Ethernet` form so that any user-supplied casing or
+        NX-OS abbreviation round-trips against the wire form. Members are always physical ethernet ports. Examples:
+
+        - `ethernet1/1` -> `Ethernet1/1`
+        - `ETHERNET1/1` -> `Ethernet1/1`
+        - `eth1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `e1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `Ethernet1/1` -> `Ethernet1/1` (idempotent)
+
+        Because the wire key is matched exactly, an abbreviated prefix that is not expanded would never match ND's
+        `Ethernet...` form, silently breaking idempotency (the port-channel re-deploys on every run). Any
+        case-insensitive prefix of `Ethernet` (`e`, `et`, `eth`, ...) is therefore expanded to the full canonical
+        name; an unrecognized prefix falls back to Title case so it still round-trips. Only the leading alphabetic
+        run is rewritten; digits and separators are preserved verbatim.
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(value, list):
+            return value
+        return [cls._normalize_member_name(name) for name in value]
+
+    @staticmethod
+    def _normalize_member_name(name):
+        """
+        # Summary
+
+        Normalize a single member interface name to ND's canonical `Ethernet` form (see `normalize_ports`).
+        Non-string or empty values are returned unchanged.
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(name, str) or not name:
+            return name
+        match = _INTERFACE_NAME_PREFIX_RE.match(name)
+        if not match:
+            return name
+        prefix, rest = match.groups()
+        if _CANONICAL_MEMBER_TYPE.lower().startswith(prefix.lower()):
+            return _CANONICAL_MEMBER_TYPE + rest
+        return prefix[0].upper() + prefix[1:].lower() + rest
+
+    @model_serializer(mode="wrap")
+    def _strip_policy_type_in_config(self, handler, info: SerializationInfo):
+        """
+        # Summary
+
+        Omit `policy_type` from `to_config()` output while leaving payload and diff modes untouched.
+
+        The field is hardcoded by the model (frozen at `TrunkPoHostPolicyTypeEnum.TRUNK_PO_HOST`), is excluded
+        from the Ansible argspec, and is therefore not something the user supplies or needs surfaced back.
+        The wire form `"trunkPoHost"` would otherwise appear under the `policy_type` key in
+        `before`/`after`/`gathered` output and confuse playbooks that compare against the Ansible
+        snake_case convention. Payload and diff serialization still emit the wire value so the POST/PUT
+        body and the round-trip diff comparison line up with what ND returns.
+
+        Implemented as a wrap-mode model serializer because `exclude_none=True` on `to_config()` evaluates
+        the field value before serialization runs — returning None from a field_serializer is too late to
+        drop the key.
+
+        ## Raises
+
+        ### AssertionError
+
+        - If the wrapped handler returns a non-`dict`. A model-level serializer always serializes to a `dict`,
+          so this is an invariant check that fails loudly rather than silently leaving `policy_type` in the
+          config output.
+        """
+        result = handler(self)
+        if not isinstance(result, dict):
+            raise AssertionError(f"Expected dict from model serialization, got {type(result).__name__}")
+        mode = (info.context or {}).get("mode", "payload")
+        if mode == "config":
+            result.pop("policy_type", None)
+            result.pop("policyType", None)
+        return result
+
+
+class PortChannelTrunkHostNetworkOSModel(NDNestedModel):
+    """
+    # Summary
+
+    Network OS container for a port-channel trunkPoHost interface. Maps to `configData.networkOS` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: PortChannelTrunkHostPolicyModel | None = Field(default=None, alias="policy")
+
+
+class PortChannelTrunkHostConfigDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Config data container for a port-channel trunkPoHost interface. Maps to `configData` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    mode: Literal["trunk"] = Field(default="trunk", alias="mode", frozen=True)
+    network_os: PortChannelTrunkHostNetworkOSModel = Field(default_factory=PortChannelTrunkHostNetworkOSModel, alias="networkOS")
+
+
+class PortChannelTrunkHostInterfaceModel(NDBaseModel):
+    """
+    # Summary
+
+    Port-channel trunkPoHost interface configuration for Nexus Dashboard.
+
+    Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
+    Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
+
+    The `interface_name` is the port-channel's own name (e.g. `port-channel501`), not a member interface. Member
+    interfaces are listed in `config_data.network_os.policy.ports`.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
+
+    # --- Fields ---
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["portChannel"] = Field(default="portChannel", alias="interfaceType", frozen=True)
+    config_data: PortChannelTrunkHostConfigDataModel | None = Field(default=None, alias="configData")
+
+    @field_validator("interface_name", mode="before")
+    @classmethod
+    def normalize_interface_name(cls, value):
+        """
+        # Summary
+
+        Normalize the port-channel interface name to lowercase to match ND API convention (e.g. `Port-Channel501` ->
+        `port-channel501`).
+
+        ## Raises
+
+        None
+        """
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_interface_port_channel_trunk_host` module.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    interface_name=dict(type="str", required=True),
+                    config_data=dict(
+                        type="dict",
+                        options=dict(
+                            network_os=dict(
+                                type="dict",
+                                options=dict(
+                                    policy=dict(
+                                        type="dict",
+                                        options=dict(
+                                            admin_state=dict(type="bool"),
+                                            allowed_vlans=dict(type="str"),
+                                            bandwidth=dict(type="int"),
+                                            bpdu_filter=dict(type="str", choices=[e.value for e in BpduFilterEnum]),
+                                            bpdu_guard=dict(type="str", choices=[e.value for e in BpduGuardEnum]),
+                                            cdp=dict(type="bool"),
+                                            copy_description=dict(type="bool"),
+                                            description=dict(type="str"),
+                                            duplex_mode=dict(type="str", choices=[e.value for e in DuplexModeEnum]),
+                                            extra_config=dict(type="str"),
+                                            inherit_bandwidth=dict(type="int"),
+                                            lacp_port_priority=dict(type="int"),
+                                            lacp_rate=dict(type="str", choices=[e.value for e in LacpRateEnum]),
+                                            lacp_suspend=dict(type="bool"),
+                                            link_type=dict(type="str", choices=[e.value for e in LinkTypeEnum]),
+                                            monitor=dict(type="bool"),
+                                            mtu=dict(type="str", choices=[e.value for e in MtuEnum]),
+                                            native_vlan=dict(type="int"),
+                                            negotiate_auto=dict(type="bool"),
+                                            netflow=dict(type="bool"),
+                                            netflow_monitor=dict(type="str"),
+                                            netflow_sampler=dict(type="str"),
+                                            orphan_port=dict(type="bool"),
+                                            pfc=dict(type="bool"),
+                                            port_channel_mode=dict(type="str", choices=[e.value for e in PortChannelModeEnum]),
+                                            port_type_edge_trunk=dict(type="bool"),
+                                            ports=dict(type="list", elements="str"),
+                                            ptp=dict(type="bool"),
+                                            qos=dict(type="bool"),
+                                            qos_policy=dict(type="str"),
+                                            queuing_policy=dict(type="str"),
+                                            speed=dict(type="str", choices=[e.value for e in SpeedEnum]),
+                                            storm_control=dict(type="bool"),
+                                            storm_control_action=dict(type="str", choices=[e.value for e in StormControlActionEnum]),
+                                            storm_control_broadcast_level=dict(type="float"),
+                                            storm_control_broadcast_level_pps=dict(type="int"),
+                                            storm_control_multicast_level=dict(type="float"),
+                                            storm_control_multicast_level_pps=dict(type="int"),
+                                            storm_control_unicast_level=dict(type="float"),
+                                            storm_control_unicast_level_pps=dict(type="int"),
+                                            vlan_mapping=dict(type="bool"),
+                                            vlan_mapping_entries=dict(
+                                                type="list",
+                                                elements="dict",
+                                                options=dict(
+                                                    customer_inner_vlan_id=dict(type="int"),
+                                                    customer_vlan_id=dict(type="list", elements="str"),
+                                                    dot1q_tunnel=dict(type="bool"),
+                                                    provider_vlan_id=dict(type="int"),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -1,0 +1,482 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+vPC access (accessVpcHost) interface Pydantic models for Nexus Dashboard.
+
+This module defines nested Pydantic models that mirror the ND Manage Interfaces API payload
+structure for vPC accessVpcHost interfaces (`int_vpc_access_host.template`). The playbook
+config uses the same nesting so that `to_payload()` and `from_response()` work via standard
+Pydantic serialization with no custom wrapping or flattening.
+
+A vPC access interface spans two switches in a vPC pair. The user supplies one peer's
+management IP as `switch_ip`; the orchestrator auto-resolves the peer serial via the
+`vpcPair` endpoint and injects it as `peerSwitchId` in the payload. Per-peer policy fields
+use the ND-native `peer1_*` / `peer2_*` naming where `peer1` corresponds to `switch_ip`
+(the switch in the URL path) and `peer2` corresponds to the auto-resolved peer.
+
+## Model Hierarchy
+
+- `AccessVpcHostInterfaceModel` (top-level, `NDBaseModel`)
+    - `switch_ip` (composite identifier; primary peer's management IP)
+    - `interface_name` (composite identifier; e.g. `vpc100`)
+    - `interface_type` (frozen: "vpc")
+    - `config_data` -> `AccessVpcHostConfigDataModel`
+        - `mode` (frozen: "access")
+        - `network_os` -> `AccessVpcHostNetworkOSModel`
+            - `network_os_type` (frozen: "nx-os")
+            - `policy` -> `AccessVpcHostPolicyModel`
+                - `policy_type` (frozen: "accessVpcHost")
+                - `peer_switch_id` (orchestrator-injected; not in argspec)
+                - per-peer fields: `peer1_*`, `peer2_*`
+                - shared fields: `admin_state`, `cdp`, `lacp_rate`, `mtu`, etc.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    SerializationInfo,
+    field_validator,
+    model_serializer,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    AccessVpcHostPolicyTypeEnum,
+    BpduFilterEnum,
+    BpduGuardEnum,
+    DuplexModeEnum,
+    LacpRateEnum,
+    LinkTypeEnum,
+    MtuEnum,
+    PortChannelModeEnum,
+    SpeedEnum,
+    StormControlActionEnum,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+
+# Splits an interface name into its leading alphabetic prefix and the rest (digits/separators).
+_INTERFACE_NAME_PREFIX_RE = re.compile(r"^([A-Za-z]+)(.*)$")
+
+# Member interfaces of a vPC are always physical ethernet ports, so the canonical wire prefix is always
+# "Ethernet". Any case-insensitive NX-OS abbreviation (e.g. "e", "eth", "ether") expands to the full form so
+# user input matches the wire key and idempotency holds.
+_CANONICAL_MEMBER_TYPE = "Ethernet"
+
+
+class AccessVpcHostPolicyModel(NDNestedModel):
+    """
+    # Summary
+
+    Policy fields for a vPC `accessVpcHost` interface. Maps directly to the `configData.networkOS.policy` object in the ND API.
+
+    Per-peer fields use the API-native `peer1*` / `peer2*` naming. `peer1` corresponds to the switch in the URL path
+    (the user-supplied `switch_ip`); `peer2` corresponds to the auto-resolved peer (the value of `peerSwitchId`).
+
+    `peer_switch_id` is set by the orchestrator from the vPC pair record. It is not exposed in the module argument spec.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Policy Discriminator ---
+
+    policy_type: AccessVpcHostPolicyTypeEnum = Field(
+        default=AccessVpcHostPolicyTypeEnum.ACCESS_VPC_HOST,
+        alias="policyType",
+        frozen=True,
+        description="Interface policy type (hardcoded for this module)",
+    )
+
+    # --- Orchestrator-Injected (Not In Argspec) ---
+
+    peer_switch_id: str | None = Field(
+        default=None,
+        alias="peerSwitchId",
+        description="Peer switch serial number, auto-resolved by the orchestrator from the vPC pair record",
+    )
+
+    # --- Shared (single-valued) access VLAN ---
+    # TODO(4.2.1) vpc-interface-peer-vlan-collapse
+    # ND accessVpcHost wire echoes a single `accessVlan` even though the create schema requires per-peer
+    # `peer1AccessVlan` / `peer2AccessVlan`. See `serialize_policy` below for the split-on-write workaround.
+    access_vlan: int | None = Field(default=None, alias="accessVlan", ge=1, le=4094, description="VLAN for the access port on both peers")
+
+    # --- Per-Peer Fields (peer1 = switch_ip, peer2 = peer_switch_id) ---
+
+    peer1_member_ports: list[str] | None = Field(default=None, alias="peer1MemberPorts", description="Member interface names on Peer-1")
+    peer1_port_channel_configuration: str | None = Field(
+        default=None, alias="peer1PortChannelConfiguration", description="Additional CLI for Peer-1's port-channel"
+    )
+    peer1_port_channel_description: AsciiDescription = Field(
+        default=None, alias="peer1PortChannelDescription", max_length=254, description="Description for Peer-1's port-channel"
+    )
+    peer1_port_channel_id: int | None = Field(default=None, alias="peer1PortChannelId", ge=1, le=4096, description="Peer-1 vPC port-channel number")
+    peer2_member_ports: list[str] | None = Field(default=None, alias="peer2MemberPorts", description="Member interface names on Peer-2")
+    peer2_port_channel_configuration: str | None = Field(
+        default=None, alias="peer2PortChannelConfiguration", description="Additional CLI for Peer-2's port-channel"
+    )
+    peer2_port_channel_description: AsciiDescription = Field(
+        default=None, alias="peer2PortChannelDescription", max_length=254, description="Description for Peer-2's port-channel"
+    )
+    peer2_port_channel_id: int | None = Field(default=None, alias="peer2PortChannelId", ge=1, le=4096, description="Peer-2 vPC port-channel number")
+
+    # --- Shared Policy Fields ---
+
+    admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
+    bandwidth: int | None = Field(default=None, alias="bandwidth", ge=1, le=100000000, description="Configured bandwidth value for the interface")
+    bpdu_filter: BpduFilterEnum | None = Field(default=None, alias="bpduFilter", description="Configure spanning-tree BPDU filter")
+    bpdu_guard: BpduGuardEnum | None = Field(default=None, alias="bpduGuard", description="Enable spanning-tree BPDU guard")
+    cdp: bool | None = Field(default=None, alias="cdp", description="Enable CDP on the interface")
+    copy_description: bool | None = Field(
+        default=None,
+        alias="copyDescription",
+        description="Propagate the port-channel description to all member interfaces (per-peer)",
+    )
+    duplex_mode: DuplexModeEnum | None = Field(default=None, alias="duplexMode", description="Port duplex mode")
+    inherit_bandwidth: int | None = Field(
+        default=None,
+        alias="inheritBandwidth",
+        ge=1,
+        le=100000000,
+        description="Bandwidth value inherited by sub-interfaces",
+    )
+    lacp_port_priority: int | None = Field(default=None, alias="lacpPortPriority", ge=1, le=65535, description="LACP port priority (1-65535, default 32768)")
+    lacp_rate: LacpRateEnum | None = Field(default=None, alias="lacpRate", description="LACP rate (normal=30s, fast=1s)")
+    lacp_suspend: bool | None = Field(default=None, alias="lacpSuspend", description="Suspend port if LACP PDUs not received")
+    lacp_vpc_convergence: bool | None = Field(default=None, alias="lacpVpcConvergence", description="Enable LACP convergence for vPC port-channels")
+    link_type: LinkTypeEnum | None = Field(default=None, alias="linkType", description="Spanning-tree link type")
+    mirror_config: bool | None = Field(default=None, alias="mirrorConfig", description="Copy Peer-1 config to Peer-2")
+    mtu: MtuEnum | None = Field(default=None, alias="mtu", description="Interface MTU")
+    negotiate_auto: bool | None = Field(default=None, alias="negotiateAuto", description="Enable link auto-negotiation")
+    netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name")
+    netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name (N7K only)")
+    pfc: bool | None = Field(default=None, alias="pfc", description="Enable priority flow control")
+    port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode (on/active/passive)")
+    port_type_edge_trunk: bool | None = Field(default=None, alias="portTypeEdgeTrunk", description="Enable spanning-tree edge port (PortFast) behavior")
+    qos: bool | None = Field(default=None, alias="qos", description="Enable QoS configuration for this interface")
+    qos_policy: str | None = Field(default=None, alias="qosPolicy", description="Custom QoS policy name")
+    queuing_policy: str | None = Field(default=None, alias="queuingPolicy", description="Custom queuing policy name")
+    speed: SpeedEnum | None = Field(default=None, alias="speed", description="Interface speed")
+    storm_control: bool | None = Field(default=None, alias="stormControl", description="Enable traffic storm control")
+    storm_control_action: StormControlActionEnum | None = Field(
+        default=None, alias="stormControlAction", description="Storm control action on threshold violation"
+    )
+    storm_control_broadcast_level: float | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Broadcast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_broadcast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Broadcast storm control level in packets per second",
+    )
+    storm_control_multicast_level: float | None = Field(
+        default=None,
+        alias="stormControlMulticastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Multicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_multicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlMulticastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Multicast storm control level in packets per second",
+    )
+    storm_control_unicast_level: float | None = Field(
+        default=None,
+        alias="stormControlUnicastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Unicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_unicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlUnicastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Unicast storm control level in packets per second",
+    )
+
+    # --- Serializers ---
+
+    # TODO(4.2.1) vpc-interface-peer-vlan-collapse
+    # accessVpcHost wire echoes a single `accessVlan` even though the create schema requires per-peer
+    # `peer1AccessVlan` / `peer2AccessVlan`. We expose a single `access_vlan` to users and split it back to the
+    # per-peer keys on the write side via this model_serializer so idempotency works against the actual wire shape.
+    @model_serializer(mode="wrap")
+    def serialize_policy(self, handler, info: SerializationInfo):
+        """
+        # Summary
+
+        Single wrap-mode model serializer for the policy block, applying two ND-specific adjustments keyed off the
+        serialization `mode` context:
+
+        - On payload serialization (`mode == "payload"`), split the single user-facing `accessVlan` into the per-peer
+          `peer1AccessVlan` / `peer2AccessVlan` keys the ND create/update schema requires. ND collapses the pair back
+          to a single `accessVlan` on read, so config / diff modes leave the field as-is and the diff stays symmetric.
+        - On config serialization (`mode == "config"`), drop the frozen, argspec-excluded `policy_type` so it does not
+          leak into `before` / `after` / `gathered` output. Payload and diff modes keep the wire value so the POST/PUT
+          body and the round-trip diff line up with what ND returns.
+
+        ## Raises
+
+        ### AssertionError
+
+        - If the wrapped handler returns a non-`dict`. A model-level serializer always serializes to a `dict`, so this
+          is an invariant check that fails loudly rather than silently mis-serializing.
+        """
+        data = handler(self)
+        if not isinstance(data, dict):
+            raise AssertionError(f"Expected dict from model serialization, got {type(data).__name__}")
+        mode = (info.context or {}).get("mode", "payload")
+        if mode == "payload" and "accessVlan" in data:
+            vlan = data.pop("accessVlan")
+            data["peer1AccessVlan"] = vlan
+            data["peer2AccessVlan"] = vlan
+        if mode == "config":
+            data.pop("policy_type", None)
+            data.pop("policyType", None)
+        return data
+
+    # --- Validators ---
+
+    @field_validator("peer1_member_ports", "peer2_member_ports", mode="before")
+    @classmethod
+    def normalize_member_ports(cls, value):
+        """
+        # Summary
+
+        Normalize each per-peer member interface name to ND's canonical `Ethernet` form so any user-supplied casing or
+        NX-OS abbreviation round-trips against the wire form. Members are always physical ethernet ports. Examples:
+
+        - `ethernet1/1` -> `Ethernet1/1`
+        - `eth1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `e1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `Ethernet1/1` -> `Ethernet1/1` (idempotent)
+
+        An abbreviated prefix that is not expanded would never match ND's `Ethernet...` wire key, silently breaking
+        idempotency (the vPC re-deploys on every run). Only the leading alphabetic run is rewritten; digits and
+        separators are preserved verbatim.
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(value, list):
+            return value
+        return [cls._normalize_member_name(name) for name in value]
+
+    @staticmethod
+    def _normalize_member_name(name):
+        """
+        # Summary
+
+        Normalize a single member interface name to ND's canonical `Ethernet` form (see `normalize_member_ports`).
+        Non-string or empty values are returned unchanged.
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(name, str) or not name:
+            return name
+        match = _INTERFACE_NAME_PREFIX_RE.match(name)
+        if not match:
+            return name
+        prefix, rest = match.groups()
+        if _CANONICAL_MEMBER_TYPE.lower().startswith(prefix.lower()):
+            return _CANONICAL_MEMBER_TYPE + rest
+        return prefix[0].upper() + prefix[1:].lower() + rest
+
+
+class AccessVpcHostNetworkOSModel(NDNestedModel):
+    """
+    # Summary
+
+    Network OS container for a vPC `accessVpcHost` interface. Maps to `configData.networkOS` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: AccessVpcHostPolicyModel | None = Field(default=None, alias="policy")
+
+
+class AccessVpcHostConfigDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Config data container for a vPC `accessVpcHost` interface. Maps to `configData` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    mode: Literal["access"] = Field(default="access", alias="mode", frozen=True)
+    network_os: AccessVpcHostNetworkOSModel = Field(alias="networkOS")
+
+
+class AccessVpcHostInterfaceModel(NDBaseModel):
+    """
+    # Summary
+
+    vPC `accessVpcHost` interface configuration for Nexus Dashboard.
+
+    Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
+    Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
+
+    The `interface_name` is the vPC's own name (e.g. `vpc100`), not a member interface. Member interfaces are listed
+    per-peer in `config_data.network_os.policy.peer1_member_ports` and `peer2_member_ports`.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+    # TODO(4.2.1) vpc-interface-dual-peer-duplicate
+    # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in the per-switch
+    # `/interfaces` GET (with identical `configData` and only `switchId` / `peerSwitchId` swapping). Using a composite
+    # (switch_ip, interface_name) identifier caused `_manage_override_deletions` to delete the peer-side duplicate. The
+    # identifier is therefore `interface_name` only; `switch_ip` is kept as a field for routing (URL-path resolution +
+    # peer-resolution) but is excluded from diff and dedup'd in `query_all`.
+
+    identifiers: ClassVar[list[str] | None] = ["interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
+    exclude_from_diff: ClassVar[set[str]] = {"switch_ip"}
+
+    # --- Fields ---
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["vpc"] = Field(default="vpc", alias="interfaceType", frozen=True)
+    config_data: AccessVpcHostConfigDataModel | None = Field(default=None, alias="configData")
+
+    @field_validator("interface_name", mode="before")
+    @classmethod
+    def normalize_interface_name(cls, value):
+        """
+        # Summary
+
+        Normalize the vPC interface name to lowercase to match ND API convention (e.g. `Vpc100` -> `vpc100`).
+
+        ## Raises
+
+        None
+        """
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_interface_vpc_access` module. Frozen scaffolding fields
+        (`interface_type`, `mode`, `network_os_type`, `policy_type`) are intentionally NOT exposed. `peer_switch_id`
+        is orchestrator-injected and NOT exposed.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    interface_name=dict(type="str", required=True),
+                    config_data=dict(
+                        type="dict",
+                        options=dict(
+                            network_os=dict(
+                                type="dict",
+                                options=dict(
+                                    policy=dict(
+                                        type="dict",
+                                        options=dict(
+                                            admin_state=dict(type="bool"),
+                                            bandwidth=dict(type="int"),
+                                            bpdu_filter=dict(type="str", choices=[e.value for e in BpduFilterEnum]),
+                                            bpdu_guard=dict(type="str", choices=[e.value for e in BpduGuardEnum]),
+                                            cdp=dict(type="bool"),
+                                            copy_description=dict(type="bool"),
+                                            duplex_mode=dict(type="str", choices=[e.value for e in DuplexModeEnum]),
+                                            inherit_bandwidth=dict(type="int"),
+                                            lacp_port_priority=dict(type="int"),
+                                            lacp_rate=dict(type="str", choices=[e.value for e in LacpRateEnum]),
+                                            lacp_suspend=dict(type="bool"),
+                                            lacp_vpc_convergence=dict(type="bool"),
+                                            link_type=dict(type="str", choices=[e.value for e in LinkTypeEnum]),
+                                            mirror_config=dict(type="bool"),
+                                            mtu=dict(type="str", choices=[e.value for e in MtuEnum]),
+                                            negotiate_auto=dict(type="bool"),
+                                            netflow=dict(type="bool"),
+                                            netflow_monitor=dict(type="str"),
+                                            netflow_sampler=dict(type="str"),
+                                            access_vlan=dict(type="int"),
+                                            peer1_member_ports=dict(type="list", elements="str"),
+                                            peer1_port_channel_configuration=dict(type="str"),
+                                            peer1_port_channel_description=dict(type="str"),
+                                            peer1_port_channel_id=dict(type="int"),
+                                            peer2_member_ports=dict(type="list", elements="str"),
+                                            peer2_port_channel_configuration=dict(type="str"),
+                                            peer2_port_channel_description=dict(type="str"),
+                                            peer2_port_channel_id=dict(type="int"),
+                                            pfc=dict(type="bool"),
+                                            port_channel_mode=dict(type="str", choices=[e.value for e in PortChannelModeEnum]),
+                                            port_type_edge_trunk=dict(type="bool"),
+                                            qos=dict(type="bool"),
+                                            qos_policy=dict(type="str"),
+                                            queuing_policy=dict(type="str"),
+                                            speed=dict(type="str", choices=[e.value for e in SpeedEnum]),
+                                            storm_control=dict(type="bool"),
+                                            storm_control_action=dict(type="str", choices=[e.value for e in StormControlActionEnum]),
+                                            storm_control_broadcast_level=dict(type="float"),
+                                            storm_control_broadcast_level_pps=dict(type="int"),
+                                            storm_control_multicast_level=dict(type="float"),
+                                            storm_control_multicast_level_pps=dict(type="int"),
+                                            storm_control_unicast_level=dict(type="float"),
+                                            storm_control_unicast_level_pps=dict(type="int"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
@@ -1,0 +1,654 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+vPC trunk (trunkVpcHost) interface Pydantic models for Nexus Dashboard.
+
+This module defines nested Pydantic models that mirror the ND Manage Interfaces API payload
+structure for vPC trunkVpcHost interfaces (`int_vpc_trunk_host.template`). The playbook
+config uses the same nesting so that `to_payload()` and `from_response()` work via standard
+Pydantic serialization with no custom wrapping or flattening.
+
+A vPC trunk-host interface spans two switches in a vPC pair. The user supplies one peer's
+management IP as `switch_ip`; the orchestrator auto-resolves the peer serial via the
+`vpcPair` endpoint and injects it as `peerSwitchId` in the payload. Per-peer policy fields
+use the ND-native `peer1_*` / `peer2_*` naming where `peer1` corresponds to `switch_ip`
+(the switch in the URL path) and `peer2` corresponds to the auto-resolved peer.
+
+## Model Hierarchy
+
+- `TrunkVpcHostInterfaceModel` (top-level, `NDBaseModel`)
+    - `switch_ip` (routing field; excluded from diff/payload)
+    - `interface_name` (identifier; e.g. `vpc100`)
+    - `interface_type` (frozen: "vpc")
+    - `config_data` -> `TrunkVpcHostConfigDataModel`
+        - `mode` (frozen: "trunk")
+        - `network_os` -> `TrunkVpcHostNetworkOSModel`
+            - `network_os_type` (frozen: "nx-os")
+            - `policy` -> `TrunkVpcHostPolicyModel`
+                - `policy_type` (frozen: "trunkVpcHost")
+                - `peer_switch_id` (orchestrator-injected; not in argspec)
+                - single user-facing `allowed_vlans`, `native_vlan` (fanned out to per-peer keys on write)
+                - per-peer fields: `peer1_*` / `peer2_*` (member_ports, port_channel_id, descriptions, configuration)
+                - `vlan_mapping`, `vlan_mapping_entries`
+                - shared fields: `admin_state`, `cdp`, `lacp_*`, `mtu`, etc.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated, ClassVar, Literal, Optional  # Optional needed for Annotated runtime expr (see types.py)
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    BeforeValidator,
+    Field,
+    SerializationInfo,
+    field_validator,
+    model_serializer,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    BpduFilterEnum,
+    BpduGuardEnum,
+    DuplexModeEnum,
+    LacpRateEnum,
+    LinkTypeEnum,
+    MtuEnum,
+    PortChannelModeEnum,
+    SpeedEnum,
+    StormControlActionEnum,
+    TrunkVpcHostPolicyTypeEnum,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+
+# Shape regex: "none", "all", or comma-separated VLAN ids/ranges. Range bounds are validated separately.
+_ALLOWED_VLANS_SHAPE = re.compile(r"^(none|all|(\d+(-\d+)?)(,\d+(-\d+)?)*)$")
+# Single VLAN id or range token (e.g. "100" or "100-200"). Range bounds are validated separately.
+_VLAN_ID_OR_RANGE_SHAPE = re.compile(r"^\d+(-\d+)?$")
+
+# Splits an interface name into its leading alphabetic prefix and the rest (digits/separators).
+_INTERFACE_NAME_PREFIX_RE = re.compile(r"^([A-Za-z]+)(.*)$")
+
+# Member interfaces of a vPC are always physical ethernet ports, so the canonical wire prefix is always
+# "Ethernet". Any case-insensitive NX-OS abbreviation (e.g. "e", "eth", "ether") expands to the full form so
+# user input matches the wire key and idempotency holds.
+_CANONICAL_MEMBER_TYPE = "Ethernet"
+
+
+def _validate_vlan_id_or_range(token: str, field_name: str) -> None:
+    """
+    # Summary
+
+    Validate a single VLAN id or range token (e.g. `"100"` or `"100-200"`) and confirm every id is in 1..4094 and any range has start <= end.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `token` does not match `\\d+(-\\d+)?`.
+    - If any VLAN id is outside 1..4094.
+    - If a range has start greater than end.
+    """
+    if not _VLAN_ID_OR_RANGE_SHAPE.match(token):
+        raise ValueError(f"{field_name} entry {token!r} must be a VLAN id or range (e.g. '100' or '100-200')")
+    if "-" in token:
+        start_str, end_str = token.split("-", 1)
+        start, end = int(start_str), int(end_str)
+        if not 1 <= start <= 4094 or not 1 <= end <= 4094:
+            raise ValueError(f"{field_name} range {token!r} is out of bounds; VLAN ids must be in 1..4094")
+        if start > end:
+            raise ValueError(f"{field_name} range {token!r} has start greater than end")
+    else:
+        vid = int(token)
+        if not 1 <= vid <= 4094:
+            raise ValueError(f"{field_name} id {vid} is out of bounds; VLAN ids must be in 1..4094")
+
+
+def _validate_allowed_vlans(value):
+    """
+    # Summary
+
+    Validate `allowed_vlans` matches `"none"`, `"all"`, or a comma-separated list of VLAN ids/ranges where every id is in 1..4094 and every range start <= end.
+    ND returns single-id values as JSON ints (e.g. `250`) but accepts both forms on input; this validator coerces int -> str so round-trips and idempotency
+    comparisons are stable.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `value` is a non-empty string that does not match the expected shape.
+    - If any VLAN id is outside 1..4094.
+    - If any range has start greater than end.
+    """
+    if value is None or value == "":
+        return value
+    # TODO(4.2.1) interface-get-field-normalization
+    # ND echoes a single-id allowed_vlans as a JSON int (e.g. 250) on GET even though POST/PUT accept (and the
+    # spec types it as) a string. We coerce int -> str here so a GET response round-trips against the str the
+    # user supplied and idempotency comparisons stay stable. Remove when the GET-side retype is fixed.
+    if isinstance(value, int) and not isinstance(value, bool):
+        value = str(value)
+    if not isinstance(value, str):
+        return value
+    if value in ("none", "all"):
+        return value
+    if not _ALLOWED_VLANS_SHAPE.match(value):
+        raise ValueError(f"allowed_vlans must be 'none', 'all', or a comma-separated list of VLAN ids/ranges (e.g. '1-200,500-2000,3000'); got {value!r}")
+    for token in value.split(","):
+        _validate_vlan_id_or_range(token, "allowed_vlans")
+    return value
+
+
+def _validate_customer_vlan_id_list(value):
+    """
+    # Summary
+
+    Validate `customer_vlan_id` is a list of non-empty VLAN id or range strings where every id is in 1..4094 and every range start <= end.
+
+    ## Raises
+
+    ### ValueError
+
+    - If any list entry is not a non-empty string.
+    - If any entry is not a VLAN id or range, has an id outside 1..4094, or has a reversed range.
+    """
+    if value is None:
+        return value
+    if not isinstance(value, list):
+        return value
+    for entry in value:
+        if not isinstance(entry, str) or not entry:
+            raise ValueError(f"customer_vlan_id entries must be non-empty strings (VLAN id or range); got {entry!r}")
+        _validate_vlan_id_or_range(entry, "customer_vlan_id")
+    return value
+
+
+# TODO: After all per-policy interface modules merge to develop, consolidate AllowedVlans, CustomerVlanIdList,
+# and _validate_vlan_id_or_range into models/types.py so siblings share a single source of truth. This module
+# carries its own copy to keep the vpc stack self-contained. Tracked in CiscoDevNet/ansible-nd#347.
+AllowedVlans = Annotated[Optional[str], BeforeValidator(_validate_allowed_vlans)]
+"""Trunk allowed-VLANs spec (`str | None`): 'none', 'all', or comma-separated VLAN ids/ranges in 1..4094."""
+
+CustomerVlanIdList = Annotated[Optional[list[str]], BeforeValidator(_validate_customer_vlan_id_list)]
+"""Customer VLAN id list (`list[str] | None`): each entry is a VLAN id or range in 1..4094 (e.g. `['100', '200-300']`)."""
+
+
+class TrunkVpcHostVlanMappingEntryModel(NDNestedModel):
+    """
+    # Summary
+
+    A single VLAN mapping entry for a vPC trunk host. Maps to one element of `policy.vlanMappingEntries` in the
+    ND API. Entries translate customer VLAN ids to a provider VLAN id, optionally using selective dot1q-tunnel mode.
+
+    ## Raises
+
+    None
+    """
+
+    customer_inner_vlan_id: int | None = Field(
+        default=None, alias="customerInnerVlanId", ge=1, le=4094, description="Inner customer VLAN id (selective dot1q-tunnel only)"
+    )
+    customer_vlan_id: CustomerVlanIdList = Field(
+        default=None,
+        alias="customerVlanId",
+        description="Customer VLAN id list; each entry is a VLAN id or range string in 1..4094 (e.g. ['100', '200-300'])",
+    )
+    dot1q_tunnel: bool | None = Field(default=None, alias="dot1qTunnel", description="Use selective dot1q-tunnel mode for this entry")
+    provider_vlan_id: int | None = Field(default=None, alias="providerVlanId", ge=1, le=4094, description="Provider VLAN id")
+
+
+class TrunkVpcHostPolicyModel(NDNestedModel):
+    """
+    # Summary
+
+    Policy fields for a vPC `trunkVpcHost` interface. Maps directly to the `configData.networkOS.policy` object in the ND API.
+
+    Per-peer fields use the API-native `peer1*` / `peer2*` naming. `peer1` corresponds to the switch in the URL path
+    (the user-supplied `switch_ip`); `peer2` corresponds to the auto-resolved peer (the value of `peerSwitchId`).
+
+    `peer_switch_id` is set by the orchestrator from the vPC pair record. It is not exposed in the module argument spec.
+
+    ND enforces wire-side consistency between `peer1AllowedVlans`/`peer2AllowedVlans` and between `peer1NativeVlan`/`peer2NativeVlan`
+    (HTTP 400 on divergent values, lab-verified 2026-05-13). The model exposes single `allowed_vlans` and `native_vlan` user fields
+    and fans them out to the per-peer keys at payload-serialization time. The GET response collapses the per-peer pair back to a
+    single key, so the diff matches the wire echo without further normalization.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `allowed_vlans` is set and does not match `none`, `all`, or comma-separated VLAN ranges.
+    """
+
+    # --- Policy Discriminator ---
+
+    policy_type: TrunkVpcHostPolicyTypeEnum = Field(
+        default=TrunkVpcHostPolicyTypeEnum.TRUNK_VPC_HOST,
+        alias="policyType",
+        frozen=True,
+        description="Interface policy type (hardcoded for this module)",
+    )
+
+    # --- Orchestrator-Injected (Not In Argspec) ---
+
+    peer_switch_id: str | None = Field(
+        default=None,
+        alias="peerSwitchId",
+        description="Peer switch serial number, auto-resolved by the orchestrator from the vPC pair record",
+    )
+
+    # --- Trunk-Specific Single-Valued Fields (collapsed by ND on read; fanned out per-peer on write) ---
+    # TODO(4.2.1) vpc-interface-peer-vlan-collapse
+    # ND trunkVpcHost wire echoes single `allowedVlans` / `nativeVlan` even though the create schema requires
+    # per-peer `peer1AllowedVlans` / `peer2AllowedVlans` and `peer1NativeVlan` / `peer2NativeVlan`. ND also rejects
+    # divergent per-peer values at the API layer (HTTP 400 "should be consistent"). We expose single user-facing fields
+    # and split them back to per-peer keys via `expand_per_peer_fields` for the write so idempotency matches the wire echo.
+
+    allowed_vlans: AllowedVlans = Field(
+        default=None,
+        alias="allowedVlans",
+        description="Trunk allowed VLANs ('none', 'all', or comma-separated VLAN ids/ranges in 1..4094, e.g. '100-200,300')",
+    )
+    native_vlan: int | None = Field(default=None, alias="nativeVlan", ge=1, le=4094, description="Trunk native VLAN id")
+
+    # --- Per-Peer Fields (peer1 = switch_ip, peer2 = peer_switch_id) ---
+
+    peer1_member_ports: list[str] | None = Field(default=None, alias="peer1MemberPorts", description="Member interface names on Peer-1")
+    peer1_port_channel_configuration: str | None = Field(
+        default=None, alias="peer1PortChannelConfiguration", description="Additional CLI for Peer-1's port-channel"
+    )
+    peer1_port_channel_description: AsciiDescription = Field(
+        default=None, alias="peer1PortChannelDescription", max_length=254, description="Description for Peer-1's port-channel"
+    )
+    peer1_port_channel_id: int | None = Field(default=None, alias="peer1PortChannelId", ge=1, le=4096, description="Peer-1 vPC port-channel number")
+    peer2_member_ports: list[str] | None = Field(default=None, alias="peer2MemberPorts", description="Member interface names on Peer-2")
+    peer2_port_channel_configuration: str | None = Field(
+        default=None, alias="peer2PortChannelConfiguration", description="Additional CLI for Peer-2's port-channel"
+    )
+    peer2_port_channel_description: AsciiDescription = Field(
+        default=None, alias="peer2PortChannelDescription", max_length=254, description="Description for Peer-2's port-channel"
+    )
+    peer2_port_channel_id: int | None = Field(default=None, alias="peer2PortChannelId", ge=1, le=4096, description="Peer-2 vPC port-channel number")
+
+    # --- VLAN Mapping ---
+
+    vlan_mapping: bool | None = Field(default=None, alias="vlanMapping", description="Enable VLAN mapping on the trunk")
+    vlan_mapping_entries: list[TrunkVpcHostVlanMappingEntryModel] | None = Field(
+        default=None, alias="vlanMappingEntries", description="VLAN mapping entries (used when vlan_mapping is enabled)"
+    )
+
+    # --- Shared Policy Fields ---
+
+    admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
+    bandwidth: int | None = Field(default=None, alias="bandwidth", ge=1, le=100000000, description="Configured bandwidth value for the interface")
+    bpdu_filter: BpduFilterEnum | None = Field(default=None, alias="bpduFilter", description="Configure spanning-tree BPDU filter")
+    bpdu_guard: BpduGuardEnum | None = Field(default=None, alias="bpduGuard", description="Enable spanning-tree BPDU guard")
+    cdp: bool | None = Field(default=None, alias="cdp", description="Enable CDP on the interface")
+    copy_description: bool | None = Field(
+        default=None,
+        alias="copyDescription",
+        description="Propagate the port-channel description to all member interfaces (per-peer)",
+    )
+    duplex_mode: DuplexModeEnum | None = Field(default=None, alias="duplexMode", description="Port duplex mode")
+    inherit_bandwidth: int | None = Field(
+        default=None,
+        alias="inheritBandwidth",
+        ge=1,
+        le=100000000,
+        description="Bandwidth value inherited by sub-interfaces",
+    )
+    lacp_port_priority: int | None = Field(default=None, alias="lacpPortPriority", ge=1, le=65535, description="LACP port priority (1-65535, default 32768)")
+    lacp_rate: LacpRateEnum | None = Field(default=None, alias="lacpRate", description="LACP rate (normal=30s, fast=1s)")
+    lacp_suspend: bool | None = Field(default=None, alias="lacpSuspend", description="Suspend port if LACP PDUs not received")
+    lacp_vpc_convergence: bool | None = Field(default=None, alias="lacpVpcConvergence", description="Enable LACP convergence for vPC port-channels")
+    link_type: LinkTypeEnum | None = Field(default=None, alias="linkType", description="Spanning-tree link type")
+    mirror_config: bool | None = Field(default=None, alias="mirrorConfig", description="Copy Peer-1 config to Peer-2")
+    mtu: MtuEnum | None = Field(default=None, alias="mtu", description="Interface MTU")
+    negotiate_auto: bool | None = Field(default=None, alias="negotiateAuto", description="Enable link auto-negotiation")
+    netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name")
+    netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name (N7K only)")
+    pfc: bool | None = Field(default=None, alias="pfc", description="Enable priority flow control")
+    port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode (on/active/passive)")
+    port_type_edge_trunk: bool | None = Field(
+        default=None, alias="portTypeEdgeTrunk", description="Enable spanning-tree edge port (PortFast) behavior on trunk"
+    )
+    qos: bool | None = Field(default=None, alias="qos", description="Enable QoS configuration for this interface")
+    qos_policy: str | None = Field(default=None, alias="qosPolicy", description="Custom QoS policy name")
+    queuing_policy: str | None = Field(default=None, alias="queuingPolicy", description="Custom queuing policy name")
+    speed: SpeedEnum | None = Field(default=None, alias="speed", description="Interface speed")
+    storm_control: bool | None = Field(default=None, alias="stormControl", description="Enable traffic storm control")
+    storm_control_action: StormControlActionEnum | None = Field(
+        default=None, alias="stormControlAction", description="Storm control action on threshold violation"
+    )
+    storm_control_broadcast_level: float | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Broadcast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_broadcast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Broadcast storm control level in packets per second",
+    )
+    storm_control_multicast_level: float | None = Field(
+        default=None,
+        alias="stormControlMulticastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Multicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_multicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlMulticastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Multicast storm control level in packets per second",
+    )
+    storm_control_unicast_level: float | None = Field(
+        default=None,
+        alias="stormControlUnicastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Unicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_unicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlUnicastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Unicast storm control level in packets per second",
+    )
+
+    # --- Serializers ---
+
+    # TODO(4.2.1) vpc-interface-peer-vlan-collapse
+    # trunkVpcHost wire echoes single `allowedVlans` and `nativeVlan` even though the create schema
+    # requires per-peer `peer1AllowedVlans` / `peer2AllowedVlans` and `peer1NativeVlan` / `peer2NativeVlan`. ND also
+    # rejects divergent per-peer values at the API layer (HTTP 400 "should be consistent"). We expose single user
+    # fields and split them back to the per-peer keys on the write side so idempotency works against the actual wire shape.
+    @model_serializer(mode="wrap")
+    def expand_per_peer_fields(self, handler, info: SerializationInfo):
+        """
+        # Summary
+
+        Single wrap-mode model serializer for the policy block, applying two ND-specific adjustments keyed off the
+        serialization `mode` context:
+
+        - On payload serialization (`mode == "payload"`), split the single user-facing `allowedVlans` / `nativeVlan`
+          into the per-peer `peer1AllowedVlans` / `peer2AllowedVlans` and `peer1NativeVlan` / `peer2NativeVlan` keys the
+          ND create/update schema requires. ND collapses each pair back to a single field on read, so config / diff
+          modes leave the fields as-is and the diff stays symmetric.
+        - On config serialization (`mode == "config"`), drop the frozen, argspec-excluded `policy_type` so it does not
+          leak into `before` / `after` / `gathered` output. Payload and diff modes keep the wire value so the POST/PUT
+          body and the round-trip diff line up with what ND returns.
+
+        ## Raises
+
+        ### AssertionError
+
+        - If the wrapped handler returns a non-`dict`. A model-level serializer always serializes to a `dict`, so this
+          is an invariant check that fails loudly rather than silently mis-serializing.
+        """
+        data = handler(self)
+        if not isinstance(data, dict):
+            raise AssertionError(f"Expected dict from model serialization, got {type(data).__name__}")
+        mode = (info.context or {}).get("mode", "payload")
+        if mode == "payload":
+            if "allowedVlans" in data:
+                vlans = data.pop("allowedVlans")
+                data["peer1AllowedVlans"] = vlans
+                data["peer2AllowedVlans"] = vlans
+            if "nativeVlan" in data:
+                vlan = data.pop("nativeVlan")
+                data["peer1NativeVlan"] = vlan
+                data["peer2NativeVlan"] = vlan
+        if mode == "config":
+            data.pop("policy_type", None)
+            data.pop("policyType", None)
+        return data
+
+    # --- Validators ---
+
+    @field_validator("peer1_member_ports", "peer2_member_ports", mode="before")
+    @classmethod
+    def normalize_member_ports(cls, value):
+        """
+        # Summary
+
+        Normalize each per-peer member interface name to ND's canonical `Ethernet` form so any user-supplied casing or
+        NX-OS abbreviation round-trips against the wire form. Members are always physical ethernet ports. Examples:
+
+        - `ethernet1/1` -> `Ethernet1/1`
+        - `eth1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `e1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `Ethernet1/1` -> `Ethernet1/1` (idempotent)
+
+        An abbreviated prefix that is not expanded would never match ND's `Ethernet...` wire key, silently breaking
+        idempotency (the vPC re-deploys on every run). Only the leading alphabetic run is rewritten; digits and
+        separators are preserved verbatim.
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(value, list):
+            return value
+        return [cls._normalize_member_name(name) for name in value]
+
+    @staticmethod
+    def _normalize_member_name(name):
+        """
+        # Summary
+
+        Normalize a single member interface name to ND's canonical `Ethernet` form (see `normalize_member_ports`).
+        Non-string or empty values are returned unchanged.
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(name, str) or not name:
+            return name
+        match = _INTERFACE_NAME_PREFIX_RE.match(name)
+        if not match:
+            return name
+        prefix, rest = match.groups()
+        if _CANONICAL_MEMBER_TYPE.lower().startswith(prefix.lower()):
+            return _CANONICAL_MEMBER_TYPE + rest
+        return prefix[0].upper() + prefix[1:].lower() + rest
+
+
+class TrunkVpcHostNetworkOSModel(NDNestedModel):
+    """
+    # Summary
+
+    Network OS container for a vPC `trunkVpcHost` interface. Maps to `configData.networkOS` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: TrunkVpcHostPolicyModel | None = Field(default=None, alias="policy")
+
+
+class TrunkVpcHostConfigDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Config data container for a vPC `trunkVpcHost` interface. Maps to `configData` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    mode: Literal["trunk"] = Field(default="trunk", alias="mode", frozen=True)
+    network_os: TrunkVpcHostNetworkOSModel = Field(alias="networkOS")
+
+
+class TrunkVpcHostInterfaceModel(NDBaseModel):
+    """
+    # Summary
+
+    vPC `trunkVpcHost` interface configuration for Nexus Dashboard.
+
+    The nested model structure mirrors the ND Manage Interfaces API payload, so `to_payload()` and `from_response()`
+    work via standard Pydantic serialization. The `interface_name` is the vPC's own name (e.g. `vpc100`), not a member
+    interface. Member interfaces are listed per-peer in `config_data.network_os.policy.peer1_member_ports` and
+    `peer2_member_ports`.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+    # TODO(4.2.1) vpc-interface-dual-peer-duplicate
+    # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in
+    # the per-switch `/interfaces` GET (with identical `configData` and only `switchId` / `peerSwitchId` swapping).
+    # Using a composite (switch_ip, interface_name) identifier caused `_manage_override_deletions` to delete the
+    # peer-side duplicate. The identifier is therefore `interface_name` only; `switch_ip` is kept as a field for
+    # routing (URL-path resolution + peer-resolution) but is excluded from diff and dedup'd in `query_all`.
+
+    identifiers: ClassVar[list[str] | None] = ["interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
+    exclude_from_diff: ClassVar[set[str]] = {"switch_ip"}
+
+    # --- Fields ---
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["vpc"] = Field(default="vpc", alias="interfaceType", frozen=True)
+    config_data: TrunkVpcHostConfigDataModel | None = Field(default=None, alias="configData")
+
+    @field_validator("interface_name", mode="before")
+    @classmethod
+    def normalize_interface_name(cls, value):
+        """
+        # Summary
+
+        Normalize the vPC interface name to lowercase to match ND API convention (e.g. `Vpc100` -> `vpc100`).
+
+        ## Raises
+
+        None
+        """
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_interface_vpc_trunk_host` module. Frozen scaffolding fields
+        (`interface_type`, `mode`, `network_os_type`, `policy_type`) are intentionally NOT exposed. `peer_switch_id`
+        is orchestrator-injected and NOT exposed.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    interface_name=dict(type="str", required=True),
+                    config_data=dict(
+                        type="dict",
+                        options=dict(
+                            network_os=dict(
+                                type="dict",
+                                options=dict(
+                                    policy=dict(
+                                        type="dict",
+                                        options=dict(
+                                            admin_state=dict(type="bool"),
+                                            allowed_vlans=dict(type="str"),
+                                            bandwidth=dict(type="int"),
+                                            bpdu_filter=dict(type="str", choices=[e.value for e in BpduFilterEnum]),
+                                            bpdu_guard=dict(type="str", choices=[e.value for e in BpduGuardEnum]),
+                                            cdp=dict(type="bool"),
+                                            copy_description=dict(type="bool"),
+                                            duplex_mode=dict(type="str", choices=[e.value for e in DuplexModeEnum]),
+                                            inherit_bandwidth=dict(type="int"),
+                                            lacp_port_priority=dict(type="int"),
+                                            lacp_rate=dict(type="str", choices=[e.value for e in LacpRateEnum]),
+                                            lacp_suspend=dict(type="bool"),
+                                            lacp_vpc_convergence=dict(type="bool"),
+                                            link_type=dict(type="str", choices=[e.value for e in LinkTypeEnum]),
+                                            mirror_config=dict(type="bool"),
+                                            mtu=dict(type="str", choices=[e.value for e in MtuEnum]),
+                                            native_vlan=dict(type="int"),
+                                            negotiate_auto=dict(type="bool"),
+                                            netflow=dict(type="bool"),
+                                            netflow_monitor=dict(type="str"),
+                                            netflow_sampler=dict(type="str"),
+                                            peer1_member_ports=dict(type="list", elements="str"),
+                                            peer1_port_channel_configuration=dict(type="str"),
+                                            peer1_port_channel_description=dict(type="str"),
+                                            peer1_port_channel_id=dict(type="int"),
+                                            peer2_member_ports=dict(type="list", elements="str"),
+                                            peer2_port_channel_configuration=dict(type="str"),
+                                            peer2_port_channel_description=dict(type="str"),
+                                            peer2_port_channel_id=dict(type="int"),
+                                            pfc=dict(type="bool"),
+                                            port_channel_mode=dict(type="str", choices=[e.value for e in PortChannelModeEnum]),
+                                            port_type_edge_trunk=dict(type="bool"),
+                                            qos=dict(type="bool"),
+                                            qos_policy=dict(type="str"),
+                                            queuing_policy=dict(type="str"),
+                                            speed=dict(type="str", choices=[e.value for e in SpeedEnum]),
+                                            storm_control=dict(type="bool"),
+                                            storm_control_action=dict(type="str", choices=[e.value for e in StormControlActionEnum]),
+                                            storm_control_broadcast_level=dict(type="float"),
+                                            storm_control_broadcast_level_pps=dict(type="int"),
+                                            storm_control_multicast_level=dict(type="float"),
+                                            storm_control_multicast_level_pps=dict(type="int"),
+                                            storm_control_unicast_level=dict(type="float"),
+                                            storm_control_unicast_level_pps=dict(type="int"),
+                                            vlan_mapping=dict(type="bool"),
+                                            vlan_mapping_entries=dict(
+                                                type="list",
+                                                elements="dict",
+                                                options=dict(
+                                                    customer_inner_vlan_id=dict(type="int"),
+                                                    customer_vlan_id=dict(type="list", elements="str"),
+                                                    dot1q_tunnel=dict(type="bool"),
+                                                    provider_vlan_id=dict(type="int"),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/orchestrators/port_channel_access_interface.py
+++ b/plugins/module_utils/orchestrators/port_channel_access_interface.py
@@ -1,0 +1,53 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Port-channel accessPoHost interface orchestrator for Nexus Dashboard.
+
+This module provides `PortChannelAccessInterfaceOrchestrator`, which manages CRUD operations
+for port-channel accessPoHost interfaces. It inherits all shared port-channel logic from
+`PortChannelBaseOrchestrator` and only defines the model class and managed policy types.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Type
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import AccessPoHostPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import (
+    PortChannelAccessInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_base import PortChannelBaseOrchestrator
+
+
+class PortChannelAccessInterfaceOrchestrator(PortChannelBaseOrchestrator):
+    """
+    # Summary
+
+    Orchestrator for port-channel accessPoHost interface CRUD operations on Nexus Dashboard.
+
+    Inherits all shared port-channel logic from `PortChannelBaseOrchestrator`. Defines `model_class` as
+    `PortChannelAccessInterfaceModel` and manages the `accessPoHost` policy type.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via inherited methods. See `PortChannelBaseOrchestrator` for full details.
+    """
+
+    model_class: ClassVar[Type[NDBaseModel]] = PortChannelAccessInterfaceModel
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator.
+
+        ## Raises
+
+        None
+        """
+        return {e.value for e in AccessPoHostPolicyTypeEnum}

--- a/plugins/module_utils/orchestrators/port_channel_access_interface.py
+++ b/plugins/module_utils/orchestrators/port_channel_access_interface.py
@@ -12,7 +12,7 @@ for port-channel accessPoHost interfaces. It inherits all shared port-channel lo
 
 from __future__ import annotations
 
-from typing import ClassVar, Type
+from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import AccessPoHostPolicyTypeEnum
@@ -38,7 +38,7 @@ class PortChannelAccessInterfaceOrchestrator(PortChannelBaseOrchestrator):
     - Via inherited methods. See `PortChannelBaseOrchestrator` for full details.
     """
 
-    model_class: ClassVar[Type[NDBaseModel]] = PortChannelAccessInterfaceModel
+    model_class: ClassVar[type[NDBaseModel]] = PortChannelAccessInterfaceModel
 
     def _managed_policy_types(self) -> set[str]:
         """

--- a/plugins/module_utils/orchestrators/port_channel_base.py
+++ b/plugins/module_utils/orchestrators/port_channel_base.py
@@ -163,7 +163,9 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
 
         ## Raises
 
-        None
+        ### RuntimeError
+
+        - Via `_resolve_switch_id` if no switch matches `model_instance.switch_ip` in the fabric.
         """
         switch_id = self._resolve_switch_id(model_instance.switch_ip)
         self._queue_remove(model_instance.interface_name, switch_id)
@@ -241,12 +243,39 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
+    def _switches_to_query(self) -> dict[str, str]:
+        """
+        # Summary
+
+        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
+
+        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
+        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
+        config, so only those switches are returned. This keeps the interface-list request count proportional to
+        config size rather than fabric size (CLAUDE.md performance rule: no per-switch fan-out over the whole fabric).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Via `FabricContext.switch_map` if the switches API query fails.
+        """
+        switch_map = self.fabric_context.switch_map
+        if self.rest_send.params.get("state") == "overridden":
+            return switch_map
+        config_items = self.rest_send.params.get("config") or []
+        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
+        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
+
     def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
         """
         # Summary
 
-        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
-        port-channel interfaces with policy types managed by this orchestrator (as defined by `_managed_policy_types()`).
+        Validate the fabric context and query interfaces, filtering for port-channel interfaces with policy types
+        managed by this orchestrator (as defined by `_managed_policy_types()`).
+
+        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`,
+        and limited to switches named in the user config for all other states.
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
 
@@ -265,12 +294,10 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         try:
             self.validate_prerequisites()
             all_port_channels = []
-            for switch_ip, switch_id in self.fabric_context.switch_map.items():
+            for switch_ip, switch_id in self._switches_to_query().items():
                 api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
                 result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                if not result:
-                    continue
-                interfaces = result.get("interfaces", []) or []
+                interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
                 port_channels = [iface for iface in interfaces if iface.get("interfaceType") == "portChannel"]
                 managed = [
                     iface for iface in port_channels if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types

--- a/plugins/module_utils/orchestrators/port_channel_base.py
+++ b/plugins/module_utils/orchestrators/port_channel_base.py
@@ -273,9 +273,7 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
                 interfaces = result.get("interfaces", []) or []
                 port_channels = [iface for iface in interfaces if iface.get("interfaceType") == "portChannel"]
                 managed = [
-                    iface
-                    for iface in port_channels
-                    if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
+                    iface for iface in port_channels if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
                 ]
                 for iface in managed:
                     iface["switchIp"] = switch_ip

--- a/plugins/module_utils/orchestrators/port_channel_base.py
+++ b/plugins/module_utils/orchestrators/port_channel_base.py
@@ -1,0 +1,285 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# pyright: reportAttributeAccessIssue=false
+# ModelType is NDBaseModel which lacks interface-specific fields (switch_ip,
+# interface_name, config_data). Concrete subclasses always bind ModelType to a
+# model that provides these fields, so the accesses are safe at runtime.
+
+"""
+Base orchestrator for port-channel interface modules on Nexus Dashboard.
+
+This module provides `PortChannelBaseOrchestrator`, which implements shared CRUD operations
+for all port-channel interface types (accessPoHost, trunkPoHost, etc.) via the ND Manage
+Interfaces API. Type-specific orchestrators inherit from this base and provide their own
+`model_class` and `_managed_policy_types()`.
+
+Inherits shared interface lifecycle operations (deploy queuing, fabric validation, switch
+resolution) from `NDBaseInterfaceOrchestrator` and adds port-channel-specific functionality:
+- Standard remove-based deletion (port-channels are virtual interfaces and are deletable)
+- Fabric-wide `query_all()` filtered by `interfaceType: "portChannel"` and per-type policy filtering
+
+Member ethernet interfaces are not managed by this orchestrator — the port-channel policy is the
+single source of truth for member configuration via the `ports` list. Member field restrictions
+on standalone ethernet modules are enforced separately by the ethernet orchestrators.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+    EpManageInterfacesRemove,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+ModelType = NDBaseModel
+
+
+class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
+    """
+    # Summary
+
+    Base orchestrator for port-channel interface CRUD operations on Nexus Dashboard.
+
+    Provides shared logic for all port-channel interface types. Subclasses must set `model_class` and implement
+    `_managed_policy_types()` to define which policy types they manage.
+
+    Supports configuring port-channels across multiple switches in a single task. Each config item includes a
+    `switch_ip` that is resolved to a `switchId` via `FabricContext`.
+
+    Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` queues port-channels for
+    bulk removal via `interfaceActions/remove` and bulk deploy. Call `remove_pending` and `deploy_pending` after
+    all mutations are complete.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
+    - Via `create` if the create API request fails.
+    - Via `update` if the update API request fails.
+    - Via `remove_pending` if the bulk remove API request fails.
+    - Via `deploy_pending` if the bulk deploy API request fails.
+    - Via `query_one` if the query API request fails.
+    - Via `query_all` if the query API request fails.
+    """
+
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = NDEndpointBaseModel  # unused; delete() uses bulk remove
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesRemove
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator. Subclasses must override this method
+        to return their specific policy types (e.g., `{"accessPoHost"}` for the access orchestrator).
+
+        ## Raises
+
+        ### NotImplementedError
+
+        - Always, if not overridden by a subclass.
+        """
+        raise NotImplementedError("Subclasses must implement _managed_policy_types()")
+
+    def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create a port-channel interface configuration. Resolves `switch_ip` from the model instance, injects `switchId`,
+        and wraps the payload in an `interfaces` array. Queues a deploy for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            request_body = {"interfaces": [payload]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update a port-channel interface configuration. Resolves `switch_ip` from the model instance, injects `switchId`
+        into the payload. Queues a deploy for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: ModelType, **kwargs) -> None:
+        """
+        # Summary
+
+        Queue a port-channel interface for deferred bulk removal via `remove_pending` and bulk deploy via
+        `deploy_pending`. The remove deletes the port-channel from ND's config; the deploy pushes that removal
+        to the switch and reverts member interfaces to their fabric default configuration.
+
+        No API calls are made until `remove_pending` and `deploy_pending` are called after all mutations are complete.
+
+        ## Raises
+
+        None
+        """
+        switch_id = self._resolve_switch_id(model_instance.switch_ip)
+        self._queue_remove(model_instance.interface_name, switch_id)
+        self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def create_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create multiple port-channel interfaces in bulk. Groups port-channels by switch and sends one POST per switch
+        with all port-channels in the `interfaces` array, reducing API calls from N to one-per-switch. Queues deploys
+        for all created port-channels for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create API request fails.
+        """
+        try:
+            groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+            for model_instance in model_instances:
+                switch_id = self._resolve_switch_id(model_instance.switch_ip)
+                payload = model_instance.to_payload()
+                payload["switchId"] = switch_id
+                groups[switch_id].append((model_instance.interface_name, payload))
+
+            results = []
+            for switch_id, items in groups.items():
+                # Guarded at runtime by @requires_bulk_support("supports_bulk_create")
+                api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
+                request_body = {"interfaces": [payload for interface_name, payload in items]}
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+                results.append(result)
+                for interface_name, payload in items:
+                    self._queue_deploy(interface_name, switch_id)
+            return results
+        except Exception as e:
+            raise RuntimeError(f"Bulk create failed: {e}") from e
+
+    def delete_bulk(self, model_instances: list[ModelType], **kwargs) -> None:
+        """
+        # Summary
+
+        Queue multiple port-channel interfaces for deferred bulk removal and deployment. Each port-channel is queued
+        for removal via `remove_pending` and deployment via `deploy_pending`. No API calls are made until those methods
+        are called after `manage_state` completes.
+
+        ## Raises
+
+        None
+        """
+        for model_instance in model_instances:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            self._queue_remove(model_instance.interface_name, switch_id)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def query_one(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Query a single port-channel interface by name on a specific switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
+        port-channel interfaces with policy types managed by this orchestrator (as defined by `_managed_policy_types()`).
+
+        Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
+
+        Each returned interface dict is enriched with a `switch_ip` field so that the model can be constructed
+        with the composite identifier `(switch_ip, interface_name)`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist on the target ND node.
+        - If the fabric is in deployment-freeze mode.
+        - If the query API request fails.
+        """
+        managed_types = self._managed_policy_types()
+        try:
+            self.validate_prerequisites()
+            all_port_channels = []
+            for switch_ip, switch_id in self.fabric_context.switch_map.items():
+                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                if not result:
+                    continue
+                interfaces = result.get("interfaces", []) or []
+                port_channels = [iface for iface in interfaces if iface.get("interfaceType") == "portChannel"]
+                managed = [
+                    iface
+                    for iface in port_channels
+                    if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
+                ]
+                for iface in managed:
+                    iface["switchIp"] = switch_ip
+                all_port_channels.extend(managed)
+            return all_port_channels
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/orchestrators/port_channel_trunk_host_interface.py
@@ -1,0 +1,53 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Port-channel trunkPoHost interface orchestrator for Nexus Dashboard.
+
+This module provides `PortChannelTrunkHostInterfaceOrchestrator`, which manages CRUD operations
+for port-channel trunkPoHost interfaces. It inherits all shared port-channel logic from
+`PortChannelBaseOrchestrator` and only defines the model class and managed policy types.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import TrunkPoHostPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_base import PortChannelBaseOrchestrator
+
+
+class PortChannelTrunkHostInterfaceOrchestrator(PortChannelBaseOrchestrator):
+    """
+    # Summary
+
+    Orchestrator for port-channel trunkPoHost interface CRUD operations on Nexus Dashboard.
+
+    Inherits all shared port-channel logic from `PortChannelBaseOrchestrator`. Defines `model_class` as
+    `PortChannelTrunkHostInterfaceModel` and manages the `trunkPoHost` policy type.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via inherited methods. See `PortChannelBaseOrchestrator` for full details.
+    """
+
+    model_class: ClassVar[type[NDBaseModel]] = PortChannelTrunkHostInterfaceModel
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator.
+
+        ## Raises
+
+        None
+        """
+        return {e.value for e in TrunkPoHostPolicyTypeEnum}

--- a/plugins/module_utils/orchestrators/vpc_access_interface.py
+++ b/plugins/module_utils/orchestrators/vpc_access_interface.py
@@ -1,0 +1,53 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+vPC accessVpcHost interface orchestrator for Nexus Dashboard.
+
+This module provides `AccessVpcHostInterfaceOrchestrator`, which manages CRUD operations for vPC
+`accessVpcHost` interfaces. It inherits all shared vPC logic from `VpcInterfaceBaseOrchestrator` and only
+defines the model class and managed policy types.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import AccessVpcHostPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+    AccessVpcHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import VpcInterfaceBaseOrchestrator
+
+
+class AccessVpcHostInterfaceOrchestrator(VpcInterfaceBaseOrchestrator):
+    """
+    # Summary
+
+    Orchestrator for vPC `accessVpcHost` interface CRUD operations on Nexus Dashboard.
+
+    Inherits all shared vPC logic from `VpcInterfaceBaseOrchestrator`. Defines `model_class` as
+    `AccessVpcHostInterfaceModel` and manages the `accessVpcHost` policy type.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via inherited methods. See `VpcInterfaceBaseOrchestrator` for full details.
+    """
+
+    model_class: ClassVar[type[NDBaseModel]] = AccessVpcHostInterfaceModel
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator.
+
+        ## Raises
+
+        None
+        """
+        return {e.value for e in AccessVpcHostPolicyTypeEnum}

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -1,0 +1,485 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# pyright: reportAttributeAccessIssue=false
+# ModelType is NDBaseModel which lacks interface-specific fields (switch_ip,
+# interface_name, config_data). Concrete subclasses always bind ModelType to a
+# model that provides these fields, so the accesses are safe at runtime.
+
+"""
+Base orchestrator for vPC interface modules on Nexus Dashboard.
+
+This module provides `VpcInterfaceBaseOrchestrator`, which implements shared CRUD operations for all vPC interface
+types (`accessVpcHost`, `trunkVpcHost`, etc.) via the ND Manage Interfaces API. Type-specific orchestrators
+inherit from this base and provide their own `model_class` and `_managed_policy_types()`.
+
+Inherits shared interface lifecycle operations (deploy queuing, fabric validation, switch resolution) from
+`NDBaseInterfaceOrchestrator` and adds vPC-specific functionality:
+
+- Peer-serial auto-resolution: each create/update reads the per-switch `vpcPair` endpoint to obtain the peer
+  serial, then injects it as `peerSwitchId` in the payload. Results are cached per orchestrator instance so
+  bulk operations make at most one lookup per primary switch.
+- Standard remove-based deletion (vPC interfaces are virtual and deletable).
+- Fabric-wide `query_all()` filtered by `interfaceType: "vpc"` and per-type policy filtering.
+
+A vPC interface spans two switches in a vPC pair; the user supplies one peer's management IP as `switch_ip`.
+If the supplied switch is not in a vPC pair the orchestrator raises a clear `RuntimeError` instructing the
+user to create the pair first via `nd_manage_vpc_pair`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switches_vpc_pair import (
+    EpVpcPairGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesDelete,
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import requires_bulk_support
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+ModelType = NDBaseModel
+
+
+class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
+    """
+    # Summary
+
+    Base orchestrator for vPC interface CRUD operations on Nexus Dashboard.
+
+    Provides shared logic for all vPC interface types. Subclasses must set `model_class` and implement
+    `_managed_policy_types()` to define which policy types they manage.
+
+    Each create/update reads the `vpcPair` record for the primary switch to obtain the peer serial, which is
+    then injected as `peerSwitchId` in the payload. Lookups are cached per orchestrator instance.
+
+    Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` issues an immediate
+    per-interface `DELETE /interfaces/{name}` (the bulk `interfaceActions/remove` endpoint rejects vPC interfaces;
+    see the `TODO(4.2.1)` below) and queues a deploy. Call `deploy_pending` after all mutations are complete.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
+    - Via `_resolve_peer_switch_id` if the switch is not in a vPC pair.
+    - Via `create` if the create API request fails.
+    - Via `update` if the update API request fails.
+    - Via `remove_pending` if the bulk remove API request fails.
+    - Via `deploy_pending` if the bulk deploy API request fails.
+    - Via `query_one` if the query API request fails.
+    - Via `query_all` if the query API request fails.
+    """
+
+    # TODO(4.2.1) vpc-interface-bulk-delete-silent-fail
+    # The bulk `/api/v1/manage/fabrics/{fabric}/interfaceActions/remove` endpoint returns
+    # `{"status":"Failed","message":"Invalid Interface"}` inside a 207 for vPC interfaces (lab-verified). The
+    # per-interface `DELETE /interfaces/{name}` endpoint works (returns 204). We therefore disable bulk delete and
+    # use the per-interface DELETE via `delete_endpoint`.
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = False
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] | None = None
+
+    def model_post_init(self, __context) -> None:
+        """
+        # Summary
+
+        Initialize mutable private state. Extends `NDBaseInterfaceOrchestrator.model_post_init` with a
+        per-instance peer-serial cache so bulk operations make at most one `vpcPair` GET per primary switch.
+
+        ## Raises
+
+        None
+        """
+        super().model_post_init(__context)
+        self._peer_serial_cache: dict[str, str] = {}
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator. Subclasses must override this method
+        to return their specific policy types (e.g., `{"accessVpcHost"}` for the access orchestrator).
+
+        ## Raises
+
+        ### NotImplementedError
+
+        - Always, if not overridden by a subclass.
+        """
+        raise NotImplementedError("Subclasses must implement _managed_policy_types()")
+
+    def _resolve_peer_switch_id(self, switch_ip: str, primary_serial: str) -> str:
+        """
+        # Summary
+
+        Resolve the peer switch's serial number for the vPC pair containing `primary_serial`. Reads the per-switch
+        `vpcPair` endpoint. Caches the result per orchestrator instance so bulk operations issue at most one lookup
+        per primary switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the switch is not in a vPC pair (the `vpcPair` GET returns 404 / empty body).
+        - If the `vpcPair` GET returns success but omits `peerSwitchId`.
+        """
+        cached = self._peer_serial_cache.get(primary_serial)
+        if cached:
+            return cached
+        api_endpoint = EpVpcPairGet()
+        api_endpoint.fabric_name = self.fabric_name
+        api_endpoint.switch_id = primary_serial
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        if not result:
+            raise RuntimeError(
+                f"Switch {switch_ip} (serial {primary_serial}) is not in a vPC pair; "
+                f"create the pair via nd_manage_vpc_pair before configuring vPC interfaces."
+            )
+        peer_serial = result.get("peerSwitchId")
+        if not peer_serial:
+            raise RuntimeError(f"vPC pair record for switch {switch_ip} (serial {primary_serial}) is missing 'peerSwitchId'; " f"received: {result!r}")
+        self._peer_serial_cache[primary_serial] = peer_serial
+        return peer_serial
+
+    def _inject_peer_switch_id(self, payload: dict, peer_serial: str) -> dict:
+        """
+        # Summary
+
+        Inject `peerSwitchId` into the nested `configData.networkOS.policy` block of an interface payload. Every vPC
+        interface requires a peer serial, so a payload without a `policy` block is structurally invalid and is rejected
+        here rather than silently sent to ND as a one-sided vPC.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the payload has no `configData.networkOS.policy` block to inject `peerSwitchId` into.
+        """
+        policy = (payload.get("configData") or {}).get("networkOS", {}).get("policy")
+        if policy is None:
+            raise RuntimeError(
+                f"vPC interface payload is missing the 'configData.networkOS.policy' block required to inject 'peerSwitchId'; received: {payload!r}"
+            )
+        policy["peerSwitchId"] = peer_serial
+        return payload
+
+    def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create a vPC interface configuration. Resolves `switch_ip` to a primary serial, resolves the peer serial via
+        the vPC pair record, injects both into the payload, and POSTs the wrapped `interfaces` array. Queues a deploy
+        for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails.
+        - If the primary switch is not in a vPC pair.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+            api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            self._inject_peer_switch_id(payload, peer_serial)
+            request_body = {"interfaces": [payload]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update a vPC interface configuration. Resolves `switch_ip` to a primary serial, resolves the peer serial via
+        the vPC pair record, injects both into the payload, and PUTs the updated configuration. Queues a deploy for
+        later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails.
+        - If the primary switch is not in a vPC pair.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+            api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            self._inject_peer_switch_id(payload, peer_serial)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: ModelType, **kwargs) -> None:
+        """
+        # Summary
+
+        Delete a vPC interface immediately via the per-interface `DELETE /interfaces/{name}` endpoint, then queue
+        a deploy for later bulk execution via `deploy_pending`. The DELETE returns 204 on success; a subsequent GET
+        returns 404. The deploy pushes the removal to both peers and reverts member interfaces to their fabric
+        default configuration.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the DELETE API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.delete_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+        except Exception as e:
+            raise RuntimeError(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    @requires_bulk_support("supports_bulk_create")
+    def create_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create multiple vPC interfaces in bulk. Groups by primary switch, resolves the peer serial once per group, and
+        sends one POST per primary switch with all vPC interfaces in the `interfaces` array. Queues deploys for all
+        created interfaces for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create API request fails.
+        - If any primary switch is not in a vPC pair.
+        """
+        try:
+            groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+            for model_instance in model_instances:
+                switch_id = self._resolve_switch_id(model_instance.switch_ip)
+                peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+                payload = model_instance.to_payload()
+                payload["switchId"] = switch_id
+                self._inject_peer_switch_id(payload, peer_serial)
+                groups[switch_id].append((model_instance.interface_name, payload))
+
+            results = []
+            for switch_id, items in groups.items():
+                # Guarded at runtime by @requires_bulk_support("supports_bulk_create")
+                api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
+                request_body = {"interfaces": [payload for interface_name, payload in items]}
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+                results.append(result)
+                for interface_name, payload in items:
+                    self._queue_deploy(interface_name, switch_id)
+            return results
+        except Exception as e:
+            raise RuntimeError(f"Bulk create failed: {e}") from e
+
+    def query_one(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Query a single vPC interface by name on a specific switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def _switches_to_query(self) -> dict[str, str]:
+        """
+        # Summary
+
+        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
+
+        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
+        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
+        config, so only those switches are returned. This keeps the interface-list request count proportional to
+        config size rather than fabric size (CLAUDE.md performance rule: no per-switch fan-out over the whole fabric).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Via `FabricContext.switch_map` if the switches API query fails.
+        """
+        switch_map = self.fabric_context.switch_map
+        if self.rest_send.params.get("state") == "overridden":
+            return switch_map
+        config_items = self.rest_send.params.get("config") or []
+        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
+        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
+
+    def _configured_switch_ip_by_interface_name(self) -> dict[str, str]:
+        """
+        # Summary
+
+        Map each config `interface_name` to the user-supplied `switch_ip`. A vPC interface spans two peers and ND
+        returns it on both; this lets `query_all` pick the peer whose IP the user actually configured so the existing
+        state's composite identifier `(switch_ip, interface_name)` matches the proposed identifier and the run stays
+        idempotent regardless of which peer the user names.
+
+        ## Raises
+
+        None
+        """
+        mapping: dict[str, str] = {}
+        for item in self.rest_send.params.get("config") or []:
+            name = item.get("interface_name")
+            switch_ip = item.get("switch_ip")
+            if name and switch_ip:
+                mapping[name] = switch_ip
+        return mapping
+
+    @staticmethod
+    def _policy_type(iface: dict) -> str | None:
+        """
+        # Summary
+
+        Return `configData.networkOS.policy.policyType` for an interface dict, tolerating a missing or null value at
+        any level of the nested chain (ND occasionally returns `configData: null`).
+
+        ## Raises
+
+        None
+        """
+        config_data = iface.get("configData") or {}
+        network_os = config_data.get("networkOS") or {}
+        policy = network_os.get("policy") or {}
+        return policy.get("policyType")
+
+    def _managed_vpc_interfaces(self, switch_ip: str, switch_id: str, managed_types: set[str]) -> list[dict]:
+        """
+        # Summary
+
+        Fetch one switch's interface list and return the vPC interfaces whose policy type this orchestrator manages,
+        each enriched with the `switchIp` of the switch it was read from. Tolerates a missing body (`not_found_ok`) and
+        a non-dict body (the `isinstance` guard) without raising.
+
+        ## Raises
+
+        ### Exception
+
+        - If the interface-list request fails (propagated to `query_all`'s wrapper).
+        """
+        api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
+        managed = [iface for iface in interfaces if iface.get("interfaceType") == "vpc" and self._policy_type(iface) in managed_types]
+        for iface in managed:
+            iface["switchIp"] = switch_ip
+        return managed
+
+    def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Validate the fabric context and query interfaces, filtering for vPC interfaces with policy types managed by
+        this orchestrator (as defined by `_managed_policy_types()`).
+
+        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`, and
+        limited to switches named in the user config for all other states.
+
+        Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
+
+        Each returned interface dict is enriched with a `switchIp` field so that the model can be constructed with the
+        composite identifier `(switch_ip, interface_name)`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist on the target ND node.
+        - If the fabric is in deployment-freeze mode.
+        - If the query API request fails.
+        """
+        managed_types = self._managed_policy_types()
+        try:
+            self.validate_prerequisites()
+            configured_ip_by_name = self._configured_switch_ip_by_interface_name()
+            # TODO(4.2.1) vpc-interface-dual-peer-duplicate
+            # ND returns each vPC interface TWICE — once per peer switch — with identical configData. Dedupe by
+            # interfaceName. When the interface is in the user config, keep the peer whose switchIp the user supplied so
+            # idempotency holds regardless of which peer they name; otherwise keep the alphabetically-lower switchId for
+            # a stable representative. Without this dedupe, `_manage_override_deletions` would see the peer-side copy as
+            # "not in proposed" and queue a spurious delete.
+            interfaces_by_name: dict[str, tuple[str, dict]] = {}
+            for switch_ip, switch_id in self._switches_to_query().items():
+                for iface in self._managed_vpc_interfaces(switch_ip, switch_id, managed_types):
+                    name = iface.get("interfaceName")
+                    if name is None:
+                        continue
+                    existing = interfaces_by_name.get(name)
+                    if self._prefers_candidate(name, switch_id, switch_ip, existing, configured_ip_by_name):
+                        interfaces_by_name[name] = (switch_id, iface)
+            return [entry[1] for entry in interfaces_by_name.values()]
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e
+
+    @staticmethod
+    def _prefers_candidate(
+        name: str,
+        switch_id: str,
+        switch_ip: str,
+        existing: tuple[str, dict] | None,
+        configured_ip_by_name: dict[str, str],
+    ) -> bool:
+        """
+        # Summary
+
+        Decide whether a newly-seen per-peer copy of a vPC interface should replace the one already kept for `name`.
+        Prefer the peer whose `switch_ip` the user configured (idempotency); when neither peer is the configured one
+        (or the interface is not in config, e.g. an `overridden` deletion candidate), prefer the alphabetically-lower
+        `switch_id` for a stable representative.
+
+        ## Raises
+
+        None
+        """
+        if existing is None:
+            return True
+        configured_ip = configured_ip_by_name.get(name)
+        if configured_ip is not None:
+            if switch_ip == configured_ip:
+                return True
+            if existing[1].get("switchIp") == configured_ip:
+                return False
+        return switch_id < existing[0]

--- a/plugins/module_utils/orchestrators/vpc_trunk_host_interface.py
+++ b/plugins/module_utils/orchestrators/vpc_trunk_host_interface.py
@@ -1,0 +1,53 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+vPC trunkVpcHost interface orchestrator for Nexus Dashboard.
+
+This module provides `TrunkVpcHostInterfaceOrchestrator`, which manages CRUD operations for vPC
+`trunkVpcHost` interfaces. It inherits all shared vPC logic from `VpcInterfaceBaseOrchestrator` and only
+defines the model class and managed policy types.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import TrunkVpcHostPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import (
+    TrunkVpcHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import VpcInterfaceBaseOrchestrator
+
+
+class TrunkVpcHostInterfaceOrchestrator(VpcInterfaceBaseOrchestrator):
+    """
+    # Summary
+
+    Orchestrator for vPC `trunkVpcHost` interface CRUD operations on Nexus Dashboard.
+
+    Inherits all shared vPC logic from `VpcInterfaceBaseOrchestrator`. Defines `model_class` as
+    `TrunkVpcHostInterfaceModel` and manages the `trunkVpcHost` policy type.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via inherited methods. See `VpcInterfaceBaseOrchestrator` for full details.
+    """
+
+    model_class: ClassVar[type[NDBaseModel]] = TrunkVpcHostInterfaceModel
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator.
+
+        ## Raises
+
+        None
+        """
+        return {e.value for e in TrunkVpcHostPolicyTypeEnum}

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -232,7 +232,8 @@ extends_documentation_fragment:
 - cisco.nd.check_mode
 notes:
 - This module is only supported on Nexus Dashboard.
-- This module manages NX-OS port-channel accessPoHost interfaces only (interface_type C(portChannel), mode C(access), network_os_type C(nx-os), policy_type C(accessPoHost)). These values are hardcoded by the module and are not user-configurable.
+- This module manages NX-OS port-channel accessPoHost interfaces only (interface_type C(portChannel), mode C(access),
+  network_os_type C(nx-os), policy_type C(accessPoHost)). These values are hardcoded by the module and are not user-configurable.
 - The port-channel policy is the source of truth for member interface configuration.
 """
 

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_interface_port_channel_access
-version_added: "1.4.0"
+version_added: "2.0.0"
 short_description: Manage port-channel accessPoHost interfaces on Cisco Nexus Dashboard
 description:
 - Manage port-channel accessPoHost interfaces on Cisco Nexus Dashboard.

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -157,13 +157,6 @@ options:
                     description:
                     - The netflow Layer-2 sampler name for the port-channel.
                     type: str
-                  policy_type:
-                    description:
-                    - The policy template type for the port-channel.
-                    - V(access_po_host) is the standard accessPoHost policy.
-                    type: str
-                    choices: [ access_po_host ]
-                    default: access_po_host
                   port_channel_mode:
                     description:
                     - The port-channel mode.

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -1,0 +1,406 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_interface_port_channel_access
+version_added: "1.4.0"
+short_description: Manage port-channel accessPoHost interfaces on Cisco Nexus Dashboard
+description:
+- Manage port-channel accessPoHost interfaces on Cisco Nexus Dashboard.
+- It supports creating, updating, querying, and deleting accessPoHost port-channel configurations on switches within a fabric.
+- Each config item represents one port-channel interface. Member ethernet interfaces are listed in
+  O(config[].config_data.network_os.policy.ports) and inherit access-mode configuration from the port-channel policy.
+- Member interface field mutability is restricted while members of a port-channel; only description, admin_state, and
+  extra_config can be modified on members via the C(nd_interface_ethernet_access) module.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target switches.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of port-channel accessPoHost interfaces to configure.
+    - Each item specifies the target switch, the port-channel interface name, and its configuration.
+    - Multiple switches can be configured in a single task.
+    - The structure mirrors the ND Manage Interfaces API payload.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of the switch on which to manage the port-channel.
+        - This is resolved to the switch serial number (switchId) internally.
+        type: str
+        required: true
+      interface_name:
+        description:
+        - The port-channel interface name (e.g. C(port-channel501)).
+        type: str
+        required: true
+      interface_type:
+        description:
+        - The type of the interface.
+        - Defaults to C(portChannel) for this module.
+        type: str
+        default: portChannel
+      config_data:
+        description:
+        - The configuration data for the port-channel, following the ND API structure.
+        type: dict
+        suboptions:
+          mode:
+            description:
+            - The interface operational mode.
+            - Defaults to C(access) for this module. The ND API uses this as a discriminator
+              to select the access-mode port-channel configuration schema.
+            type: str
+            default: access
+          network_os:
+            description:
+            - Network OS specific configuration.
+            type: dict
+            suboptions:
+              network_os_type:
+                description:
+                - The network OS type of the switch.
+                type: str
+                default: nx-os
+              policy:
+                description:
+                - The policy configuration for the accessPoHost port-channel.
+                type: dict
+                suboptions:
+                  admin_state:
+                    description:
+                    - The administrative state of the port-channel.
+                    type: bool
+                  access_vlan:
+                    description:
+                    - The access VLAN for the port-channel.
+                    - Valid range is 1-4094.
+                    type: int
+                  bpdu_filter:
+                    description:
+                    - BPDU filter setting for the port-channel.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  bpdu_guard:
+                    description:
+                    - BPDU guard setting for the port-channel.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  cdp:
+                    description:
+                    - Whether Cisco Discovery Protocol is enabled on the port-channel.
+                    type: bool
+                  copy_description:
+                    description:
+                    - Whether to propagate the port-channel description to all member interfaces.
+                    type: bool
+                  description:
+                    description:
+                    - The description of the port-channel.
+                    - Maximum 254 characters.
+                    type: str
+                  duplex_mode:
+                    description:
+                    - The duplex mode of the port-channel.
+                    type: str
+                    choices: [ auto, full, half ]
+                  extra_config:
+                    description:
+                    - Additional CLI configuration commands to apply to the port-channel.
+                    type: str
+                  lacp_port_priority:
+                    description:
+                    - LACP port priority.
+                    - Valid range is 1-65535. Default 32768.
+                    type: int
+                  lacp_rate:
+                    description:
+                    - LACP rate (PDU transmit interval).
+                    - V(normal) = 30 seconds, V(fast) = 1 second.
+                    type: str
+                    choices: [ normal, fast ]
+                  lacp_suspend:
+                    description:
+                    - Whether to suspend the port if LACP PDUs are not received.
+                    type: bool
+                  monitor:
+                    description:
+                    - Whether the port-channel is configured as a SPAN/ERSPAN monitor source.
+                    type: bool
+                  mtu:
+                    description:
+                    - The MTU setting for the port-channel.
+                    type: str
+                    choices: [ default, jumbo ]
+                  netflow:
+                    description:
+                    - Whether netflow is enabled on the port-channel.
+                    type: bool
+                  netflow_monitor:
+                    description:
+                    - The netflow Layer-2 monitor name for the port-channel.
+                    type: str
+                  netflow_sampler:
+                    description:
+                    - The netflow Layer-2 sampler name for the port-channel.
+                    type: str
+                  policy_type:
+                    description:
+                    - The policy template type for the port-channel.
+                    - V(access_po_host) is the standard accessPoHost policy.
+                    type: str
+                    choices: [ access_po_host ]
+                    default: access_po_host
+                  port_channel_mode:
+                    description:
+                    - The port-channel mode.
+                    type: str
+                    choices: [ on, active, passive ]
+                  ports:
+                    description:
+                    - The list of member ethernet interface names for this port-channel.
+                    - Each name should be in the format C(Ethernet1/1), C(Ethernet1/2), etc.
+                    - The port-channel policy is the single source of truth for member configuration; member
+                      interfaces inherit access-mode settings from this policy.
+                    type: list
+                    elements: str
+                  qos:
+                    description:
+                    - Whether a QoS policy is applied to the port-channel.
+                    type: bool
+                  qos_policy:
+                    description:
+                    - Custom QoS policy name associated with the port-channel.
+                    type: str
+                  queuing_policy:
+                    description:
+                    - Custom queuing policy name associated with the port-channel.
+                    type: str
+                  speed:
+                    description:
+                    - The speed setting for the port-channel.
+                    type: str
+                    choices: [ auto, 10Mb, 100Mb, 1Gb, 2.5Gb, 5Gb, 10Gb, 25Gb, 40Gb, 50Gb, 100Gb, 200Gb, 400Gb, 800Gb ]
+                  storm_control:
+                    description:
+                    - Whether traffic storm control is enabled on the port-channel.
+                    type: bool
+                  storm_control_action:
+                    description:
+                    - Storm control action on threshold violation.
+                    type: str
+                    choices: [ shutdown, trap, default ]
+                  storm_control_broadcast_level:
+                    description:
+                    - Broadcast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_broadcast_level_pps:
+                    description:
+                    - Broadcast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_multicast_level:
+                    description:
+                    - Multicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_multicast_level_pps:
+                    description:
+                    - Multicast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_unicast_level:
+                    description:
+                    - Unicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_unicast_level_pps:
+                    description:
+                    - Unicast storm control level in packets per second (0-200000000).
+                    type: int
+  deploy:
+    description:
+    - Whether to deploy port-channel changes after mutations are complete.
+    - When V(true), all queued port-channel changes are deployed in a single bulk API call at the end of module
+      execution via the C(interfaceActions/deploy) API. Only the port-channels modified by this task are deployed.
+    - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+    - Setting O(deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+    type: bool
+    default: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the resources specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      The resources on ND will be modified to exactly match the configuration.
+      Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
+    - Use O(state=deleted) to remove the specified port-channels via the C(interfaceActions/remove) API.
+      Member ethernet interfaces are reverted to their fabric default configuration.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This module manages NX-OS port-channel accessPoHost interfaces only.
+- The port-channel policy is the source of truth for member interface configuration.
+"""
+
+EXAMPLES = r"""
+- name: Create an accessPoHost port-channel with two members
+  cisco.nd.nd_interface_port_channel_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 100
+              ports:
+                - Ethernet1/1
+                - Ethernet1/2
+              port_channel_mode: active
+              lacp_rate: fast
+              description: Server bundle
+    state: merged
+  register: result
+
+- name: Add a third member to an existing port-channel
+  cisco.nd.nd_interface_port_channel_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              ports:
+                - Ethernet1/1
+                - Ethernet1/2
+                - Ethernet1/3
+    state: merged
+
+- name: Delete a port-channel
+  cisco.nd.nd_interface_port_channel_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+    state: deleted
+
+- name: Stage port-channel changes without deploying
+  cisco.nd.nd_interface_port_channel_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 100
+              ports:
+                - Ethernet1/1
+    deploy: false
+    state: merged
+
+"""
+
+RETURN = r"""
+"""
+
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import (
+    PortChannelAccessInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_access_interface import (
+    PortChannelAccessInterfaceOrchestrator,
+)
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_interface_port_channel_access` Ansible module. Initializes the
+    `NDStateMachine` with `PortChannelAccessInterfaceOrchestrator` and executes the requested state operation.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(PortChannelAccessInterfaceModel.get_argument_spec())
+    argument_spec.update(
+        deploy=dict(type="bool", default=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_interface_port_channel_access")
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=PortChannelAccessInterfaceOrchestrator,
+        )
+        if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
+            raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        nd_state_machine.model_orchestrator.deploy = module.params["deploy"]
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            module.params["deploy"],
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.remove_pending()
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -379,6 +379,14 @@ def main():
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
 
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
 
 if __name__ == "__main__":
     main()

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -49,34 +49,16 @@ options:
         - The port-channel interface name (e.g. C(port-channel501)).
         type: str
         required: true
-      interface_type:
-        description:
-        - The type of the interface.
-        - Defaults to C(portChannel) for this module.
-        type: str
-        default: portChannel
       config_data:
         description:
         - The configuration data for the port-channel, following the ND API structure.
         type: dict
         suboptions:
-          mode:
-            description:
-            - The interface operational mode.
-            - Defaults to C(access) for this module. The ND API uses this as a discriminator
-              to select the access-mode port-channel configuration schema.
-            type: str
-            default: access
           network_os:
             description:
             - Network OS specific configuration.
             type: dict
             suboptions:
-              network_os_type:
-                description:
-                - The network OS type of the switch.
-                type: str
-                default: nx-os
               policy:
                 description:
                 - The policy configuration for the accessPoHost port-channel.
@@ -250,7 +232,7 @@ extends_documentation_fragment:
 - cisco.nd.check_mode
 notes:
 - This module is only supported on Nexus Dashboard.
-- This module manages NX-OS port-channel accessPoHost interfaces only.
+- This module manages NX-OS port-channel accessPoHost interfaces only (interface_type C(portChannel), mode C(access), network_os_type C(nx-os), policy_type C(accessPoHost)). These values are hardcoded by the module and are not user-configurable.
 - The port-channel policy is the source of truth for member interface configuration.
 """
 

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -145,7 +145,7 @@ options:
                     description:
                     - The port-channel mode.
                     type: str
-                    choices: [ on, active, passive ]
+                    choices: [ 'on', active, passive ]
                   ports:
                     description:
                     - The list of member ethernet interface names for this port-channel.

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -296,7 +296,6 @@ EXAMPLES = r"""
                 - Ethernet1/1
     deploy: false
     state: merged
-
 """
 
 RETURN = r"""

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -346,6 +346,90 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching interface configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: port-channel501
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          access_vlan: 100
+          ports:
+          - Ethernet1/1
+          - Ethernet1/2
+          port_channel_mode: active
+after:
+  description:
+  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: port-channel501
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          access_vlan: 200
+          ports:
+          - Ethernet1/1
+          - Ethernet1/2
+          port_channel_mode: active
+diff:
+  description: The per-interface difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: port-channel501
+    config_data:
+      network_os:
+        policy:
+          access_vlan: 200
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: port-channel501
+    config_data:
+      network_os:
+        policy:
+          access_vlan: 200
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing port-channel interface configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
 """
 
 # pylint: disable=wrong-import-position

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -204,15 +204,20 @@ options:
                     description:
                     - Unicast storm control level in packets per second (0-200000000).
                     type: int
-  deploy:
+  config_actions:
     description:
-    - Whether to deploy port-channel changes after mutations are complete.
-    - When V(true), all queued port-channel changes are deployed in a single bulk API call at the end of module
-      execution via the C(interfaceActions/deploy) API. Only the port-channels modified by this task are deployed.
-    - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
-    - Setting O(deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
-    type: bool
-    default: true
+    - Controls deploy behavior after port-channel mutations are complete.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether to deploy port-channel changes after mutations are complete.
+        - When V(true), all queued port-channel changes are deployed in a single bulk API call at the end of module
+          execution via the C(interfaceActions/deploy) API. Only the port-channels modified by this task are deployed.
+        - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        type: bool
+        default: true
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -294,8 +299,50 @@ EXAMPLES = r"""
               access_vlan: 100
               ports:
                 - Ethernet1/1
-    deploy: false
+    config_actions:
+      deploy: false
     state: merged
+
+# state=replaced reconciles ONLY the port-channels listed in config so that each
+# exactly matches the given policy. Port-channels not listed are left unchanged.
+# Here port-channel501 is reduced to a single member on access_vlan 200; any
+# previously configured members or settings not present below are removed from it.
+- name: Replace a single port-channel so its config exactly matches
+  cisco.nd.nd_interface_port_channel_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 200
+              ports:
+                - Ethernet1/1
+              port_channel_mode: active
+    state: replaced
+
+# WARNING: state=overridden is FABRIC-WIDE. Every accessPoHost port-channel on
+# ANY switch in my_fabric that is not listed in config below is DELETED (its
+# member interfaces revert to their fabric default configuration), and the
+# listed port-channels are reconciled to exactly match. Use with extra caution.
+- name: Enforce config as the single source of truth for all accessPoHost port-channels in the fabric
+  cisco.nd.nd_interface_port_channel_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 100
+              ports:
+                - Ethernet1/1
+                - Ethernet1/2
+              port_channel_mode: active
+    state: overridden
 """
 
 RETURN = r"""
@@ -334,7 +381,12 @@ def main():
     argument_spec = nd_argument_spec()
     argument_spec.update(PortChannelAccessInterfaceModel.get_argument_spec())
     argument_spec.update(
-        deploy={"type": "bool", "default": True},
+        config_actions={
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
     )
 
     module = AnsibleModule(
@@ -354,13 +406,15 @@ def main():
         )
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
-        nd_state_machine.model_orchestrator.deploy = module.params["deploy"]
+        config_actions = module.params.get("config_actions") or {}
+        deploy = config_actions.get("deploy", True)
+        nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(
             "manage_state begin state=%s check_mode=%s deploy=%s",
             module.params.get("state"),
             module.check_mode,
-            module.params["deploy"],
+            deploy,
         )
         nd_state_machine.manage_state()
         module_log.debug("manage_state end")

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -4,6 +4,8 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+"""Ansible module for managing port-channel accessPoHost interfaces on Cisco Nexus Dashboard."""
+
 ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
 
 DOCUMENTATION = r"""
@@ -317,6 +319,7 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
+# pylint: disable=wrong-import-position
 import logging
 import traceback
 
@@ -349,7 +352,7 @@ def main():
     argument_spec = nd_argument_spec()
     argument_spec.update(PortChannelAccessInterfaceModel.get_argument_spec())
     argument_spec.update(
-        deploy=dict(type="bool", default=True),
+        deploy={"type": "bool", "default": True},
     )
 
     module = AnsibleModule(

--- a/plugins/modules/nd_interface_port_channel_trunk_host.py
+++ b/plugins/modules/nd_interface_port_channel_trunk_host.py
@@ -1,0 +1,617 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Ansible module for managing port-channel (trunkPoHost) interfaces on Cisco Nexus Dashboard."""
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_interface_port_channel_trunk_host
+version_added: "2.0.0"
+short_description: Manage port-channel (trunkPoHost) interfaces on Cisco Nexus Dashboard
+description:
+- Manage port-channel (trunkPoHost) interfaces on Cisco Nexus Dashboard.
+- It supports creating, updating, and deleting (trunkPoHost) port-channel configurations on switches within a fabric.
+- Each config item represents one port-channel interface. Member ethernet interfaces are listed in
+  O(config[].config_data.network_os.policy.ports) and inherit trunk-mode configuration from the port-channel policy.
+- Member interface field mutability is restricted while members of a port-channel; only description, admin_state, and
+  extra_config can be modified on members via the C(nd_interface_ethernet_trunk_host) module.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target switches.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of port-channel trunkPoHost interfaces to configure.
+    - Each item specifies the target switch, the port-channel interface name, and its configuration.
+    - Multiple switches can be configured in a single task.
+    - The structure mirrors the ND Manage Interfaces API payload.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of the switch on which to manage the port-channel.
+        - This is resolved to the switch serial number (switchId) internally.
+        type: str
+        required: true
+      interface_name:
+        description:
+        - The port-channel interface name (e.g. C(port-channel501)).
+        type: str
+        required: true
+      config_data:
+        description:
+        - The configuration data for the port-channel, following the ND API structure.
+        type: dict
+        suboptions:
+          network_os:
+            description:
+            - Network OS specific configuration.
+            type: dict
+            suboptions:
+              policy:
+                description:
+                - The policy configuration for the trunkPoHost port-channel.
+                type: dict
+                suboptions:
+                  admin_state:
+                    description:
+                    - The administrative state of the port-channel.
+                    type: bool
+                  allowed_vlans:
+                    description:
+                    - Trunk allowed VLANs.
+                    - Accepts V(none), V(all), or a comma-separated list of VLAN ids/ranges (e.g. V(100-200,300)).
+                    - VLAN ids must be in the range 1-4094.
+                    type: str
+                  bandwidth:
+                    description:
+                    - Interface bandwidth in kilobits per second.
+                    - Valid range is 1-100000000.
+                    type: int
+                  bpdu_filter:
+                    description:
+                    - BPDU filter setting for the port-channel.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  bpdu_guard:
+                    description:
+                    - BPDU guard setting for the port-channel.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  cdp:
+                    description:
+                    - Whether Cisco Discovery Protocol is enabled on the port-channel.
+                    type: bool
+                  copy_description:
+                    description:
+                    - Whether to propagate the port-channel description to all member interfaces.
+                    type: bool
+                  description:
+                    description:
+                    - The description of the port-channel.
+                    - Maximum 254 characters.
+                    type: str
+                  duplex_mode:
+                    description:
+                    - The duplex mode of the port-channel.
+                    type: str
+                    choices: [ auto, full, half ]
+                  extra_config:
+                    description:
+                    - Additional CLI configuration commands to apply to the port-channel.
+                    type: str
+                  inherit_bandwidth:
+                    description:
+                    - Inherited interface bandwidth in kilobits per second.
+                    - Valid range is 1-100000000.
+                    type: int
+                  lacp_port_priority:
+                    description:
+                    - LACP port priority.
+                    - Valid range is 1-65535. Default 32768.
+                    type: int
+                  lacp_rate:
+                    description:
+                    - LACP rate (PDU transmit interval).
+                    - V(normal) = 30 seconds, V(fast) = 1 second.
+                    type: str
+                    choices: [ normal, fast ]
+                  lacp_suspend:
+                    description:
+                    - Whether to suspend the port if LACP PDUs are not received.
+                    type: bool
+                  link_type:
+                    description:
+                    - Spanning-tree link type for the port-channel.
+                    type: str
+                    choices: [ auto, pointToPoint, shared ]
+                  monitor:
+                    description:
+                    - Whether the port-channel is configured as a SPAN/ERSPAN monitor source.
+                    type: bool
+                  mtu:
+                    description:
+                    - The MTU setting for the port-channel.
+                    type: str
+                    choices: [ default, jumbo ]
+                  native_vlan:
+                    description:
+                    - Trunk native VLAN id.
+                    - Valid range is 1-4094.
+                    type: int
+                  negotiate_auto:
+                    description:
+                    - Whether link auto-negotiation is enabled.
+                    type: bool
+                  netflow:
+                    description:
+                    - Whether netflow is enabled on the port-channel.
+                    type: bool
+                  netflow_monitor:
+                    description:
+                    - The netflow Layer-2 monitor name for the port-channel.
+                    type: str
+                  netflow_sampler:
+                    description:
+                    - The netflow Layer-2 sampler name for the port-channel.
+                    type: str
+                  orphan_port:
+                    description:
+                    - Configure the port-channel as a vPC orphan port.
+                    - When V(true), the port is suspended by the secondary peer on vPC failure.
+                    type: bool
+                  pfc:
+                    description:
+                    - Whether Priority Flow Control is enabled on the port-channel.
+                    type: bool
+                  port_channel_mode:
+                    description:
+                    - The port-channel mode.
+                    type: str
+                    choices: [ 'on', active, passive ]
+                  port_type_edge_trunk:
+                    description:
+                    - Configure the port-channel as an edge trunk port (PortFast on trunk).
+                    type: bool
+                  ports:
+                    description:
+                    - The list of member ethernet interface names for this port-channel.
+                    - Each name should be in the format C(Ethernet1/1), C(Ethernet1/2), etc.
+                    - The port-channel policy is the single source of truth for member configuration; member
+                      interfaces inherit trunk-mode settings from this policy.
+                    type: list
+                    elements: str
+                  ptp:
+                    description:
+                    - Whether Precision Time Protocol is enabled on the port-channel.
+                    type: bool
+                  qos:
+                    description:
+                    - Whether a QoS policy is applied to the port-channel.
+                    type: bool
+                  qos_policy:
+                    description:
+                    - Custom QoS policy name associated with the port-channel.
+                    type: str
+                  queuing_policy:
+                    description:
+                    - Custom queuing policy name associated with the port-channel.
+                    type: str
+                  speed:
+                    description:
+                    - The speed setting for the port-channel.
+                    type: str
+                    choices: [ auto, 10Mb, 100Mb, 1Gb, 2.5Gb, 5Gb, 10Gb, 25Gb, 40Gb, 50Gb, 100Gb, 200Gb, 400Gb, 800Gb ]
+                  storm_control:
+                    description:
+                    - Whether traffic storm control is enabled on the port-channel.
+                    type: bool
+                  storm_control_action:
+                    description:
+                    - Storm control action on threshold violation.
+                    type: str
+                    choices: [ shutdown, trap, default ]
+                  storm_control_broadcast_level:
+                    description:
+                    - Broadcast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_broadcast_level_pps:
+                    description:
+                    - Broadcast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_multicast_level:
+                    description:
+                    - Multicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_multicast_level_pps:
+                    description:
+                    - Multicast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_unicast_level:
+                    description:
+                    - Unicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_unicast_level_pps:
+                    description:
+                    - Unicast storm control level in packets per second (0-200000000).
+                    type: int
+                  vlan_mapping:
+                    description:
+                    - Whether VLAN mapping is enabled on the trunk.
+                    - Use with O(config[].config_data.network_os.policy.vlan_mapping_entries) to translate customer VLAN ids to provider VLAN ids.
+                    - Note that virtual switches (e.g. N9K-C9300v) may reject VLAN mapping with selective dot1q-tunnel.
+                    type: bool
+                  vlan_mapping_entries:
+                    description:
+                    - VLAN mapping entries. Used when O(config[].config_data.network_os.policy.vlan_mapping=true).
+                    type: list
+                    elements: dict
+                    suboptions:
+                      customer_inner_vlan_id:
+                        description:
+                        - Inner customer VLAN id (selective dot1q-tunnel only).
+                        - Valid range is 1-4094.
+                        type: int
+                      customer_vlan_id:
+                        description:
+                        - Customer VLAN id list (single id or range strings, e.g. V(["100", "200-300"])).
+                        - VLAN ids must be in the range 1-4094.
+                        type: list
+                        elements: str
+                      dot1q_tunnel:
+                        description:
+                        - Use selective dot1q-tunnel mode for this entry.
+                        type: bool
+                      provider_vlan_id:
+                        description:
+                        - Provider VLAN id.
+                        - Valid range is 1-4094.
+                        type: int
+  config_actions:
+    description:
+    - Controls deploy behavior after interface mutations are complete.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether to deploy port-channel changes after mutations are complete.
+        - When V(true), all queued port-channel changes are deployed in a single bulk API call at the end of module
+          execution via the C(interfaceActions/deploy) API. Only the port-channels modified by this task are deployed.
+        - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        type: bool
+        default: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the resources specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      The resources on ND will be modified to exactly match the configuration.
+      Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
+    - Use O(state=deleted) to remove the specified port-channels via the C(interfaceActions/remove) API.
+      Member ethernet interfaces are reverted to their fabric default configuration.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This module manages NX-OS port-channel trunkPoHost interfaces only (interface_type C(portChannel), mode C(trunk),
+  network_os_type C(nx-os), policy_type C(trunkPoHost)). These values are hardcoded by the module and are not user-configurable.
+- The port-channel policy is the source of truth for member interface configuration.
+"""
+
+EXAMPLES = r"""
+- name: Create a trunkPoHost port-channel with two members
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "100-200"
+              native_vlan: 99
+              ports:
+                - Ethernet1/1
+                - Ethernet1/2
+              port_channel_mode: active
+              lacp_rate: fast
+              description: Server trunk bundle
+    state: merged
+  register: result
+
+- name: Add a third member and update allowed VLANs
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              allowed_vlans: "100-200,300"
+              ports:
+                - Ethernet1/1
+                - Ethernet1/2
+                - Ethernet1/3
+    state: merged
+
+- name: Configure VLAN mapping with selective dot1q-tunnel
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              vlan_mapping: true
+              vlan_mapping_entries:
+                - customer_vlan_id: ["100"]
+                  provider_vlan_id: 200
+                  dot1q_tunnel: true
+    state: merged
+
+- name: Replace a port-channel configuration
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "all"
+              ports:
+                - Ethernet1/1
+              port_channel_mode: active
+              description: Replaced port-channel configuration
+    state: replaced
+
+- name: Override all port-channels in the fabric to match this configuration
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "100-200"
+              ports:
+                - Ethernet1/1
+                - Ethernet1/2
+              port_channel_mode: active
+    state: overridden
+
+- name: Delete a port-channel
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+    state: deleted
+
+- name: Stage port-channel changes without deploying
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "all"
+              ports:
+                - Ethernet1/1
+    config_actions:
+      deploy: false
+    state: merged
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching interface configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: port-channel501
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          allowed_vlans: "100-200"
+          native_vlan: 99
+          ports:
+          - Ethernet1/1
+          - Ethernet1/2
+          port_channel_mode: active
+after:
+  description:
+  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: port-channel501
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          allowed_vlans: "100-300"
+          native_vlan: 99
+          ports:
+          - Ethernet1/1
+          - Ethernet1/2
+          port_channel_mode: active
+diff:
+  description: The per-interface difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: port-channel501
+    config_data:
+      network_os:
+        policy:
+          allowed_vlans: "100-300"
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: port-channel501
+    config_data:
+      network_os:
+        policy:
+          allowed_vlans: "100-300"
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing port-channel interface configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
+"""
+
+# pylint: disable=wrong-import-position
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostInterfaceOrchestrator,
+)
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_interface_port_channel_trunk_host` Ansible module. Initializes the
+    `NDStateMachine` with `PortChannelTrunkHostInterfaceOrchestrator` and executes the requested state operation.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(PortChannelTrunkHostInterfaceModel.get_argument_spec())
+    argument_spec.update(
+        config_actions={
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_interface_port_channel_trunk_host")
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=PortChannelTrunkHostInterfaceOrchestrator,
+        )
+        if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
+            raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        config_actions = module.params.get("config_actions") or {}
+        deploy = config_actions.get("deploy", True)
+        nd_state_machine.model_orchestrator.deploy = deploy
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            deploy,
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.remove_pending()
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -1,0 +1,605 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Ansible module for managing vPC accessVpcHost interfaces on Cisco Nexus Dashboard."""
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_interface_vpc_access
+version_added: "2.0.0"
+short_description: Manage vPC accessVpcHost interfaces on Cisco Nexus Dashboard
+description:
+- Manage vPC accessVpcHost interfaces on Cisco Nexus Dashboard.
+- It supports creating, updating, and deleting accessVpcHost vPC configurations on switches within a fabric.
+- Each config item represents one vPC interface that spans the two switches in a vPC pair.
+- The user supplies one peer's management IP as O(config[].switch_ip); the module reads the vPC pair record to
+  auto-resolve the second peer's serial and injects it as C(peerSwitchId) in the payload.
+- Per-peer policy fields use the API-native C(peer1_*) / C(peer2_*) naming, where C(peer1) corresponds to the
+  switch supplied in O(config[].switch_ip) and C(peer2) corresponds to the auto-resolved peer.
+- The switch supplied in O(config[].switch_ip) must already be in a vPC pair (created via M(cisco.nd.nd_manage_vpc_pair))
+  before this module can manage interfaces on it.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target vPC pair.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of vPC accessVpcHost interfaces to configure.
+    - Each item specifies the primary switch, the vPC interface name, and its configuration.
+    - Multiple vPC pairs can be configured in a single task.
+    - The structure mirrors the ND Manage Interfaces API payload.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of one peer in the vPC pair (typically the primary).
+        - This is resolved to the switch serial number (switchId) internally; the peer's serial is auto-resolved
+          via the vPC pair record.
+        type: str
+        required: true
+      interface_name:
+        description:
+        - The vPC interface name (e.g. C(vpc100)).
+        type: str
+        required: true
+      config_data:
+        description:
+        - The configuration data for the vPC interface, following the ND API structure.
+        type: dict
+        suboptions:
+          network_os:
+            description:
+            - Network OS specific configuration.
+            type: dict
+            suboptions:
+              policy:
+                description:
+                - The policy configuration for the accessVpcHost vPC interface.
+                type: dict
+                suboptions:
+                  admin_state:
+                    description:
+                    - The administrative state of the vPC interface.
+                    type: bool
+                  bandwidth:
+                    description:
+                    - Configured bandwidth value for the interface.
+                    - Valid range is 1-100000000.
+                    type: int
+                  bpdu_filter:
+                    description:
+                    - BPDU filter setting for the vPC interface.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  bpdu_guard:
+                    description:
+                    - BPDU guard setting for the vPC interface.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  cdp:
+                    description:
+                    - Whether Cisco Discovery Protocol is enabled on the vPC interface.
+                    type: bool
+                  copy_description:
+                    description:
+                    - Whether to propagate the per-peer port-channel description to all member interfaces.
+                    type: bool
+                  duplex_mode:
+                    description:
+                    - The duplex mode of the vPC interface.
+                    type: str
+                    choices: [ auto, full, half ]
+                  inherit_bandwidth:
+                    description:
+                    - Bandwidth value inherited by sub-interfaces.
+                    - Valid range is 1-100000000.
+                    type: int
+                  lacp_port_priority:
+                    description:
+                    - LACP port priority.
+                    - Valid range is 1-65535. Default 32768.
+                    type: int
+                  lacp_rate:
+                    description:
+                    - LACP rate (PDU transmit interval).
+                    - V(normal) = 30 seconds, V(fast) = 1 second.
+                    type: str
+                    choices: [ normal, fast ]
+                  lacp_suspend:
+                    description:
+                    - If disabled, LACP puts the port in individual state instead of suspending when LACP BPDUs are
+                      not received.
+                    type: bool
+                  lacp_vpc_convergence:
+                    description:
+                    - Enable LACP convergence for vPC port-channels.
+                    type: bool
+                  link_type:
+                    description:
+                    - Spanning-tree link type.
+                    type: str
+                    choices: [ auto, pointToPoint, shared ]
+                  mirror_config:
+                    description:
+                    - Copy Peer-1 configuration to Peer-2.
+                    type: bool
+                  mtu:
+                    description:
+                    - Interface MTU.
+                    type: str
+                    choices: [ default, jumbo ]
+                  negotiate_auto:
+                    description:
+                    - Enable link auto-negotiation.
+                    type: bool
+                  netflow:
+                    description:
+                    - Enable Netflow on the vPC interface.
+                    type: bool
+                  netflow_monitor:
+                    description:
+                    - Layer 2 Netflow monitor name.
+                    type: str
+                  netflow_sampler:
+                    description:
+                    - Netflow sampler name (N7K only).
+                    type: str
+                  access_vlan:
+                    description:
+                    - Access VLAN for the vPC. Applied identically on both peers.
+                    - ND collapses the OpenAPI per-peer C(peer1AccessVlan)/C(peer2AccessVlan) into a single
+                      C(accessVlan) value on the wire; this module splits the single value back to both per-peer
+                      keys when writing.
+                    - Valid range is 1-4094.
+                    type: int
+                  peer1_member_ports:
+                    description:
+                    - Member interface names on Peer-1 (e.g. C(Ethernet1/1)).
+                    type: list
+                    elements: str
+                  peer1_port_channel_configuration:
+                    description:
+                    - Additional CLI configuration commands for Peer-1's port-channel.
+                    type: str
+                  peer1_port_channel_description:
+                    description:
+                    - Description for Peer-1's port-channel.
+                    - Maximum 254 characters.
+                    type: str
+                  peer1_port_channel_id:
+                    description:
+                    - Peer-1 vPC port-channel number.
+                    - Valid range is 1-4096.
+                    type: int
+                  peer2_member_ports:
+                    description:
+                    - Member interface names on Peer-2 (e.g. C(Ethernet1/1)).
+                    type: list
+                    elements: str
+                  peer2_port_channel_configuration:
+                    description:
+                    - Additional CLI configuration commands for Peer-2's port-channel.
+                    type: str
+                  peer2_port_channel_description:
+                    description:
+                    - Description for Peer-2's port-channel.
+                    - Maximum 254 characters.
+                    type: str
+                  peer2_port_channel_id:
+                    description:
+                    - Peer-2 vPC port-channel number.
+                    - Valid range is 1-4096.
+                    type: int
+                  pfc:
+                    description:
+                    - Enable priority flow control.
+                    type: bool
+                  port_channel_mode:
+                    description:
+                    - Port-channel mode.
+                    type: str
+                    choices: [ 'on', active, passive ]
+                  port_type_edge_trunk:
+                    description:
+                    - Enable spanning-tree edge port (PortFast) behavior.
+                    type: bool
+                  qos:
+                    description:
+                    - Enable QoS configuration for the vPC interface.
+                    type: bool
+                  qos_policy:
+                    description:
+                    - Custom QoS policy name.
+                    type: str
+                  queuing_policy:
+                    description:
+                    - Custom queuing policy name.
+                    type: str
+                  speed:
+                    description:
+                    - Interface speed.
+                    type: str
+                    choices: [ auto, 10Mb, 100Mb, 1Gb, 2.5Gb, 5Gb, 10Gb, 25Gb, 40Gb, 50Gb, 100Gb, 200Gb, 400Gb, 800Gb ]
+                  storm_control:
+                    description:
+                    - Enable traffic storm control on the vPC interface.
+                    type: bool
+                  storm_control_action:
+                    description:
+                    - Storm control action on threshold violation.
+                    type: str
+                    choices: [ shutdown, trap, default ]
+                  storm_control_broadcast_level:
+                    description:
+                    - Broadcast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_broadcast_level_pps:
+                    description:
+                    - Broadcast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_multicast_level:
+                    description:
+                    - Multicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_multicast_level_pps:
+                    description:
+                    - Multicast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_unicast_level:
+                    description:
+                    - Unicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_unicast_level_pps:
+                    description:
+                    - Unicast storm control level in packets per second (0-200000000).
+                    type: int
+  config_actions:
+    description:
+    - Controls deploy behavior after interface mutations are complete.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether to deploy vPC interface changes after mutations are complete.
+        - When V(true), all queued vPC interface changes are deployed in a single bulk API call at the end of module
+          execution via the C(interfaceActions/deploy) API. Only the vPC interfaces modified by this task are deployed.
+        - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        type: bool
+        default: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the resources specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      The resources on ND will be modified to exactly match the configuration.
+      Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
+    - Use O(state=deleted) to remove the specified vPC interfaces via a per-interface C(DELETE) request to the
+      interfaces endpoint. Member ethernet interfaces on both peers are reverted to their fabric default configuration.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This module manages NX-OS vPC accessVpcHost interfaces only (interface_type C(vpc), mode C(access),
+  network_os_type C(nx-os), policy_type C(accessVpcHost)). These values are hardcoded by the module and are
+  not user-configurable.
+- The primary switch supplied in O(config[].switch_ip) must already be in a vPC pair (managed by
+  M(cisco.nd.nd_manage_vpc_pair)). The peer serial is auto-resolved from the pair record.
+- C(peer1) refers to the switch supplied in O(config[].switch_ip); C(peer2) refers to the auto-resolved peer.
+"""
+
+EXAMPLES = r"""
+- name: Create an accessVpcHost vPC with one member on each peer
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 10
+              peer1_port_channel_id: 100
+              peer1_member_ports:
+                - Ethernet1/1
+              peer2_port_channel_id: 100
+              peer2_member_ports:
+                - Ethernet1/1
+              port_channel_mode: active
+              lacp_rate: fast
+              peer1_port_channel_description: Server-A on peer1
+              peer2_port_channel_description: Server-A on peer2
+    state: merged
+  register: result
+
+- name: Update member ports on Peer-1 only
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              peer1_member_ports:
+                - Ethernet1/1
+                - Ethernet1/2
+    state: merged
+
+- name: Replace the configuration of a specific vPC interface
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 20
+              peer1_port_channel_id: 100
+              peer1_member_ports:
+                - Ethernet1/3
+              peer2_port_channel_id: 100
+              peer2_member_ports:
+                - Ethernet1/3
+              port_channel_mode: active
+              peer1_port_channel_description: Reprovisioned Server-A on peer1
+              peer2_port_channel_description: Reprovisioned Server-A on peer2
+    state: replaced
+
+# state=overridden is fabric-wide: every vPC interface in the fabric that is managed by this module and is NOT
+# listed below is deleted. An empty config list deletes ALL such vPC interfaces in the fabric. Use with caution.
+- name: Enforce vPC interfaces fabric-wide, deleting all others managed by this module
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 10
+              peer1_port_channel_id: 100
+              peer1_member_ports:
+                - Ethernet1/1
+              peer2_port_channel_id: 100
+              peer2_member_ports:
+                - Ethernet1/1
+              port_channel_mode: active
+    state: overridden
+
+- name: Delete a vPC interface
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+    state: deleted
+
+- name: Stage vPC interface changes without deploying
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 10
+              peer1_port_channel_id: 100
+              peer2_port_channel_id: 100
+    config_actions:
+      deploy: false
+    state: merged
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching interface configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc100
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          access_vlan: 10
+          peer1_port_channel_id: 100
+          peer1_member_ports:
+          - Ethernet1/1
+          peer2_port_channel_id: 100
+          peer2_member_ports:
+          - Ethernet1/1
+          port_channel_mode: active
+after:
+  description:
+  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc100
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          access_vlan: 20
+          peer1_port_channel_id: 100
+          peer1_member_ports:
+          - Ethernet1/1
+          peer2_port_channel_id: 100
+          peer2_member_ports:
+          - Ethernet1/1
+          port_channel_mode: active
+diff:
+  description: The per-interface difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc100
+    config_data:
+      network_os:
+        policy:
+          access_vlan: 20
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc100
+    config_data:
+      network_os:
+        policy:
+          access_vlan: 20
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing vPC interface configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
+"""
+
+# pylint: disable=wrong-import-position
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+    AccessVpcHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_access_interface import (
+    AccessVpcHostInterfaceOrchestrator,
+)
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_interface_vpc_access` Ansible module. Initializes the
+    `NDStateMachine` with `AccessVpcHostInterfaceOrchestrator` and executes the requested state operation.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(AccessVpcHostInterfaceModel.get_argument_spec())
+    argument_spec.update(
+        config_actions={
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_interface_vpc_access")
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=AccessVpcHostInterfaceOrchestrator,
+        )
+        if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
+            raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        config_actions = module.params.get("config_actions") or {}
+        deploy = config_actions.get("deploy", True)
+        nd_state_machine.model_orchestrator.deploy = deploy
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            deploy,
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.remove_pending()
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_interface_vpc_trunk_host.py
+++ b/plugins/modules/nd_interface_vpc_trunk_host.py
@@ -1,0 +1,671 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Ansible module for managing vPC trunkVpcHost interfaces on Cisco Nexus Dashboard."""
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_interface_vpc_trunk_host
+version_added: "2.0.0"
+short_description: Manage vPC trunkVpcHost interfaces on Cisco Nexus Dashboard
+description:
+- Manage vPC trunkVpcHost interfaces on Cisco Nexus Dashboard.
+- It supports creating, updating, and deleting trunkVpcHost vPC configurations on switches within a fabric.
+- Each config item represents one vPC interface that spans the two switches in a vPC pair.
+- The user supplies one peer's management IP as O(config[].switch_ip); the module reads the vPC pair record to
+  auto-resolve the second peer's serial and injects it as C(peerSwitchId) in the payload.
+- Per-peer policy fields use the API-native C(peer1_*) / C(peer2_*) naming, where C(peer1) corresponds to the
+  switch supplied in O(config[].switch_ip) and C(peer2) corresponds to the auto-resolved peer.
+- The switch supplied in O(config[].switch_ip) must already be in a vPC pair (created via M(cisco.nd.nd_manage_vpc_pair))
+  before this module can manage interfaces on it.
+- The trunk VLAN fields O(config[].config_data.network_os.policy.allowed_vlans) and
+  O(config[].config_data.network_os.policy.native_vlan) are single user-facing values. ND requires per-peer
+  C(peer1AllowedVlans)/C(peer2AllowedVlans) and C(peer1NativeVlan)/C(peer2NativeVlan) on the wire but enforces
+  consistency between the two peers (divergent values return HTTP 400) and collapses them back to a single value
+  in the GET response. The module fans out the single values to both per-peer keys on write.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target vPC pair.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of vPC trunkVpcHost interfaces to configure.
+    - Each item specifies the primary switch, the vPC interface name, and its configuration.
+    - Multiple vPC pairs can be configured in a single task.
+    - The structure mirrors the ND Manage Interfaces API payload.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of one peer in the vPC pair (typically the primary).
+        - This is resolved to the switch serial number (switchId) internally; the peer's serial is auto-resolved
+          via the vPC pair record.
+        type: str
+        required: true
+      interface_name:
+        description:
+        - The vPC interface name (e.g. C(vpc100)).
+        type: str
+        required: true
+      config_data:
+        description:
+        - The configuration data for the vPC interface, following the ND API structure.
+        type: dict
+        suboptions:
+          network_os:
+            description:
+            - Network OS specific configuration.
+            type: dict
+            suboptions:
+              policy:
+                description:
+                - The policy configuration for the trunkVpcHost vPC interface.
+                type: dict
+                suboptions:
+                  admin_state:
+                    description:
+                    - The administrative state of the vPC interface.
+                    type: bool
+                  allowed_vlans:
+                    description:
+                    - Trunk allowed VLANs on both peers.
+                    - One of V(none), V(all), or a comma-separated list of VLAN ids/ranges in the 1-4094 range
+                      (e.g. V(100-200,300)).
+                    - ND requires per-peer C(peer1AllowedVlans)/C(peer2AllowedVlans) on the wire but enforces
+                      consistency between them and collapses them to a single C(allowedVlans) in the GET response.
+                      The module fans out the single value to both per-peer keys on write.
+                    type: str
+                  bandwidth:
+                    description:
+                    - Configured bandwidth value for the interface.
+                    - Valid range is 1-100000000.
+                    type: int
+                  bpdu_filter:
+                    description:
+                    - BPDU filter setting for the vPC interface.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  bpdu_guard:
+                    description:
+                    - BPDU guard setting for the vPC interface.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  cdp:
+                    description:
+                    - Whether Cisco Discovery Protocol is enabled on the vPC interface.
+                    type: bool
+                  copy_description:
+                    description:
+                    - Whether to propagate the per-peer port-channel description to all member interfaces.
+                    type: bool
+                  duplex_mode:
+                    description:
+                    - The duplex mode of the vPC interface.
+                    type: str
+                    choices: [ auto, full, half ]
+                  inherit_bandwidth:
+                    description:
+                    - Bandwidth value inherited by sub-interfaces.
+                    - Valid range is 1-100000000.
+                    type: int
+                  lacp_port_priority:
+                    description:
+                    - LACP port priority.
+                    - Valid range is 1-65535. Default 32768.
+                    type: int
+                  lacp_rate:
+                    description:
+                    - LACP rate (PDU transmit interval).
+                    - V(normal) = 30 seconds, V(fast) = 1 second.
+                    type: str
+                    choices: [ normal, fast ]
+                  lacp_suspend:
+                    description:
+                    - If disabled, LACP puts the port in individual state instead of suspending when LACP BPDUs are
+                      not received.
+                    type: bool
+                  lacp_vpc_convergence:
+                    description:
+                    - Enable LACP convergence for vPC port-channels.
+                    type: bool
+                  link_type:
+                    description:
+                    - Spanning-tree link type.
+                    type: str
+                    choices: [ auto, pointToPoint, shared ]
+                  mirror_config:
+                    description:
+                    - Copy Peer-1 configuration to Peer-2.
+                    type: bool
+                  mtu:
+                    description:
+                    - Interface MTU.
+                    type: str
+                    choices: [ default, jumbo ]
+                  native_vlan:
+                    description:
+                    - Trunk native VLAN id on both peers.
+                    - Valid range is 1-4094.
+                    - ND requires per-peer C(peer1NativeVlan)/C(peer2NativeVlan) on the wire but enforces consistency
+                      and collapses them to a single C(nativeVlan) in the GET response. The module fans out the
+                      single value to both per-peer keys on write.
+                    type: int
+                  negotiate_auto:
+                    description:
+                    - Enable link auto-negotiation.
+                    type: bool
+                  netflow:
+                    description:
+                    - Enable Netflow on the vPC interface.
+                    type: bool
+                  netflow_monitor:
+                    description:
+                    - Layer 2 Netflow monitor name.
+                    type: str
+                  netflow_sampler:
+                    description:
+                    - Netflow sampler name (N7K only).
+                    type: str
+                  peer1_member_ports:
+                    description:
+                    - Member interface names on Peer-1 (e.g. C(Ethernet1/1)).
+                    type: list
+                    elements: str
+                  peer1_port_channel_configuration:
+                    description:
+                    - Additional CLI configuration commands for Peer-1's port-channel.
+                    type: str
+                  peer1_port_channel_description:
+                    description:
+                    - Description for Peer-1's port-channel.
+                    - Maximum 254 characters.
+                    type: str
+                  peer1_port_channel_id:
+                    description:
+                    - Peer-1 vPC port-channel number.
+                    - Valid range is 1-4096.
+                    type: int
+                  peer2_member_ports:
+                    description:
+                    - Member interface names on Peer-2 (e.g. C(Ethernet1/1)).
+                    type: list
+                    elements: str
+                  peer2_port_channel_configuration:
+                    description:
+                    - Additional CLI configuration commands for Peer-2's port-channel.
+                    type: str
+                  peer2_port_channel_description:
+                    description:
+                    - Description for Peer-2's port-channel.
+                    - Maximum 254 characters.
+                    type: str
+                  peer2_port_channel_id:
+                    description:
+                    - Peer-2 vPC port-channel number.
+                    - Valid range is 1-4096.
+                    type: int
+                  pfc:
+                    description:
+                    - Enable priority flow control.
+                    type: bool
+                  port_channel_mode:
+                    description:
+                    - Port-channel mode.
+                    type: str
+                    choices: [ 'on', active, passive ]
+                  port_type_edge_trunk:
+                    description:
+                    - Enable spanning-tree edge port (PortFast) behavior on trunk.
+                    type: bool
+                  qos:
+                    description:
+                    - Enable QoS configuration for the vPC interface.
+                    type: bool
+                  qos_policy:
+                    description:
+                    - Custom QoS policy name.
+                    type: str
+                  queuing_policy:
+                    description:
+                    - Custom queuing policy name.
+                    type: str
+                  speed:
+                    description:
+                    - Interface speed.
+                    type: str
+                    choices: [ auto, 10Mb, 100Mb, 1Gb, 2.5Gb, 5Gb, 10Gb, 25Gb, 40Gb, 50Gb, 100Gb, 200Gb, 400Gb, 800Gb ]
+                  storm_control:
+                    description:
+                    - Enable traffic storm control on the vPC interface.
+                    type: bool
+                  storm_control_action:
+                    description:
+                    - Storm control action on threshold violation.
+                    type: str
+                    choices: [ shutdown, trap, default ]
+                  storm_control_broadcast_level:
+                    description:
+                    - Broadcast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_broadcast_level_pps:
+                    description:
+                    - Broadcast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_multicast_level:
+                    description:
+                    - Multicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_multicast_level_pps:
+                    description:
+                    - Multicast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_unicast_level:
+                    description:
+                    - Unicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_unicast_level_pps:
+                    description:
+                    - Unicast storm control level in packets per second (0-200000000).
+                    type: int
+                  vlan_mapping:
+                    description:
+                    - Enable VLAN mapping on the trunk.
+                    type: bool
+                  vlan_mapping_entries:
+                    description:
+                    - VLAN mapping entries (used when O(config[].config_data.network_os.policy.vlan_mapping=true)).
+                    type: list
+                    elements: dict
+                    suboptions:
+                      customer_inner_vlan_id:
+                        description:
+                        - Inner customer VLAN id (selective dot1q-tunnel only).
+                        - Valid range is 1-4094.
+                        type: int
+                      customer_vlan_id:
+                        description:
+                        - Customer VLAN id list; each entry is a VLAN id or range string in 1-4094 (e.g. V(['100', '200-300'])).
+                        type: list
+                        elements: str
+                      dot1q_tunnel:
+                        description:
+                        - Use selective dot1q-tunnel mode for this entry.
+                        type: bool
+                      provider_vlan_id:
+                        description:
+                        - Provider VLAN id.
+                        - Valid range is 1-4094.
+                        type: int
+  config_actions:
+    description:
+    - Controls deploy behavior after interface mutations are complete.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether to deploy vPC interface changes after mutations are complete.
+        - When V(true), all queued vPC interface changes are deployed in a single bulk API call at the end of module
+          execution via the C(interfaceActions/deploy) API. Only the vPC interfaces modified by this task are deployed.
+        - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        type: bool
+        default: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the resources specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      The resources on ND will be modified to exactly match the configuration.
+      Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
+    - Use O(state=deleted) to remove the specified vPC interfaces via per-interface DELETE.
+      Member ethernet interfaces on both peers are reverted to their fabric default configuration.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This module manages NX-OS vPC trunkVpcHost interfaces only (interface_type C(vpc), mode C(trunk),
+  network_os_type C(nx-os), policy_type C(trunkVpcHost)). These values are hardcoded by the module and
+  are not user-configurable.
+- The primary switch supplied in O(config[].switch_ip) must already be in a vPC pair (managed by
+  M(cisco.nd.nd_manage_vpc_pair)). The peer serial is auto-resolved from the pair record.
+- C(peer1) refers to the switch supplied in O(config[].switch_ip); C(peer2) refers to the auto-resolved peer.
+"""
+
+EXAMPLES = r"""
+- name: Create a trunkVpcHost vPC with one member on each peer
+  cisco.nd.nd_interface_vpc_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc500
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "100-200,300"
+              native_vlan: 99
+              peer1_port_channel_id: 500
+              peer1_member_ports:
+                - Ethernet1/1
+              peer2_port_channel_id: 500
+              peer2_member_ports:
+                - Ethernet1/1
+              port_channel_mode: active
+              lacp_rate: fast
+              peer1_port_channel_description: Server-A on peer1
+              peer2_port_channel_description: Server-A on peer2
+    state: merged
+  register: result
+
+- name: Update allowed VLANs and native VLAN on an existing vPC
+  cisco.nd.nd_interface_vpc_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc500
+        config_data:
+          network_os:
+            policy:
+              allowed_vlans: all
+              native_vlan: 1
+    state: merged
+
+- name: Enable VLAN mapping with two entries
+  cisco.nd.nd_interface_vpc_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc500
+        config_data:
+          network_os:
+            policy:
+              vlan_mapping: true
+              vlan_mapping_entries:
+                - customer_vlan_id:
+                    - "100"
+                    - "200-300"
+                  provider_vlan_id: 1000
+                - customer_vlan_id:
+                    - "500"
+                  customer_inner_vlan_id: 510
+                  provider_vlan_id: 1010
+                  dot1q_tunnel: true
+    state: merged
+
+- name: Replace a vPC trunk-host policy (un-set fields revert to ND defaults)
+  cisco.nd.nd_interface_vpc_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc500
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "100-200"
+              native_vlan: 100
+              peer1_port_channel_id: 500
+              peer1_member_ports:
+                - Ethernet1/1
+              peer2_port_channel_id: 500
+              peer2_member_ports:
+                - Ethernet1/1
+              port_channel_mode: active
+    state: replaced
+
+- name: Override the fabric vPC trunk-host inventory to a single managed vPC
+  cisco.nd.nd_interface_vpc_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc500
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "100-200"
+              native_vlan: 100
+              peer1_port_channel_id: 500
+              peer1_member_ports:
+                - Ethernet1/1
+              peer2_port_channel_id: 500
+              peer2_member_ports:
+                - Ethernet1/1
+              port_channel_mode: active
+    state: overridden
+
+- name: Delete a vPC interface (cascades to both peers)
+  cisco.nd.nd_interface_vpc_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc500
+    state: deleted
+
+- name: Stage vPC interface changes without deploying
+  cisco.nd.nd_interface_vpc_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc500
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "100-200"
+              native_vlan: 100
+              peer1_port_channel_id: 500
+              peer2_port_channel_id: 500
+    config_actions:
+      deploy: false
+    state: merged
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching interface configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc500
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          allowed_vlans: "100-200,300"
+          native_vlan: 99
+          peer1_port_channel_id: 500
+          peer1_member_ports:
+          - Ethernet1/1
+          peer2_port_channel_id: 500
+          peer2_member_ports:
+          - Ethernet1/1
+          port_channel_mode: active
+after:
+  description:
+  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc500
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          allowed_vlans: "100-200,300,400"
+          native_vlan: 99
+          peer1_port_channel_id: 500
+          peer1_member_ports:
+          - Ethernet1/1
+          peer2_port_channel_id: 500
+          peer2_member_ports:
+          - Ethernet1/1
+          port_channel_mode: active
+diff:
+  description: The per-interface difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc500
+    config_data:
+      network_os:
+        policy:
+          allowed_vlans: "100-200,300,400"
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc500
+    config_data:
+      network_os:
+        policy:
+          allowed_vlans: "100-200,300,400"
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing vPC interface configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
+"""
+
+# pylint: disable=wrong-import-position
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import (
+    TrunkVpcHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_trunk_host_interface import (
+    TrunkVpcHostInterfaceOrchestrator,
+)
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_interface_vpc_trunk_host` Ansible module. Initializes the
+    `NDStateMachine` with `TrunkVpcHostInterfaceOrchestrator` and executes the requested state operation.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(TrunkVpcHostInterfaceModel.get_argument_spec())
+    argument_spec.update(
+        config_actions={
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_interface_vpc_trunk_host")
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=TrunkVpcHostInterfaceOrchestrator,
+        )
+        if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
+            raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        config_actions = module.params.get("config_actions") or {}
+        deploy = config_actions.get("deploy", True)
+        nd_state_machine.model_orchestrator.deploy = deploy
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            deploy,
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.remove_pending()
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/deleted.yaml
@@ -10,7 +10,7 @@
 # --- DELETED: SINGLE PORT-CHANNEL ---
 
 - name: "DELETED: Delete port-channel502 (check mode)"
-  cisco.nd.nd_interface_port_channel_access:
+  cisco.nd.nd_interface_port_channel_access: &delete_pc502
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -21,13 +21,7 @@
   register: cm_deleted_502
 
 - name: "DELETED: Delete port-channel502 (normal mode)"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel502
-    state: deleted
+  cisco.nd.nd_interface_port_channel_access: *delete_pc502
   register: nm_deleted_502
 
 - name: "DELETED: Verify port-channel502 was deleted"
@@ -40,13 +34,7 @@
 # --- DELETED: IDEMPOTENCY ---
 
 - name: "DELETED IDEMPOTENT: Delete port-channel502 again"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel502
-    state: deleted
+  cisco.nd.nd_interface_port_channel_access: *delete_pc502
   register: nm_deleted_502_idem
 
 - name: "DELETED IDEMPOTENT: Verify no change when already absent"
@@ -96,7 +84,7 @@
     state: merged
 
 - name: "DELETED MULTI: Delete port-channel501, port-channel502, port-channel503 (check mode)"
-  cisco.nd.nd_interface_port_channel_access:
+  cisco.nd.nd_interface_port_channel_access: &delete_multi
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -111,17 +99,7 @@
   register: cm_deleted_multi
 
 - name: "DELETED MULTI: Delete port-channel501, port-channel502, port-channel503 (normal mode)"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel501
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel502
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel503
-    state: deleted
+  cisco.nd.nd_interface_port_channel_access: *delete_multi
   register: nm_deleted_multi
 
 - name: "DELETED MULTI: Verify all test port-channels were deleted"

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/deleted.yaml
@@ -1,0 +1,151 @@
+---
+# Deleted state tests for nd_interface_port_channel_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point port-channel502 and port-channel503 exist from overridden tests.
+
+# --- DELETED: SINGLE PORT-CHANNEL ---
+
+- name: "DELETED: Delete port-channel502 (check mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+    state: deleted
+  check_mode: true
+  register: cm_deleted_502
+
+- name: "DELETED: Delete port-channel502 (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+    state: deleted
+  register: nm_deleted_502
+
+- name: "DELETED: Verify port-channel502 was deleted"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_502 is changed
+      - nm_deleted_502 is changed
+      - nm_deleted_502.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 0
+
+# --- DELETED: IDEMPOTENCY ---
+
+- name: "DELETED IDEMPOTENT: Delete port-channel502 again"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+    state: deleted
+  register: nm_deleted_502_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change when already absent"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_502_idem is not changed
+
+# --- DELETED: MEMBER REVERT ---
+# After deleting a port-channel, its former member ethernet interfaces should be reverted
+# to fabric defaults. We can't directly assert that here without the ethernet module,
+# but we verify the port-channel itself is gone and that the API accepted the remove.
+
+- name: "DELETED MEMBER REVERT: Recreate port-channel501 with two members"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+    state: merged
+
+- name: "DELETED MEMBER REVERT: Delete port-channel501"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+    state: deleted
+  register: nm_deleted_501_with_members
+
+- name: "DELETED MEMBER REVERT: Verify port-channel501 was removed"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_501_with_members is changed
+      - nm_deleted_501_with_members.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 0
+
+# --- DELETED: MULTIPLE PORT-CHANNELS ---
+
+# Recreate port-channel501 and port-channel502 so we can test multi-delete
+- name: "SETUP: Recreate port-channel501 and port-channel502 for multi-delete test"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+      - "{{ test_pc_502 }}"
+    state: merged
+
+- name: "DELETED MULTI: Delete port-channel501, port-channel502, port-channel503 (check mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel503
+    state: deleted
+  check_mode: true
+  register: cm_deleted_multi
+
+- name: "DELETED MULTI: Delete port-channel501, port-channel502, port-channel503 (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel503
+    state: deleted
+  register: nm_deleted_multi
+
+- name: "DELETED MULTI: Verify all test port-channels were deleted"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_multi is changed
+      - nm_deleted_multi is changed
+      - nm_deleted_multi.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 0
+      - nm_deleted_multi.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 0
+      - nm_deleted_multi.after | selectattr('interface_name', 'equalto', 'port-channel503') | list | length == 0
+
+# --- DELETED: NON-EXISTENT PORT-CHANNEL ---
+
+- name: "DELETED NON-EXISTENT: Delete port-channel that does not exist"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel599
+    state: deleted
+  register: nm_deleted_nonexistent
+
+- name: "DELETED NON-EXISTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_nonexistent is not changed

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/main.yaml
@@ -51,6 +51,9 @@
     cisco.nd.nd_interface_port_channel_access:
       timeout: 300
   block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
     - name: Run nd_interface_port_channel_access merged state tests
       ansible.builtin.include_tasks: merged.yaml
 

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/main.yaml
@@ -1,0 +1,66 @@
+---
+# Test code for the nd_interface_port_channel_access module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#
+#   ansible-test network-integration nd_interface_port_channel_access
+#
+# --- Required testbed configuration ---
+#
+# In tests/integration/inventory.networking [nd:vars]:
+#
+#   nd_test_fabric_name=<your fabric>
+#   nd_test_switch_ip=<switch IP within that fabric>
+#   nd_test_pc_member_a=Ethernet1/10
+#   nd_test_pc_member_b=Ethernet1/11
+#   nd_test_pc_member_c=Ethernet1/12
+#   nd_test_pc_member_d=Ethernet1/13
+#
+# Members must exist on the target switch and must not already be in another
+# port-channel. The cleanup at the start of merged.yaml resets them.
+#
+# --- Optional test variables ---
+#
+# nd_logging_config (str, default: "")
+#   Path to a JSON file conforming to logging.config.dictConfig (see
+#   plugins/module_utils/common/log.py for an example).
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info:
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_interface_port_channel_access state tests with optional logging env
+  # The `timeout` module arg propagates via sender_nd.set_params() into the
+  # httpapi plugin, which calls connection.set_option("persistent_command_timeout", ...).
+  # 300s gives the switch enough time to build the PC bundle, pull members,
+  # and apply LACP on slow testbeds (e.g. 9000v) where the default 30s is too
+  # short. Scoped to this test target via module_defaults so we don't modify
+  # shared argspec defaults.
+  module_defaults:
+    cisco.nd.nd_interface_port_channel_access:
+      timeout: 300
+  block:
+    - name: Run nd_interface_port_channel_access merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run nd_interface_port_channel_access replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run nd_interface_port_channel_access overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run nd_interface_port_channel_access deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
@@ -1,0 +1,255 @@
+---
+# Merged state tests for nd_interface_port_channel_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Test order: single-PC tests first, then multi-PC. The MEMBER ADD test pulls
+# `test_pc_member_c` into port-channel501, so it must run BEFORE PC 502 (which
+# claims member_c) is created — ND rejects adding a port to a PC if it's
+# already a member of another. After MEMBER REMOVE, all members except a are
+# free, so the multi-create that follows succeeds.
+
+# --- CLEANUP ---
+
+- name: "SETUP: Remove test port-channels before merged tests"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel503
+    state: deleted
+  tags: always
+
+# --- MERGED CREATE: SINGLE PC ---
+
+- name: "MERGED CREATE: Create port-channel501 with two members (check mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_501
+
+- name: "MERGED CREATE: Create port-channel501 with two members (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+    state: merged
+  register: nm_merged_create_501
+
+- name: "MERGED CREATE: Verify port-channel501 creation"
+  vars:
+    pc501_after: "{{ nm_merged_create_501.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_501 is changed
+      - nm_merged_create_501 is changed
+      - nm_merged_create_501.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 1
+      - pc501_after.config_data.network_os.policy.access_vlan == 100
+      - pc501_after.config_data.network_os.policy.port_channel_mode == "active"
+      - pc501_after.config_data.network_os.policy.lacp_rate == "fast"
+      - pc501_after.config_data.network_os.policy.ports | length == 2
+      - test_pc_member_a in pc501_after.config_data.network_os.policy.ports
+      - test_pc_member_b in pc501_after.config_data.network_os.policy.ports
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Re-apply port-channel501 creation (check mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_idem_501
+
+- name: "MERGED IDEMPOTENT: Re-apply port-channel501 creation (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+    state: merged
+  register: nm_merged_idem_501
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem_501 is not changed
+      - nm_merged_idem_501 is not changed
+
+# --- MERGED UPDATE: change access_vlan ---
+
+- name: "MERGED UPDATE: Change port-channel501 access_vlan and description (check mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501_updated_vlan }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_update_501
+
+- name: "MERGED UPDATE: Change port-channel501 access_vlan and description (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501_updated_vlan }}"
+    state: merged
+  register: nm_merged_update_501
+
+- name: "MERGED UPDATE: Verify port-channel501 was updated"
+  vars:
+    pc501_after: "{{ nm_merged_update_501.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_update_501 is changed
+      - nm_merged_update_501 is changed
+      - pc501_after.config_data.network_os.policy.access_vlan == 150
+      - pc501_after.config_data.network_os.policy.description == "Ansible integration test PC 501 updated"
+
+- name: "MERGED UPDATE: Re-apply update for idempotency"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501_updated_vlan }}"
+    state: merged
+  register: nm_merged_update_501_idem
+
+- name: "MERGED UPDATE: Verify idempotency after update"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_501_idem is not changed
+
+# --- MERGED MEMBERSHIP: add a third member ---
+# Must run BEFORE PC 502/503 are created, so the third member (member_c) is free.
+
+- name: "SETUP: Reset port-channel501 to baseline before membership tests"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+    state: merged
+
+- name: "MERGED MEMBER ADD: Add a third member to port-channel501 (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501_added_member }}"
+    state: merged
+  register: nm_merged_add_member
+
+- name: "MERGED MEMBER ADD: Verify member was added"
+  vars:
+    pc501_after: "{{ nm_merged_add_member.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_add_member is changed
+      - pc501_after.config_data.network_os.policy.ports | length == 3
+      - test_pc_member_c in pc501_after.config_data.network_os.policy.ports
+
+# --- MERGED MEMBERSHIP: remove members ---
+
+- name: "MERGED MEMBER REMOVE: Reduce port-channel501 to a single member (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501_removed_member }}"
+    state: merged
+  register: nm_merged_remove_member
+
+- name: "MERGED MEMBER REMOVE: Verify members were removed"
+  vars:
+    pc501_after: "{{ nm_merged_remove_member.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_remove_member is changed
+      - pc501_after.config_data.network_os.policy.ports | length == 1
+      - test_pc_member_a in pc501_after.config_data.network_os.policy.ports
+      - test_pc_member_b not in pc501_after.config_data.network_os.policy.ports
+      - test_pc_member_c not in pc501_after.config_data.network_os.policy.ports
+
+# --- MERGED CREATE: MULTIPLE PCs ---
+# Runs AFTER membership tests so that member_c (used by PC 502) and member_d
+# (used by PC 503) are not currently claimed by PC 501.
+
+- name: "MERGED CREATE: Create multiple port-channels in a single task (check mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_502 }}"
+      - "{{ test_pc_503 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_multi
+
+- name: "MERGED CREATE: Create multiple port-channels in a single task (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_502 }}"
+      - "{{ test_pc_503 }}"
+    state: merged
+  register: nm_merged_create_multi
+
+- name: "MERGED CREATE: Verify multiple port-channel creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_multi is changed
+      - nm_merged_create_multi is changed
+      - nm_merged_create_multi.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 1
+      - nm_merged_create_multi.after | selectattr('interface_name', 'equalto', 'port-channel503') | list | length == 1
+
+# --- MERGED WITH deploy: false ---
+
+- name: "MERGED NO-DEPLOY: Stage a port-channel without deploying"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel504
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 400
+              ports: []
+              description: "No-deploy test port-channel504"
+              policy_type: access_po_host
+    deploy: false
+    state: merged
+  register: nm_merged_no_deploy
+
+- name: "MERGED NO-DEPLOY: Verify change was staged"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_no_deploy is changed
+
+# Cleanup the no-deploy test port-channel
+- name: "CLEANUP: Remove port-channel504"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel504
+    state: deleted

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
@@ -234,7 +234,6 @@
               access_vlan: 400
               ports: []
               description: "No-deploy test port-channel504"
-              policy_type: access_po_host
     deploy: false
     state: merged
   register: nm_merged_no_deploy

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
@@ -182,7 +182,8 @@
               access_vlan: 400
               ports: []
               description: "No-deploy test port-channel504"
-    deploy: false
+    config_actions:
+      deploy: false
     state: merged
   register: nm_merged_no_deploy
 

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
@@ -29,7 +29,7 @@
 # --- MERGED CREATE: SINGLE PC ---
 
 - name: "MERGED CREATE: Create port-channel501 with two members (check mode)"
-  cisco.nd.nd_interface_port_channel_access:
+  cisco.nd.nd_interface_port_channel_access: &merge_pc501
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -39,12 +39,7 @@
   register: cm_merged_create_501
 
 - name: "MERGED CREATE: Create port-channel501 with two members (normal mode)"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ test_pc_501 }}"
-    state: merged
+  cisco.nd.nd_interface_port_channel_access: *merge_pc501
   register: nm_merged_create_501
 
 - name: "MERGED CREATE: Verify port-channel501 creation"
@@ -65,22 +60,12 @@
 # --- MERGED IDEMPOTENCY ---
 
 - name: "MERGED IDEMPOTENT: Re-apply port-channel501 creation (check mode)"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ test_pc_501 }}"
-    state: merged
+  cisco.nd.nd_interface_port_channel_access: *merge_pc501
   check_mode: true
   register: cm_merged_idem_501
 
 - name: "MERGED IDEMPOTENT: Re-apply port-channel501 creation (normal mode)"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ test_pc_501 }}"
-    state: merged
+  cisco.nd.nd_interface_port_channel_access: *merge_pc501
   register: nm_merged_idem_501
 
 - name: "MERGED IDEMPOTENT: Verify no change on second run"
@@ -92,7 +77,7 @@
 # --- MERGED UPDATE: change access_vlan ---
 
 - name: "MERGED UPDATE: Change port-channel501 access_vlan and description (check mode)"
-  cisco.nd.nd_interface_port_channel_access:
+  cisco.nd.nd_interface_port_channel_access: &merge_pc501_updated
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -102,12 +87,7 @@
   register: cm_merged_update_501
 
 - name: "MERGED UPDATE: Change port-channel501 access_vlan and description (normal mode)"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ test_pc_501_updated_vlan }}"
-    state: merged
+  cisco.nd.nd_interface_port_channel_access: *merge_pc501_updated
   register: nm_merged_update_501
 
 - name: "MERGED UPDATE: Verify port-channel501 was updated"
@@ -121,12 +101,7 @@
       - pc501_after.config_data.network_os.policy.description == "Ansible integration test PC 501 updated"
 
 - name: "MERGED UPDATE: Re-apply update for idempotency"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ test_pc_501_updated_vlan }}"
-    state: merged
+  cisco.nd.nd_interface_port_channel_access: *merge_pc501_updated
   register: nm_merged_update_501_idem
 
 - name: "MERGED UPDATE: Verify idempotency after update"
@@ -138,12 +113,7 @@
 # Must run BEFORE PC 502/503 are created, so the third member (member_c) is free.
 
 - name: "SETUP: Reset port-channel501 to baseline before membership tests"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ test_pc_501 }}"
-    state: merged
+  cisco.nd.nd_interface_port_channel_access: *merge_pc501
 
 - name: "MERGED MEMBER ADD: Add a third member to port-channel501 (normal mode)"
   cisco.nd.nd_interface_port_channel_access:
@@ -190,7 +160,7 @@
 # (used by PC 503) are not currently claimed by PC 501.
 
 - name: "MERGED CREATE: Create multiple port-channels in a single task (check mode)"
-  cisco.nd.nd_interface_port_channel_access:
+  cisco.nd.nd_interface_port_channel_access: &merge_pc502_503
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -201,13 +171,7 @@
   register: cm_merged_create_multi
 
 - name: "MERGED CREATE: Create multiple port-channels in a single task (normal mode)"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ test_pc_502 }}"
-      - "{{ test_pc_503 }}"
-    state: merged
+  cisco.nd.nd_interface_port_channel_access: *merge_pc502_503
   register: nm_merged_create_multi
 
 - name: "MERGED CREATE: Verify multiple port-channel creation"

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/merged.yaml
@@ -10,22 +10,6 @@
 # already a member of another. After MEMBER REMOVE, all members except a are
 # free, so the multi-create that follows succeeds.
 
-# --- CLEANUP ---
-
-- name: "SETUP: Remove test port-channels before merged tests"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel501
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel502
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel503
-    state: deleted
-  tags: always
-
 # --- MERGED CREATE: SINGLE PC ---
 
 - name: "MERGED CREATE: Create port-channel501 with two members (check mode)"

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/overridden.yaml
@@ -11,7 +11,7 @@
 # --- OVERRIDDEN: REDUCE TO SINGLE PORT-CHANNEL ---
 
 - name: "OVERRIDDEN: Override to only port-channel501 (check mode)"
-  cisco.nd.nd_interface_port_channel_access:
+  cisco.nd.nd_interface_port_channel_access: &override_pc501
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -30,21 +30,7 @@
   register: cm_overridden_single
 
 - name: "OVERRIDDEN: Override to only port-channel501 (normal mode)"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel501
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              access_vlan: 175
-              ports:
-                - "{{ test_pc_member_a }}"
-              description: "Overridden port-channel501"
-    state: overridden
+  cisco.nd.nd_interface_port_channel_access: *override_pc501
   register: nm_overridden_single
 
 - name: "OVERRIDDEN: Verify override removed extra port-channels"
@@ -64,21 +50,7 @@
 # --- OVERRIDDEN: IDEMPOTENCY ---
 
 - name: "OVERRIDDEN IDEMPOTENT: Re-apply same overridden config"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel501
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              access_vlan: 175
-              ports:
-                - "{{ test_pc_member_a }}"
-              description: "Overridden port-channel501"
-    state: overridden
+  cisco.nd.nd_interface_port_channel_access: *override_pc501
   register: nm_overridden_idem
 
 - name: "OVERRIDDEN IDEMPOTENT: Verify no change on second run"
@@ -90,7 +62,7 @@
 # Restore port-channel502 and port-channel503 to a known baseline by overriding to a new set.
 
 - name: "OVERRIDDEN SWAP: Override to port-channel502 and port-channel503, removing port-channel501"
-  cisco.nd.nd_interface_port_channel_access:
+  cisco.nd.nd_interface_port_channel_access: &override_pc502_503
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -112,13 +84,7 @@
 # Standalone ethernet interfaces and other interface types must NOT be touched by this module.
 
 - name: "OVERRIDDEN FILTER: Re-apply prior swap config to confirm idempotency / no leakage"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - "{{ test_pc_502 }}"
-      - "{{ test_pc_503 }}"
-    state: overridden
+  cisco.nd.nd_interface_port_channel_access: *override_pc502_503
   register: nm_overridden_filter
 
 - name: "OVERRIDDEN FILTER: Verify only port-channel interfaces appear in before collection"

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/overridden.yaml
@@ -1,0 +1,133 @@
+---
+# Overridden state tests for nd_interface_port_channel_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point port-channel501 (replaced), port-channel502 (replaced), port-channel503 (replaced) exist.
+# Override will reduce the set to only what is specified in config.
+
+# --- OVERRIDDEN: REDUCE TO SINGLE PORT-CHANNEL ---
+
+- name: "OVERRIDDEN: Override to only port-channel501 (check mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 175
+              ports:
+                - "{{ test_pc_member_a }}"
+              description: "Overridden port-channel501"
+              policy_type: access_po_host
+    state: overridden
+  check_mode: true
+  register: cm_overridden_single
+
+- name: "OVERRIDDEN: Override to only port-channel501 (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 175
+              ports:
+                - "{{ test_pc_member_a }}"
+              description: "Overridden port-channel501"
+              policy_type: access_po_host
+    state: overridden
+  register: nm_overridden_single
+
+- name: "OVERRIDDEN: Verify override removed extra port-channels"
+  vars:
+    pc501_after: "{{ nm_overridden_single.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_overridden_single is changed
+      - nm_overridden_single is changed
+      # After should contain only port-channel501. port-channel502 and 503 should have been removed.
+      - nm_overridden_single.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 1
+      - nm_overridden_single.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 0
+      - nm_overridden_single.after | selectattr('interface_name', 'equalto', 'port-channel503') | list | length == 0
+      - pc501_after.config_data.network_os.policy.access_vlan == 175
+      - pc501_after.config_data.network_os.policy.description == "Overridden port-channel501"
+
+# --- OVERRIDDEN: IDEMPOTENCY ---
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply same overridden config"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 175
+              ports:
+                - "{{ test_pc_member_a }}"
+              description: "Overridden port-channel501"
+              policy_type: access_po_host
+    state: overridden
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_idem is not changed
+
+# --- OVERRIDDEN: SWAP ---
+# Restore port-channel502 and port-channel503 to a known baseline by overriding to a new set.
+
+- name: "OVERRIDDEN SWAP: Override to port-channel502 and port-channel503, removing port-channel501"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_502 }}"
+      - "{{ test_pc_503 }}"
+    state: overridden
+  register: nm_overridden_swap
+
+- name: "OVERRIDDEN SWAP: Verify port-channel501 removed and port-channel502/503 present"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_swap is changed
+      - nm_overridden_swap.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 0
+      - nm_overridden_swap.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 1
+      - nm_overridden_swap.after | selectattr('interface_name', 'equalto', 'port-channel503') | list | length == 1
+
+# --- OVERRIDDEN: NON-PORT-CHANNEL FILTERING ---
+# Verifies that overridden state only operates on portChannel interfaces with managed policy types.
+# Standalone ethernet interfaces and other interface types must NOT be touched by this module.
+
+- name: "OVERRIDDEN FILTER: Re-apply prior swap config to confirm idempotency / no leakage"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_502 }}"
+      - "{{ test_pc_503 }}"
+    state: overridden
+  register: nm_overridden_filter
+
+- name: "OVERRIDDEN FILTER: Verify only port-channel interfaces appear in before collection"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_filter is not changed
+      # Before collection must contain only portChannel interfaces; non-PC types would
+      # indicate the orchestrator's interfaceType filter is broken.
+      - nm_overridden_filter.before | rejectattr('interface_type', 'equalto', 'portChannel') | list | length == 0

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/overridden.yaml
@@ -25,7 +25,6 @@
               ports:
                 - "{{ test_pc_member_a }}"
               description: "Overridden port-channel501"
-              policy_type: access_po_host
     state: overridden
   check_mode: true
   register: cm_overridden_single
@@ -45,7 +44,6 @@
               ports:
                 - "{{ test_pc_member_a }}"
               description: "Overridden port-channel501"
-              policy_type: access_po_host
     state: overridden
   register: nm_overridden_single
 
@@ -80,7 +78,6 @@
               ports:
                 - "{{ test_pc_member_a }}"
               description: "Overridden port-channel501"
-              policy_type: access_po_host
     state: overridden
   register: nm_overridden_idem
 

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/replaced.yaml
@@ -1,0 +1,131 @@
+---
+# Replaced state tests for nd_interface_port_channel_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point port-channel501 (single member, vlan 100), port-channel502, port-channel503 exist from merged tests.
+
+# --- REPLACED: FULL REPLACE ---
+
+- name: "REPLACED: Replace port-channel501 with a minimal config (check mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 250
+              ports:
+                - "{{ test_pc_member_a }}"
+              description: "Replaced port-channel501"
+              policy_type: access_po_host
+    state: replaced
+  check_mode: true
+  register: cm_replaced_501
+
+- name: "REPLACED: Replace port-channel501 with a minimal config (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 250
+              ports:
+                - "{{ test_pc_member_a }}"
+              description: "Replaced port-channel501"
+              policy_type: access_po_host
+    state: replaced
+  register: nm_replaced_501
+
+- name: "REPLACED: Verify port-channel501 was replaced"
+  vars:
+    pc501_after: "{{ nm_replaced_501.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_501 is changed
+      - nm_replaced_501 is changed
+      - pc501_after.config_data.network_os.policy.access_vlan == 250
+      - pc501_after.config_data.network_os.policy.description == "Replaced port-channel501"
+      - pc501_after.config_data.network_os.policy.ports | length == 1
+      - test_pc_member_a in pc501_after.config_data.network_os.policy.ports
+
+# --- REPLACED: IDEMPOTENCY ---
+
+- name: "REPLACED IDEMPOTENT: Re-apply same replaced config"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 250
+              ports:
+                - "{{ test_pc_member_a }}"
+              description: "Replaced port-channel501"
+              policy_type: access_po_host
+    state: replaced
+  register: nm_replaced_501_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_501_idem is not changed
+
+# --- REPLACED: MULTIPLE PORT-CHANNELS ---
+
+- name: "REPLACED MULTI: Replace port-channel502 and port-channel503 (normal mode)"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 222
+              ports:
+                - "{{ test_pc_member_c }}"
+              description: "Replaced port-channel502"
+              policy_type: access_po_host
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel503
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              access_vlan: 333
+              ports:
+                - "{{ test_pc_member_d }}"
+              description: "Replaced port-channel503"
+              policy_type: access_po_host
+    state: replaced
+  register: nm_replaced_multi
+
+- name: "REPLACED MULTI: Verify both port-channels were replaced"
+  vars:
+    pc502_after: "{{ nm_replaced_multi.after | selectattr('interface_name', 'equalto', 'port-channel502') | first }}"
+    pc503_after: "{{ nm_replaced_multi.after | selectattr('interface_name', 'equalto', 'port-channel503') | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_multi is changed
+      - pc502_after.config_data.network_os.policy.access_vlan == 222
+      - pc502_after.config_data.network_os.policy.description == "Replaced port-channel502"
+      - pc503_after.config_data.network_os.policy.access_vlan == 333
+      - pc503_after.config_data.network_os.policy.admin_state == false

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/replaced.yaml
@@ -24,7 +24,6 @@
               ports:
                 - "{{ test_pc_member_a }}"
               description: "Replaced port-channel501"
-              policy_type: access_po_host
     state: replaced
   check_mode: true
   register: cm_replaced_501
@@ -44,7 +43,6 @@
               ports:
                 - "{{ test_pc_member_a }}"
               description: "Replaced port-channel501"
-              policy_type: access_po_host
     state: replaced
   register: nm_replaced_501
 
@@ -77,7 +75,6 @@
               ports:
                 - "{{ test_pc_member_a }}"
               description: "Replaced port-channel501"
-              policy_type: access_po_host
     state: replaced
   register: nm_replaced_501_idem
 
@@ -103,7 +100,6 @@
               ports:
                 - "{{ test_pc_member_c }}"
               description: "Replaced port-channel502"
-              policy_type: access_po_host
       - switch_ip: "{{ test_switch_ip }}"
         interface_name: port-channel503
         config_data:
@@ -114,7 +110,6 @@
               ports:
                 - "{{ test_pc_member_d }}"
               description: "Replaced port-channel503"
-              policy_type: access_po_host
     state: replaced
   register: nm_replaced_multi
 

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/replaced.yaml
@@ -10,7 +10,7 @@
 # --- REPLACED: FULL REPLACE ---
 
 - name: "REPLACED: Replace port-channel501 with a minimal config (check mode)"
-  cisco.nd.nd_interface_port_channel_access:
+  cisco.nd.nd_interface_port_channel_access: &replace_pc501
     output_level: "{{ nd_info.output_level }}"
     fabric_name: "{{ test_fabric_name }}"
     config:
@@ -29,21 +29,7 @@
   register: cm_replaced_501
 
 - name: "REPLACED: Replace port-channel501 with a minimal config (normal mode)"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel501
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              access_vlan: 250
-              ports:
-                - "{{ test_pc_member_a }}"
-              description: "Replaced port-channel501"
-    state: replaced
+  cisco.nd.nd_interface_port_channel_access: *replace_pc501
   register: nm_replaced_501
 
 - name: "REPLACED: Verify port-channel501 was replaced"
@@ -61,21 +47,7 @@
 # --- REPLACED: IDEMPOTENCY ---
 
 - name: "REPLACED IDEMPOTENT: Re-apply same replaced config"
-  cisco.nd.nd_interface_port_channel_access:
-    output_level: "{{ nd_info.output_level }}"
-    fabric_name: "{{ test_fabric_name }}"
-    config:
-      - switch_ip: "{{ test_switch_ip }}"
-        interface_name: port-channel501
-        config_data:
-          network_os:
-            policy:
-              admin_state: true
-              access_vlan: 250
-              ports:
-                - "{{ test_pc_member_a }}"
-              description: "Replaced port-channel501"
-    state: replaced
+  cisco.nd.nd_interface_port_channel_access: *replace_pc501
   register: nm_replaced_501_idem
 
 - name: "REPLACED IDEMPOTENT: Verify no change on second run"

--- a/tests/integration/targets/nd_interface_port_channel_access/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/tasks/setup.yaml
@@ -1,0 +1,23 @@
+---
+# Pre-test cleanup for nd_interface_port_channel_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Called from main.yaml before the merged/replaced/overridden/deleted state
+# blocks. Ensures no test port-channels exist on the target switch before
+# the state tests run.
+
+- name: "SETUP: Remove test port-channels before state tests"
+  cisco.nd.nd_interface_port_channel_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel503
+    state: deleted
+  tags: always

--- a/tests/integration/targets/nd_interface_port_channel_access/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/vars/main.yaml
@@ -1,0 +1,112 @@
+---
+# Variables for nd_interface_port_channel_access integration tests.
+#
+# Override these in your inventory or extra-vars to match a real ND 4.2 testbed.
+# Member ethernet interfaces (test_pc_member_*) MUST exist on the target switch and
+# MUST NOT be members of any other port-channel before tests run, or the cleanup
+# at the start of each state file will revert them to fabric defaults.
+
+test_fabric_name: "{{ nd_test_fabric_name | default('test_fabric') }}"
+test_switch_ip: "{{ nd_test_switch_ip | default('192.168.1.1') }}"
+
+# Member ethernet interface names. Override per-testbed.
+test_pc_member_a: "{{ nd_test_pc_member_a | default('Ethernet1/10') }}"
+test_pc_member_b: "{{ nd_test_pc_member_b | default('Ethernet1/11') }}"
+test_pc_member_c: "{{ nd_test_pc_member_c | default('Ethernet1/12') }}"
+test_pc_member_d: "{{ nd_test_pc_member_d | default('Ethernet1/13') }}"
+
+# Port-channel IDs 501-509 are reserved for these integration tests.
+
+test_pc_501:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel501
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 100
+        ports:
+          - "{{ test_pc_member_a }}"
+          - "{{ test_pc_member_b }}"
+        port_channel_mode: active
+        lacp_rate: fast
+        description: "Ansible integration test PC 501"
+        policy_type: access_po_host
+
+test_pc_502:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel502
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 200
+        ports:
+          - "{{ test_pc_member_c }}"
+        port_channel_mode: active
+        description: "Ansible integration test PC 502"
+        policy_type: access_po_host
+
+test_pc_503:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel503
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 300
+        ports:
+          - "{{ test_pc_member_d }}"
+        port_channel_mode: passive
+        description: "Ansible integration test PC 503"
+        policy_type: access_po_host
+
+# Updated variants for merge/replace tests
+
+test_pc_501_updated_vlan:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel501
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 150
+        ports:
+          - "{{ test_pc_member_a }}"
+          - "{{ test_pc_member_b }}"
+        port_channel_mode: active
+        lacp_rate: fast
+        description: "Ansible integration test PC 501 updated"
+        policy_type: access_po_host
+
+test_pc_501_added_member:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel501
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 100
+        ports:
+          - "{{ test_pc_member_a }}"
+          - "{{ test_pc_member_b }}"
+          - "{{ test_pc_member_c }}"
+        port_channel_mode: active
+        lacp_rate: fast
+        description: "Ansible integration test PC 501"
+        policy_type: access_po_host
+
+test_pc_501_removed_member:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel501
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 100
+        ports:
+          - "{{ test_pc_member_a }}"
+        port_channel_mode: active
+        lacp_rate: fast
+        description: "Ansible integration test PC 501"
+        policy_type: access_po_host

--- a/tests/integration/targets/nd_interface_port_channel_access/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_access/vars/main.yaml
@@ -31,7 +31,6 @@ test_pc_501:
         port_channel_mode: active
         lacp_rate: fast
         description: "Ansible integration test PC 501"
-        policy_type: access_po_host
 
 test_pc_502:
   switch_ip: "{{ test_switch_ip }}"
@@ -45,7 +44,6 @@ test_pc_502:
           - "{{ test_pc_member_c }}"
         port_channel_mode: active
         description: "Ansible integration test PC 502"
-        policy_type: access_po_host
 
 test_pc_503:
   switch_ip: "{{ test_switch_ip }}"
@@ -59,7 +57,6 @@ test_pc_503:
           - "{{ test_pc_member_d }}"
         port_channel_mode: passive
         description: "Ansible integration test PC 503"
-        policy_type: access_po_host
 
 # Updated variants for merge/replace tests
 
@@ -77,7 +74,6 @@ test_pc_501_updated_vlan:
         port_channel_mode: active
         lacp_rate: fast
         description: "Ansible integration test PC 501 updated"
-        policy_type: access_po_host
 
 test_pc_501_added_member:
   switch_ip: "{{ test_switch_ip }}"
@@ -94,7 +90,6 @@ test_pc_501_added_member:
         port_channel_mode: active
         lacp_rate: fast
         description: "Ansible integration test PC 501"
-        policy_type: access_po_host
 
 test_pc_501_removed_member:
   switch_ip: "{{ test_switch_ip }}"
@@ -109,4 +104,3 @@ test_pc_501_removed_member:
         port_channel_mode: active
         lacp_rate: fast
         description: "Ansible integration test PC 501"
-        policy_type: access_po_host

--- a/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/deleted.yaml
@@ -1,0 +1,129 @@
+---
+# Deleted state tests for nd_interface_port_channel_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point port-channel502 and port-channel503 exist from overridden tests.
+
+# --- DELETED: SINGLE PORT-CHANNEL ---
+
+- name: "DELETED: Delete port-channel502 (check mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: &delete_pc502
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+    state: deleted
+  check_mode: true
+  register: cm_deleted_502
+
+- name: "DELETED: Delete port-channel502 (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *delete_pc502
+  register: nm_deleted_502
+
+- name: "DELETED: Verify port-channel502 was deleted"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_502 is changed
+      - nm_deleted_502 is changed
+      - nm_deleted_502.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 0
+
+# --- DELETED: IDEMPOTENCY ---
+
+- name: "DELETED IDEMPOTENT: Delete port-channel502 again"
+  cisco.nd.nd_interface_port_channel_trunk_host: *delete_pc502
+  register: nm_deleted_502_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change when already absent"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_502_idem is not changed
+
+# --- DELETED: MEMBER REVERT ---
+# After deleting a port-channel, its former member ethernet interfaces should be reverted
+# to fabric defaults. We can't directly assert that here without the ethernet module,
+# but we verify the port-channel itself is gone and that the API accepted the remove.
+
+- name: "DELETED MEMBER REVERT: Recreate port-channel501 with two members"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+    state: merged
+
+- name: "DELETED MEMBER REVERT: Delete port-channel501"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+    state: deleted
+  register: nm_deleted_501_with_members
+
+- name: "DELETED MEMBER REVERT: Verify port-channel501 was removed"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_501_with_members is changed
+      - nm_deleted_501_with_members.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 0
+
+# --- DELETED: MULTIPLE PORT-CHANNELS ---
+
+# Recreate port-channel501 and port-channel502 so we can test multi-delete
+- name: "SETUP: Recreate port-channel501 and port-channel502 for multi-delete test"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+      - "{{ test_pc_502 }}"
+    state: merged
+
+- name: "DELETED MULTI: Delete port-channel501, port-channel502, port-channel503 (check mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: &delete_multi
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel503
+    state: deleted
+  check_mode: true
+  register: cm_deleted_multi
+
+- name: "DELETED MULTI: Delete port-channel501, port-channel502, port-channel503 (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *delete_multi
+  register: nm_deleted_multi
+
+- name: "DELETED MULTI: Verify all test port-channels were deleted"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_multi is changed
+      - nm_deleted_multi is changed
+      - nm_deleted_multi.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 0
+      - nm_deleted_multi.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 0
+      - nm_deleted_multi.after | selectattr('interface_name', 'equalto', 'port-channel503') | list | length == 0
+
+# --- DELETED: NON-EXISTENT PORT-CHANNEL ---
+
+- name: "DELETED NON-EXISTENT: Delete port-channel that does not exist"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel599
+    state: deleted
+  register: nm_deleted_nonexistent
+
+- name: "DELETED NON-EXISTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_nonexistent is not changed

--- a/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/main.yaml
@@ -1,0 +1,78 @@
+---
+# Test code for the nd_interface_port_channel_trunk_host module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#
+#   ansible-test network-integration nd_interface_port_channel_trunk_host
+#
+# --- Required testbed configuration ---
+#
+# In tests/integration/inventory.networking [nd:vars]:
+#
+#   nd_test_fabric_name=<your fabric>
+#   nd_test_switch_ip=<switch IP within that fabric>
+#   nd_test_pc_member_a=Ethernet1/10
+#   nd_test_pc_member_b=Ethernet1/11
+#   nd_test_pc_member_c=Ethernet1/12
+#   nd_test_pc_member_d=Ethernet1/13
+#
+# Members must exist on the target switch and must not already be in another
+# port-channel. The cleanup at the start of merged.yaml resets them.
+#
+# --- Optional test variables ---
+#
+# nd_logging_config (str, default: "")
+#   Path to a JSON file conforming to logging.config.dictConfig (see
+#   plugins/module_utils/common/log.py for an example).
+#
+# nd_test_platform (str, default: "9000v")
+#   Identifies the testbed platform. When "9000v", the vlan_mapping test block
+#   is skipped because virtual switches reject `switchport vlan mapping ... dot1q-tunnel`
+#   (ND surfaces this as HTTP 400 from the trunkPoHost validator).
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info:
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_interface_port_channel_trunk_host state tests with optional logging env
+  # The `timeout` module arg propagates via sender_nd.set_params() into the
+  # httpapi plugin, which calls connection.set_option("persistent_command_timeout", ...).
+  # 300s gives the switch enough time to build the PC bundle, pull members,
+  # and apply LACP on slow testbeds (e.g. 9000v) where the default 30s is too
+  # short. Scoped to this test target via module_defaults so we don't modify
+  # shared argspec defaults.
+  module_defaults:
+    cisco.nd.nd_interface_port_channel_trunk_host:
+      timeout: 300
+  block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run nd_interface_port_channel_trunk_host merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run nd_interface_port_channel_trunk_host replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run nd_interface_port_channel_trunk_host overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run nd_interface_port_channel_trunk_host deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+
+    - name: Run nd_interface_port_channel_trunk_host vlan_mapping tests (non-9000v only)
+      ansible.builtin.include_tasks: vlan_mapping.yaml
+      when: nd_test_platform | default('9000v') != '9000v'
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/merged.yaml
@@ -1,0 +1,205 @@
+---
+# Merged state tests for nd_interface_port_channel_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Test order: single-PC tests first, then multi-PC. The MEMBER ADD test pulls
+# `test_pc_member_c` into port-channel501, so it must run BEFORE PC 502 (which
+# claims member_c) is created — ND rejects adding a port to a PC if it's
+# already a member of another. After MEMBER REMOVE, all members except a are
+# free, so the multi-create that follows succeeds.
+
+# --- MERGED CREATE: SINGLE PC ---
+
+- name: "MERGED CREATE: Create port-channel501 with two members (check mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: &merge_pc501
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_501
+
+- name: "MERGED CREATE: Create port-channel501 with two members (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *merge_pc501
+  register: nm_merged_create_501
+
+- name: "MERGED CREATE: Verify port-channel501 creation"
+  vars:
+    pc501_after: "{{ nm_merged_create_501.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_501 is changed
+      - nm_merged_create_501 is changed
+      - nm_merged_create_501.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 1
+      - pc501_after.config_data.network_os.policy.allowed_vlans == "100-200"
+      - pc501_after.config_data.network_os.policy.native_vlan == 99
+      - pc501_after.config_data.network_os.policy.port_channel_mode == "active"
+      - pc501_after.config_data.network_os.policy.lacp_rate == "fast"
+      - pc501_after.config_data.network_os.policy.ports | length == 2
+      - test_pc_member_a in pc501_after.config_data.network_os.policy.ports
+      - test_pc_member_b in pc501_after.config_data.network_os.policy.ports
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Re-apply port-channel501 creation (check mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *merge_pc501
+  check_mode: true
+  register: cm_merged_idem_501
+
+- name: "MERGED IDEMPOTENT: Re-apply port-channel501 creation (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *merge_pc501
+  register: nm_merged_idem_501
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem_501 is not changed
+      - nm_merged_idem_501 is not changed
+
+# --- MERGED UPDATE: change allowed_vlans and native_vlan ---
+
+- name: "MERGED UPDATE: Change port-channel501 allowed_vlans/native_vlan/description (check mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: &merge_pc501_updated
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501_updated_vlan }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_update_501
+
+- name: "MERGED UPDATE: Change port-channel501 allowed_vlans/native_vlan/description (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *merge_pc501_updated
+  register: nm_merged_update_501
+
+- name: "MERGED UPDATE: Verify port-channel501 was updated"
+  vars:
+    pc501_after: "{{ nm_merged_update_501.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_update_501 is changed
+      - nm_merged_update_501 is changed
+      - pc501_after.config_data.network_os.policy.allowed_vlans == "100-200,500"
+      - pc501_after.config_data.network_os.policy.native_vlan == 88
+      - pc501_after.config_data.network_os.policy.description == "Ansible integration test PC 501 updated"
+
+- name: "MERGED UPDATE: Re-apply update for idempotency"
+  cisco.nd.nd_interface_port_channel_trunk_host: *merge_pc501_updated
+  register: nm_merged_update_501_idem
+
+- name: "MERGED UPDATE: Verify idempotency after update"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_501_idem is not changed
+
+# --- MERGED MEMBERSHIP: add a third member ---
+# Must run BEFORE PC 502/503 are created, so the third member (member_c) is free.
+
+- name: "SETUP: Reset port-channel501 to baseline before membership tests"
+  cisco.nd.nd_interface_port_channel_trunk_host: *merge_pc501
+
+- name: "MERGED MEMBER ADD: Add a third member to port-channel501 (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501_added_member }}"
+    state: merged
+  register: nm_merged_add_member
+
+- name: "MERGED MEMBER ADD: Verify member was added"
+  vars:
+    pc501_after: "{{ nm_merged_add_member.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_add_member is changed
+      - pc501_after.config_data.network_os.policy.ports | length == 3
+      - test_pc_member_c in pc501_after.config_data.network_os.policy.ports
+
+# --- MERGED MEMBERSHIP: remove members ---
+
+- name: "MERGED MEMBER REMOVE: Reduce port-channel501 to a single member (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501_removed_member }}"
+    state: merged
+  register: nm_merged_remove_member
+
+- name: "MERGED MEMBER REMOVE: Verify members were removed"
+  vars:
+    pc501_after: "{{ nm_merged_remove_member.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_remove_member is changed
+      - pc501_after.config_data.network_os.policy.ports | length == 1
+      - test_pc_member_a in pc501_after.config_data.network_os.policy.ports
+      - test_pc_member_b not in pc501_after.config_data.network_os.policy.ports
+      - test_pc_member_c not in pc501_after.config_data.network_os.policy.ports
+
+# --- MERGED CREATE: MULTIPLE PCs ---
+# Runs AFTER membership tests so that member_c (used by PC 502) and member_d
+# (used by PC 503) are not currently claimed by PC 501.
+
+- name: "MERGED CREATE: Create multiple port-channels in a single task (check mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: &merge_pc502_503
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_502 }}"
+      - "{{ test_pc_503 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_multi
+
+- name: "MERGED CREATE: Create multiple port-channels in a single task (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *merge_pc502_503
+  register: nm_merged_create_multi
+
+- name: "MERGED CREATE: Verify multiple port-channel creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_multi is changed
+      - nm_merged_create_multi is changed
+      - nm_merged_create_multi.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 1
+      - nm_merged_create_multi.after | selectattr('interface_name', 'equalto', 'port-channel503') | list | length == 1
+
+# --- MERGED WITH deploy: false ---
+
+- name: "MERGED NO-DEPLOY: Stage a port-channel without deploying"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel504
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "all"
+              ports: []
+              description: "No-deploy test port-channel504"
+    config_actions:
+      deploy: false
+    state: merged
+  register: nm_merged_no_deploy
+
+- name: "MERGED NO-DEPLOY: Verify change was staged"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_no_deploy is changed
+
+# Cleanup the no-deploy test port-channel
+- name: "CLEANUP: Remove port-channel504"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel504
+    state: deleted

--- a/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/overridden.yaml
@@ -1,0 +1,98 @@
+---
+# Overridden state tests for nd_interface_port_channel_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point port-channel501 (replaced), port-channel502 (replaced), port-channel503 (replaced) exist.
+# Override will reduce the set to only what is specified in config.
+
+# --- OVERRIDDEN: REDUCE TO SINGLE PORT-CHANNEL ---
+
+- name: "OVERRIDDEN: Override to only port-channel501 (check mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: &override_pc501
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "175"
+              native_vlan: 17
+              ports:
+                - "{{ test_pc_member_a }}"
+              description: "Overridden port-channel501"
+    state: overridden
+  check_mode: true
+  register: cm_overridden_single
+
+- name: "OVERRIDDEN: Override to only port-channel501 (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *override_pc501
+  register: nm_overridden_single
+
+- name: "OVERRIDDEN: Verify override removed extra port-channels"
+  vars:
+    pc501_after: "{{ nm_overridden_single.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_overridden_single is changed
+      - nm_overridden_single is changed
+      # After should contain only port-channel501. port-channel502 and 503 should have been removed.
+      - nm_overridden_single.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 1
+      - nm_overridden_single.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 0
+      - nm_overridden_single.after | selectattr('interface_name', 'equalto', 'port-channel503') | list | length == 0
+      - pc501_after.config_data.network_os.policy.allowed_vlans == "175"
+      - pc501_after.config_data.network_os.policy.description == "Overridden port-channel501"
+
+# --- OVERRIDDEN: IDEMPOTENCY ---
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply same overridden config"
+  cisco.nd.nd_interface_port_channel_trunk_host: *override_pc501
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_idem is not changed
+
+# --- OVERRIDDEN: SWAP ---
+# Restore port-channel502 and port-channel503 to a known baseline by overriding to a new set.
+
+- name: "OVERRIDDEN SWAP: Override to port-channel502 and port-channel503, removing port-channel501"
+  cisco.nd.nd_interface_port_channel_trunk_host: &override_pc502_503
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_502 }}"
+      - "{{ test_pc_503 }}"
+    state: overridden
+  register: nm_overridden_swap
+
+- name: "OVERRIDDEN SWAP: Verify port-channel501 removed and port-channel502/503 present"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_swap is changed
+      - nm_overridden_swap.after | selectattr('interface_name', 'equalto', 'port-channel501') | list | length == 0
+      - nm_overridden_swap.after | selectattr('interface_name', 'equalto', 'port-channel502') | list | length == 1
+      - nm_overridden_swap.after | selectattr('interface_name', 'equalto', 'port-channel503') | list | length == 1
+
+# --- OVERRIDDEN: NON-PORT-CHANNEL FILTERING ---
+# Verifies that overridden state only operates on portChannel interfaces with managed policy types.
+# Standalone ethernet interfaces and other interface types must NOT be touched by this module.
+# Likewise, accessPoHost port-channels must NOT be visible to or removed by this module.
+
+- name: "OVERRIDDEN FILTER: Re-apply prior swap config to confirm idempotency / no leakage"
+  cisco.nd.nd_interface_port_channel_trunk_host: *override_pc502_503
+  register: nm_overridden_filter
+
+- name: "OVERRIDDEN FILTER: Verify only port-channel interfaces appear in before collection"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_filter is not changed
+      # Before collection must contain only portChannel interfaces; non-PC types would
+      # indicate the orchestrator's interfaceType filter is broken.
+      - nm_overridden_filter.before | rejectattr('interface_type', 'equalto', 'portChannel') | list | length == 0

--- a/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/replaced.yaml
@@ -1,0 +1,102 @@
+---
+# Replaced state tests for nd_interface_port_channel_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point port-channel501 (single member, allowed_vlans 100-200), port-channel502, port-channel503 exist from merged tests.
+
+# --- REPLACED: FULL REPLACE ---
+
+- name: "REPLACED: Replace port-channel501 with a minimal config (check mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: &replace_pc501
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "250"
+              native_vlan: 50
+              ports:
+                - "{{ test_pc_member_a }}"
+              description: "Replaced port-channel501"
+    state: replaced
+  check_mode: true
+  register: cm_replaced_501
+
+- name: "REPLACED: Replace port-channel501 with a minimal config (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *replace_pc501
+  register: nm_replaced_501
+
+- name: "REPLACED: Verify port-channel501 was replaced"
+  vars:
+    pc501_after: "{{ nm_replaced_501.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_501 is changed
+      - nm_replaced_501 is changed
+      - pc501_after.config_data.network_os.policy.allowed_vlans == "250"
+      - pc501_after.config_data.network_os.policy.native_vlan == 50
+      - pc501_after.config_data.network_os.policy.description == "Replaced port-channel501"
+      - pc501_after.config_data.network_os.policy.ports | length == 1
+      - test_pc_member_a in pc501_after.config_data.network_os.policy.ports
+
+# --- REPLACED: IDEMPOTENCY ---
+
+- name: "REPLACED IDEMPOTENT: Re-apply same replaced config"
+  cisco.nd.nd_interface_port_channel_trunk_host: *replace_pc501
+  register: nm_replaced_501_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_501_idem is not changed
+
+# --- REPLACED: MULTIPLE PORT-CHANNELS ---
+
+- name: "REPLACED MULTI: Replace port-channel502 and port-channel503 (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "222"
+              native_vlan: 22
+              ports:
+                - "{{ test_pc_member_c }}"
+              description: "Replaced port-channel502"
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel503
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              allowed_vlans: "333,444"
+              native_vlan: 33
+              ports:
+                - "{{ test_pc_member_d }}"
+              description: "Replaced port-channel503"
+    state: replaced
+  register: nm_replaced_multi
+
+- name: "REPLACED MULTI: Verify both port-channels were replaced"
+  vars:
+    pc502_after: "{{ nm_replaced_multi.after | selectattr('interface_name', 'equalto', 'port-channel502') | first }}"
+    pc503_after: "{{ nm_replaced_multi.after | selectattr('interface_name', 'equalto', 'port-channel503') | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_multi is changed
+      - pc502_after.config_data.network_os.policy.allowed_vlans == "222"
+      - pc502_after.config_data.network_os.policy.description == "Replaced port-channel502"
+      - pc503_after.config_data.network_os.policy.allowed_vlans == "333,444"
+      - pc503_after.config_data.network_os.policy.admin_state == false

--- a/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/setup.yaml
@@ -1,0 +1,23 @@
+---
+# Pre-test cleanup for nd_interface_port_channel_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Called from main.yaml before the merged/replaced/overridden/deleted/vlan_mapping
+# state blocks. Ensures no test port-channels exist on the target switch before
+# the state tests run.
+
+- name: "SETUP: Remove test port-channels before state tests"
+  cisco.nd.nd_interface_port_channel_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel502
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel503
+    state: deleted
+  tags: always

--- a/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/vlan_mapping.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_trunk_host/tasks/vlan_mapping.yaml
@@ -1,0 +1,66 @@
+---
+# vlan_mapping tests for nd_interface_port_channel_trunk_host (non-9000v testbeds only)
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# This file is included from main.yaml only when nd_test_platform != "9000v".
+# Virtual switches reject `switchport vlan mapping ... dot1q-tunnel`; ND surfaces
+# this as HTTP 400 from the trunkPoHost validator
+# ("Validation failed for following fields: [vlanMappingEntries-dot1qTunnel]").
+
+# --- SETUP ---
+
+- name: "SETUP: Remove test port-channels before vlan_mapping tests"
+  cisco.nd.nd_interface_port_channel_trunk_host: &delete_pc501
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: port-channel501
+    state: deleted
+
+# --- VLAN_MAPPING CREATE ---
+
+- name: "VLAN_MAPPING: Create port-channel501 with vlan_mapping enabled (check mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: &merge_pc501_vlan_mapping
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ test_pc_501_with_vlan_mapping }}"
+    state: merged
+  check_mode: true
+  register: cm_vlan_mapping_create
+
+- name: "VLAN_MAPPING: Create port-channel501 with vlan_mapping enabled (normal mode)"
+  cisco.nd.nd_interface_port_channel_trunk_host: *merge_pc501_vlan_mapping
+  register: nm_vlan_mapping_create
+
+- name: "VLAN_MAPPING: Verify vlan_mapping was applied"
+  vars:
+    pc501_after: "{{ nm_vlan_mapping_create.after | selectattr('interface_name', 'equalto', 'port-channel501') | first }}"
+    entries: "{{ pc501_after.config_data.network_os.policy.vlan_mapping_entries }}"
+  ansible.builtin.assert:
+    that:
+      - cm_vlan_mapping_create is changed
+      - nm_vlan_mapping_create is changed
+      - pc501_after.config_data.network_os.policy.vlan_mapping == true
+      - entries | length == 1
+      - entries[0].provider_vlan_id == 1100
+      - entries[0].dot1q_tunnel == true
+
+# --- VLAN_MAPPING IDEMPOTENCY ---
+
+- name: "VLAN_MAPPING IDEMPOTENT: Re-apply same vlan_mapping config"
+  cisco.nd.nd_interface_port_channel_trunk_host: *merge_pc501_vlan_mapping
+  register: nm_vlan_mapping_idem
+
+- name: "VLAN_MAPPING IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_vlan_mapping_idem is not changed
+
+# --- CLEANUP ---
+
+- name: "CLEANUP: Remove vlan_mapping test port-channel"
+  cisco.nd.nd_interface_port_channel_trunk_host: *delete_pc501

--- a/tests/integration/targets/nd_interface_port_channel_trunk_host/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_port_channel_trunk_host/vars/main.yaml
@@ -1,0 +1,132 @@
+---
+# Variables for nd_interface_port_channel_trunk_host integration tests.
+#
+# Override these in your inventory or extra-vars to match a real ND 4.2 testbed.
+# Member ethernet interfaces (test_pc_member_*) MUST exist on the target switch and
+# MUST NOT be members of any other port-channel before tests run, or the cleanup
+# at the start of each state file will revert them to fabric defaults.
+
+test_fabric_name: "{{ nd_test_fabric_name | default('test_fabric') }}"
+test_switch_ip: "{{ nd_test_switch_ip | default('192.168.1.1') }}"
+
+# Member ethernet interface names. Override per-testbed.
+test_pc_member_a: "{{ nd_test_pc_member_a | default('Ethernet1/10') }}"
+test_pc_member_b: "{{ nd_test_pc_member_b | default('Ethernet1/11') }}"
+test_pc_member_c: "{{ nd_test_pc_member_c | default('Ethernet1/12') }}"
+test_pc_member_d: "{{ nd_test_pc_member_d | default('Ethernet1/13') }}"
+
+# Port-channel IDs 501-509 are reserved for these integration tests.
+
+test_pc_501:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel501
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-200"
+        native_vlan: 99
+        ports:
+          - "{{ test_pc_member_a }}"
+          - "{{ test_pc_member_b }}"
+        port_channel_mode: active
+        lacp_rate: fast
+        description: "Ansible integration test PC 501"
+
+test_pc_502:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel502
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "300-400"
+        native_vlan: 199
+        ports:
+          - "{{ test_pc_member_c }}"
+        port_channel_mode: active
+        description: "Ansible integration test PC 502"
+
+test_pc_503:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel503
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "all"
+        ports:
+          - "{{ test_pc_member_d }}"
+        port_channel_mode: passive
+        description: "Ansible integration test PC 503"
+
+# Updated variants for merge/replace tests
+
+test_pc_501_updated_vlan:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel501
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-200,500"
+        native_vlan: 88
+        ports:
+          - "{{ test_pc_member_a }}"
+          - "{{ test_pc_member_b }}"
+        port_channel_mode: active
+        lacp_rate: fast
+        description: "Ansible integration test PC 501 updated"
+
+test_pc_501_added_member:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel501
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-200"
+        native_vlan: 99
+        ports:
+          - "{{ test_pc_member_a }}"
+          - "{{ test_pc_member_b }}"
+          - "{{ test_pc_member_c }}"
+        port_channel_mode: active
+        lacp_rate: fast
+        description: "Ansible integration test PC 501"
+
+test_pc_501_removed_member:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel501
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-200"
+        native_vlan: 99
+        ports:
+          - "{{ test_pc_member_a }}"
+        port_channel_mode: active
+        lacp_rate: fast
+        description: "Ansible integration test PC 501"
+
+# vlan_mapping fixture for non-9000v testbeds (used by tasks/vlan_mapping.yaml).
+
+test_pc_501_with_vlan_mapping:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: port-channel501
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-200"
+        native_vlan: 99
+        ports:
+          - "{{ test_pc_member_a }}"
+        port_channel_mode: active
+        description: "Ansible integration test PC 501 vlan-mapping"
+        vlan_mapping: true
+        vlan_mapping_entries:
+          - customer_vlan_id: ["100"]
+            provider_vlan_id: 1100
+            dot1q_tunnel: true

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/deleted.yaml
@@ -1,0 +1,41 @@
+---
+# Deleted state tests for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# After overridden.yaml, only vpc101 exists. Remove it explicitly and verify idempotency.
+
+- name: "DELETED: Remove vpc101 (check mode)"
+  cisco.nd.nd_interface_vpc_access: &delete_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip_peer1 }}"
+        interface_name: vpc101
+    state: deleted
+  check_mode: true
+  register: cm_deleted
+
+- name: "DELETED: Remove vpc101 (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *delete_vpc
+  register: nm_deleted
+
+- name: "DELETED: Verify delete produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted is changed
+      - nm_deleted is changed
+
+- name: "DELETED IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "DELETED IDEMPOTENT: Re-apply delete (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *delete_vpc
+  register: nm_deleted_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change after second delete"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
@@ -1,0 +1,63 @@
+---
+# Test code for the nd_interface_vpc_access module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#
+#   ansible-test integration nd_interface_vpc_access
+#
+# Lab pre-conditions (verified in reference_nd_lab.md):
+#   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.152) reachable
+#   - Ethernet1/5, Ethernet1/6, Ethernet1/7 free on both peers for vPC member testing
+#   - vPC pair uses a virtual peer-link (no physical peer-link cable required); see vars/main.yaml
+#
+# Setup creates the vPC pair if missing; teardown unpairs it (which cascades and removes all
+# member vPC interfaces, so we don't need an explicit vPC-interface teardown).
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_interface_vpc_access state tests
+  block:
+    - name: Pre-test setup (create vPC pair, clean any prior vPC interfaces)
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run nd_interface_vpc_access merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run nd_interface_vpc_access replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run nd_interface_vpc_access overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run nd_interface_vpc_access deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  always:
+    - name: Teardown (unpair vPC, cascades to remove any remaining vPC interfaces)
+      cisco.nd.nd_manage_vpc_pair:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - peer1_switch_id: "{{ test_switch_ip_peer1 }}"
+            peer2_switch_id: "{{ test_switch_ip_peer2 }}"
+        state: deleted
+      ignore_errors: true
+  module_defaults:
+    cisco.nd.nd_interface_vpc_access:
+      timeout: 300
+    cisco.nd.nd_manage_vpc_pair:
+      timeout: 300
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/merged.yaml
@@ -1,0 +1,48 @@
+---
+# Merged state tests for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- MERGED CREATE ---
+
+- name: "MERGED CREATE: Create vpc100 (check mode)"
+  cisco.nd.nd_interface_vpc_access: &merge_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_access_baseline }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create
+
+- name: "MERGED CREATE: Create vpc100 (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *merge_vpc
+  register: nm_merged_create
+
+- name: "MERGED CREATE: Verify creation produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create is changed
+      - nm_merged_create is changed
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Pause for switch convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "MERGED IDEMPOTENT: Re-apply vpc100 (check mode)"
+  cisco.nd.nd_interface_vpc_access: *merge_vpc
+  check_mode: true
+  register: cm_merged_idem
+
+- name: "MERGED IDEMPOTENT: Re-apply vpc100 (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *merge_vpc
+  register: nm_merged_idem
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem is not changed
+      - nm_merged_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/overridden.yaml
@@ -1,0 +1,41 @@
+---
+# Overridden state tests for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# After replaced.yaml, vpc100 exists. State overridden with a single new vpc (vpc101) should
+# remove vpc100 and create vpc101 fabric-wide.
+
+- name: "OVERRIDDEN: Single source of truth = vpc101 only (check mode)"
+  cisco.nd.nd_interface_vpc_access: &override_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_access_overridden }}"
+    state: overridden
+  check_mode: true
+  register: cm_overridden
+
+- name: "OVERRIDDEN: Single source of truth = vpc101 only (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *override_vpc
+  register: nm_overridden
+
+- name: "OVERRIDDEN: Verify override produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_overridden is changed
+      - nm_overridden is changed
+
+- name: "OVERRIDDEN IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *override_vpc
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change on re-apply"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/replaced.yaml
@@ -1,0 +1,41 @@
+---
+# Replaced state tests for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# vpc100 was created in merged.yaml. Replace its config (change VLAN, add a peer1 member)
+# and verify the change is reflected.
+
+- name: "REPLACED: Update vpc100 policy (check mode)"
+  cisco.nd.nd_interface_vpc_access: &replace_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_access_updated }}"
+    state: replaced
+  check_mode: true
+  register: cm_replaced
+
+- name: "REPLACED: Update vpc100 policy (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *replace_vpc
+  register: nm_replaced
+
+- name: "REPLACED: Verify replace produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced is changed
+      - nm_replaced is changed
+
+- name: "REPLACED IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "REPLACED IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *replace_vpc
+  register: nm_replaced_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on re-apply"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/setup.yaml
@@ -1,0 +1,40 @@
+---
+# Pre-test setup for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Ensures:
+#   1. Any pre-existing vPC pair on the test peers is removed (clears any stale vPC interfaces).
+#   2. A fresh vPC pair is created so the access tests have a stable substrate.
+#   3. ND switch poller has time to discover the new pair before tests start.
+
+- name: "SETUP: Tear down any existing vPC pair on test peers"
+  cisco.nd.nd_manage_vpc_pair:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - peer1_switch_id: "{{ test_switch_ip_peer1 }}"
+        peer2_switch_id: "{{ test_switch_ip_peer2 }}"
+    state: deleted
+  ignore_errors: true
+  tags: always
+
+- name: "SETUP: Pause for unpair convergence"
+  ansible.builtin.pause:
+    seconds: 30
+  tags: always
+
+- name: "SETUP: Create vPC pair"
+  cisco.nd.nd_manage_vpc_pair:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_pair_setup }}"
+    state: merged
+  tags: always
+
+- name: "SETUP: Pause for pair-establishment convergence"
+  ansible.builtin.pause:
+    seconds: 30
+  tags: always

--- a/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
@@ -1,0 +1,92 @@
+---
+# Variables for nd_interface_vpc_access integration tests.
+#
+# Override the defaults in your inventory or extra-vars to match a real ND 4.2 testbed.
+# The defaults below match the SITE1 lab documented in reference_nd_lab.md.
+
+test_fabric_name: "{{ nd_test_vpc_access_fabric_name | default(nd_test_fabric_name | default('SITE1')) }}"
+test_switch_ip_peer1: "{{ nd_test_vpc_peer1_ip | default('192.168.12.151') }}"
+test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.152') }}"
+
+# vPC pair substrate created by setup via M(cisco.nd.nd_manage_vpc_pair) (from PR #197 on develop).
+# The previous nd_vpc_pair module was closed (PR #278); the shared vPC interface infrastructure was
+# re-homed onto the nd_interface_vpc_base branch, and this substrate now uses nd_manage_vpc_pair.
+#
+# peer1_switch_id / peer2_switch_id accept management IPs (or serials).
+#
+# This substrate uses a VIRTUAL peer-link (use_virtual_peer_link: true). A PHYSICAL peer-link is the
+# real-world-preferred config, but it is currently broken at the ND controller layer: actions/configSave
+# fails to generate physical vPC peer-link config with HTTP 500 "Member port <Eth> is a member of
+# VPC_PAIR, remove ... first" (lab-verified on ND with NX-OS 10.6(2), reproducible via the raw API and
+# independent of nd_manage_vpc_pair). A virtual peer-link generates, deploys, and forms cleanly on the
+# same N9000v switches (both peers vpcConfigured, consistency OK). Virtual peer-link is sufficient here
+# because the vPC interface tests only need the pair to exist for peer-serial resolution.
+#
+# TODO(4.2.1) vpc-physical-peer-link-configsave-fails
+# Revert to a physical peer-link once ND fixes physical peer-link config generation, i.e. restore
+# use_virtual_peer_link: false plus switch_po_id / peer_switch_po_id / switch_member_interfaces /
+# peer_switch_member_interfaces (Ethernet1/2 on both peers) under vpc_pair_details.
+vpc_pair_setup:
+  peer1_switch_id: "{{ test_switch_ip_peer1 }}"
+  peer2_switch_id: "{{ test_switch_ip_peer2 }}"
+  use_virtual_peer_link: true
+  vpc_pair_details:
+    type: default
+    domain_id: 1
+    keep_alive_vrf: management
+    switch_keep_alive_local_ip: "{{ test_switch_ip_peer1 }}"
+    peer_switch_keep_alive_local_ip: "{{ test_switch_ip_peer2 }}"
+
+# Baseline vPC access interface used by merged + idempotency tests.
+vpc_access_baseline:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc100
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 10
+        peer1_port_channel_id: 100
+        peer1_member_ports:
+          - Ethernet1/5
+        peer2_port_channel_id: 100
+        peer2_member_ports:
+          - Ethernet1/5
+        port_channel_mode: active
+        lacp_rate: fast
+
+# Updated config for replaced tests (different access VLAN + add a member on peer1).
+vpc_access_updated:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc100
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 20
+        peer1_port_channel_id: 100
+        peer1_member_ports:
+          - Ethernet1/5
+          - Ethernet1/6
+        peer2_port_channel_id: 100
+        peer2_member_ports:
+          - Ethernet1/5
+        port_channel_mode: active
+        lacp_rate: fast
+
+# Second vPC for overridden test: define only this one, expect vpc100 to be removed.
+vpc_access_overridden:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc101
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 30
+        peer1_port_channel_id: 101
+        peer1_member_ports:
+          - Ethernet1/7
+        peer2_port_channel_id: 101
+        peer2_member_ports:
+          - Ethernet1/7
+        port_channel_mode: active

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/deleted.yaml
@@ -1,0 +1,41 @@
+---
+# Deleted state tests for nd_interface_vpc_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# After overridden.yaml, only vpc201 exists. Remove it explicitly and verify idempotency.
+
+- name: "DELETED: Remove vpc201 (check mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: &delete_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip_peer1 }}"
+        interface_name: vpc201
+    state: deleted
+  check_mode: true
+  register: cm_deleted
+
+- name: "DELETED: Remove vpc201 (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *delete_vpc
+  register: nm_deleted
+
+- name: "DELETED: Verify delete produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted is changed
+      - nm_deleted is changed
+
+- name: "DELETED IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "DELETED IDEMPOTENT: Re-apply delete (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *delete_vpc
+  register: nm_deleted_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change after second delete"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
@@ -1,0 +1,63 @@
+---
+# Test code for the nd_interface_vpc_trunk_host module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#
+#   ansible-test integration nd_interface_vpc_trunk_host
+#
+# Lab pre-conditions (verified in reference_nd_lab.md):
+#   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.152) reachable
+#   - Ethernet1/8, Ethernet1/9, Ethernet1/10 free on both peers for vPC member testing
+#   - vPC pair uses a virtual peer-link (no physical peer-link cable required); see vars/main.yaml
+#
+# Setup creates the vPC pair if missing; teardown unpairs it (which cascades and removes all
+# member vPC interfaces, so we don't need an explicit vPC-interface teardown).
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_interface_vpc_trunk_host state tests
+  block:
+    - name: Pre-test setup (create vPC pair, clean any prior vPC interfaces)
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run nd_interface_vpc_trunk_host merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run nd_interface_vpc_trunk_host replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run nd_interface_vpc_trunk_host overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run nd_interface_vpc_trunk_host deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  always:
+    - name: Teardown (unpair vPC, cascades to remove any remaining vPC interfaces)
+      cisco.nd.nd_manage_vpc_pair:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - peer1_switch_id: "{{ test_switch_ip_peer1 }}"
+            peer2_switch_id: "{{ test_switch_ip_peer2 }}"
+        state: deleted
+      ignore_errors: true
+  module_defaults:
+    cisco.nd.nd_interface_vpc_trunk_host:
+      timeout: 300
+    cisco.nd.nd_manage_vpc_pair:
+      timeout: 300
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/merged.yaml
@@ -1,0 +1,85 @@
+---
+# Merged state tests for nd_interface_vpc_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- MERGED CREATE ---
+
+- name: "MERGED CREATE: Create vpc200 (check mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: &merge_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_trunk_host_baseline }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create
+
+- name: "MERGED CREATE: Create vpc200 (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *merge_vpc
+  register: nm_merged_create
+
+- name: "MERGED CREATE: Verify creation produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create is changed
+      - nm_merged_create is changed
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Pause for switch convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "MERGED IDEMPOTENT: Re-apply vpc200 (check mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *merge_vpc
+  check_mode: true
+  register: cm_merged_idem
+
+- name: "MERGED IDEMPOTENT: Re-apply vpc200 (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *merge_vpc
+  register: nm_merged_idem
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem is not changed
+      - nm_merged_idem is not changed
+
+# --- VLAN MAPPING (gated on supports_vlan_mapping) ---
+# Skipped by default because Nexus 9000v virtual switches reject
+# `switchport vlan mapping ... dot1q-tunnel ...`. Set ND_SUPPORTS_VLAN_MAPPING=true on
+# hardware-backed testbeds to exercise these blocks.
+
+- name: "MERGED VLAN MAPPING: Apply vlan_mapping_entries (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: &merge_vpc_vlan_map
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_trunk_host_with_vlan_mapping }}"
+    state: merged
+  register: nm_merged_vlan_map
+  when: supports_vlan_mapping | default(false) | bool
+
+- name: "MERGED VLAN MAPPING: Verify vlan mapping change applied"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_vlan_map is changed
+  when: supports_vlan_mapping | default(false) | bool
+
+- name: "MERGED VLAN MAPPING IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+  when: supports_vlan_mapping | default(false) | bool
+
+- name: "MERGED VLAN MAPPING IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *merge_vpc_vlan_map
+  register: nm_merged_vlan_map_idem
+  when: supports_vlan_mapping | default(false) | bool
+
+- name: "MERGED VLAN MAPPING IDEMPOTENT: Verify no change on re-apply"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_vlan_map_idem is not changed
+  when: supports_vlan_mapping | default(false) | bool

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/overridden.yaml
@@ -1,0 +1,41 @@
+---
+# Overridden state tests for nd_interface_vpc_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# After replaced.yaml, vpc200 exists. State overridden with a single new vpc (vpc201) should
+# remove vpc200 and create vpc201 fabric-wide.
+
+- name: "OVERRIDDEN: Single source of truth = vpc201 only (check mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: &override_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_trunk_host_overridden }}"
+    state: overridden
+  check_mode: true
+  register: cm_overridden
+
+- name: "OVERRIDDEN: Single source of truth = vpc201 only (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *override_vpc
+  register: nm_overridden
+
+- name: "OVERRIDDEN: Verify override produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_overridden is changed
+      - nm_overridden is changed
+
+- name: "OVERRIDDEN IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *override_vpc
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change on re-apply"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/replaced.yaml
@@ -1,0 +1,41 @@
+---
+# Replaced state tests for nd_interface_vpc_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# vpc200 was created in merged.yaml. Replace its config (change allowed_vlans, native_vlan,
+# add a peer1 member) and verify the change is reflected.
+
+- name: "REPLACED: Update vpc200 policy (check mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: &replace_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_trunk_host_updated }}"
+    state: replaced
+  check_mode: true
+  register: cm_replaced
+
+- name: "REPLACED: Update vpc200 policy (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *replace_vpc
+  register: nm_replaced
+
+- name: "REPLACED: Verify replace produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced is changed
+      - nm_replaced is changed
+
+- name: "REPLACED IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "REPLACED IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *replace_vpc
+  register: nm_replaced_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on re-apply"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/setup.yaml
@@ -1,0 +1,40 @@
+---
+# Pre-test setup for nd_interface_vpc_trunk_host
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Ensures:
+#   1. Any pre-existing vPC pair on the test peers is removed (clears any stale vPC interfaces).
+#   2. A fresh vPC pair is created so the trunk-host tests have a stable substrate.
+#   3. ND switch poller has time to discover the new pair before tests start.
+
+- name: "SETUP: Tear down any existing vPC pair on test peers"
+  cisco.nd.nd_manage_vpc_pair:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - peer1_switch_id: "{{ test_switch_ip_peer1 }}"
+        peer2_switch_id: "{{ test_switch_ip_peer2 }}"
+    state: deleted
+  ignore_errors: true
+  tags: always
+
+- name: "SETUP: Pause for unpair convergence"
+  ansible.builtin.pause:
+    seconds: 30
+  tags: always
+
+- name: "SETUP: Create vPC pair"
+  cisco.nd.nd_manage_vpc_pair:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_pair_setup }}"
+    state: merged
+  tags: always
+
+- name: "SETUP: Pause for pair-establishment convergence"
+  ansible.builtin.pause:
+    seconds: 30
+  tags: always

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/vars/main.yaml
@@ -1,0 +1,130 @@
+---
+# Variables for nd_interface_vpc_trunk_host integration tests.
+#
+# Override the defaults in your inventory or extra-vars to match a real ND 4.2 testbed.
+# The defaults below match the SITE1 lab documented in reference_nd_lab.md.
+
+test_fabric_name: "{{ nd_test_vpc_trunk_host_fabric_name | default(nd_test_fabric_name | default('SITE1')) }}"
+test_switch_ip_peer1: "{{ nd_test_vpc_peer1_ip | default('192.168.12.151') }}"
+test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.152') }}"
+
+# vPC pair substrate created by setup via M(cisco.nd.nd_manage_vpc_pair) (from PR #197 on develop).
+# The previous nd_vpc_pair module was closed (PR #278); the shared vPC interface infrastructure was
+# re-homed onto the nd_interface_vpc_base branch, and this substrate now uses nd_manage_vpc_pair.
+#
+# peer1_switch_id / peer2_switch_id accept management IPs (or serials).
+#
+# This substrate uses a VIRTUAL peer-link (use_virtual_peer_link: true). A PHYSICAL peer-link is the
+# real-world-preferred config, but it is currently broken at the ND controller layer: actions/configSave
+# fails to generate physical vPC peer-link config with HTTP 500 "Member port <Eth> is a member of
+# VPC_PAIR, remove ... first" (lab-verified on ND with NX-OS 10.6(2), reproducible via the raw API and
+# independent of nd_manage_vpc_pair). A virtual peer-link generates, deploys, and forms cleanly on the
+# same N9000v switches (both peers vpcConfigured, consistency OK). Virtual peer-link is sufficient here
+# because the vPC interface tests only need the pair to exist for peer-serial resolution.
+#
+# TODO(4.2.1) vpc-physical-peer-link-configsave-fails
+# Revert to a physical peer-link once ND fixes physical peer-link config generation, i.e. restore
+# use_virtual_peer_link: false plus switch_po_id / peer_switch_po_id / switch_member_interfaces /
+# peer_switch_member_interfaces (Ethernet1/2 on both peers) under vpc_pair_details.
+vpc_pair_setup:
+  peer1_switch_id: "{{ test_switch_ip_peer1 }}"
+  peer2_switch_id: "{{ test_switch_ip_peer2 }}"
+  use_virtual_peer_link: true
+  vpc_pair_details:
+    type: default
+    domain_id: 1
+    keep_alive_vrf: management
+    switch_keep_alive_local_ip: "{{ test_switch_ip_peer1 }}"
+    peer_switch_keep_alive_local_ip: "{{ test_switch_ip_peer2 }}"
+
+# Baseline vPC trunk-host interface used by merged + idempotency tests.
+# ND requires per-peer peer1AllowedVlans/peer2AllowedVlans and peer1NativeVlan/peer2NativeVlan
+# but enforces consistency between them and collapses to single values on GET. The model exposes
+# single user-facing `allowed_vlans` and `native_vlan` and fans them out on write.
+vpc_trunk_host_baseline:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc200
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-200"
+        native_vlan: 99
+        peer1_port_channel_id: 200
+        peer1_member_ports:
+          - Ethernet1/8
+        peer2_port_channel_id: 200
+        peer2_member_ports:
+          - Ethernet1/8
+        port_channel_mode: active
+        lacp_rate: fast
+        mtu: jumbo
+
+# Updated config for replaced tests (different allowed_vlans + native_vlan + add a member on peer1).
+vpc_trunk_host_updated:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc200
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-300"
+        native_vlan: 100
+        peer1_port_channel_id: 200
+        peer1_member_ports:
+          - Ethernet1/8
+          - Ethernet1/9
+        peer2_port_channel_id: 200
+        peer2_member_ports:
+          - Ethernet1/8
+        port_channel_mode: active
+        lacp_rate: fast
+        mtu: jumbo
+
+# Second vPC for overridden test: define only this one, expect vpc200 to be removed.
+vpc_trunk_host_overridden:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc201
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: all
+        native_vlan: 1
+        peer1_port_channel_id: 201
+        peer1_member_ports:
+          - Ethernet1/10
+        peer2_port_channel_id: 201
+        peer2_member_ports:
+          - Ethernet1/10
+        port_channel_mode: active
+
+# VLAN mapping case — only run when supports_vlan_mapping is true (hardware-backed testbeds).
+# Nexus 9000v virtual switches reject `switchport vlan mapping ... dot1q-tunnel ...`.
+vpc_trunk_host_with_vlan_mapping:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc200
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-200"
+        native_vlan: 99
+        peer1_port_channel_id: 200
+        peer1_member_ports:
+          - Ethernet1/8
+        peer2_port_channel_id: 200
+        peer2_member_ports:
+          - Ethernet1/8
+        port_channel_mode: active
+        vlan_mapping: true
+        vlan_mapping_entries:
+          - customer_vlan_id:
+              - "100"
+              - "200-300"
+            provider_vlan_id: 1000
+          - customer_vlan_id:
+              - "500"
+            customer_inner_vlan_id: 510
+            provider_vlan_id: 1010
+            dot1q_tunnel: true

--- a/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
@@ -240,6 +240,66 @@
         "DATA": {}
     },
 
+    "test_query_all_config_scoped_00440a": {
+        "TEST_NOTES": [
+            "Fabric summary: fabric exists (for validate_prerequisites)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_config_scoped_00440b": {
+        "TEST_NOTES": [
+            "Switch list: two switches in fabric_1, but config names only 192.168.1.1.",
+            "Expect: query_all (state!=overridden) scopes to the config switch and never GETs FDO22222BBB's interfaces."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_query_all_config_scoped_00440c": {
+        "TEST_NOTES": [
+            "Interfaces for the config-named switch FDO11111AAA: one accessPoHost port-channel.",
+            "If query_all were NOT config-scoped it would also GET FDO22222BBB and exhaust the response generator."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "accessVlan": 100,
+                                "ports": ["Ethernet1/1"],
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+
     "test_port_channel_access_orchestrator_00200a": {
         "TEST_NOTES": ["create happy path: switches list (1 switch)"],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
@@ -1,0 +1,270 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py",
+        "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
+        "The fixtures simulate ND responses for:",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/summary  (fabric_summary via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/deploymentFreeze (deploymentFreeze via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches (switch_map via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/interfaces (EpManageInterfacesListGet per switch)"
+    ],
+    "test_query_all_happy_path_00400a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_happy_path_00400_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_happy_path_00400b": {
+        "TEST_NOTES": ["Switch list: two switches in fabric_1"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDO22222BBB"
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400c": {
+        "TEST_NOTES": [
+            "Interfaces for switch FDO11111AAA: configured accessPoHost portChannel, trunkPoHost portChannel, ethernet trunkHost.",
+            "Expect: only the accessPoHost port-channel is retained after filtering."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "accessVlan": 100,
+                                "ports": ["Ethernet1/1", "Ethernet1/2"],
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "allowedVlans": "1-100",
+                                "ports": ["Ethernet1/3"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400d": {
+        "TEST_NOTES": ["Interfaces for switch FDO22222BBB: one configured accessPoHost port-channel."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel601",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "accessVlan": 200,
+                                "ports": ["Ethernet1/5"],
+                                "portChannelMode": "passive"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_no_match_00410_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_no_match_00410b": {
+        "TEST_NOTES": ["Switch list: one switch"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410c": {
+        "TEST_NOTES": [
+            "Interfaces for switch FDO11111AAA: only ethernet and non-accessPoHost port-channel interfaces.",
+            "Expect: filter returns an empty list."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel700",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessHost",
+                                "accessVlan": 10
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_fabric_not_found_00420a": {
+        "TEST_NOTES": ["Fabric summary: 404 not found; validate_prerequisites should raise RuntimeError."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_query_all_switch_404_00430a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_switch_404_00430_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_switch_404_00430b": {
+        "TEST_NOTES": ["Switch list: one switch"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_query_all_switch_404_00430c": {
+        "TEST_NOTES": [
+            "Interfaces endpoint returns 404 for the switch (no interfaces present).",
+            "PortChannelBaseOrchestrator.query_all uses not_found_ok=True; the empty result is skipped."
+        ],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
@@ -3,8 +3,7 @@
         "Fixture data for tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py",
         "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
         "The fixtures simulate ND responses for:",
-        "  - GET /api/v1/manage/fabrics/{fabric_name}/summary  (fabric_summary via FabricContext)",
-        "  - GET /api/v1/manage/fabrics/{fabric_name}/deploymentFreeze (deploymentFreeze via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/summary  (fabric_summary via FabricContext; FabricContext.fabric_is_deployment_frozen() reads the fabricStatus field from this response, not a separate /deploymentFreeze endpoint)",
         "  - GET /api/v1/manage/fabrics/{fabric_name}/switches (switch_map via FabricContext)",
         "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/interfaces (EpManageInterfacesListGet per switch)"
     ],
@@ -17,16 +16,6 @@
         "DATA": {
             "name": "fabric_1",
             "ownerCluster": "cluster_a"
-        }
-    },
-    "test_query_all_happy_path_00400_freeze": {
-        "TEST_NOTES": ["Deployment freeze: disabled (for validate_prerequisites)"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
-        "MESSAGE": "OK",
-        "DATA": {
-            "deploymentFreeze": false
         }
     },
     "test_query_all_happy_path_00400b": {
@@ -145,16 +134,6 @@
             "ownerCluster": "cluster_a"
         }
     },
-    "test_query_all_no_match_00410_freeze": {
-        "TEST_NOTES": ["Deployment freeze: disabled"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
-        "MESSAGE": "OK",
-        "DATA": {
-            "deploymentFreeze": false
-        }
-    },
     "test_query_all_no_match_00410b": {
         "TEST_NOTES": ["Switch list: one switch"],
         "RETURN_CODE": 200,
@@ -229,16 +208,6 @@
         "DATA": {
             "name": "fabric_1",
             "ownerCluster": "cluster_a"
-        }
-    },
-    "test_query_all_switch_404_00430_freeze": {
-        "TEST_NOTES": ["Deployment freeze: disabled"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
-        "MESSAGE": "OK",
-        "DATA": {
-            "deploymentFreeze": false
         }
     },
     "test_query_all_switch_404_00430b": {

--- a/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
@@ -5,7 +5,10 @@
         "The fixtures simulate ND responses for:",
         "  - GET /api/v1/manage/fabrics/{fabric_name}/summary  (fabric_summary via FabricContext; FabricContext.fabric_is_deployment_frozen() reads the fabricStatus field from this response, not a separate /deploymentFreeze endpoint)",
         "  - GET /api/v1/manage/fabrics/{fabric_name}/switches (switch_map via FabricContext)",
-        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/interfaces (EpManageInterfacesListGet per switch)"
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/interfaces (EpManageInterfacesListGet per switch)",
+        "  - POST/PUT/GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/interfaces[/{name}] (create/update/query_one/create_bulk for the 00200-00800 CRUD tests)",
+        "query_all tests (00400-00430) use descriptive keys; CRUD tests (00200-00800) use the test_<module>_<NNNNN><suffix> convention.",
+        "Switch A: fabricManagementIp=192.168.1.1, switchId=FDO11111AAA. Switch B: fabricManagementIp=192.168.1.2, switchId=FDO22222BBB."
     ],
     "test_query_all_happy_path_00400a": {
         "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)"],
@@ -235,5 +238,309 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
         "MESSAGE": "Not Found",
         "DATA": {}
+    },
+
+    "test_port_channel_access_orchestrator_00200a": {
+        "TEST_NOTES": ["create happy path: switches list (1 switch)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00200b": {
+        "TEST_NOTES": ["create happy path: POST /interfaces (200)"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_port_channel_access_orchestrator_00210a": {
+        "TEST_NOTES": ["create _request failure: switches list (1 switch)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00210b": {
+        "TEST_NOTES": ["create _request failure: POST returns 500"],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"error": "boom"}
+    },
+
+    "test_port_channel_access_orchestrator_00220a": {
+        "TEST_NOTES": ["create unknown switch_ip: switches list has a DIFFERENT IP than the model's switch_ip"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+
+    "test_port_channel_access_orchestrator_00300a": {
+        "TEST_NOTES": ["update happy path: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00300b": {
+        "TEST_NOTES": ["update happy path: PUT /interfaces/port-channel501"],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/port-channel501",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_port_channel_access_orchestrator_00310a": {
+        "TEST_NOTES": ["update _request failure: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00310b": {
+        "TEST_NOTES": ["update _request failure: PUT returns 500"],
+        "RETURN_CODE": 500,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/port-channel501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"error": "boom"}
+    },
+
+    "test_port_channel_access_orchestrator_00320a": {
+        "TEST_NOTES": ["delete: only switches list consumed (no API call by delete itself)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+
+    "test_port_channel_access_orchestrator_00330a": {
+        "TEST_NOTES": ["delete unknown switch: switches list has a DIFFERENT IP"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+
+    "test_port_channel_access_orchestrator_00500a": {
+        "TEST_NOTES": ["create_bulk: switches list with 2 switches"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00500b": {
+        "TEST_NOTES": ["create_bulk: POST switch A (port-channel501+port-channel502)"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+    "test_port_channel_access_orchestrator_00500c": {
+        "TEST_NOTES": ["create_bulk: POST switch B (port-channel601)"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_port_channel_access_orchestrator_00510a": {
+        "TEST_NOTES": ["create_bulk failure: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00510b": {
+        "TEST_NOTES": ["create_bulk failure: POST switch A succeeds"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+    "test_port_channel_access_orchestrator_00510c": {
+        "TEST_NOTES": ["create_bulk failure: POST switch B fails"],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"error": "boom"}
+    },
+
+    "test_port_channel_access_orchestrator_00520a": {
+        "TEST_NOTES": ["create_bulk single: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00520b": {
+        "TEST_NOTES": ["create_bulk single: POST switch A (port-channel501)"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_port_channel_access_orchestrator_00600a": {
+        "TEST_NOTES": ["delete_bulk: only switches list consumed"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_port_channel_access_orchestrator_00700a": {
+        "TEST_NOTES": ["query_one happy: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00700b": {
+        "TEST_NOTES": ["query_one happy: GET /interfaces/port-channel501"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/port-channel501",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaceName": "port-channel501",
+            "interfaceType": "portChannel",
+            "configData": {
+                "mode": "access",
+                "networkOS": {
+                    "networkOSType": "nx-os",
+                    "policy": {
+                        "policyType": "accessPoHost",
+                        "accessVlan": 100,
+                        "ports": ["Ethernet1/1"],
+                        "portChannelMode": "active"
+                    }
+                }
+            }
+        }
+    },
+
+    "test_port_channel_access_orchestrator_00710a": {
+        "TEST_NOTES": ["query_one failure: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00710b": {
+        "TEST_NOTES": ["query_one failure: GET returns 500"],
+        "RETURN_CODE": 500,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/port-channel501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"error": "boom"}
+    },
+
+    "test_port_channel_access_orchestrator_00800a": {
+        "TEST_NOTES": ["deploy queue de-dup: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00800b": {
+        "TEST_NOTES": ["deploy queue de-dup: first POST"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+    "test_port_channel_access_orchestrator_00800c": {
+        "TEST_NOTES": ["deploy queue de-dup: second POST (same identifier — should NOT add a second queue entry)"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_trunk_host_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_trunk_host_interface.json
@@ -1,0 +1,339 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for tests/unit/module_utils/orchestrators/test_port_channel_trunk_host_interface.py",
+        "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
+        "The fixtures simulate ND responses for:",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/summary  (fabric_summary via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/deploymentFreeze (deploymentFreeze via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches (switch_map via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/interfaces (EpManageInterfacesListGet per switch)"
+    ],
+    "test_query_all_happy_path_00400a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_happy_path_00400_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_happy_path_00400b": {
+        "TEST_NOTES": ["Switch list: two switches in fabric_1"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDO22222BBB"
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400c": {
+        "TEST_NOTES": [
+            "Interfaces for switch FDO11111AAA: configured trunkPoHost portChannel, accessPoHost portChannel, ethernet trunkHost.",
+            "Expect: only the trunkPoHost port-channel is retained after filtering."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "ports": ["Ethernet1/1", "Ethernet1/2"],
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "accessVlan": 100,
+                                "ports": ["Ethernet1/3"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400d": {
+        "TEST_NOTES": ["Interfaces for switch FDO22222BBB: one configured trunkPoHost port-channel."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel601",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "allowedVlans": "all",
+                                "ports": ["Ethernet1/5"],
+                                "portChannelMode": "passive"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_no_match_00410_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_no_match_00410b": {
+        "TEST_NOTES": ["Switch list: one switch"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410c": {
+        "TEST_NOTES": [
+            "Interfaces for switch FDO11111AAA: only ethernet and non-trunkPoHost port-channel interfaces.",
+            "Expect: filter returns an empty list."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel700",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "accessVlan": 10
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_fabric_not_found_00420a": {
+        "TEST_NOTES": ["Fabric summary: 404 not found; validate_prerequisites should raise RuntimeError."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_query_all_switch_404_00430a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_switch_404_00430_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_switch_404_00430b": {
+        "TEST_NOTES": ["Switch list: one switch"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_query_all_switch_404_00430c": {
+        "TEST_NOTES": [
+            "Interfaces endpoint returns 404 for the switch (no interfaces present).",
+            "PortChannelBaseOrchestrator.query_all uses not_found_ok=True; the empty result is skipped."
+        ],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_query_all_config_scoped_00440a": {
+        "TEST_NOTES": [
+            "Fabric summary: fabric exists (for validate_prerequisites)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_config_scoped_00440b": {
+        "TEST_NOTES": [
+            "Switch list: two switches in fabric_1, but config names only 192.168.1.1.",
+            "Expect: query_all (state!=overridden) scopes to the config switch and never GETs FDO22222BBB's interfaces."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDO22222BBB"
+                }
+            ]
+        }
+    },
+    "test_query_all_config_scoped_00440c": {
+        "TEST_NOTES": [
+            "Interfaces for the config-named switch FDO11111AAA: one trunkPoHost port-channel.",
+            "If query_all were NOT config-scoped it would also GET FDO22222BBB and exhaust the response generator."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_access_interface_orchestrator.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_access_interface_orchestrator.json
@@ -1,0 +1,356 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for tests/unit/module_utils/orchestrators/test_vpc_access_interface.py",
+        "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
+        "The fixtures simulate ND responses for:",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/summary  (fabric_summary via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/deploymentFreeze (deploymentFreeze via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches (switch_map via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/vpcPair (peer-serial resolve)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/interfaces (EpManageInterfacesListGet per switch)"
+    ],
+    "test_peer_resolve_happy_path_00500a": {
+        "TEST_NOTES": ["vpcPair GET on primary FDO11111AAA returns peer serial FDO22222BBB."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "peerSwitchId": "FDO22222BBB",
+            "vpcPairDetails": {
+                "domainId": 100,
+                "keepAliveVrf": "management"
+            }
+        }
+    },
+    "test_peer_resolve_not_paired_00510a": {
+        "TEST_NOTES": ["vpcPair GET returns 404 with structured error body (live lab shape)."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {
+            "code": 404,
+            "description": "",
+            "message": "No vPC Pair found for switch serial number: FDO11111AAA"
+        }
+    },
+    "test_peer_resolve_missing_field_00520a": {
+        "TEST_NOTES": ["vpcPair GET returns success but the response body omits peerSwitchId."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA"
+        }
+    },
+    "test_query_all_happy_path_00400a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_happy_path_00400_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_happy_path_00400b": {
+        "TEST_NOTES": ["Switch list: two switches forming a vPC pair."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDO22222BBB"
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400c": {
+        "TEST_NOTES": [
+            "Interfaces for FDO11111AAA: configured accessVpcHost vPC, trunkVpcHost vPC, ethernet trunkHost.",
+            "Expect: only accessVpcHost vPC is retained after filtering."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDO22222BBB",
+                                "peer1AccessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": ["Ethernet1/1"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "vpc101",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDO22222BBB"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400d": {
+        "TEST_NOTES": ["Interfaces for FDO22222BBB: one accessVpcHost vPC (the same vPC shows on both peers in the API)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc200",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDO11111AAA",
+                                "peer1AccessVlan": 20,
+                                "peer1PortChannelId": 200,
+                                "peer1MemberPorts": ["Ethernet1/3"]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_no_match_00410_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_no_match_00410b": {
+        "TEST_NOTES": ["Switch list: one switch."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410c": {
+        "TEST_NOTES": ["Switch interfaces: only ethernet and non-accessVpcHost interfaces."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "vpc999",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_dedup_00430a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_dedup_00430_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_dedup_00430b": {
+        "TEST_NOTES": ["Switch list: two switches in a vPC pair."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_query_all_dedup_00430c": {
+        "TEST_NOTES": ["S1 interfaces: vpc100 returned (peerSwitchId=FDOBBBBBBBB)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDOBBBBBBBB",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": ["Ethernet1/1"],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": ["Ethernet1/1"]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_dedup_00430d": {
+        "TEST_NOTES": ["S2 interfaces: same vpc100 returned (peerSwitchId=FDOAAAAAAAA)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDOAAAAAAAA",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": ["Ethernet1/1"],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": ["Ethernet1/1"]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_fabric_not_found_00420a": {
+        "TEST_NOTES": ["Fabric summary 404 -> validate_prerequisites raises."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
@@ -1,0 +1,637 @@
+{
+    "TEST_NOTES": [
+        "Fixtures for tests/unit/module_utils/orchestrators/test_vpc_interface_base.py.",
+        "Exercises the shared VpcInterfaceBaseOrchestrator via the _StubVpcOrchestrator concrete subclass.",
+        "Switch A: fabricManagementIp 192.168.1.1 -> switchId FDO11111AAA (vPC peer FDO22222BBB).",
+        "Switch B: fabricManagementIp 192.168.1.2 -> switchId FDO22222BBB (vPC peer FDO11111AAA).",
+        "Response order per test matches the API call order in the code under test.",
+        "To refresh: capture the corresponding GET/POST/PUT/DELETE responses against a live ND 4.2 fabric with a vPC pair."
+    ],
+
+    "test_vpc_interface_base_00200a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id happy path: vpcPair GET returns the peer serial."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "peerSwitchId": "FDO22222BBB",
+            "vpcDomainId": 1
+        }
+    },
+
+    "test_vpc_interface_base_00210a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id caching: only one vpcPair GET is provided for two calls."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "peerSwitchId": "FDO22222BBB",
+            "vpcDomainId": 1
+        }
+    },
+
+    "test_vpc_interface_base_00220a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id missing pair: vpcPair GET returns 404 (switch not in a vPC pair)."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00230a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id missing peerSwitchId: vpcPair GET succeeds but omits peerSwitchId."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "vpcDomainId": 1
+        }
+    },
+
+    "test_vpc_interface_base_00400a": {
+        "TEST_NOTES": ["create happy path: switches list (one switch) for _resolve_switch_id."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00400b": {
+        "TEST_NOTES": ["create happy path: vpcPair GET for _resolve_peer_switch_id."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00400c": {
+        "TEST_NOTES": ["create happy path: POST /interfaces (200)."],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_vpc_interface_base_00410a": {
+        "TEST_NOTES": ["create failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00410b": {
+        "TEST_NOTES": ["create failure: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00410c": {
+        "TEST_NOTES": ["create failure: POST /interfaces returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00420a": {
+        "TEST_NOTES": ["create not-in-pair: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00420b": {
+        "TEST_NOTES": ["create not-in-pair: vpcPair GET returns 404."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00500a": {
+        "TEST_NOTES": ["update happy path: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00500b": {
+        "TEST_NOTES": ["update happy path: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00500c": {
+        "TEST_NOTES": ["update happy path: PUT /interfaces/{name} (200)."],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_vpc_interface_base_00510a": {
+        "TEST_NOTES": ["update failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00510b": {
+        "TEST_NOTES": ["update failure: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00510c": {
+        "TEST_NOTES": ["update failure: PUT returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00600a": {
+        "TEST_NOTES": ["delete happy path: switches list for _resolve_switch_id."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00600b": {
+        "TEST_NOTES": ["delete happy path: per-interface DELETE returns 204 (no body)."],
+        "RETURN_CODE": 204,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "No Content",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00610a": {
+        "TEST_NOTES": ["delete failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00610b": {
+        "TEST_NOTES": ["delete failure: per-interface DELETE returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00700a": {
+        "TEST_NOTES": ["create_bulk peer cache: switches list (one switch, fetched once and cached)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00700b": {
+        "TEST_NOTES": ["create_bulk peer cache: a single vpcPair GET serves both interfaces on the same primary switch."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00700c": {
+        "TEST_NOTES": ["create_bulk peer cache: one POST /interfaces carrying both vPC interfaces."],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_vpc_interface_base_00710a": {
+        "TEST_NOTES": ["create_bulk failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00710b": {
+        "TEST_NOTES": ["create_bulk failure: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00710c": {
+        "TEST_NOTES": ["create_bulk failure: per-switch POST returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00800a": {
+        "TEST_NOTES": ["query_one happy path: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00800b": {
+        "TEST_NOTES": ["query_one happy path: GET /interfaces/{name} returns the vPC interface."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaceName": "vpc501",
+            "interfaceType": "vpc",
+            "configData": {
+                "mode": "access",
+                "networkOS": {
+                    "networkOSType": "nx-os",
+                    "policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO22222BBB"}
+                }
+            }
+        }
+    },
+
+    "test_vpc_interface_base_00810a": {
+        "TEST_NOTES": ["query_one failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00810b": {
+        "TEST_NOTES": ["query_one failure: GET returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00900a": {
+        "TEST_NOTES": ["query_all dedupe: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00900b": {
+        "TEST_NOTES": ["query_all dedupe: switches list (two vPC peers)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00900c": {
+        "TEST_NOTES": [
+            "query_all dedupe: switch A (FDO11111AAA) interfaces.",
+            "Contains the managed accessVpcHost vpc501, an other-policy trunkVpcHost vpc502 (filtered out),",
+            "and a non-vPC ethernet (filtered out). vpc501 also appears on switch B (peer copy)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                },
+                {
+                    "interfaceName": "vpc502",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "trunkVpcHost", "allowedVlans": "1-10"}}}
+                },
+                {
+                    "interfaceName": "Ethernet1/5",
+                    "interfaceType": "ethernet",
+                    "configData": {"networkOS": {"policy": {"policyType": "trunkHost"}}}
+                }
+            ]
+        }
+    },
+    "test_vpc_interface_base_00900d": {
+        "TEST_NOTES": [
+            "query_all dedupe: switch B (FDO22222BBB) interfaces.",
+            "Returns the peer-side copy of vpc501 (same interfaceName) which must be deduped away,",
+            "keeping the alphabetically-lower switchId (FDO11111AAA) representative."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00910a": {
+        "TEST_NOTES": ["query_all no-name skip: fabric summary."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00910b": {
+        "TEST_NOTES": ["query_all no-name skip: switches list (one switch)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00910c": {
+        "TEST_NOTES": [
+            "query_all no-name skip: a managed accessVpcHost vPC interface with no interfaceName.",
+            "It passes the type + policy filters but must be skipped because it has no name to key on."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00930a": {
+        "TEST_NOTES": ["query_all fabric-not-found: summary returns 404; validate_prerequisites raises."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00940a": {
+        "TEST_NOTES": ["query_all switch-404: fabric summary."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00940b": {
+        "TEST_NOTES": ["query_all switch-404: switches list (one switch)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00940c": {
+        "TEST_NOTES": ["query_all switch-404: switch interfaces endpoint returns 404 (no body); switch is skipped."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00920a": {
+        "TEST_NOTES": ["query_all config-scoped: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+
+    "test_vpc_interface_base_00920b": {
+        "TEST_NOTES": ["query_all config-scoped: switches list (two switches); only the config switch is queried."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00920c": {
+        "TEST_NOTES": ["query_all config-scoped: config switch (FDO11111AAA) interfaces; switch B is never fetched."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00950a": {
+        "TEST_NOTES": ["query_all peer-preference: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+
+    "test_vpc_interface_base_00950b": {
+        "TEST_NOTES": ["query_all peer-preference: switches list (two vPC peers)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00950c": {
+        "TEST_NOTES": ["query_all peer-preference: switch A (lower switchId) returns vpc501; deduped away in favor of the configured peer."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00950d": {
+        "TEST_NOTES": ["query_all peer-preference: switch B (higher switchId, the configured peer 192.168.1.2) returns vpc501; kept because the user configured it."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00960a": {
+        "TEST_NOTES": ["query_all malformed-body: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+
+    "test_vpc_interface_base_00960b": {
+        "TEST_NOTES": ["query_all malformed-body: switches list (two switches)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00960c": {
+        "TEST_NOTES": ["query_all malformed-body: switch A returns a vPC with configData:null; the null-safe policy-type accessor filters it out."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {"interfaceName": "vpc501", "interfaceType": "vpc", "configData": null}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00960d": {
+        "TEST_NOTES": ["query_all malformed-body: switch B returns a bare list as DATA (non-dict); the isinstance guard skips it without AttributeError."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": [{"interfaceName": "junk", "interfaceType": "vpc"}]
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_trunk_host_interface_orchestrator.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_trunk_host_interface_orchestrator.json
@@ -1,0 +1,360 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for tests/unit/module_utils/orchestrators/test_vpc_trunk_host_interface.py",
+        "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
+        "The fixtures simulate ND responses for:",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/summary  (fabric_summary via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/deploymentFreeze (deploymentFreeze via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches (switch_map via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/vpcPair (peer-serial resolve)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/interfaces (EpManageInterfacesListGet per switch)"
+    ],
+    "test_peer_resolve_happy_path_00500a": {
+        "TEST_NOTES": ["vpcPair GET on primary FDO11111AAA returns peer serial FDO22222BBB."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "peerSwitchId": "FDO22222BBB",
+            "vpcPairDetails": {
+                "domainId": 100,
+                "keepAliveVrf": "management"
+            }
+        }
+    },
+    "test_peer_resolve_not_paired_00510a": {
+        "TEST_NOTES": ["vpcPair GET returns 404 with structured error body (live lab shape)."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {
+            "code": 404,
+            "description": "",
+            "message": "No vPC Pair found for switch serial number: FDO11111AAA"
+        }
+    },
+    "test_peer_resolve_missing_field_00520a": {
+        "TEST_NOTES": ["vpcPair GET returns success but the response body omits peerSwitchId."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA"
+        }
+    },
+    "test_query_all_happy_path_00400a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_happy_path_00400_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_happy_path_00400b": {
+        "TEST_NOTES": ["Switch list: two switches forming a vPC pair."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDO22222BBB"
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400c": {
+        "TEST_NOTES": [
+            "Interfaces for FDO11111AAA: trunkVpcHost vPC, accessVpcHost vPC, ethernet trunkHost.",
+            "Expect: only the trunkVpcHost vPC is retained after filtering."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDO22222BBB",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": ["Ethernet1/1"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDO22222BBB"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400d": {
+        "TEST_NOTES": ["Interfaces for FDO22222BBB: one trunkVpcHost vPC (a different one for cross-switch coverage)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc600",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDO11111AAA",
+                                "allowedVlans": "300-400",
+                                "nativeVlan": 100,
+                                "peer1PortChannelId": 600,
+                                "peer1MemberPorts": ["Ethernet1/3"]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_no_match_00410_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_no_match_00410b": {
+        "TEST_NOTES": ["Switch list: one switch."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410c": {
+        "TEST_NOTES": ["Switch interfaces: only ethernet and non-trunkVpcHost interfaces."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "vpc999",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_dedup_00430a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_dedup_00430_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_dedup_00430b": {
+        "TEST_NOTES": ["Switch list: two switches in a vPC pair."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_query_all_dedup_00430c": {
+        "TEST_NOTES": ["S1 interfaces: vpc500 returned (peerSwitchId=FDOBBBBBBBB)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDOBBBBBBBB",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": ["Ethernet1/1"],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": ["Ethernet1/1"]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_dedup_00430d": {
+        "TEST_NOTES": ["S2 interfaces: same vpc500 returned (peerSwitchId=FDOAAAAAAAA)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDOAAAAAAAA",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": ["Ethernet1/1"],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": ["Ethernet1/1"]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_fabric_not_found_00420a": {
+        "TEST_NOTES": ["Fabric summary 404 -> validate_prerequisites raises."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    }
+}

--- a/tests/unit/module_utils/models/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_access_interface.py
@@ -18,7 +18,6 @@ Tests the Port-channel accessPoHost Interface Pydantic model classes.
 from __future__ import annotations
 
 import copy
-from contextlib import contextmanager
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
@@ -37,14 +36,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_ch
     PortChannelAccessNetworkOSModel,
     PortChannelAccessPolicyModel,
 )
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
 from pydantic import ValidationError
-
-
-@contextmanager
-def does_not_raise():
-    """A context manager that does not raise an exception."""
-    yield
-
 
 # =============================================================================
 # Test data constants
@@ -96,7 +89,6 @@ SAMPLE_ANSIBLE_CONFIG = {
                 "bpdu_guard": "enable",
                 "bpdu_filter": "disable",
                 "description": "uplink to host",
-                "policy_type": "accessPoHost",
                 "speed": "10Gb",
                 "duplex_mode": "auto",
                 "mtu": "jumbo",
@@ -629,19 +621,22 @@ def test_port_channel_access_interface_00470():
     """
     # Summary
 
-    Verify `network_os` is a required field.
+    Verify `network_os` defaults to an empty `PortChannelAccessNetworkOSModel` when omitted, so constructing
+    `config_data` without an explicit `network_os` does not raise a raw `ValidationError`.
 
     ## Test
 
     - Construct without network_os
-    - ValidationError raised
+    - config_data.network_os is a PortChannelAccessNetworkOSModel with a None policy
 
     ## Classes and Methods
 
     - PortChannelAccessConfigDataModel.__init__()
     """
-    with pytest.raises(ValidationError, match=r"network_os|networkOS"):
-        PortChannelAccessConfigDataModel()
+    with does_not_raise():
+        instance = PortChannelAccessConfigDataModel()
+    assert isinstance(instance.network_os, PortChannelAccessNetworkOSModel)
+    assert instance.network_os.policy is None
 
 
 # =============================================================================
@@ -922,19 +917,26 @@ def test_port_channel_access_interface_00710():
     """
     # Summary
 
-    Verify `policy_type` round-trips as the API value in config output.
+    Verify `policy_type` is omitted from `to_config()` output (the field is hardcoded by the model and is
+    not in the argspec, so surfacing the wire form `"accessPoHost"` back to playbooks would only confuse
+    assertions that compare against the snake_case Ansible convention).
 
     ## Test
 
-    - Stored "accessPoHost" -> output "accessPoHost" (no Ansible↔API translation; field is hardcoded by the model)
+    - From a full API response, to_config() does NOT include `policy_type` in the policy dict
+    - All other policy fields ARE present (sanity check that we only omitted policy_type)
 
     ## Classes and Methods
 
     - PortChannelAccessInterfaceModel.to_config()
+    - PortChannelAccessPolicyModel._strip_policy_type_in_config()
     """
     instance = PortChannelAccessInterfaceModel.from_response(copy.deepcopy(SAMPLE_API_RESPONSE))
     result = instance.to_config()
-    assert result["config_data"]["network_os"]["policy"]["policy_type"] == "accessPoHost"
+    policy = result["config_data"]["network_os"]["policy"]
+    assert "policy_type" not in policy
+    assert policy["admin_state"] is True
+    assert policy["access_vlan"] == 100
 
 
 def test_port_channel_access_interface_00720():

--- a/tests/unit/module_utils/models/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_access_interface.py
@@ -1,0 +1,1495 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for port_channel_access_interface.py
+
+Tests the Port-channel accessPoHost Interface Pydantic model classes.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    AccessPoHostPolicyTypeEnum,
+    BpduFilterEnum,
+    BpduGuardEnum,
+    DuplexModeEnum,
+    LacpRateEnum,
+    MtuEnum,
+    PortChannelModeEnum,
+    SpeedEnum,
+    StormControlActionEnum,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import (
+    PortChannelAccessConfigDataModel,
+    PortChannelAccessInterfaceModel,
+    PortChannelAccessNetworkOSModel,
+    PortChannelAccessPolicyModel,
+)
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test data constants
+# =============================================================================
+
+SAMPLE_API_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "port-channel501",
+    "interfaceType": "portChannel",
+    "configData": {
+        "mode": "access",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "adminState": True,
+                "accessVlan": 100,
+                "ports": ["Ethernet1/1", "Ethernet1/2"],
+                "portChannelMode": "active",
+                "lacpRate": "fast",
+                "lacpPortPriority": 32768,
+                "bpduGuard": "enable",
+                "bpduFilter": "disable",
+                "description": "uplink to host",
+                "policyType": "accessPoHost",
+                "speed": "10Gb",
+                "duplexMode": "auto",
+                "mtu": "jumbo",
+                "copyDescription": True,
+            },
+        },
+    },
+}
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "port-channel501",
+    "interface_type": "portChannel",
+    "config_data": {
+        "mode": "access",
+        "network_os": {
+            "network_os_type": "nx-os",
+            "policy": {
+                "admin_state": True,
+                "access_vlan": 100,
+                "ports": ["Ethernet1/1", "Ethernet1/2"],
+                "port_channel_mode": "active",
+                "lacp_rate": "fast",
+                "lacp_port_priority": 32768,
+                "bpdu_guard": "enable",
+                "bpdu_filter": "disable",
+                "description": "uplink to host",
+                "policy_type": "access_po_host",
+                "speed": "10Gb",
+                "duplex_mode": "auto",
+                "mtu": "jumbo",
+                "copy_description": True,
+            },
+        },
+    },
+}
+
+
+# =============================================================================
+# Test: PortChannelAccessPolicyModel — initialization
+# =============================================================================
+
+
+def test_port_channel_access_interface_00100():
+    """
+    # Summary
+
+    Verify every policy field defaults to None.
+
+    ## Test
+
+    - Instantiate with no arguments
+    - Every field is None
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessPolicyModel()
+    assert instance.admin_state is None
+    assert instance.access_vlan is None
+    assert instance.bpdu_filter is None
+    assert instance.bpdu_guard is None
+    assert instance.cdp is None
+    assert instance.copy_description is None
+    assert instance.description is None
+    assert instance.duplex_mode is None
+    assert instance.extra_config is None
+    assert instance.lacp_port_priority is None
+    assert instance.lacp_rate is None
+    assert instance.lacp_suspend is None
+    assert instance.monitor is None
+    assert instance.mtu is None
+    assert instance.netflow is None
+    assert instance.netflow_monitor is None
+    assert instance.netflow_sampler is None
+    assert instance.policy_type is None
+    assert instance.port_channel_mode is None
+    assert instance.ports is None
+    assert instance.qos is None
+    assert instance.qos_policy is None
+    assert instance.queuing_policy is None
+    assert instance.speed is None
+    assert instance.storm_control is None
+    assert instance.storm_control_action is None
+    assert instance.storm_control_broadcast_level is None
+    assert instance.storm_control_broadcast_level_pps is None
+    assert instance.storm_control_multicast_level is None
+    assert instance.storm_control_multicast_level_pps is None
+    assert instance.storm_control_unicast_level is None
+    assert instance.storm_control_unicast_level_pps is None
+
+
+def test_port_channel_access_interface_00110():
+    """
+    # Summary
+
+    Verify construction with snake_case field names.
+
+    ## Test
+
+    - Construct with Python field names
+    - Values accessible
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessPolicyModel(
+            admin_state=True,
+            access_vlan=100,
+            ports=["Ethernet1/1"],
+            port_channel_mode="active",
+            lacp_rate="fast",
+            description="test",
+            policy_type="access_po_host",
+            speed="10Gb",
+        )
+    assert instance.admin_state is True
+    assert instance.access_vlan == 100
+    assert instance.ports == ["Ethernet1/1"]
+    assert instance.port_channel_mode == "active"
+    assert instance.lacp_rate == "fast"
+    assert instance.description == "test"
+    # After normalize + use_enum_values the stored value is the API string.
+    assert instance.policy_type == "accessPoHost"
+    assert instance.speed == "10Gb"
+
+
+def test_port_channel_access_interface_00120():
+    """
+    # Summary
+
+    Verify construction with camelCase aliases.
+
+    ## Test
+
+    - Construct with API alias names
+    - Values accessible by Python names
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessPolicyModel(
+            adminState=True,
+            accessVlan=200,
+            ports=["Ethernet1/3", "Ethernet1/4"],
+            portChannelMode="passive",
+            policyType="accessPoHost",
+            bpduGuard="enable",
+            duplexMode="full",
+            copyDescription=True,
+        )
+    assert instance.admin_state is True
+    assert instance.access_vlan == 200
+    assert instance.ports == ["Ethernet1/3", "Ethernet1/4"]
+    assert instance.port_channel_mode == "passive"
+    assert instance.policy_type == "accessPoHost"
+    assert instance.bpdu_guard == "enable"
+    assert instance.duplex_mode == "full"
+    assert instance.copy_description is True
+
+
+# =============================================================================
+# Test: PortChannelAccessPolicyModel — validators
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected,raises",
+    [
+        ("access_po_host", "accessPoHost", False),
+        ("accessPoHost", "accessPoHost", False),
+        (None, None, False),
+        ("unknown_value", None, True),
+    ],
+    ids=[
+        "ansible_name",
+        "api_value_passthrough",
+        "none_passthrough",
+        "unknown_rejected_by_enum",
+    ],
+)
+def test_port_channel_access_interface_00170(value, expected, raises):
+    """
+    # Summary
+
+    Verify `normalize_policy_type` maps Ansible names to API values and passes through API values unchanged.
+
+    ## Test
+
+    - "access_po_host" normalizes to "accessPoHost"
+    - "accessPoHost" passes through
+    - None passes through
+    - Unknown values fail enum validation
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.normalize_policy_type()
+    """
+    if raises:
+        with pytest.raises(ValidationError):
+            PortChannelAccessPolicyModel(policy_type=value)
+    else:
+        with does_not_raise():
+            instance = PortChannelAccessPolicyModel(policy_type=value)
+        assert instance.policy_type == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
+        (["Ethernet1/1"], ["Ethernet1/1"]),
+        (["e1/1"], ["E1/1"]),
+        ([], []),
+        (None, None),
+        # Mixed and breakout-style names preserve everything after the first character.
+        (["ethernet1/1/1", "ETHERNET1/2"], ["Ethernet1/1/1", "ETHERNET1/2"]),
+    ],
+    ids=[
+        "lowercase_to_capitalized",
+        "already_capitalized_passthrough",
+        "single_letter",
+        "empty_list",
+        "none_passthrough",
+        "mixed_breakout",
+    ],
+)
+def test_port_channel_access_interface_00180(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_ports` capitalizes the first character of each member interface name.
+
+    ## Test
+
+    - Lowercase member names are capitalized
+    - Already-capitalized values pass through
+    - Empty list and None pass through
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.normalize_ports()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessPolicyModel(ports=value)
+    assert instance.ports == expected
+
+
+def test_port_channel_access_interface_00190():
+    """
+    # Summary
+
+    Verify `normalize_ports` passes a non-list, non-None value straight through to fail Pydantic type validation
+    rather than coercing it. This keeps misconfigured input surfaced as a `ValidationError` instead of silently
+    succeeding.
+
+    ## Test
+
+    - A scalar string for `ports` raises ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.normalize_ports()
+    """
+    with pytest.raises(ValidationError):
+        PortChannelAccessPolicyModel(ports="Ethernet1/1")
+
+
+# =============================================================================
+# Test: PortChannelAccessPolicyModel — range and enum validation
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "field,value,should_raise",
+    [
+        ("access_vlan", 1, False),
+        ("access_vlan", 4094, False),
+        ("access_vlan", 0, True),
+        ("access_vlan", 4095, True),
+        ("lacp_port_priority", 1, False),
+        ("lacp_port_priority", 65535, False),
+        ("lacp_port_priority", 0, True),
+        ("lacp_port_priority", 65536, True),
+        ("storm_control_broadcast_level_pps", 0, False),
+        ("storm_control_broadcast_level_pps", 200000000, False),
+        ("storm_control_broadcast_level_pps", -1, True),
+        ("storm_control_broadcast_level_pps", 200000001, True),
+        ("storm_control_multicast_level_pps", 0, False),
+        ("storm_control_multicast_level_pps", 200000000, False),
+        ("storm_control_multicast_level_pps", -1, True),
+        ("storm_control_multicast_level_pps", 200000001, True),
+        ("storm_control_unicast_level_pps", 0, False),
+        ("storm_control_unicast_level_pps", 200000000, False),
+        ("storm_control_unicast_level_pps", -1, True),
+        ("storm_control_unicast_level_pps", 200000001, True),
+    ],
+    ids=lambda v: str(v) if not isinstance(v, bool) else ("raise" if v else "ok"),
+)
+def test_port_channel_access_interface_00220(field, value, should_raise):
+    """
+    # Summary
+
+    Verify ge/le constraints on every numeric policy field.
+
+    ## Test
+
+    - At-min and at-max values accepted
+    - Below-min and above-max values rejected with ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.__init__()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError):
+            PortChannelAccessPolicyModel(**{field: value})
+    else:
+        with does_not_raise():
+            instance = PortChannelAccessPolicyModel(**{field: value})
+        assert getattr(instance, field) == value
+
+
+@pytest.mark.parametrize(
+    "field,value,should_raise",
+    [
+        ("storm_control_broadcast_level", 0.0, False),
+        ("storm_control_broadcast_level", 100.0, False),
+        ("storm_control_broadcast_level", -0.1, True),
+        ("storm_control_broadcast_level", 100.01, True),
+        ("storm_control_multicast_level", 0.0, False),
+        ("storm_control_multicast_level", 100.0, False),
+        ("storm_control_multicast_level", -0.1, True),
+        ("storm_control_multicast_level", 100.01, True),
+        ("storm_control_unicast_level", 0.0, False),
+        ("storm_control_unicast_level", 100.0, False),
+        ("storm_control_unicast_level", -0.1, True),
+        ("storm_control_unicast_level", 100.01, True),
+    ],
+    ids=lambda v: str(v) if not isinstance(v, bool) else ("raise" if v else "ok"),
+)
+def test_port_channel_access_interface_00225(field, value, should_raise):
+    """
+    # Summary
+
+    Verify storm-control percentage fields enforce the 0.0-100.0 range.
+
+    ## Test
+
+    - 0.0 and 100.0 accepted
+    - -0.1 and 100.01 rejected
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.__init__()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError):
+            PortChannelAccessPolicyModel(**{field: value})
+    else:
+        with does_not_raise():
+            instance = PortChannelAccessPolicyModel(**{field: value})
+        assert getattr(instance, field) == value
+
+
+def test_port_channel_access_interface_00230():
+    """
+    # Summary
+
+    Verify `description` max_length=254.
+
+    ## Test
+
+    - 254-char description accepted
+    - 255-char description rejected with ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.__init__()
+    """
+    at_limit = "a" * 254
+    over_limit = "a" * 255
+    with does_not_raise():
+        instance = PortChannelAccessPolicyModel(description=at_limit)
+    assert instance.description == at_limit
+
+    with pytest.raises(ValidationError):
+        PortChannelAccessPolicyModel(description=over_limit)
+
+
+@pytest.mark.parametrize(
+    "value,should_raise",
+    [
+        ("plain ASCII", False),
+        ("with-hyphen and 123", False),
+        ("em — dash", True),
+        ("smart “quotes”", True),
+        ("emoji \U0001f600", True),
+        ("latin-1 \xe9", True),
+    ],
+    ids=[
+        "ascii_ok",
+        "ascii_punct_digits",
+        "em_dash_rejected",
+        "smart_quotes_rejected",
+        "emoji_rejected",
+        "latin1_rejected",
+    ],
+)
+def test_port_channel_access_interface_00235(value, should_raise):
+    """
+    # Summary
+
+    Verify `description` (typed `AsciiDescription`) rejects any non-ASCII character.
+
+    Cisco backend pipes interface descriptions through CLI generators that 500 on UTF-8. Catching this client-side
+    gives users a clear error instead of a generic "unexpected error during policy execution" 500.
+
+    ## Test
+
+    - ASCII strings accepted
+    - Non-ASCII characters (em-dash, smart quotes, emoji, latin-1) raise
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.__init__()
+    - models.types.ascii_only()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError, match="description must contain only ASCII"):
+            PortChannelAccessPolicyModel(description=value)
+    else:
+        instance = PortChannelAccessPolicyModel(description=value)
+        assert instance.description == value
+
+
+@pytest.mark.parametrize(
+    "field,enum_cls",
+    [
+        ("speed", SpeedEnum),
+        ("duplex_mode", DuplexModeEnum),
+        ("bpdu_guard", BpduGuardEnum),
+        ("bpdu_filter", BpduFilterEnum),
+        ("mtu", MtuEnum),
+        ("storm_control_action", StormControlActionEnum),
+        ("port_channel_mode", PortChannelModeEnum),
+        ("lacp_rate", LacpRateEnum),
+    ],
+    ids=["speed", "duplex_mode", "bpdu_guard", "bpdu_filter", "mtu", "storm_control_action", "port_channel_mode", "lacp_rate"],
+)
+def test_port_channel_access_interface_00240(field, enum_cls):
+    """
+    # Summary
+
+    Verify enum-constrained fields accept any valid enum value and reject invalid strings.
+
+    ## Test
+
+    - Valid enum value sets the stored value (enum `.value` due to use_enum_values=True)
+    - Invalid value raises ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.__init__()
+    """
+    valid_value = next(iter(enum_cls)).value
+    with does_not_raise():
+        instance = PortChannelAccessPolicyModel(**{field: valid_value})
+    assert getattr(instance, field) == valid_value
+
+    with pytest.raises(ValidationError):
+        PortChannelAccessPolicyModel(**{field: "not_a_real_value"})
+
+
+# =============================================================================
+# Test: PortChannelAccessPolicyModel — serializer
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "stored_value,mode,expected",
+    [
+        ("accessPoHost", "payload", "accessPoHost"),
+        ("accessPoHost", "config", "access_po_host"),
+        (None, "payload", None),
+        (None, "config", None),
+    ],
+    ids=["payload_known", "config_known", "payload_none", "config_none"],
+)
+def test_port_channel_access_interface_00300(stored_value, mode, expected):
+    """
+    # Summary
+
+    Verify `serialize_policy_type` emits API value in payload mode and Ansible name in config mode.
+
+    ## Test
+
+    - model_dump with context={"mode": "payload"} returns camelCase API value
+    - model_dump with context={"mode": "config"} returns Ansible-friendly snake_case
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel.serialize_policy_type()
+    """
+    instance = PortChannelAccessPolicyModel(policy_type=stored_value) if stored_value is not None else PortChannelAccessPolicyModel()
+    dumped = instance.model_dump(context={"mode": mode}, exclude_none=False)
+    assert dumped["policy_type"] == expected
+
+
+# =============================================================================
+# Test: PortChannelAccessNetworkOSModel
+# =============================================================================
+
+
+def test_port_channel_access_interface_00400():
+    """
+    # Summary
+
+    Verify `network_os_type` defaults to "nx-os".
+
+    ## Test
+
+    - Instantiate without args
+    - network_os_type is "nx-os"
+    - policy is None
+
+    ## Classes and Methods
+
+    - PortChannelAccessNetworkOSModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessNetworkOSModel()
+    assert instance.network_os_type == "nx-os"
+    assert instance.policy is None
+
+
+def test_port_channel_access_interface_00410():
+    """
+    # Summary
+
+    Verify nested `policy` assignment accepts a dict and coerces to PortChannelAccessPolicyModel.
+
+    ## Test
+
+    - Construct with policy as dict
+    - policy is a PortChannelAccessPolicyModel instance
+
+    ## Classes and Methods
+
+    - PortChannelAccessNetworkOSModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessNetworkOSModel(policy={"admin_state": True, "access_vlan": 100})
+    assert isinstance(instance.policy, PortChannelAccessPolicyModel)
+    assert instance.policy.admin_state is True
+    assert instance.policy.access_vlan == 100
+
+
+def test_port_channel_access_interface_00420():
+    """
+    # Summary
+
+    Verify camelCase alias `networkOSType` populates network_os_type.
+
+    ## Test
+
+    - Construct with camelCase alias
+    - Python field accessible
+
+    ## Classes and Methods
+
+    - PortChannelAccessNetworkOSModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessNetworkOSModel(networkOSType="ios-xe")
+    assert instance.network_os_type == "ios-xe"
+
+
+# =============================================================================
+# Test: PortChannelAccessConfigDataModel
+# =============================================================================
+
+
+def test_port_channel_access_interface_00450():
+    """
+    # Summary
+
+    Verify `mode` defaults to "access".
+
+    ## Test
+
+    - Construct with only network_os
+    - mode is "access"
+
+    ## Classes and Methods
+
+    - PortChannelAccessConfigDataModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessConfigDataModel(network_os=PortChannelAccessNetworkOSModel())
+    assert instance.mode == "access"
+
+
+def test_port_channel_access_interface_00460():
+    """
+    # Summary
+
+    Verify camelCase alias `networkOS` populates network_os.
+
+    ## Test
+
+    - Construct with camelCase alias
+    - Python field accessible
+
+    ## Classes and Methods
+
+    - PortChannelAccessConfigDataModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessConfigDataModel(networkOS={"networkOSType": "nx-os"})
+    assert isinstance(instance.network_os, PortChannelAccessNetworkOSModel)
+    assert instance.network_os.network_os_type == "nx-os"
+
+
+def test_port_channel_access_interface_00470():
+    """
+    # Summary
+
+    Verify `network_os` is a required field.
+
+    ## Test
+
+    - Construct without network_os
+    - ValidationError raised
+
+    ## Classes and Methods
+
+    - PortChannelAccessConfigDataModel.__init__()
+    """
+    with pytest.raises(ValidationError, match=r"network_os|networkOS"):
+        PortChannelAccessConfigDataModel()
+
+
+# =============================================================================
+# Test: PortChannelAccessInterfaceModel — initialization and ClassVars
+# =============================================================================
+
+
+def test_port_channel_access_interface_00500():
+    """
+    # Summary
+
+    Verify ClassVar `identifiers` and `identifier_strategy`.
+
+    ## Test
+
+    - identifiers == ["switch_ip", "interface_name"]
+    - identifier_strategy == "composite"
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel
+    """
+    assert PortChannelAccessInterfaceModel.identifiers == ["switch_ip", "interface_name"]
+    assert PortChannelAccessInterfaceModel.identifier_strategy == "composite"
+
+
+def test_port_channel_access_interface_00510():
+    """
+    # Summary
+
+    Verify `payload_exclude_fields` excludes `switch_ip`.
+
+    ## Test
+
+    - payload_exclude_fields == {"switch_ip"}
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel
+    """
+    assert PortChannelAccessInterfaceModel.payload_exclude_fields == {"switch_ip"}
+
+
+def test_port_channel_access_interface_00520():
+    """
+    # Summary
+
+    Verify `switch_ip` and `interface_name` are required.
+
+    ## Test
+
+    - Missing switch_ip raises ValidationError
+    - Missing interface_name raises ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.__init__()
+    """
+    with pytest.raises(ValidationError, match=r"switch_ip|switchIp"):
+        PortChannelAccessInterfaceModel(interface_name="port-channel501")
+
+    with pytest.raises(ValidationError, match=r"interface_name|interfaceName"):
+        PortChannelAccessInterfaceModel(switch_ip="192.168.1.1")
+
+
+def test_port_channel_access_interface_00530():
+    """
+    # Summary
+
+    Verify `interface_type` defaults to "portChannel" and `config_data` defaults to None.
+
+    ## Test
+
+    - Minimal construction
+    - Defaults applied
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.interface_name == "port-channel501"
+    assert instance.interface_type == "portChannel"
+    assert instance.config_data is None
+
+
+# =============================================================================
+# Test: PortChannelAccessInterfaceModel — normalize_interface_name
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("port-channel501", "port-channel501"),
+        ("Port-Channel501", "port-channel501"),
+        ("PORT-CHANNEL501", "port-channel501"),
+        ("Port-channel1", "port-channel1"),
+        ("", ""),
+    ],
+    ids=["already_lower", "title_case", "upper", "mixed_case", "empty_passthrough"],
+)
+def test_port_channel_access_interface_00550(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` lowercases the entire interface name (port-channel convention).
+
+    ## Test
+
+    - Mixed-case inputs normalized to lowercase
+    - Already-lowercase input unchanged
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.normalize_interface_name()
+    """
+    instance = PortChannelAccessInterfaceModel(switch_ip="192.168.1.1", interface_name=value)
+    assert instance.interface_name == expected
+
+
+# =============================================================================
+# Test: PortChannelAccessInterfaceModel — to_payload
+# =============================================================================
+
+
+def test_port_channel_access_interface_00600():
+    """
+    # Summary
+
+    Verify `to_payload` emits camelCase keys and excludes `switch_ip`.
+
+    ## Test
+
+    - Top-level keys are camelCase
+    - switchIp / switch_ip not present
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.to_payload()
+    """
+    instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_payload()
+    assert "interfaceName" in result
+    assert "interfaceType" in result
+    assert "configData" in result
+    assert "switchIp" not in result
+    assert "switch_ip" not in result
+
+
+def test_port_channel_access_interface_00610():
+    """
+    # Summary
+
+    Verify deeply nested structure preserves camelCase aliases throughout.
+
+    ## Test
+
+    - configData.networkOS.policy has camelCase keys
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.to_payload()
+    """
+    instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_payload()
+    policy = result["configData"]["networkOS"]["policy"]
+    assert "adminState" in policy
+    assert "accessVlan" in policy
+    assert "ports" in policy
+    assert "portChannelMode" in policy
+    assert "lacpRate" in policy
+    assert "lacpPortPriority" in policy
+    assert "policyType" in policy
+    assert "bpduGuard" in policy
+    assert "copyDescription" in policy
+
+
+def test_port_channel_access_interface_00620():
+    """
+    # Summary
+
+    Verify `policyType` is the API camelCase value in payload mode.
+
+    ## Test
+
+    - policy_type="access_po_host" in config -> "accessPoHost" in payload
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.to_payload()
+    - PortChannelAccessPolicyModel.serialize_policy_type()
+    """
+    instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_payload()
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "accessPoHost"
+
+
+def test_port_channel_access_interface_00630():
+    """
+    # Summary
+
+    Verify member ports list survives serialization with normalized names.
+
+    ## Test
+
+    - ports list survives in payload as a list of capitalized member names
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.to_payload()
+    - PortChannelAccessPolicyModel.normalize_ports()
+    """
+    config = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    config["config_data"]["network_os"]["policy"]["ports"] = ["ethernet1/5", "ethernet1/6"]
+    instance = PortChannelAccessInterfaceModel.from_config(config)
+    result = instance.to_payload()
+    assert result["configData"]["networkOS"]["policy"]["ports"] == ["Ethernet1/5", "Ethernet1/6"]
+
+
+def test_port_channel_access_interface_00640():
+    """
+    # Summary
+
+    Verify None-valued fields are excluded from payload output.
+
+    ## Test
+
+    - Minimal model with config_data=None
+    - configData not present in payload
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.to_payload()
+    """
+    instance = PortChannelAccessInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    result = instance.to_payload()
+    assert "configData" not in result
+    assert "interfaceName" in result
+
+
+# =============================================================================
+# Test: PortChannelAccessInterfaceModel — to_config
+# =============================================================================
+
+
+def test_port_channel_access_interface_00700():
+    """
+    # Summary
+
+    Verify `to_config` emits snake_case keys throughout.
+
+    ## Test
+
+    - Top-level keys are snake_case
+    - Nested keys are snake_case
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.to_config()
+    """
+    instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_config()
+    assert "interface_name" in result
+    assert "interface_type" in result
+    assert "config_data" in result
+    policy = result["config_data"]["network_os"]["policy"]
+    assert "admin_state" in policy
+    assert "access_vlan" in policy
+    assert "ports" in policy
+    assert "port_channel_mode" in policy
+    assert "lacp_rate" in policy
+    assert "copy_description" in policy
+
+
+def test_port_channel_access_interface_00710():
+    """
+    # Summary
+
+    Verify `policy_type` is normalized back to the Ansible-friendly name in config mode.
+
+    ## Test
+
+    - Stored "accessPoHost" -> output "access_po_host"
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.to_config()
+    - PortChannelAccessPolicyModel.serialize_policy_type()
+    """
+    instance = PortChannelAccessInterfaceModel.from_response(copy.deepcopy(SAMPLE_API_RESPONSE))
+    result = instance.to_config()
+    assert result["config_data"]["network_os"]["policy"]["policy_type"] == "access_po_host"
+
+
+def test_port_channel_access_interface_00720():
+    """
+    # Summary
+
+    Verify `switch_ip` is included in config output (differs from payload).
+
+    ## Test
+
+    - switch_ip present at top level of config
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.to_config()
+    """
+    instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_config()
+    assert result["switch_ip"] == "192.168.1.1"
+
+
+# =============================================================================
+# Test: PortChannelAccessInterfaceModel — from_response
+# =============================================================================
+
+
+def test_port_channel_access_interface_00800():
+    """
+    # Summary
+
+    Verify `from_response` constructs a model from the ND API response.
+
+    ## Test
+
+    - All fields accessible by Python names
+    - Nested structure populated
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.from_response()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessInterfaceModel.from_response(copy.deepcopy(SAMPLE_API_RESPONSE))
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.interface_name == "port-channel501"
+    assert instance.interface_type == "portChannel"
+    assert instance.config_data.mode == "access"
+    assert instance.config_data.network_os.policy.admin_state is True
+    assert instance.config_data.network_os.policy.access_vlan == 100
+    assert instance.config_data.network_os.policy.ports == ["Ethernet1/1", "Ethernet1/2"]
+    assert instance.config_data.network_os.policy.port_channel_mode == "active"
+    # policyType "accessPoHost" from API is stored as "accessPoHost" after normalization (already API form).
+    assert instance.config_data.network_os.policy.policy_type == "accessPoHost"
+
+
+def test_port_channel_access_interface_00810():
+    """
+    # Summary
+
+    Verify `from_response` re-serialized via `to_payload` yields an equivalent dict (minus switchIp).
+
+    ## Test
+
+    - API response -> model -> payload matches original (except switchIp which is excluded)
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.from_response()
+    - PortChannelAccessInterfaceModel.to_payload()
+    """
+    original = copy.deepcopy(SAMPLE_API_RESPONSE)
+    instance = PortChannelAccessInterfaceModel.from_response(original)
+    result = instance.to_payload()
+    expected = {k: v for k, v in original.items() if k != "switchIp"}
+    assert result == expected
+
+
+def test_port_channel_access_interface_00820():
+    """
+    # Summary
+
+    Verify `from_response` tolerates missing `configData`.
+
+    ## Test
+
+    - Response with only switchIp + interfaceName constructs valid model
+    - config_data is None
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.from_response()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessInterfaceModel.from_response({"switchIp": "192.168.1.1", "interfaceName": "port-channel501"})
+    assert instance.config_data is None
+
+
+def test_port_channel_access_interface_00830():
+    """
+    # Summary
+
+    Verify `from_response` ignores unknown top-level and nested keys (extra="ignore").
+
+    ## Test
+
+    - Response with extra keys constructs valid model
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.from_response()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    response["unknownField"] = "ignored"
+    response["configData"]["somethingExtra"] = "also_ignored"
+    with does_not_raise():
+        instance = PortChannelAccessInterfaceModel.from_response(response)
+    assert instance.interface_name == "port-channel501"
+
+
+# =============================================================================
+# Test: PortChannelAccessInterfaceModel — from_config
+# =============================================================================
+
+
+def test_port_channel_access_interface_00900():
+    """
+    # Summary
+
+    Verify `from_config` constructs a model from an Ansible snake_case config.
+
+    ## Test
+
+    - All fields accessible
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.from_config()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.interface_name == "port-channel501"
+    assert instance.config_data.network_os.policy.access_vlan == 100
+    assert instance.config_data.network_os.policy.description == "uplink to host"
+    assert instance.config_data.network_os.policy.ports == ["Ethernet1/1", "Ethernet1/2"]
+
+
+def test_port_channel_access_interface_00910():
+    """
+    # Summary
+
+    Verify Ansible `policy_type: "access_po_host"` is normalized to API value internally.
+
+    ## Test
+
+    - After from_config, stored policy_type is the API value "accessPoHost"
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.from_config()
+    - PortChannelAccessPolicyModel.normalize_policy_type()
+    """
+    instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    assert instance.config_data.network_os.policy.policy_type == "accessPoHost"
+
+
+def test_port_channel_access_interface_00920():
+    """
+    # Summary
+
+    Verify `from_config` -> `to_config` round-trip preserves original data.
+
+    ## Test
+
+    - Input config equals to_config() output
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.from_config()
+    - PortChannelAccessInterfaceModel.to_config()
+    """
+    original = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    instance = PortChannelAccessInterfaceModel.from_config(original)
+    result = instance.to_config()
+    assert result == original
+
+
+def test_port_channel_access_interface_00930():
+    """
+    # Summary
+
+    Verify `from_config` accepts a minimal config with just identifiers.
+
+    ## Test
+
+    - Construct with switch_ip + interface_name only
+    - config_data is None
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.from_config()
+    """
+    with does_not_raise():
+        instance = PortChannelAccessInterfaceModel.from_config({"switch_ip": "192.168.1.1", "interface_name": "port-channel501"})
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.config_data is None
+
+
+def test_port_channel_access_interface_00940():
+    """
+    # Summary
+
+    Verify full round-trip through all serialization methods.
+
+    ## Test
+
+    - config -> from_config -> to_payload -> from_response (with switchIp injected) -> to_config
+      matches original config
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.from_config()
+    - PortChannelAccessInterfaceModel.to_payload()
+    - PortChannelAccessInterfaceModel.from_response()
+    - PortChannelAccessInterfaceModel.to_config()
+    """
+    original = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    instance = PortChannelAccessInterfaceModel.from_config(original)
+    payload = instance.to_payload()
+    payload["switchIp"] = original["switch_ip"]
+    instance2 = PortChannelAccessInterfaceModel.from_response(payload)
+    result = instance2.to_config()
+    assert result == original
+
+
+# =============================================================================
+# Test: PortChannelAccessInterfaceModel — identifier, diff, merge
+# =============================================================================
+
+
+def test_port_channel_access_interface_01000():
+    """
+    # Summary
+
+    Verify `get_identifier_value` returns the composite `(switch_ip, interface_name)` tuple.
+
+    ## Test
+
+    - Composite tuple returned
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.get_identifier_value()
+    """
+    instance = PortChannelAccessInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    assert instance.get_identifier_value() == ("192.168.1.1", "port-channel501")
+
+
+def test_port_channel_access_interface_01010():
+    """
+    # Summary
+
+    Verify `get_diff` returns True when two models are identical.
+
+    ## Test
+
+    - Two identical models
+    - get_diff returns True
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.get_diff()
+    """
+    instance1 = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    instance2 = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    assert instance1.get_diff(instance2) is True
+
+
+def test_port_channel_access_interface_01020():
+    """
+    # Summary
+
+    Verify `get_diff` returns False when a nested field differs.
+
+    ## Test
+
+    - Access VLAN differs between two models
+    - get_diff returns False
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.get_diff()
+    """
+    config1 = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    config2 = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    config2["config_data"]["network_os"]["policy"]["access_vlan"] = 999
+    instance1 = PortChannelAccessInterfaceModel.from_config(config1)
+    instance2 = PortChannelAccessInterfaceModel.from_config(config2)
+    assert instance1.get_diff(instance2) is False
+
+
+def test_port_channel_access_interface_01030():
+    """
+    # Summary
+
+    Verify `merge` applies non-None values from `other` into `self`.
+
+    ## Test
+
+    - Other sets a field self did not have
+    - After merge, self has the field
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.merge()
+    """
+    base = {
+        "switch_ip": "192.168.1.1",
+        "interface_name": "port-channel501",
+        "config_data": {
+            "network_os": {
+                "policy": {"admin_state": True},
+            },
+        },
+    }
+    other = {
+        "switch_ip": "192.168.1.1",
+        "interface_name": "port-channel501",
+        "config_data": {
+            "network_os": {
+                "policy": {"access_vlan": 100},
+            },
+        },
+    }
+    instance = PortChannelAccessInterfaceModel.from_config(base)
+    instance.merge(PortChannelAccessInterfaceModel.from_config(other))
+    assert instance.config_data.network_os.policy.admin_state is True
+    assert instance.config_data.network_os.policy.access_vlan == 100
+
+
+def test_port_channel_access_interface_01040():
+    """
+    # Summary
+
+    Verify `merge` preserves existing values when `other` has unset fields (model_fields_set semantics).
+
+    ## Test
+
+    - Self has a value, other does not mention that field
+    - After merge, self still has the original value
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.merge()
+    """
+    instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    other = PortChannelAccessInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    instance.merge(other)
+    assert instance.config_data.network_os.policy.access_vlan == 100
+
+
+def test_port_channel_access_interface_01050():
+    """
+    # Summary
+
+    Verify `merge` raises TypeError when given a model of the wrong type.
+
+    ## Test
+
+    - Passing a policy model to the interface model merge raises TypeError
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.merge()
+    """
+    instance = PortChannelAccessInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    with pytest.raises(TypeError, match=r"Cannot merge"):
+        instance.merge(PortChannelAccessPolicyModel())
+
+
+# =============================================================================
+# Test: PortChannelAccessInterfaceModel — get_argument_spec
+# =============================================================================
+
+
+def test_port_channel_access_interface_01100():
+    """
+    # Summary
+
+    Verify top-level structural layout of the Ansible argument spec.
+
+    ## Test
+
+    - fabric_name, config, state keys present
+    - switch_ip is under config.options, not top-level
+    - config.type == "list", elements == "dict"
+    - state choices and default
+    - policy_type default is "access_po_host"
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.get_argument_spec()
+    """
+    spec = PortChannelAccessInterfaceModel.get_argument_spec()
+    assert "fabric_name" in spec
+    assert "config" in spec
+    assert "state" in spec
+    assert "switch_ip" not in spec
+    assert "switch_ip" in spec["config"]["options"]
+    assert spec["config"]["type"] == "list"
+    assert spec["config"]["elements"] == "dict"
+    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert spec["state"]["default"] == "merged"
+    policy_spec = spec["config"]["options"]["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    assert policy_spec["policy_type"]["default"] == "access_po_host"
+
+
+def test_port_channel_access_interface_01110():
+    """
+    # Summary
+
+    Verify `interface_type` default is "portChannel" in the argument spec.
+
+    ## Test
+
+    - config.options.interface_type.default == "portChannel"
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.get_argument_spec()
+    """
+    spec = PortChannelAccessInterfaceModel.get_argument_spec()
+    assert spec["config"]["options"]["interface_type"]["default"] == "portChannel"
+
+
+@pytest.mark.parametrize(
+    "field,enum_cls,key",
+    [
+        ("bpdu_filter", BpduFilterEnum, "value"),
+        ("bpdu_guard", BpduGuardEnum, "value"),
+        ("duplex_mode", DuplexModeEnum, "value"),
+        ("lacp_rate", LacpRateEnum, "value"),
+        ("mtu", MtuEnum, "value"),
+        ("port_channel_mode", PortChannelModeEnum, "value"),
+        ("speed", SpeedEnum, "value"),
+        ("storm_control_action", StormControlActionEnum, "value"),
+        ("policy_type", AccessPoHostPolicyTypeEnum, "name"),
+    ],
+    ids=[
+        "bpdu_filter",
+        "bpdu_guard",
+        "duplex_mode",
+        "lacp_rate",
+        "mtu",
+        "port_channel_mode",
+        "speed",
+        "storm_control_action",
+        "policy_type",
+    ],
+)
+def test_port_channel_access_interface_01120(field, enum_cls, key):
+    """
+    # Summary
+
+    Verify enum-constrained policy fields expose correct `choices` in the argument spec.
+
+    ## Test
+
+    - Each enum field's choices list exactly matches the enum values (or Ansible names for policy_type)
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceModel.get_argument_spec()
+    """
+    spec = PortChannelAccessInterfaceModel.get_argument_spec()
+    policy_spec = spec["config"]["options"]["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    if key == "name":
+        expected = [e.name.lower() for e in enum_cls]
+    else:
+        expected = [e.value for e in enum_cls]
+    assert policy_spec[field]["choices"] == expected

--- a/tests/unit/module_utils/models/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_access_interface.py
@@ -560,20 +560,23 @@ def test_port_channel_access_interface_00420():
     """
     # Summary
 
-    Verify camelCase alias `networkOSType` populates network_os_type.
+    Verify camelCase alias `networkOSType` populates network_os_type, and that the field is locked to `nx-os`.
 
     ## Test
 
-    - Construct with camelCase alias
-    - Python field accessible
+    - Construct with camelCase alias and the only valid value
+    - Construct with a non-nx-os value raises ValidationError (Literal lock)
 
     ## Classes and Methods
 
     - PortChannelAccessNetworkOSModel.__init__()
     """
     with does_not_raise():
-        instance = PortChannelAccessNetworkOSModel(networkOSType="ios-xe")
-    assert instance.network_os_type == "ios-xe"
+        instance = PortChannelAccessNetworkOSModel(networkOSType="nx-os")
+    assert instance.network_os_type == "nx-os"
+
+    with pytest.raises(ValidationError, match="Input should be 'nx-os'"):
+        PortChannelAccessNetworkOSModel(networkOSType="ios-xe")
 
 
 # =============================================================================
@@ -1344,7 +1347,14 @@ def test_port_channel_access_interface_01100():
     assert spec["config"]["elements"] == "dict"
     assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
     assert spec["state"]["default"] == "merged"
-    policy_spec = spec["config"]["options"]["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    # interface_type, mode, and network_os_type are hardcoded in the Pydantic model
+    # and intentionally absent from the user-facing argument spec.
+    config_options = spec["config"]["options"]
+    assert "interface_type" not in config_options
+    config_data_spec = config_options["config_data"]["options"]
+    assert "mode" not in config_data_spec
+    assert "network_os_type" not in config_data_spec["network_os"]["options"]
+    policy_spec = config_data_spec["network_os"]["options"]["policy"]["options"]
     assert "policy_type" not in policy_spec
 
 
@@ -1352,18 +1362,21 @@ def test_port_channel_access_interface_01110():
     """
     # Summary
 
-    Verify `interface_type` default is "portChannel" in the argument spec.
+    Verify `interface_type` is hardcoded on the Pydantic model and absent from the user-facing argument spec.
 
     ## Test
 
-    - config.options.interface_type.default == "portChannel"
+    - Model field default is "portChannel"
+    - argument spec does not expose interface_type as a user option
 
     ## Classes and Methods
 
     - PortChannelAccessInterfaceModel.get_argument_spec()
     """
     spec = PortChannelAccessInterfaceModel.get_argument_spec()
-    assert spec["config"]["options"]["interface_type"]["default"] == "portChannel"
+    assert "interface_type" not in spec["config"]["options"]
+    instance = PortChannelAccessInterfaceModel(switch_ip="1.2.3.4", interface_name="port-channel501")
+    assert instance.interface_type == "portChannel"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/module_utils/models/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_access_interface.py
@@ -237,31 +237,40 @@ def test_port_channel_access_interface_00120():
     [
         (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
         (["Ethernet1/1"], ["Ethernet1/1"]),
-        (["e1/1"], ["E1/1"]),
+        # NX-OS abbreviations expand to the canonical Ethernet form so they match the wire key (idempotency).
+        (["e1/1"], ["Ethernet1/1"]),
+        (["eth1/1", "et1/1"], ["Ethernet1/1", "Ethernet1/1"]),
+        # Any casing of the full prefix canonicalizes to "Ethernet".
+        (["ETHERNET1/2", "etHernet1/3"], ["Ethernet1/2", "Ethernet1/3"]),
         ([], []),
         (None, None),
-        # Mixed and breakout-style names preserve everything after the first character.
-        (["ethernet1/1/1", "ETHERNET1/2"], ["Ethernet1/1/1", "ETHERNET1/2"]),
+        # Digits and separators after the alphabetic prefix are preserved (breakout/subinterface forms).
+        (["ethernet1/1/1"], ["Ethernet1/1/1"]),
     ],
     ids=[
-        "lowercase_to_capitalized",
-        "already_capitalized_passthrough",
-        "single_letter",
+        "lowercase_to_canonical",
+        "already_canonical_passthrough",
+        "single_letter_abbreviation",
+        "eth_and_et_abbreviations",
+        "uppercase_canonicalized",
         "empty_list",
         "none_passthrough",
-        "mixed_breakout",
+        "breakout_separators_preserved",
     ],
 )
 def test_port_channel_access_interface_00180(value, expected):
     """
     # Summary
 
-    Verify `normalize_ports` capitalizes the first character of each member interface name.
+    Verify `normalize_ports` expands any case-insensitive NX-OS abbreviation of a member interface name to ND's
+    canonical `Ethernet` form so user input round-trips against the wire key.
 
     ## Test
 
-    - Lowercase member names are capitalized
-    - Already-capitalized values pass through
+    - Lowercase and abbreviated member names (`e1/1`, `eth1/1`, `et1/1`) expand to `Ethernet...`
+    - Any casing of the full prefix canonicalizes to `Ethernet`
+    - Already-canonical values pass through unchanged
+    - Digits/separators after the prefix are preserved
     - Empty list and None pass through
 
     ## Classes and Methods

--- a/tests/unit/module_utils/models/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_access_interface.py
@@ -22,7 +22,6 @@ from contextlib import contextmanager
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
-    AccessPoHostPolicyTypeEnum,
     BpduFilterEnum,
     BpduGuardEnum,
     DuplexModeEnum,
@@ -97,7 +96,7 @@ SAMPLE_ANSIBLE_CONFIG = {
                 "bpdu_guard": "enable",
                 "bpdu_filter": "disable",
                 "description": "uplink to host",
-                "policy_type": "access_po_host",
+                "policy_type": "accessPoHost",
                 "speed": "10Gb",
                 "duplex_mode": "auto",
                 "mtu": "jumbo",
@@ -147,7 +146,7 @@ def test_port_channel_access_interface_00100():
     assert instance.netflow is None
     assert instance.netflow_monitor is None
     assert instance.netflow_sampler is None
-    assert instance.policy_type is None
+    assert instance.policy_type == "accessPoHost"
     assert instance.port_channel_mode is None
     assert instance.ports is None
     assert instance.qos is None
@@ -187,7 +186,6 @@ def test_port_channel_access_interface_00110():
             port_channel_mode="active",
             lacp_rate="fast",
             description="test",
-            policy_type="access_po_host",
             speed="10Gb",
         )
     assert instance.admin_state is True
@@ -196,7 +194,7 @@ def test_port_channel_access_interface_00110():
     assert instance.port_channel_mode == "active"
     assert instance.lacp_rate == "fast"
     assert instance.description == "test"
-    # After normalize + use_enum_values the stored value is the API string.
+    # Hardcoded model default; user no longer supplies this field.
     assert instance.policy_type == "accessPoHost"
     assert instance.speed == "10Gb"
 
@@ -240,47 +238,6 @@ def test_port_channel_access_interface_00120():
 # =============================================================================
 # Test: PortChannelAccessPolicyModel — validators
 # =============================================================================
-
-
-@pytest.mark.parametrize(
-    "value,expected,raises",
-    [
-        ("access_po_host", "accessPoHost", False),
-        ("accessPoHost", "accessPoHost", False),
-        (None, None, False),
-        ("unknown_value", None, True),
-    ],
-    ids=[
-        "ansible_name",
-        "api_value_passthrough",
-        "none_passthrough",
-        "unknown_rejected_by_enum",
-    ],
-)
-def test_port_channel_access_interface_00170(value, expected, raises):
-    """
-    # Summary
-
-    Verify `normalize_policy_type` maps Ansible names to API values and passes through API values unchanged.
-
-    ## Test
-
-    - "access_po_host" normalizes to "accessPoHost"
-    - "accessPoHost" passes through
-    - None passes through
-    - Unknown values fail enum validation
-
-    ## Classes and Methods
-
-    - PortChannelAccessPolicyModel.normalize_policy_type()
-    """
-    if raises:
-        with pytest.raises(ValidationError):
-            PortChannelAccessPolicyModel(policy_type=value)
-    else:
-        with does_not_raise():
-            instance = PortChannelAccessPolicyModel(policy_type=value)
-        assert instance.policy_type == expected
 
 
 @pytest.mark.parametrize(
@@ -548,41 +505,6 @@ def test_port_channel_access_interface_00240(field, enum_cls):
 
     with pytest.raises(ValidationError):
         PortChannelAccessPolicyModel(**{field: "not_a_real_value"})
-
-
-# =============================================================================
-# Test: PortChannelAccessPolicyModel — serializer
-# =============================================================================
-
-
-@pytest.mark.parametrize(
-    "stored_value,mode,expected",
-    [
-        ("accessPoHost", "payload", "accessPoHost"),
-        ("accessPoHost", "config", "access_po_host"),
-        (None, "payload", None),
-        (None, "config", None),
-    ],
-    ids=["payload_known", "config_known", "payload_none", "config_none"],
-)
-def test_port_channel_access_interface_00300(stored_value, mode, expected):
-    """
-    # Summary
-
-    Verify `serialize_policy_type` emits API value in payload mode and Ansible name in config mode.
-
-    ## Test
-
-    - model_dump with context={"mode": "payload"} returns camelCase API value
-    - model_dump with context={"mode": "config"} returns Ansible-friendly snake_case
-
-    ## Classes and Methods
-
-    - PortChannelAccessPolicyModel.serialize_policy_type()
-    """
-    instance = PortChannelAccessPolicyModel(policy_type=stored_value) if stored_value is not None else PortChannelAccessPolicyModel()
-    dumped = instance.model_dump(context={"mode": mode}, exclude_none=False)
-    assert dumped["policy_type"] == expected
 
 
 # =============================================================================
@@ -905,12 +827,11 @@ def test_port_channel_access_interface_00620():
 
     ## Test
 
-    - policy_type="access_po_host" in config -> "accessPoHost" in payload
+    - Hardcoded model default for `policy_type` serializes as `"accessPoHost"` under the `policyType` alias.
 
     ## Classes and Methods
 
     - PortChannelAccessInterfaceModel.to_payload()
-    - PortChannelAccessPolicyModel.serialize_policy_type()
     """
     instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
     result = instance.to_payload()
@@ -998,20 +919,19 @@ def test_port_channel_access_interface_00710():
     """
     # Summary
 
-    Verify `policy_type` is normalized back to the Ansible-friendly name in config mode.
+    Verify `policy_type` round-trips as the API value in config output.
 
     ## Test
 
-    - Stored "accessPoHost" -> output "access_po_host"
+    - Stored "accessPoHost" -> output "accessPoHost" (no Ansible↔API translation; field is hardcoded by the model)
 
     ## Classes and Methods
 
     - PortChannelAccessInterfaceModel.to_config()
-    - PortChannelAccessPolicyModel.serialize_policy_type()
     """
     instance = PortChannelAccessInterfaceModel.from_response(copy.deepcopy(SAMPLE_API_RESPONSE))
     result = instance.to_config()
-    assert result["config_data"]["network_os"]["policy"]["policy_type"] == "access_po_host"
+    assert result["config_data"]["network_os"]["policy"]["policy_type"] == "accessPoHost"
 
 
 def test_port_channel_access_interface_00720():
@@ -1163,16 +1083,15 @@ def test_port_channel_access_interface_00910():
     """
     # Summary
 
-    Verify Ansible `policy_type: "access_po_host"` is normalized to API value internally.
+    Verify model hardcodes the `accessPoHost` policy type regardless of input.
 
     ## Test
 
-    - After from_config, stored policy_type is the API value "accessPoHost"
+    - After from_config (no policy_type in input), stored policy_type is the API value "accessPoHost"
 
     ## Classes and Methods
 
     - PortChannelAccessInterfaceModel.from_config()
-    - PortChannelAccessPolicyModel.normalize_policy_type()
     """
     instance = PortChannelAccessInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
     assert instance.config_data.network_os.policy.policy_type == "accessPoHost"
@@ -1409,7 +1328,7 @@ def test_port_channel_access_interface_01100():
     - switch_ip is under config.options, not top-level
     - config.type == "list", elements == "dict"
     - state choices and default
-    - policy_type default is "access_po_host"
+    - policy_type is not exposed in the argspec (hardcoded by the model)
 
     ## Classes and Methods
 
@@ -1426,7 +1345,7 @@ def test_port_channel_access_interface_01100():
     assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
     assert spec["state"]["default"] == "merged"
     policy_spec = spec["config"]["options"]["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
-    assert policy_spec["policy_type"]["default"] == "access_po_host"
+    assert "policy_type" not in policy_spec
 
 
 def test_port_channel_access_interface_01110():
@@ -1458,7 +1377,6 @@ def test_port_channel_access_interface_01110():
         ("port_channel_mode", PortChannelModeEnum, "value"),
         ("speed", SpeedEnum, "value"),
         ("storm_control_action", StormControlActionEnum, "value"),
-        ("policy_type", AccessPoHostPolicyTypeEnum, "name"),
     ],
     ids=[
         "bpdu_filter",
@@ -1469,7 +1387,6 @@ def test_port_channel_access_interface_01110():
         "port_channel_mode",
         "speed",
         "storm_control_action",
-        "policy_type",
     ],
 )
 def test_port_channel_access_interface_01120(field, enum_cls, key):
@@ -1480,7 +1397,7 @@ def test_port_channel_access_interface_01120(field, enum_cls, key):
 
     ## Test
 
-    - Each enum field's choices list exactly matches the enum values (or Ansible names for policy_type)
+    - Each enum field's choices list exactly matches the enum values
 
     ## Classes and Methods
 

--- a/tests/unit/module_utils/models/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_access_interface.py
@@ -429,7 +429,7 @@ def test_port_channel_access_interface_00230():
         ("plain ASCII", False),
         ("with-hyphen and 123", False),
         ("em — dash", True),
-        ("smart “quotes”", True),
+        ("smart \u201cquotes\u201d", True),
         ("emoji \U0001f600", True),
         ("latin-1 \xe9", True),
     ],

--- a/tests/unit/module_utils/models/test_port_channel_trunk_host_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_trunk_host_interface.py
@@ -657,7 +657,7 @@ def test_port_channel_trunk_host_interface_00230():
         ("plain ASCII", False),
         ("with-hyphen and 123", False),
         ("em — dash", True),
-        ("smart “quotes”", True),
+        ("smart \u201cquotes\u201d", True),
         ("emoji \U0001f600", True),
         ("latin-1 \xe9", True),
     ],

--- a/tests/unit/module_utils/models/test_port_channel_trunk_host_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_trunk_host_interface.py
@@ -1,0 +1,1989 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for port_channel_trunk_host_interface.py
+
+Tests the Port-channel trunkPoHost Interface Pydantic model classes.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    BpduFilterEnum,
+    BpduGuardEnum,
+    DuplexModeEnum,
+    LacpRateEnum,
+    LinkTypeEnum,
+    MtuEnum,
+    PortChannelModeEnum,
+    SpeedEnum,
+    StormControlActionEnum,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostConfigDataModel,
+    PortChannelTrunkHostInterfaceModel,
+    PortChannelTrunkHostNetworkOSModel,
+    PortChannelTrunkHostPolicyModel,
+    PortChannelTrunkHostVlanMappingEntryModel,
+)
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test data constants
+# =============================================================================
+
+SAMPLE_API_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "port-channel501",
+    "interfaceType": "portChannel",
+    "configData": {
+        "mode": "trunk",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "adminState": True,
+                "allowedVlans": "100-200,300",
+                "nativeVlan": 99,
+                "ports": ["Ethernet1/1", "Ethernet1/2"],
+                "portChannelMode": "active",
+                "lacpRate": "fast",
+                "lacpPortPriority": 32768,
+                "bpduGuard": "enable",
+                "bpduFilter": "disable",
+                "linkType": "auto",
+                "description": "trunk to host",
+                "policyType": "trunkPoHost",
+                "speed": "10Gb",
+                "duplexMode": "auto",
+                "mtu": "jumbo",
+                "copyDescription": True,
+                "portTypeEdgeTrunk": True,
+                "negotiateAuto": True,
+                "vlanMapping": False,
+            },
+        },
+    },
+}
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "port-channel501",
+    "interface_type": "portChannel",
+    "config_data": {
+        "mode": "trunk",
+        "network_os": {
+            "network_os_type": "nx-os",
+            "policy": {
+                "admin_state": True,
+                "allowed_vlans": "100-200,300",
+                "native_vlan": 99,
+                "ports": ["Ethernet1/1", "Ethernet1/2"],
+                "port_channel_mode": "active",
+                "lacp_rate": "fast",
+                "lacp_port_priority": 32768,
+                "bpdu_guard": "enable",
+                "bpdu_filter": "disable",
+                "link_type": "auto",
+                "description": "trunk to host",
+                "speed": "10Gb",
+                "duplex_mode": "auto",
+                "mtu": "jumbo",
+                "copy_description": True,
+                "port_type_edge_trunk": True,
+                "negotiate_auto": True,
+                "vlan_mapping": False,
+            },
+        },
+    },
+}
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostPolicyModel — initialization
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_00100():
+    """
+    # Summary
+
+    Verify every policy field defaults to None (except hardcoded `policy_type`).
+
+    ## Test
+
+    - Instantiate with no arguments
+    - Every field is None except `policy_type` which is "trunkPoHost"
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostPolicyModel()
+    assert instance.admin_state is None
+    assert instance.allowed_vlans is None
+    assert instance.bandwidth is None
+    assert instance.bpdu_filter is None
+    assert instance.bpdu_guard is None
+    assert instance.cdp is None
+    assert instance.copy_description is None
+    assert instance.description is None
+    assert instance.duplex_mode is None
+    assert instance.extra_config is None
+    assert instance.inherit_bandwidth is None
+    assert instance.lacp_port_priority is None
+    assert instance.lacp_rate is None
+    assert instance.lacp_suspend is None
+    assert instance.link_type is None
+    assert instance.monitor is None
+    assert instance.mtu is None
+    assert instance.native_vlan is None
+    assert instance.negotiate_auto is None
+    assert instance.netflow is None
+    assert instance.netflow_monitor is None
+    assert instance.netflow_sampler is None
+    assert instance.orphan_port is None
+    assert instance.pfc is None
+    assert instance.policy_type == "trunkPoHost"
+    assert instance.port_channel_mode is None
+    assert instance.port_type_edge_trunk is None
+    assert instance.ports is None
+    assert instance.ptp is None
+    assert instance.qos is None
+    assert instance.qos_policy is None
+    assert instance.queuing_policy is None
+    assert instance.speed is None
+    assert instance.storm_control is None
+    assert instance.storm_control_action is None
+    assert instance.storm_control_broadcast_level is None
+    assert instance.storm_control_broadcast_level_pps is None
+    assert instance.storm_control_multicast_level is None
+    assert instance.storm_control_multicast_level_pps is None
+    assert instance.storm_control_unicast_level is None
+    assert instance.storm_control_unicast_level_pps is None
+    assert instance.vlan_mapping is None
+    assert instance.vlan_mapping_entries is None
+
+
+def test_port_channel_trunk_host_interface_00110():
+    """
+    # Summary
+
+    Verify construction with snake_case field names.
+
+    ## Test
+
+    - Construct with Python field names
+    - Values accessible
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostPolicyModel(
+            admin_state=True,
+            allowed_vlans="100-200",
+            native_vlan=99,
+            ports=["Ethernet1/1"],
+            port_channel_mode="active",
+            lacp_rate="fast",
+            description="test",
+            speed="10Gb",
+            link_type="auto",
+        )
+    assert instance.admin_state is True
+    assert instance.allowed_vlans == "100-200"
+    assert instance.native_vlan == 99
+    assert instance.ports == ["Ethernet1/1"]
+    assert instance.port_channel_mode == "active"
+    assert instance.lacp_rate == "fast"
+    assert instance.description == "test"
+    # Hardcoded model default; user no longer supplies this field.
+    assert instance.policy_type == "trunkPoHost"
+    assert instance.speed == "10Gb"
+    assert instance.link_type == "auto"
+
+
+def test_port_channel_trunk_host_interface_00120():
+    """
+    # Summary
+
+    Verify construction with camelCase aliases.
+
+    ## Test
+
+    - Construct with API alias names
+    - Values accessible by Python names
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostPolicyModel(
+            adminState=True,
+            allowedVlans="all",
+            nativeVlan=200,
+            ports=["Ethernet1/3", "Ethernet1/4"],
+            portChannelMode="passive",
+            policyType="trunkPoHost",
+            bpduGuard="enable",
+            duplexMode="full",
+            copyDescription=True,
+            portTypeEdgeTrunk=True,
+            negotiateAuto=False,
+        )
+    assert instance.admin_state is True
+    assert instance.allowed_vlans == "all"
+    assert instance.native_vlan == 200
+    assert instance.ports == ["Ethernet1/3", "Ethernet1/4"]
+    assert instance.port_channel_mode == "passive"
+    assert instance.policy_type == "trunkPoHost"
+    assert instance.bpdu_guard == "enable"
+    assert instance.duplex_mode == "full"
+    assert instance.copy_description is True
+    assert instance.port_type_edge_trunk is True
+    assert instance.negotiate_auto is False
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostPolicyModel — validators
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
+        (["Ethernet1/1"], ["Ethernet1/1"]),
+        # NX-OS abbreviations expand to the canonical Ethernet form so they match the wire key (idempotency).
+        (["e1/1"], ["Ethernet1/1"]),
+        (["eth1/1", "et1/1"], ["Ethernet1/1", "Ethernet1/1"]),
+        # Any casing of the full prefix canonicalizes to "Ethernet".
+        (["ETHERNET1/2", "etHernet1/3"], ["Ethernet1/2", "Ethernet1/3"]),
+        ([], []),
+        (None, None),
+        # Digits and separators after the alphabetic prefix are preserved (breakout/subinterface forms).
+        (["ethernet1/1/1"], ["Ethernet1/1/1"]),
+    ],
+    ids=[
+        "lowercase_to_canonical",
+        "already_canonical_passthrough",
+        "single_letter_abbreviation",
+        "eth_and_et_abbreviations",
+        "uppercase_canonicalized",
+        "empty_list",
+        "none_passthrough",
+        "breakout_separators_preserved",
+    ],
+)
+def test_port_channel_trunk_host_interface_00180(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_ports` expands any case-insensitive NX-OS abbreviation of a member interface name to ND's
+    canonical `Ethernet` form so user input round-trips against the wire key.
+
+    ## Test
+
+    - Lowercase and abbreviated member names (`e1/1`, `eth1/1`, `et1/1`) expand to `Ethernet...`
+    - Any casing of the full prefix canonicalizes to `Ethernet`
+    - Already-canonical values pass through unchanged
+    - Digits/separators after the prefix are preserved
+    - Empty list and None pass through
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.normalize_ports()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostPolicyModel(ports=value)
+    assert instance.ports == expected
+
+
+def test_port_channel_trunk_host_interface_00190():
+    """
+    # Summary
+
+    Verify `normalize_ports` passes a non-list, non-None value through to fail Pydantic type validation
+    rather than coercing it. This keeps misconfigured input surfaced as a `ValidationError`.
+
+    ## Test
+
+    - A scalar string for `ports` raises ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.normalize_ports()
+    """
+    with pytest.raises(ValidationError):
+        PortChannelTrunkHostPolicyModel(ports="Ethernet1/1")
+
+
+@pytest.mark.parametrize(
+    "value,should_raise",
+    [
+        ("none", False),
+        ("all", False),
+        ("1", False),
+        ("4094", False),
+        ("100", False),
+        ("100-200", False),
+        ("1-4094", False),
+        ("1-200,500-2000,3000", False),
+        ("1,2,3,4-10", False),
+        ("", False),
+        (None, False),
+        ("abc", True),
+        ("1-", True),
+        ("100-200,", True),
+        ("None", True),  # case-sensitive
+        ("ALL", True),
+        ("0", True),  # below valid VLAN range
+        ("4095", True),  # above valid VLAN range
+        ("5000", True),  # above valid VLAN range
+        ("1-4095", True),  # range end out of bounds
+        ("0-100", True),  # range start out of bounds
+        ("200-100", True),  # reversed range
+        ("4094-1", True),  # reversed range
+    ],
+    ids=[
+        "none_keyword",
+        "all_keyword",
+        "min_vlan_id",
+        "max_vlan_id",
+        "single_id",
+        "single_range",
+        "full_range",
+        "multiple_ranges",
+        "mixed_ids_ranges",
+        "empty_passthrough",
+        "none_passthrough",
+        "non_numeric_rejected",
+        "trailing_dash_rejected",
+        "trailing_comma_rejected",
+        "case_none_rejected",
+        "case_all_rejected",
+        "vlan_zero_rejected",
+        "vlan_4095_rejected",
+        "vlan_5000_rejected",
+        "range_end_out_of_bounds_rejected",
+        "range_start_out_of_bounds_rejected",
+        "reversed_range_rejected",
+        "reversed_range_max_rejected",
+    ],
+)
+def test_port_channel_trunk_host_interface_00200(value, should_raise):
+    """
+    # Summary
+
+    Verify `allowed_vlans` validator accepts `none`, `all`, or comma-separated VLAN ids/ranges where every id is in 1..4094 and every range start <= end,
+    and rejects malformed input or out-of-range values.
+
+    ## Test
+
+    - Valid forms (including 1 and 4094 boundary values) are accepted
+    - Out-of-range ids (0, 4095+) raise ValidationError
+    - Out-of-range range bounds raise ValidationError
+    - Reversed ranges raise ValidationError
+    - Shape-invalid strings raise ValidationError
+
+    ## Classes and Methods
+
+    - port_channel_trunk_host_interface._validate_allowed_vlans()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError, match=r"allowed_vlans"):
+            PortChannelTrunkHostPolicyModel(allowed_vlans=value)
+    else:
+        with does_not_raise():
+            instance = PortChannelTrunkHostPolicyModel(allowed_vlans=value)
+        assert instance.allowed_vlans == value
+
+
+@pytest.mark.parametrize(
+    "value,match",
+    [
+        ("0", r"out of bounds"),
+        ("4095", r"out of bounds"),
+        ("1-4095", r"out of bounds"),
+        ("0-100", r"out of bounds"),
+        ("200-100", r"start greater than end"),
+        ("abc", r"comma-separated list"),
+    ],
+    ids=[
+        "vlan_zero_message",
+        "vlan_4095_message",
+        "range_end_out_of_bounds_message",
+        "range_start_out_of_bounds_message",
+        "reversed_range_message",
+        "shape_error_message",
+    ],
+)
+def test_port_channel_trunk_host_interface_00202(value, match):
+    """
+    # Summary
+
+    Verify `allowed_vlans` validator raises `ValueError` with a specific, actionable message identifying
+    the failure mode (out-of-bounds id, out-of-bounds range, reversed range, or shape mismatch).
+
+    ## Test
+
+    - Each failure mode surfaces a distinguishable message substring
+
+    ## Classes and Methods
+
+    - port_channel_trunk_host_interface._validate_allowed_vlans()
+    """
+    with pytest.raises(ValidationError, match=match):
+        PortChannelTrunkHostPolicyModel(allowed_vlans=value)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (250, "250"),
+        (1, "1"),
+        (4094, "4094"),
+    ],
+    ids=["single_vlan_int", "min_vlan_int", "max_vlan_int"],
+)
+def test_port_channel_trunk_host_interface_00205(value, expected):
+    """
+    # Summary
+
+    Verify `allowed_vlans` coerces JSON int responses to str. ND returns single-id values as JSON ints
+    (e.g. `250` instead of `"250"`) when the field is set to a single VLAN with no commas/dashes. The model
+    normalizes to str so round-trips and idempotency comparisons stay stable.
+
+    ## Test
+
+    - JSON int 250 is coerced to "250"
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.validate_allowed_vlans()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostPolicyModel(allowed_vlans=value)
+    assert instance.allowed_vlans == expected
+    assert isinstance(instance.allowed_vlans, str)
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostPolicyModel — range and enum validation
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "field,value,should_raise",
+    [
+        ("native_vlan", 1, False),
+        ("native_vlan", 4094, False),
+        ("native_vlan", 0, True),
+        ("native_vlan", 4095, True),
+        ("bandwidth", 1, False),
+        ("bandwidth", 100000000, False),
+        ("bandwidth", 0, True),
+        ("bandwidth", 100000001, True),
+        ("inherit_bandwidth", 1, False),
+        ("inherit_bandwidth", 100000000, False),
+        ("inherit_bandwidth", 0, True),
+        ("inherit_bandwidth", 100000001, True),
+        ("lacp_port_priority", 1, False),
+        ("lacp_port_priority", 65535, False),
+        ("lacp_port_priority", 0, True),
+        ("lacp_port_priority", 65536, True),
+        ("storm_control_broadcast_level_pps", 0, False),
+        ("storm_control_broadcast_level_pps", 200000000, False),
+        ("storm_control_broadcast_level_pps", -1, True),
+        ("storm_control_broadcast_level_pps", 200000001, True),
+        ("storm_control_multicast_level_pps", 0, False),
+        ("storm_control_multicast_level_pps", 200000000, False),
+        ("storm_control_multicast_level_pps", -1, True),
+        ("storm_control_multicast_level_pps", 200000001, True),
+        ("storm_control_unicast_level_pps", 0, False),
+        ("storm_control_unicast_level_pps", 200000000, False),
+        ("storm_control_unicast_level_pps", -1, True),
+        ("storm_control_unicast_level_pps", 200000001, True),
+    ],
+    ids=lambda v: str(v) if not isinstance(v, bool) else ("raise" if v else "ok"),
+)
+def test_port_channel_trunk_host_interface_00220(field, value, should_raise):
+    """
+    # Summary
+
+    Verify ge/le constraints on every numeric policy field.
+
+    ## Test
+
+    - At-min and at-max values accepted
+    - Below-min and above-max values rejected with ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError):
+            PortChannelTrunkHostPolicyModel(**{field: value})
+    else:
+        with does_not_raise():
+            instance = PortChannelTrunkHostPolicyModel(**{field: value})
+        assert getattr(instance, field) == value
+
+
+@pytest.mark.parametrize(
+    "field,value,should_raise",
+    [
+        ("storm_control_broadcast_level", 0.0, False),
+        ("storm_control_broadcast_level", 100.0, False),
+        ("storm_control_broadcast_level", -0.1, True),
+        ("storm_control_broadcast_level", 100.01, True),
+        ("storm_control_multicast_level", 0.0, False),
+        ("storm_control_multicast_level", 100.0, False),
+        ("storm_control_multicast_level", -0.1, True),
+        ("storm_control_multicast_level", 100.01, True),
+        ("storm_control_unicast_level", 0.0, False),
+        ("storm_control_unicast_level", 100.0, False),
+        ("storm_control_unicast_level", -0.1, True),
+        ("storm_control_unicast_level", 100.01, True),
+    ],
+    ids=lambda v: str(v) if not isinstance(v, bool) else ("raise" if v else "ok"),
+)
+def test_port_channel_trunk_host_interface_00225(field, value, should_raise):
+    """
+    # Summary
+
+    Verify storm-control percentage fields enforce the 0.0-100.0 range.
+
+    ## Test
+
+    - 0.0 and 100.0 accepted
+    - -0.1 and 100.01 rejected
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError):
+            PortChannelTrunkHostPolicyModel(**{field: value})
+    else:
+        with does_not_raise():
+            instance = PortChannelTrunkHostPolicyModel(**{field: value})
+        assert getattr(instance, field) == value
+
+
+@pytest.mark.parametrize(
+    "field,value,expected",
+    [
+        ("storm_control_broadcast_level", "50.5", 50.5),
+        ("storm_control_multicast_level", "75.25", 75.25),
+        ("storm_control_unicast_level", "0.0", 0.0),
+    ],
+    ids=["broadcast_str_to_float", "multicast_str_to_float", "unicast_str_to_float"],
+)
+def test_port_channel_trunk_host_interface_00227(field, value, expected):
+    """
+    # Summary
+
+    Verify Pydantic coerces JSON-string storm-control levels to float. ND returns these fields as quoted
+    strings on the wire even though they are typed as `float | None` in the model.
+
+    ## Test
+
+    - String "50.5" parses to float 50.5
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostPolicyModel(**{field: value})
+    assert getattr(instance, field) == expected
+    assert isinstance(getattr(instance, field), float)
+
+
+def test_port_channel_trunk_host_interface_00230():
+    """
+    # Summary
+
+    Verify `description` max_length=254.
+
+    ## Test
+
+    - 254-char description accepted
+    - 255-char description rejected with ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    """
+    at_limit = "a" * 254
+    over_limit = "a" * 255
+    with does_not_raise():
+        instance = PortChannelTrunkHostPolicyModel(description=at_limit)
+    assert instance.description == at_limit
+
+    with pytest.raises(ValidationError):
+        PortChannelTrunkHostPolicyModel(description=over_limit)
+
+
+@pytest.mark.parametrize(
+    "value,should_raise",
+    [
+        ("plain ASCII", False),
+        ("with-hyphen and 123", False),
+        ("em — dash", True),
+        ("smart “quotes”", True),
+        ("emoji \U0001f600", True),
+        ("latin-1 \xe9", True),
+    ],
+    ids=[
+        "ascii_ok",
+        "ascii_punct_digits",
+        "em_dash_rejected",
+        "smart_quotes_rejected",
+        "emoji_rejected",
+        "latin1_rejected",
+    ],
+)
+def test_port_channel_trunk_host_interface_00235(value, should_raise):
+    """
+    # Summary
+
+    Verify `description` (typed `AsciiDescription`) rejects any non-ASCII character.
+
+    Cisco backend pipes interface descriptions through CLI generators that 500 on UTF-8. Catching this client-side
+    gives users a clear error instead of a generic "unexpected error during policy execution" 500.
+
+    ## Test
+
+    - ASCII strings accepted
+    - Non-ASCII characters (em-dash, smart quotes, emoji, latin-1) raise
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    - models.types.ascii_only()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError, match="description must contain only ASCII"):
+            PortChannelTrunkHostPolicyModel(description=value)
+    else:
+        instance = PortChannelTrunkHostPolicyModel(description=value)
+        assert instance.description == value
+
+
+@pytest.mark.parametrize(
+    "field,enum_cls",
+    [
+        ("speed", SpeedEnum),
+        ("duplex_mode", DuplexModeEnum),
+        ("bpdu_guard", BpduGuardEnum),
+        ("bpdu_filter", BpduFilterEnum),
+        ("mtu", MtuEnum),
+        ("storm_control_action", StormControlActionEnum),
+        ("port_channel_mode", PortChannelModeEnum),
+        ("lacp_rate", LacpRateEnum),
+        ("link_type", LinkTypeEnum),
+    ],
+    ids=["speed", "duplex_mode", "bpdu_guard", "bpdu_filter", "mtu", "storm_control_action", "port_channel_mode", "lacp_rate", "link_type"],
+)
+def test_port_channel_trunk_host_interface_00240(field, enum_cls):
+    """
+    # Summary
+
+    Verify enum-constrained fields accept any valid enum value and reject invalid strings.
+
+    ## Test
+
+    - Valid enum value sets the stored value
+    - Invalid value raises ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    """
+    valid_value = next(iter(enum_cls)).value
+    with does_not_raise():
+        instance = PortChannelTrunkHostPolicyModel(**{field: valid_value})
+    assert getattr(instance, field) == valid_value
+
+    with pytest.raises(ValidationError):
+        PortChannelTrunkHostPolicyModel(**{field: "not_a_real_value"})
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostVlanMappingEntryModel
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_00300():
+    """
+    # Summary
+
+    Verify VLAN mapping entry construction with all fields.
+
+    ## Test
+
+    - All fields accessible
+    - camelCase aliases populate snake_case fields
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostVlanMappingEntryModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostVlanMappingEntryModel(
+            customer_inner_vlan_id=10,
+            customer_vlan_id=["100", "200"],
+            dot1q_tunnel=True,
+            provider_vlan_id=1000,
+        )
+    assert instance.customer_inner_vlan_id == 10
+    assert instance.customer_vlan_id == ["100", "200"]
+    assert instance.dot1q_tunnel is True
+    assert instance.provider_vlan_id == 1000
+
+
+@pytest.mark.parametrize(
+    "field,value,should_raise",
+    [
+        ("customer_inner_vlan_id", 1, False),
+        ("customer_inner_vlan_id", 4094, False),
+        ("customer_inner_vlan_id", 0, True),
+        ("customer_inner_vlan_id", 4095, True),
+        ("provider_vlan_id", 1, False),
+        ("provider_vlan_id", 4094, False),
+        ("provider_vlan_id", 0, True),
+        ("provider_vlan_id", 4095, True),
+    ],
+    ids=lambda v: str(v) if not isinstance(v, bool) else ("raise" if v else "ok"),
+)
+def test_port_channel_trunk_host_interface_00310(field, value, should_raise):
+    """
+    # Summary
+
+    Verify VLAN mapping entry id range constraints.
+
+    ## Test
+
+    - At-min and at-max values accepted
+    - Below-min and above-max values rejected
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostVlanMappingEntryModel.__init__()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError):
+            PortChannelTrunkHostVlanMappingEntryModel(**{field: value})
+    else:
+        with does_not_raise():
+            instance = PortChannelTrunkHostVlanMappingEntryModel(**{field: value})
+        assert getattr(instance, field) == value
+
+
+@pytest.mark.parametrize(
+    "value,should_raise",
+    [
+        (None, False),
+        ([], False),
+        (["1"], False),
+        (["4094"], False),
+        (["100"], False),
+        (["100", "200"], False),
+        (["100-200"], False),
+        (["1-4094", "500"], False),
+        (["100-200", "300", "500-600"], False),
+        (["0"], True),
+        (["4095"], True),
+        (["5000"], True),
+        (["1-4095"], True),
+        (["0-100"], True),
+        (["200-100"], True),
+        (["abc"], True),
+        (["1-"], True),
+        (["100,200"], True),  # comma not allowed inside list element
+        ([""], True),
+        ([100], True),  # non-string entry rejected
+    ],
+    ids=[
+        "none_passthrough",
+        "empty_list",
+        "min_vlan_id",
+        "max_vlan_id",
+        "single_id",
+        "multiple_ids",
+        "single_range",
+        "range_and_id",
+        "ranges_and_ids",
+        "vlan_zero_rejected",
+        "vlan_4095_rejected",
+        "vlan_5000_rejected",
+        "range_end_out_of_bounds_rejected",
+        "range_start_out_of_bounds_rejected",
+        "reversed_range_rejected",
+        "non_numeric_rejected",
+        "trailing_dash_rejected",
+        "comma_in_element_rejected",
+        "empty_string_rejected",
+        "non_string_entry_rejected",
+    ],
+)
+def test_port_channel_trunk_host_interface_00315(value, should_raise):
+    """
+    # Summary
+
+    Verify `customer_vlan_id` validator accepts a list of VLAN id or range strings where every id is in 1..4094 and every range start <= end,
+    and rejects malformed entries, out-of-range values, reversed ranges, comma-joined elements, empty strings, and non-string entries.
+
+    ## Test
+
+    - Valid entries (boundary values, ids, ranges, mixed) are accepted
+    - Out-of-range ids and range bounds raise ValidationError
+    - Reversed ranges raise ValidationError
+    - Shape-invalid entries raise ValidationError
+
+    ## Classes and Methods
+
+    - port_channel_trunk_host_interface._validate_customer_vlan_id_list()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError, match=r"customer_vlan_id"):
+            PortChannelTrunkHostVlanMappingEntryModel(customer_vlan_id=value)
+    else:
+        with does_not_raise():
+            instance = PortChannelTrunkHostVlanMappingEntryModel(customer_vlan_id=value)
+        assert instance.customer_vlan_id == value
+
+
+@pytest.mark.parametrize(
+    "value,match",
+    [
+        (["0"], r"out of bounds"),
+        (["4095"], r"out of bounds"),
+        (["1-4095"], r"out of bounds"),
+        (["200-100"], r"start greater than end"),
+        (["abc"], r"VLAN id or range"),
+        ([""], r"non-empty strings"),
+        ([42], r"non-empty strings"),
+    ],
+    ids=[
+        "vlan_zero_message",
+        "vlan_4095_message",
+        "range_out_of_bounds_message",
+        "reversed_range_message",
+        "shape_error_message",
+        "empty_string_message",
+        "non_string_message",
+    ],
+)
+def test_port_channel_trunk_host_interface_00316(value, match):
+    """
+    # Summary
+
+    Verify `customer_vlan_id` validator raises `ValueError` with a specific, actionable message identifying the failure mode (out-of-bounds id,
+    out-of-bounds range, reversed range, shape mismatch, empty string, or non-string entry).
+
+    ## Test
+
+    - Each failure mode surfaces a distinguishable message substring
+
+    ## Classes and Methods
+
+    - port_channel_trunk_host_interface._validate_customer_vlan_id_list()
+    """
+    with pytest.raises(ValidationError, match=match):
+        PortChannelTrunkHostVlanMappingEntryModel(customer_vlan_id=value)
+
+
+def test_port_channel_trunk_host_interface_00320():
+    """
+    # Summary
+
+    Verify policy accepts a list of VLAN mapping entries via dict input.
+
+    ## Test
+
+    - vlan_mapping_entries accepts a list of dicts
+    - Each dict is coerced to PortChannelTrunkHostVlanMappingEntryModel
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostPolicyModel(
+            vlan_mapping=True,
+            vlan_mapping_entries=[
+                {"customer_vlan_id": ["100"], "provider_vlan_id": 200, "dot1q_tunnel": True},
+                {"customer_vlan_id": ["300"], "provider_vlan_id": 400},
+            ],
+        )
+    assert instance.vlan_mapping is True
+    assert len(instance.vlan_mapping_entries) == 2
+    assert isinstance(instance.vlan_mapping_entries[0], PortChannelTrunkHostVlanMappingEntryModel)
+    assert instance.vlan_mapping_entries[0].provider_vlan_id == 200
+    assert instance.vlan_mapping_entries[0].dot1q_tunnel is True
+    assert instance.vlan_mapping_entries[1].dot1q_tunnel is None
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostNetworkOSModel
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_00400():
+    """
+    # Summary
+
+    Verify `network_os_type` defaults to "nx-os".
+
+    ## Test
+
+    - Instantiate without args
+    - network_os_type is "nx-os"
+    - policy is None
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostNetworkOSModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostNetworkOSModel()
+    assert instance.network_os_type == "nx-os"
+    assert instance.policy is None
+
+
+def test_port_channel_trunk_host_interface_00410():
+    """
+    # Summary
+
+    Verify nested `policy` assignment accepts a dict and coerces to PortChannelTrunkHostPolicyModel.
+
+    ## Test
+
+    - Construct with policy as dict
+    - policy is a PortChannelTrunkHostPolicyModel instance
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostNetworkOSModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostNetworkOSModel(policy={"admin_state": True, "allowed_vlans": "100-200"})
+    assert isinstance(instance.policy, PortChannelTrunkHostPolicyModel)
+    assert instance.policy.admin_state is True
+    assert instance.policy.allowed_vlans == "100-200"
+
+
+def test_port_channel_trunk_host_interface_00420():
+    """
+    # Summary
+
+    Verify camelCase alias `networkOSType` populates network_os_type, and that the field is locked to `nx-os`.
+
+    ## Test
+
+    - Construct with camelCase alias and the only valid value
+    - Construct with a non-nx-os value raises ValidationError (Literal lock)
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostNetworkOSModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostNetworkOSModel(networkOSType="nx-os")
+    assert instance.network_os_type == "nx-os"
+
+    with pytest.raises(ValidationError, match="Input should be 'nx-os'"):
+        PortChannelTrunkHostNetworkOSModel(networkOSType="ios-xe")
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostConfigDataModel
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_00450():
+    """
+    # Summary
+
+    Verify `mode` defaults to "trunk".
+
+    ## Test
+
+    - Construct with only network_os
+    - mode is "trunk"
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostConfigDataModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostConfigDataModel(network_os=PortChannelTrunkHostNetworkOSModel())
+    assert instance.mode == "trunk"
+
+
+def test_port_channel_trunk_host_interface_00460():
+    """
+    # Summary
+
+    Verify camelCase alias `networkOS` populates network_os.
+
+    ## Test
+
+    - Construct with camelCase alias
+    - Python field accessible
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostConfigDataModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostConfigDataModel(networkOS={"networkOSType": "nx-os"})
+    assert isinstance(instance.network_os, PortChannelTrunkHostNetworkOSModel)
+    assert instance.network_os.network_os_type == "nx-os"
+
+
+def test_port_channel_trunk_host_interface_00470():
+    """
+    # Summary
+
+    Verify `network_os` defaults to an empty `PortChannelTrunkHostNetworkOSModel` when omitted, so constructing
+    `config_data` without an explicit `network_os` does not raise a raw `ValidationError`.
+
+    ## Test
+
+    - Construct without network_os
+    - config_data.network_os is a PortChannelTrunkHostNetworkOSModel with a None policy
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostConfigDataModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostConfigDataModel()
+    assert isinstance(instance.network_os, PortChannelTrunkHostNetworkOSModel)
+    assert instance.network_os.policy is None
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostInterfaceModel — initialization and ClassVars
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_00500():
+    """
+    # Summary
+
+    Verify ClassVar `identifiers` and `identifier_strategy`.
+
+    ## Test
+
+    - identifiers == ["switch_ip", "interface_name"]
+    - identifier_strategy == "composite"
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel
+    """
+    assert PortChannelTrunkHostInterfaceModel.identifiers == ["switch_ip", "interface_name"]
+    assert PortChannelTrunkHostInterfaceModel.identifier_strategy == "composite"
+
+
+def test_port_channel_trunk_host_interface_00510():
+    """
+    # Summary
+
+    Verify `payload_exclude_fields` excludes `switch_ip`.
+
+    ## Test
+
+    - payload_exclude_fields == {"switch_ip"}
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel
+    """
+    assert PortChannelTrunkHostInterfaceModel.payload_exclude_fields == {"switch_ip"}
+
+
+def test_port_channel_trunk_host_interface_00520():
+    """
+    # Summary
+
+    Verify `switch_ip` and `interface_name` are required.
+
+    ## Test
+
+    - Missing switch_ip raises ValidationError
+    - Missing interface_name raises ValidationError
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.__init__()
+    """
+    with pytest.raises(ValidationError, match=r"switch_ip|switchIp"):
+        PortChannelTrunkHostInterfaceModel(interface_name="port-channel501")
+
+    with pytest.raises(ValidationError, match=r"interface_name|interfaceName"):
+        PortChannelTrunkHostInterfaceModel(switch_ip="192.168.1.1")
+
+
+def test_port_channel_trunk_host_interface_00530():
+    """
+    # Summary
+
+    Verify `interface_type` defaults to "portChannel" and `config_data` defaults to None.
+
+    ## Test
+
+    - Minimal construction
+    - Defaults applied
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.__init__()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.interface_name == "port-channel501"
+    assert instance.interface_type == "portChannel"
+    assert instance.config_data is None
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostInterfaceModel — normalize_interface_name
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("port-channel501", "port-channel501"),
+        ("Port-Channel501", "port-channel501"),
+        ("PORT-CHANNEL501", "port-channel501"),
+        ("Port-channel1", "port-channel1"),
+        ("", ""),
+    ],
+    ids=["already_lower", "title_case", "upper", "mixed_case", "empty_passthrough"],
+)
+def test_port_channel_trunk_host_interface_00550(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` lowercases the entire interface name (port-channel convention).
+
+    ## Test
+
+    - Mixed-case inputs normalized to lowercase
+    - Already-lowercase input unchanged
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.normalize_interface_name()
+    """
+    instance = PortChannelTrunkHostInterfaceModel(switch_ip="192.168.1.1", interface_name=value)
+    assert instance.interface_name == expected
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostInterfaceModel — to_payload
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_00600():
+    """
+    # Summary
+
+    Verify `to_payload` emits camelCase keys and excludes `switch_ip`.
+
+    ## Test
+
+    - Top-level keys are camelCase
+    - switchIp / switch_ip not present
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.to_payload()
+    """
+    instance = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_payload()
+    assert "interfaceName" in result
+    assert "interfaceType" in result
+    assert "configData" in result
+    assert "switchIp" not in result
+    assert "switch_ip" not in result
+
+
+def test_port_channel_trunk_host_interface_00610():
+    """
+    # Summary
+
+    Verify deeply nested structure preserves camelCase aliases throughout.
+
+    ## Test
+
+    - configData.networkOS.policy has camelCase keys
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.to_payload()
+    """
+    instance = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_payload()
+    policy = result["configData"]["networkOS"]["policy"]
+    assert "adminState" in policy
+    assert "allowedVlans" in policy
+    assert "nativeVlan" in policy
+    assert "ports" in policy
+    assert "portChannelMode" in policy
+    assert "lacpRate" in policy
+    assert "lacpPortPriority" in policy
+    assert "policyType" in policy
+    assert "bpduGuard" in policy
+    assert "copyDescription" in policy
+    assert "linkType" in policy
+    assert "portTypeEdgeTrunk" in policy
+    assert "negotiateAuto" in policy
+
+
+def test_port_channel_trunk_host_interface_00620():
+    """
+    # Summary
+
+    Verify `policyType` is the API camelCase value in payload mode.
+
+    ## Test
+
+    - Hardcoded model default for `policy_type` serializes as `"trunkPoHost"` under the `policyType` alias.
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.to_payload()
+    """
+    instance = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_payload()
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "trunkPoHost"
+
+
+def test_port_channel_trunk_host_interface_00630():
+    """
+    # Summary
+
+    Verify member ports list survives serialization with normalized names.
+
+    ## Test
+
+    - ports list survives in payload as a list of capitalized member names
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.to_payload()
+    - PortChannelTrunkHostPolicyModel.normalize_ports()
+    """
+    config = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    config["config_data"]["network_os"]["policy"]["ports"] = ["ethernet1/5", "ethernet1/6"]
+    instance = PortChannelTrunkHostInterfaceModel.from_config(config)
+    result = instance.to_payload()
+    assert result["configData"]["networkOS"]["policy"]["ports"] == ["Ethernet1/5", "Ethernet1/6"]
+
+
+def test_port_channel_trunk_host_interface_00640():
+    """
+    # Summary
+
+    Verify None-valued fields are excluded from payload output.
+
+    ## Test
+
+    - Minimal model with config_data=None
+    - configData not present in payload
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.to_payload()
+    """
+    instance = PortChannelTrunkHostInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    result = instance.to_payload()
+    assert "configData" not in result
+    assert "interfaceName" in result
+
+
+def test_port_channel_trunk_host_interface_00650():
+    """
+    # Summary
+
+    Verify VLAN mapping entries survive serialization.
+
+    ## Test
+
+    - vlan_mapping_entries is preserved in payload as a list of camelCase dicts
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.to_payload()
+    """
+    config = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    config["config_data"]["network_os"]["policy"]["vlan_mapping"] = True
+    config["config_data"]["network_os"]["policy"]["vlan_mapping_entries"] = [
+        {"customer_vlan_id": ["100"], "provider_vlan_id": 200, "dot1q_tunnel": True},
+    ]
+    instance = PortChannelTrunkHostInterfaceModel.from_config(config)
+    result = instance.to_payload()
+    entries = result["configData"]["networkOS"]["policy"]["vlanMappingEntries"]
+    assert len(entries) == 1
+    assert entries[0]["customerVlanId"] == ["100"]
+    assert entries[0]["providerVlanId"] == 200
+    assert entries[0]["dot1qTunnel"] is True
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostInterfaceModel — to_config
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_00700():
+    """
+    # Summary
+
+    Verify `to_config` emits snake_case keys throughout.
+
+    ## Test
+
+    - Top-level keys are snake_case
+    - Nested keys are snake_case
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.to_config()
+    """
+    instance = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_config()
+    assert "interface_name" in result
+    assert "interface_type" in result
+    assert "config_data" in result
+    policy = result["config_data"]["network_os"]["policy"]
+    assert "admin_state" in policy
+    assert "allowed_vlans" in policy
+    assert "native_vlan" in policy
+    assert "ports" in policy
+    assert "port_channel_mode" in policy
+    assert "lacp_rate" in policy
+    assert "copy_description" in policy
+    assert "link_type" in policy
+
+
+def test_port_channel_trunk_host_interface_00710():
+    """
+    # Summary
+
+    Verify `policy_type` is omitted from `to_config()` output (the field is hardcoded by the model and is
+    not in the argspec, so surfacing the wire form `"trunkPoHost"` back to playbooks would only confuse
+    assertions that compare against the snake_case Ansible convention).
+
+    ## Test
+
+    - From a full API response, to_config() does NOT include `policy_type` in the policy dict
+    - All other policy fields ARE present (sanity check that we only omitted policy_type)
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.to_config()
+    - PortChannelTrunkHostPolicyModel._strip_policy_type_in_config()
+    """
+    instance = PortChannelTrunkHostInterfaceModel.from_response(copy.deepcopy(SAMPLE_API_RESPONSE))
+    result = instance.to_config()
+    policy = result["config_data"]["network_os"]["policy"]
+    assert "policy_type" not in policy
+    assert policy["admin_state"] is True
+    assert policy["allowed_vlans"] == "100-200,300"
+
+
+def test_port_channel_trunk_host_interface_00720():
+    """
+    # Summary
+
+    Verify `switch_ip` is included in config output (differs from payload).
+
+    ## Test
+
+    - switch_ip present at top level of config
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.to_config()
+    """
+    instance = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    result = instance.to_config()
+    assert result["switch_ip"] == "192.168.1.1"
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostInterfaceModel — from_response
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_00800():
+    """
+    # Summary
+
+    Verify `from_response` constructs a model from the ND API response.
+
+    ## Test
+
+    - All fields accessible by Python names
+    - Nested structure populated
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_response()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostInterfaceModel.from_response(copy.deepcopy(SAMPLE_API_RESPONSE))
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.interface_name == "port-channel501"
+    assert instance.interface_type == "portChannel"
+    assert instance.config_data.mode == "trunk"
+    assert instance.config_data.network_os.policy.admin_state is True
+    assert instance.config_data.network_os.policy.allowed_vlans == "100-200,300"
+    assert instance.config_data.network_os.policy.native_vlan == 99
+    assert instance.config_data.network_os.policy.ports == ["Ethernet1/1", "Ethernet1/2"]
+    assert instance.config_data.network_os.policy.port_channel_mode == "active"
+    assert instance.config_data.network_os.policy.policy_type == "trunkPoHost"
+
+
+def test_port_channel_trunk_host_interface_00810():
+    """
+    # Summary
+
+    Verify `from_response` re-serialized via `to_payload` yields an equivalent dict (minus switchIp).
+
+    ## Test
+
+    - API response -> model -> payload matches original (except switchIp which is excluded)
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_response()
+    - PortChannelTrunkHostInterfaceModel.to_payload()
+    """
+    original = copy.deepcopy(SAMPLE_API_RESPONSE)
+    instance = PortChannelTrunkHostInterfaceModel.from_response(original)
+    result = instance.to_payload()
+    expected = {k: v for k, v in original.items() if k != "switchIp"}
+    assert result == expected
+
+
+def test_port_channel_trunk_host_interface_00820():
+    """
+    # Summary
+
+    Verify `from_response` tolerates missing `configData`.
+
+    ## Test
+
+    - Response with only switchIp + interfaceName constructs valid model
+    - config_data is None
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_response()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostInterfaceModel.from_response({"switchIp": "192.168.1.1", "interfaceName": "port-channel501"})
+    assert instance.config_data is None
+
+
+def test_port_channel_trunk_host_interface_00830():
+    """
+    # Summary
+
+    Verify `from_response` ignores unknown top-level and nested keys (extra="ignore").
+
+    ## Test
+
+    - Response with extra keys constructs valid model
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_response()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    response["unknownField"] = "ignored"
+    response["configData"]["somethingExtra"] = "also_ignored"
+    with does_not_raise():
+        instance = PortChannelTrunkHostInterfaceModel.from_response(response)
+    assert instance.interface_name == "port-channel501"
+
+
+def test_port_channel_trunk_host_interface_00840():
+    """
+    # Summary
+
+    Verify `from_response` accepts the wire-format response shape with `portChannelId` and `ptp` fields that
+    ND auto-fills. These fields are present in actual API responses but not always in the OpenAPI spec.
+
+    ## Test
+
+    - Response with portChannelId and ptp fields constructs valid model
+    - `portChannelId` is a response-only echo of interface_name and is silently ignored (extra="ignore"), so it
+      never leaks into config-shaped output
+    - `ptp` is a modeled field and is stored
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_response()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    response["configData"]["networkOS"]["policy"]["portChannelId"] = "port-channel501"
+    response["configData"]["networkOS"]["policy"]["ptp"] = False
+    with does_not_raise():
+        instance = PortChannelTrunkHostInterfaceModel.from_response(response)
+    assert not hasattr(instance.config_data.network_os.policy, "port_channel_id")
+    assert instance.config_data.network_os.policy.ptp is False
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostInterfaceModel — from_config
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_00900():
+    """
+    # Summary
+
+    Verify `from_config` constructs a model from an Ansible snake_case config.
+
+    ## Test
+
+    - All fields accessible
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_config()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.interface_name == "port-channel501"
+    assert instance.config_data.network_os.policy.allowed_vlans == "100-200,300"
+    assert instance.config_data.network_os.policy.native_vlan == 99
+    assert instance.config_data.network_os.policy.description == "trunk to host"
+    assert instance.config_data.network_os.policy.ports == ["Ethernet1/1", "Ethernet1/2"]
+
+
+def test_port_channel_trunk_host_interface_00910():
+    """
+    # Summary
+
+    Verify model hardcodes the `trunkPoHost` policy type regardless of input.
+
+    ## Test
+
+    - After from_config (no policy_type in input), stored policy_type is the API value "trunkPoHost"
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_config()
+    """
+    instance = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    assert instance.config_data.network_os.policy.policy_type == "trunkPoHost"
+
+
+def test_port_channel_trunk_host_interface_00920():
+    """
+    # Summary
+
+    Verify `from_config` -> `to_config` round-trip preserves original data.
+
+    ## Test
+
+    - Input config equals to_config() output
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_config()
+    - PortChannelTrunkHostInterfaceModel.to_config()
+    """
+    original = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    instance = PortChannelTrunkHostInterfaceModel.from_config(original)
+    result = instance.to_config()
+    assert result == original
+
+
+def test_port_channel_trunk_host_interface_00930():
+    """
+    # Summary
+
+    Verify `from_config` accepts a minimal config with just identifiers.
+
+    ## Test
+
+    - Construct with switch_ip + interface_name only
+    - config_data is None
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_config()
+    """
+    with does_not_raise():
+        instance = PortChannelTrunkHostInterfaceModel.from_config({"switch_ip": "192.168.1.1", "interface_name": "port-channel501"})
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.config_data is None
+
+
+def test_port_channel_trunk_host_interface_00940():
+    """
+    # Summary
+
+    Verify full round-trip through all serialization methods.
+
+    ## Test
+
+    - config -> from_config -> to_payload -> from_response (with switchIp injected) -> to_config
+      matches original config
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.from_config()
+    - PortChannelTrunkHostInterfaceModel.to_payload()
+    - PortChannelTrunkHostInterfaceModel.from_response()
+    - PortChannelTrunkHostInterfaceModel.to_config()
+    """
+    original = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    instance = PortChannelTrunkHostInterfaceModel.from_config(original)
+    payload = instance.to_payload()
+    payload["switchIp"] = original["switch_ip"]
+    instance2 = PortChannelTrunkHostInterfaceModel.from_response(payload)
+    result = instance2.to_config()
+    assert result == original
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostInterfaceModel — identifier, diff, merge
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_01000():
+    """
+    # Summary
+
+    Verify `get_identifier_value` returns the composite `(switch_ip, interface_name)` tuple.
+
+    ## Test
+
+    - Composite tuple returned
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.get_identifier_value()
+    """
+    instance = PortChannelTrunkHostInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    assert instance.get_identifier_value() == ("192.168.1.1", "port-channel501")
+
+
+def test_port_channel_trunk_host_interface_01010():
+    """
+    # Summary
+
+    Verify `get_diff` returns True when two models are identical.
+
+    ## Test
+
+    - Two identical models
+    - get_diff returns True
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.get_diff()
+    """
+    instance1 = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    instance2 = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    assert instance1.get_diff(instance2) is True
+
+
+def test_port_channel_trunk_host_interface_01020():
+    """
+    # Summary
+
+    Verify `get_diff` returns False when a nested field differs.
+
+    ## Test
+
+    - Allowed VLANs differ between two models
+    - get_diff returns False
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.get_diff()
+    """
+    config1 = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    config2 = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    config2["config_data"]["network_os"]["policy"]["allowed_vlans"] = "999"
+    instance1 = PortChannelTrunkHostInterfaceModel.from_config(config1)
+    instance2 = PortChannelTrunkHostInterfaceModel.from_config(config2)
+    assert instance1.get_diff(instance2) is False
+
+
+def test_port_channel_trunk_host_interface_01030():
+    """
+    # Summary
+
+    Verify `merge` applies non-None values from `other` into `self`.
+
+    ## Test
+
+    - Other sets a field self did not have
+    - After merge, self has the field
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.merge()
+    """
+    base = {
+        "switch_ip": "192.168.1.1",
+        "interface_name": "port-channel501",
+        "config_data": {
+            "network_os": {
+                "policy": {"admin_state": True},
+            },
+        },
+    }
+    other = {
+        "switch_ip": "192.168.1.1",
+        "interface_name": "port-channel501",
+        "config_data": {
+            "network_os": {
+                "policy": {"allowed_vlans": "100-200"},
+            },
+        },
+    }
+    instance = PortChannelTrunkHostInterfaceModel.from_config(base)
+    instance.merge(PortChannelTrunkHostInterfaceModel.from_config(other))
+    assert instance.config_data.network_os.policy.admin_state is True
+    assert instance.config_data.network_os.policy.allowed_vlans == "100-200"
+
+
+def test_port_channel_trunk_host_interface_01040():
+    """
+    # Summary
+
+    Verify `merge` preserves existing values when `other` has unset fields (model_fields_set semantics).
+
+    ## Test
+
+    - Self has a value, other does not mention that field
+    - After merge, self still has the original value
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.merge()
+    """
+    instance = PortChannelTrunkHostInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    other = PortChannelTrunkHostInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    instance.merge(other)
+    assert instance.config_data.network_os.policy.allowed_vlans == "100-200,300"
+
+
+def test_port_channel_trunk_host_interface_01050():
+    """
+    # Summary
+
+    Verify `merge` raises TypeError when given a model of the wrong type.
+
+    ## Test
+
+    - Passing a policy model to the interface model merge raises TypeError
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.merge()
+    """
+    instance = PortChannelTrunkHostInterfaceModel(switch_ip="192.168.1.1", interface_name="port-channel501")
+    with pytest.raises(TypeError, match=r"Cannot merge"):
+        instance.merge(PortChannelTrunkHostPolicyModel())
+
+
+# =============================================================================
+# Test: PortChannelTrunkHostInterfaceModel — get_argument_spec
+# =============================================================================
+
+
+def test_port_channel_trunk_host_interface_01100():
+    """
+    # Summary
+
+    Verify top-level structural layout of the Ansible argument spec.
+
+    ## Test
+
+    - fabric_name, config, state keys present
+    - switch_ip is under config.options, not top-level
+    - config.type == "list", elements == "dict"
+    - state choices and default
+    - policy_type is not exposed in the argspec (hardcoded by the model)
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    """
+    spec = PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    assert "fabric_name" in spec
+    assert "config" in spec
+    assert "state" in spec
+    assert "switch_ip" not in spec
+    assert "switch_ip" in spec["config"]["options"]
+    assert spec["config"]["type"] == "list"
+    assert spec["config"]["elements"] == "dict"
+    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert spec["state"]["default"] == "merged"
+    # interface_type, mode, and network_os_type are hardcoded in the Pydantic model
+    # and intentionally absent from the user-facing argument spec.
+    config_options = spec["config"]["options"]
+    assert "interface_type" not in config_options
+    config_data_spec = config_options["config_data"]["options"]
+    assert "mode" not in config_data_spec
+    assert "network_os_type" not in config_data_spec["network_os"]["options"]
+    policy_spec = config_data_spec["network_os"]["options"]["policy"]["options"]
+    assert "policy_type" not in policy_spec
+
+
+def test_port_channel_trunk_host_interface_01110():
+    """
+    # Summary
+
+    Verify `interface_type` is hardcoded on the Pydantic model and absent from the user-facing argument spec.
+
+    ## Test
+
+    - Model field default is "portChannel"
+    - argument spec does not expose interface_type as a user option
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    """
+    spec = PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    assert "interface_type" not in spec["config"]["options"]
+    instance = PortChannelTrunkHostInterfaceModel(switch_ip="1.2.3.4", interface_name="port-channel501")
+    assert instance.interface_type == "portChannel"
+
+
+def test_port_channel_trunk_host_interface_01115():
+    """
+    # Summary
+
+    Verify the `mode` is hardcoded to "trunk" on the Pydantic model and absent from the user-facing argument spec.
+
+    ## Test
+
+    - PortChannelTrunkHostConfigDataModel default mode is "trunk"
+    - argument spec does not expose mode as a user option
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    """
+    spec = PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    assert "mode" not in spec["config"]["options"]["config_data"]["options"]
+    instance = PortChannelTrunkHostConfigDataModel(network_os={})
+    assert instance.mode == "trunk"
+
+
+@pytest.mark.parametrize(
+    "field,enum_cls",
+    [
+        ("bpdu_filter", BpduFilterEnum),
+        ("bpdu_guard", BpduGuardEnum),
+        ("duplex_mode", DuplexModeEnum),
+        ("lacp_rate", LacpRateEnum),
+        ("link_type", LinkTypeEnum),
+        ("mtu", MtuEnum),
+        ("port_channel_mode", PortChannelModeEnum),
+        ("speed", SpeedEnum),
+        ("storm_control_action", StormControlActionEnum),
+    ],
+    ids=[
+        "bpdu_filter",
+        "bpdu_guard",
+        "duplex_mode",
+        "lacp_rate",
+        "link_type",
+        "mtu",
+        "port_channel_mode",
+        "speed",
+        "storm_control_action",
+    ],
+)
+def test_port_channel_trunk_host_interface_01120(field, enum_cls):
+    """
+    # Summary
+
+    Verify enum-constrained policy fields expose correct `choices` in the argument spec.
+
+    ## Test
+
+    - Each enum field's choices list exactly matches the enum values
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    """
+    spec = PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    policy_spec = spec["config"]["options"]["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    expected = [e.value for e in enum_cls]
+    assert policy_spec[field]["choices"] == expected
+
+
+def test_port_channel_trunk_host_interface_01130():
+    """
+    # Summary
+
+    Verify `vlan_mapping_entries` in argspec is a list of dicts with the expected suboptions.
+
+    ## Test
+
+    - vlan_mapping_entries.type == "list"
+    - vlan_mapping_entries.elements == "dict"
+    - All four entry suboptions present
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    """
+    spec = PortChannelTrunkHostInterfaceModel.get_argument_spec()
+    policy_spec = spec["config"]["options"]["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    entries_spec = policy_spec["vlan_mapping_entries"]
+    assert entries_spec["type"] == "list"
+    assert entries_spec["elements"] == "dict"
+    assert "customer_inner_vlan_id" in entries_spec["options"]
+    assert "customer_vlan_id" in entries_spec["options"]
+    assert "dot1q_tunnel" in entries_spec["options"]
+    assert "provider_vlan_id" in entries_spec["options"]

--- a/tests/unit/module_utils/models/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_access_interface.py
@@ -1,0 +1,658 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for vpc_access_interface.py
+
+Tests the vPC accessVpcHost Interface Pydantic model classes.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+    AccessVpcHostConfigDataModel,
+    AccessVpcHostInterfaceModel,
+    AccessVpcHostNetworkOSModel,
+    AccessVpcHostPolicyModel,
+)
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test data constants
+# =============================================================================
+
+SAMPLE_API_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "vpc100",
+    "interfaceType": "vpc",
+    "configData": {
+        "mode": "access",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "policyType": "accessVpcHost",
+                "peerSwitchId": "FDOPEER0001",
+                "adminState": True,
+                "accessVlan": 10,
+                "peer1PortChannelId": 100,
+                "peer1MemberPorts": ["Ethernet1/1"],
+                "peer2PortChannelId": 100,
+                "peer2MemberPorts": ["Ethernet1/2"],
+                "portChannelMode": "active",
+                "lacpRate": "fast",
+                "mtu": "jumbo",
+            },
+        },
+    },
+}
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "vpc100",
+    "config_data": {
+        "network_os": {
+            "policy": {
+                "admin_state": True,
+                "access_vlan": 10,
+                "peer1_port_channel_id": 100,
+                "peer1_member_ports": ["Ethernet1/1"],
+                "peer2_port_channel_id": 100,
+                "peer2_member_ports": ["Ethernet1/2"],
+                "port_channel_mode": "active",
+                "lacp_rate": "fast",
+                "mtu": "jumbo",
+            },
+        },
+    },
+}
+
+
+# =============================================================================
+# Test: AccessVpcHostPolicyModel — initialization
+# =============================================================================
+
+
+def test_vpc_access_interface_00100():
+    """
+    # Summary
+
+    Verify every policy field defaults to None except the frozen policy_type.
+
+    ## Test
+
+    - Instantiate with no arguments
+    - Every per-peer and shared field is None
+    - policy_type defaults to "accessVpcHost"
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel()
+    assert instance.policy_type == "accessVpcHost"
+    assert instance.peer_switch_id is None
+    # Shared access VLAN
+    assert instance.access_vlan is None
+    # Per-peer
+    assert instance.peer1_member_ports is None
+    assert instance.peer1_port_channel_configuration is None
+    assert instance.peer1_port_channel_description is None
+    assert instance.peer1_port_channel_id is None
+    assert instance.peer2_member_ports is None
+    assert instance.peer2_port_channel_configuration is None
+    assert instance.peer2_port_channel_description is None
+    assert instance.peer2_port_channel_id is None
+    # Shared
+    assert instance.admin_state is None
+    assert instance.bandwidth is None
+    assert instance.bpdu_filter is None
+    assert instance.bpdu_guard is None
+    assert instance.cdp is None
+    assert instance.copy_description is None
+    assert instance.duplex_mode is None
+    assert instance.inherit_bandwidth is None
+    assert instance.lacp_port_priority is None
+    assert instance.lacp_rate is None
+    assert instance.lacp_suspend is None
+    assert instance.lacp_vpc_convergence is None
+    assert instance.link_type is None
+    assert instance.mirror_config is None
+    assert instance.mtu is None
+    assert instance.negotiate_auto is None
+    assert instance.netflow is None
+    assert instance.netflow_monitor is None
+    assert instance.netflow_sampler is None
+    assert instance.pfc is None
+    assert instance.port_channel_mode is None
+    assert instance.port_type_edge_trunk is None
+    assert instance.qos is None
+    assert instance.qos_policy is None
+    assert instance.queuing_policy is None
+    assert instance.speed is None
+    assert instance.storm_control is None
+    assert instance.storm_control_action is None
+
+
+def test_vpc_access_interface_00110():
+    """
+    # Summary
+
+    Verify construction with snake_case field names.
+
+    ## Test
+
+    - Construct with Python field names
+    - Values accessible via Python attributes
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel(
+            admin_state=True,
+            access_vlan=10,
+            peer1_port_channel_id=100,
+            peer1_member_ports=["Ethernet1/1"],
+            peer2_port_channel_id=100,
+            peer2_member_ports=["Ethernet1/2"],
+            port_channel_mode="active",
+            lacp_rate="fast",
+        )
+    assert instance.admin_state is True
+    assert instance.access_vlan == 10
+    assert instance.peer1_port_channel_id == 100
+    assert instance.peer1_member_ports == ["Ethernet1/1"]
+    assert instance.peer2_port_channel_id == 100
+    assert instance.peer2_member_ports == ["Ethernet1/2"]
+    assert instance.port_channel_mode == "active"
+    assert instance.lacp_rate == "fast"
+    assert instance.policy_type == "accessVpcHost"
+
+
+def test_vpc_access_interface_00120():
+    """
+    # Summary
+
+    Verify construction with camelCase aliases.
+
+    ## Test
+
+    - Construct with API alias names
+    - Values accessible by Python names
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel(
+            adminState=True,
+            accessVlan=20,
+            peer1PortChannelId=200,
+            peer1MemberPorts=["Ethernet1/5"],
+            peer2PortChannelId=200,
+            peer2MemberPorts=["Ethernet1/6"],
+            portChannelMode="passive",
+            policyType="accessVpcHost",
+            peerSwitchId="FDOPEER0001",
+        )
+    assert instance.admin_state is True
+    assert instance.access_vlan == 20
+    assert instance.peer1_port_channel_id == 200
+    assert instance.peer1_member_ports == ["Ethernet1/5"]
+    assert instance.peer2_port_channel_id == 200
+    assert instance.peer2_member_ports == ["Ethernet1/6"]
+    assert instance.port_channel_mode == "passive"
+    assert instance.policy_type == "accessVpcHost"
+    assert instance.peer_switch_id == "FDOPEER0001"
+
+
+# =============================================================================
+# Test: AccessVpcHostPolicyModel — validators
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
+        (["Ethernet1/1"], ["Ethernet1/1"]),
+        # NX-OS abbreviations expand to the canonical Ethernet form so they match the wire key (idempotency).
+        (["e1/1"], ["Ethernet1/1"]),
+        (["eth1/1", "et1/1"], ["Ethernet1/1", "Ethernet1/1"]),
+        # Any casing of the full prefix canonicalizes to "Ethernet".
+        (["ETHERNET1/2", "etHernet1/3"], ["Ethernet1/2", "Ethernet1/3"]),
+        ([], []),
+        (None, None),
+        (["ethernet1/1/1"], ["Ethernet1/1/1"]),
+    ],
+    ids=[
+        "lowercase_to_canonical",
+        "already_canonical_passthrough",
+        "single_letter_expanded",
+        "abbreviations_expanded",
+        "any_casing_canonicalized",
+        "empty_list",
+        "none_passthrough",
+        "breakout_preserved",
+    ],
+)
+def test_vpc_access_interface_00180_peer1(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_member_ports` expands each peer1 member name to ND's canonical `Ethernet` form.
+
+    ## Test
+
+    - Lowercase and abbreviated member names (`e1/1`, `eth1/1`, `et1/1`) expand to `Ethernet...`
+    - Any casing of the full prefix canonicalizes to `Ethernet`
+    - Already-canonical values pass through; empty list and None pass through; breakout suffixes are preserved
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.normalize_member_ports()
+    - AccessVpcHostPolicyModel._normalize_member_name()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel(peer1_member_ports=value)
+    assert instance.peer1_member_ports == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
+        (["Ethernet1/1"], ["Ethernet1/1"]),
+        (["eth1/1"], ["Ethernet1/1"]),
+        (None, None),
+    ],
+    ids=["lowercase_to_canonical", "already_canonical_passthrough", "abbreviation_expanded", "none_passthrough"],
+)
+def test_vpc_access_interface_00185_peer2(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_member_ports` also applies to peer2_member_ports.
+
+    ## Test
+
+    - Same normalization rules as peer1
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.normalize_member_ports()
+    - AccessVpcHostPolicyModel._normalize_member_name()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel(peer2_member_ports=value)
+    assert instance.peer2_member_ports == expected
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("access_vlan", 0),
+        ("access_vlan", 4095),
+        ("peer1_port_channel_id", 0),
+        ("peer1_port_channel_id", 4097),
+        ("peer2_port_channel_id", 0),
+        ("peer2_port_channel_id", 4097),
+    ],
+    ids=[
+        "vlan_below_min",
+        "vlan_above_max",
+        "peer1_pc_id_below_min",
+        "peer1_pc_id_above_max",
+        "peer2_pc_id_below_min",
+        "peer2_pc_id_above_max",
+    ],
+)
+def test_vpc_access_interface_00200_range(field, value):
+    """
+    # Summary
+
+    Verify VLAN (1-4094) and port-channel-id (1-4096) range validation.
+
+    ## Test
+
+    - Values outside the valid range raise ValidationError
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel (Pydantic Field constraints)
+    """
+    with pytest.raises(ValidationError):
+        AccessVpcHostPolicyModel(**{field: value})
+
+
+def test_vpc_access_interface_00210_policy_type_frozen():
+    """
+    # Summary
+
+    Verify `policy_type` cannot be reassigned to a different value (frozen=True).
+
+    ## Test
+
+    - Construct with default policy_type
+    - Attempt to assign a different value raises ValidationError
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel (frozen Field)
+    """
+    instance = AccessVpcHostPolicyModel()
+    with pytest.raises(ValidationError):
+        instance.policy_type = "trunkVpcHost"
+
+
+# =============================================================================
+# Test: AccessVpcHostInterfaceModel — identifier behavior
+# =============================================================================
+
+
+def test_vpc_access_interface_00300_identifier():
+    """
+    # Summary
+
+    Verify the identifier is `interface_name` only (single strategy). A vPC interface is one fabric-level resource;
+    ND echoes it from both peers but it must collapse to one identity for diff/override-deletion correctness.
+
+    ## Test
+
+    - Identifier is `["interface_name"]`
+    - Identifier strategy is `"single"`
+    - get_identifier_value returns the interface name string
+    - `switch_ip` is excluded from the diff dict (routing-only field)
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.get_identifier_value()
+    - AccessVpcHostInterfaceModel.to_diff_dict()
+    """
+    instance = AccessVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc100")
+    assert instance.identifiers == ["interface_name"]
+    assert instance.identifier_strategy == "single"
+    assert instance.get_identifier_value() == "vpc100"
+    # switch_ip is for routing only; it must not appear in the diff dict so two peers' echoes diff-equal.
+    assert "switchIp" not in instance.to_diff_dict()
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("Vpc100", "vpc100"),
+        ("VPC100", "vpc100"),
+        ("vpc100", "vpc100"),
+        ("vPC100", "vpc100"),
+    ],
+    ids=["title_case", "upper_case", "lower_case_passthrough", "mixed_case"],
+)
+def test_vpc_access_interface_00310_normalize_name(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` lowercases interface names.
+
+    ## Test
+
+    - Various casings are normalized to lowercase
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.normalize_interface_name()
+    """
+    instance = AccessVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name=value)
+    assert instance.interface_name == expected
+
+
+# =============================================================================
+# Test: AccessVpcHostInterfaceModel — round-trip
+# =============================================================================
+
+
+def test_vpc_access_interface_00400_round_trip_from_api():
+    """
+    # Summary
+
+    Verify the model accepts the camelCase API response shape and exposes values via Python attributes.
+
+    ## Test
+
+    - Construct from SAMPLE_API_RESPONSE
+    - Nested values accessible
+    - peerSwitchId reads through
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.__init__()
+    """
+    instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.interface_name == "vpc100"
+    assert instance.interface_type == "vpc"
+    policy = instance.config_data.network_os.policy
+    assert policy.policy_type == "accessVpcHost"
+    assert policy.peer_switch_id == "FDOPEER0001"
+    assert policy.access_vlan == 10
+    assert policy.peer1_member_ports == ["Ethernet1/1"]
+    assert policy.peer2_member_ports == ["Ethernet1/2"]
+    assert policy.admin_state is True
+
+
+def test_vpc_access_interface_00410_round_trip_from_ansible():
+    """
+    # Summary
+
+    Verify the model accepts the snake_case Ansible config shape.
+
+    ## Test
+
+    - Construct from SAMPLE_ANSIBLE_CONFIG
+    - Nested values accessible
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.__init__()
+    """
+    instance = AccessVpcHostInterfaceModel(**copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    assert instance.switch_ip == "192.168.1.1"
+    policy = instance.config_data.network_os.policy
+    assert policy.peer1_port_channel_id == 100
+    assert policy.peer2_port_channel_id == 100
+    assert policy.access_vlan == 10
+    assert policy.policy_type == "accessVpcHost"
+
+
+def test_vpc_access_interface_00420_to_payload():
+    """
+    # Summary
+
+    Verify `to_payload()` serializes the model back to camelCase, drops the `switch_ip` identifier, and splits the
+    user-facing single `access_vlan` into the per-peer write keys (`peer1AccessVlan` + `peer2AccessVlan`) that ND's
+    create schema requires.
+
+    ## Test
+
+    - to_payload() returns wire-shaped dict
+    - switchIp is excluded (Ansible-facing only)
+    - interfaceType is present
+    - Nested policy aliases are camelCase
+    - accessVlan is absent from the payload (split into per-peer keys)
+    - peer1AccessVlan and peer2AccessVlan are both present with the same value
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.to_payload()
+    - AccessVpcHostPolicyModel.serialize_policy()
+    """
+    instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+    assert "switchIp" not in payload
+    assert payload["interfaceName"] == "vpc100"
+    assert payload["interfaceType"] == "vpc"
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert policy["policyType"] == "accessVpcHost"
+    assert policy["peer1MemberPorts"] == ["Ethernet1/1"]
+    assert policy["peer2MemberPorts"] == ["Ethernet1/2"]
+    assert policy["peer1PortChannelId"] == 100
+    assert policy["peer2PortChannelId"] == 100
+    # access_vlan split to both per-peer keys; the single-valued accessVlan key is removed on payload.
+    assert "accessVlan" not in policy
+    assert policy["peer1AccessVlan"] == 10
+    assert policy["peer2AccessVlan"] == 10
+
+
+def test_vpc_access_interface_00425_to_config_keeps_single_vlan():
+    """
+    # Summary
+
+    Verify `to_config()` keeps `access_vlan` as a single field (does NOT expand to per-peer). The expansion only
+    happens for payload mode; config / diff modes use the wire-echo (single) shape so idempotency works.
+
+    ## Test
+
+    - to_config() returns the snake_case field `access_vlan`
+    - `peer1_access_vlan` and `peer2_access_vlan` are NOT in the config
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.to_config()
+    - AccessVpcHostPolicyModel.serialize_policy()
+    """
+    instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    config = instance.to_config()
+    policy = config["config_data"]["network_os"]["policy"]
+    assert policy["access_vlan"] == 10
+    assert "peer1_access_vlan" not in policy
+    assert "peer2_access_vlan" not in policy
+
+
+def test_vpc_access_interface_00427_to_config_strips_policy_type():
+    """
+    # Summary
+
+    Verify `to_config()` omits the frozen, argspec-excluded `policy_type` so it does not leak into
+    `before` / `after` / `gathered` output, while `to_payload()` still emits the wire `policyType`.
+
+    ## Test
+
+    - to_config() output does NOT contain `policy_type` or `policyType`
+    - to_payload() output DOES contain `policyType` (the wire key ND expects)
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.to_config()
+    - AccessVpcHostInterfaceModel.to_payload()
+    - AccessVpcHostPolicyModel.serialize_policy()
+    """
+    instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    config_policy = instance.to_config()["config_data"]["network_os"]["policy"]
+    assert "policy_type" not in config_policy
+    assert "policyType" not in config_policy
+    payload_policy = instance.to_payload()["configData"]["networkOS"]["policy"]
+    assert payload_policy["policyType"] == "accessVpcHost"
+
+
+# =============================================================================
+# Test: Argument spec exposure
+# =============================================================================
+
+
+def test_vpc_access_interface_00500_argument_spec_shape():
+    """
+    # Summary
+
+    Verify the argument spec exposes the right shape: fabric_name, config list, state choices.
+
+    ## Test
+
+    - top-level keys: fabric_name, config, state
+    - state choices contain merged/replaced/overridden/deleted
+    - config has nested policy options including peer1_/peer2_ fields
+    - Frozen scaffolding (interface_type, mode, network_os_type, policy_type) is NOT exposed
+    - peer_switch_id (orchestrator-injected) is NOT exposed
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.get_argument_spec()
+    """
+    spec = AccessVpcHostInterfaceModel.get_argument_spec()
+    assert set(spec) == {"fabric_name", "config", "state"}
+    assert spec["fabric_name"]["required"] is True
+    assert set(spec["state"]["choices"]) == {"merged", "replaced", "overridden", "deleted"}
+
+    config_options = spec["config"]["options"]
+    assert "switch_ip" in config_options
+    assert "interface_name" in config_options
+    assert "config_data" in config_options
+
+    policy_options = config_options["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    # Shared access VLAN (collapsed by ND on read; single field on the user side)
+    assert "access_vlan" in policy_options
+    # Per-peer presence
+    assert "peer1_port_channel_id" in policy_options
+    assert "peer1_member_ports" in policy_options
+    assert "peer2_port_channel_id" in policy_options
+    assert "peer2_member_ports" in policy_options
+    # Shared field samples
+    assert "admin_state" in policy_options
+    assert "lacp_rate" in policy_options
+    assert "port_channel_mode" in policy_options
+    # Frozen/injected exclusions
+    assert "interface_type" not in config_options
+    assert "policy_type" not in policy_options
+    assert "mode" not in policy_options
+    assert "network_os_type" not in policy_options
+    assert "peer_switch_id" not in policy_options
+    # Per-peer access VLANs are explicitly NOT exposed (ND collapses to single accessVlan on read).
+    assert "peer1_access_vlan" not in policy_options
+    assert "peer2_access_vlan" not in policy_options
+
+
+# =============================================================================
+# Test: Nested-model sanity (Config / NetworkOS)
+# =============================================================================
+
+
+def test_vpc_access_interface_00600_nested_defaults():
+    """
+    # Summary
+
+    Verify ConfigData and NetworkOS containers default their frozen discriminators.
+
+    ## Test
+
+    - AccessVpcHostConfigDataModel.mode defaults to "access"
+    - AccessVpcHostNetworkOSModel.network_os_type defaults to "nx-os"
+
+    ## Classes and Methods
+
+    - AccessVpcHostConfigDataModel
+    - AccessVpcHostNetworkOSModel
+    """
+    network_os = AccessVpcHostNetworkOSModel(policy=AccessVpcHostPolicyModel())
+    config = AccessVpcHostConfigDataModel(network_os=network_os)
+    assert config.mode == "access"
+    assert config.network_os.network_os_type == "nx-os"

--- a/tests/unit/module_utils/models/test_vpc_trunk_host_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_trunk_host_interface.py
@@ -1,0 +1,884 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for vpc_trunk_host_interface.py
+
+Tests the vPC trunkVpcHost Interface Pydantic model classes.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import (
+    TrunkVpcHostConfigDataModel,
+    TrunkVpcHostInterfaceModel,
+    TrunkVpcHostNetworkOSModel,
+    TrunkVpcHostPolicyModel,
+    TrunkVpcHostVlanMappingEntryModel,
+)
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test data constants
+# =============================================================================
+
+SAMPLE_API_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "vpc500",
+    "interfaceType": "vpc",
+    "configData": {
+        "mode": "trunk",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "policyType": "trunkVpcHost",
+                "peerSwitchId": "FDOPEER0001",
+                "adminState": True,
+                "allowedVlans": "100-200",
+                "nativeVlan": 99,
+                "peer1PortChannelId": 500,
+                "peer1MemberPorts": ["Ethernet1/1"],
+                "peer2PortChannelId": 500,
+                "peer2MemberPorts": ["Ethernet1/2"],
+                "portChannelMode": "active",
+                "lacpRate": "fast",
+                "mtu": "jumbo",
+            },
+        },
+    },
+}
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "vpc500",
+    "config_data": {
+        "network_os": {
+            "policy": {
+                "admin_state": True,
+                "allowed_vlans": "100-200",
+                "native_vlan": 99,
+                "peer1_port_channel_id": 500,
+                "peer1_member_ports": ["Ethernet1/1"],
+                "peer2_port_channel_id": 500,
+                "peer2_member_ports": ["Ethernet1/2"],
+                "port_channel_mode": "active",
+                "lacp_rate": "fast",
+                "mtu": "jumbo",
+            },
+        },
+    },
+}
+
+
+# =============================================================================
+# Test: TrunkVpcHostPolicyModel — initialization
+# =============================================================================
+
+
+def test_vpc_trunk_host_interface_00100():
+    """
+    # Summary
+
+    Verify every policy field defaults to None except the frozen policy_type.
+
+    ## Test
+
+    - Instantiate with no arguments
+    - Every per-peer and shared field is None
+    - policy_type defaults to "trunkVpcHost"
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = TrunkVpcHostPolicyModel()
+    assert instance.policy_type == "trunkVpcHost"
+    assert instance.peer_switch_id is None
+    # Trunk-specific single-valued fields
+    assert instance.allowed_vlans is None
+    assert instance.native_vlan is None
+    # Per-peer
+    assert instance.peer1_member_ports is None
+    assert instance.peer1_port_channel_configuration is None
+    assert instance.peer1_port_channel_description is None
+    assert instance.peer1_port_channel_id is None
+    assert instance.peer2_member_ports is None
+    assert instance.peer2_port_channel_configuration is None
+    assert instance.peer2_port_channel_description is None
+    assert instance.peer2_port_channel_id is None
+    # VLAN mapping
+    assert instance.vlan_mapping is None
+    assert instance.vlan_mapping_entries is None
+    # Shared
+    assert instance.admin_state is None
+    assert instance.bandwidth is None
+    assert instance.bpdu_filter is None
+    assert instance.bpdu_guard is None
+    assert instance.cdp is None
+    assert instance.copy_description is None
+    assert instance.duplex_mode is None
+    assert instance.inherit_bandwidth is None
+    assert instance.lacp_port_priority is None
+    assert instance.lacp_rate is None
+    assert instance.lacp_suspend is None
+    assert instance.lacp_vpc_convergence is None
+    assert instance.link_type is None
+    assert instance.mirror_config is None
+    assert instance.mtu is None
+    assert instance.negotiate_auto is None
+    assert instance.netflow is None
+    assert instance.netflow_monitor is None
+    assert instance.netflow_sampler is None
+    assert instance.pfc is None
+    assert instance.port_channel_mode is None
+    assert instance.port_type_edge_trunk is None
+    assert instance.qos is None
+    assert instance.qos_policy is None
+    assert instance.queuing_policy is None
+    assert instance.speed is None
+    assert instance.storm_control is None
+    assert instance.storm_control_action is None
+
+
+def test_vpc_trunk_host_interface_00110():
+    """
+    # Summary
+
+    Verify construction with snake_case field names.
+
+    ## Test
+
+    - Construct with Python field names
+    - Values accessible via Python attributes
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = TrunkVpcHostPolicyModel(
+            admin_state=True,
+            allowed_vlans="100-200,300",
+            native_vlan=99,
+            peer1_port_channel_id=500,
+            peer1_member_ports=["Ethernet1/1"],
+            peer2_port_channel_id=500,
+            peer2_member_ports=["Ethernet1/2"],
+            port_channel_mode="active",
+            lacp_rate="fast",
+        )
+    assert instance.admin_state is True
+    assert instance.allowed_vlans == "100-200,300"
+    assert instance.native_vlan == 99
+    assert instance.peer1_port_channel_id == 500
+    assert instance.peer1_member_ports == ["Ethernet1/1"]
+    assert instance.peer2_port_channel_id == 500
+    assert instance.peer2_member_ports == ["Ethernet1/2"]
+    assert instance.port_channel_mode == "active"
+    assert instance.lacp_rate == "fast"
+    assert instance.policy_type == "trunkVpcHost"
+
+
+def test_vpc_trunk_host_interface_00120():
+    """
+    # Summary
+
+    Verify construction with camelCase aliases.
+
+    ## Test
+
+    - Construct with API alias names
+    - Values accessible by Python names
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = TrunkVpcHostPolicyModel(
+            adminState=True,
+            allowedVlans="all",
+            nativeVlan=1,
+            peer1PortChannelId=600,
+            peer1MemberPorts=["Ethernet1/5"],
+            peer2PortChannelId=600,
+            peer2MemberPorts=["Ethernet1/6"],
+            portChannelMode="passive",
+            policyType="trunkVpcHost",
+            peerSwitchId="FDOPEER0001",
+        )
+    assert instance.admin_state is True
+    assert instance.allowed_vlans == "all"
+    assert instance.native_vlan == 1
+    assert instance.peer1_port_channel_id == 600
+    assert instance.peer1_member_ports == ["Ethernet1/5"]
+    assert instance.peer2_port_channel_id == 600
+    assert instance.peer2_member_ports == ["Ethernet1/6"]
+    assert instance.port_channel_mode == "passive"
+    assert instance.policy_type == "trunkVpcHost"
+    assert instance.peer_switch_id == "FDOPEER0001"
+
+
+# =============================================================================
+# Test: TrunkVpcHostPolicyModel — allowed_vlans validator
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("none", "none"),
+        ("all", "all"),
+        ("100", "100"),
+        ("100-200", "100-200"),
+        ("100,200,300", "100,200,300"),
+        ("1-200,500-2000,3000", "1-200,500-2000,3000"),
+        (250, "250"),  # int -> str coercion (per ND wire echo)
+        (None, None),
+        ("", ""),
+    ],
+    ids=[
+        "none_keyword",
+        "all_keyword",
+        "single_vlan",
+        "single_range",
+        "comma_list",
+        "comma_with_ranges",
+        "int_coerced_to_str",
+        "none_passthrough",
+        "empty_str_passthrough",
+    ],
+)
+def test_vpc_trunk_host_interface_00150_allowed_vlans_accepts(value, expected):
+    """
+    # Summary
+
+    Verify `allowed_vlans` validator accepts valid shapes and coerces ND's int echo to str.
+
+    ## Test
+
+    - "none" / "all" / single id / range / comma-list pass through unchanged
+    - An int value is coerced to a string for idempotency stability
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel._validate_allowed_vlans()
+    """
+    with does_not_raise():
+        instance = TrunkVpcHostPolicyModel(allowed_vlans=value)
+    assert instance.allowed_vlans == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "abc",
+        "100-",
+        "-100",
+        "100,abc",
+        "200-100",  # reversed range
+        "100-5000",  # out of bounds high
+        "0-100",  # out of bounds low
+        "0",
+        "4095",
+        "100--200",
+    ],
+    ids=[
+        "non_numeric",
+        "trailing_dash",
+        "leading_dash",
+        "mixed_garbage",
+        "reversed_range",
+        "high_out_of_bounds",
+        "low_out_of_bounds",
+        "zero",
+        "above_4094",
+        "double_dash",
+    ],
+)
+def test_vpc_trunk_host_interface_00155_allowed_vlans_rejects(value):
+    """
+    # Summary
+
+    Verify `allowed_vlans` validator rejects invalid shapes and out-of-bounds values.
+
+    ## Test
+
+    - Garbage strings raise ValueError
+    - Reversed ranges raise ValueError
+    - VLAN ids outside 1..4094 raise ValueError
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel._validate_allowed_vlans()
+    """
+    with pytest.raises(ValidationError):
+        TrunkVpcHostPolicyModel(allowed_vlans=value)
+
+
+# =============================================================================
+# Test: TrunkVpcHostPolicyModel — member_ports normalizer
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
+        (["Ethernet1/1"], ["Ethernet1/1"]),
+        # NX-OS abbreviations expand to the canonical Ethernet form so they match the wire key (idempotency).
+        (["e1/1"], ["Ethernet1/1"]),
+        (["eth1/1", "et1/1"], ["Ethernet1/1", "Ethernet1/1"]),
+        # Any casing of the full prefix canonicalizes to "Ethernet".
+        (["ETHERNET1/2", "etHernet1/3"], ["Ethernet1/2", "Ethernet1/3"]),
+        ([], []),
+        (None, None),
+        (["ethernet1/1/1"], ["Ethernet1/1/1"]),
+    ],
+    ids=[
+        "lowercase_to_canonical",
+        "already_canonical_passthrough",
+        "single_letter_expanded",
+        "abbreviations_expanded",
+        "any_casing_canonicalized",
+        "empty_list",
+        "none_passthrough",
+        "breakout_preserved",
+    ],
+)
+def test_vpc_trunk_host_interface_00180_peer1(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_member_ports` expands each peer1 member name to ND's canonical `Ethernet` form.
+
+    ## Test
+
+    - Lowercase and abbreviated member names (`e1/1`, `eth1/1`, `et1/1`) expand to `Ethernet...`
+    - Any casing of the full prefix canonicalizes to `Ethernet`
+    - Already-canonical values pass through; empty list and None pass through; breakout suffixes are preserved
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel.normalize_member_ports()
+    - TrunkVpcHostPolicyModel._normalize_member_name()
+    """
+    with does_not_raise():
+        instance = TrunkVpcHostPolicyModel(peer1_member_ports=value)
+    assert instance.peer1_member_ports == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
+        (["Ethernet1/1"], ["Ethernet1/1"]),
+        (["eth1/1"], ["Ethernet1/1"]),
+        (None, None),
+    ],
+    ids=["lowercase_to_canonical", "already_canonical_passthrough", "abbreviation_expanded", "none_passthrough"],
+)
+def test_vpc_trunk_host_interface_00185_peer2(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_member_ports` also applies to peer2_member_ports.
+
+    ## Test
+
+    - Same normalization rules as peer1
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel.normalize_member_ports()
+    - TrunkVpcHostPolicyModel._normalize_member_name()
+    """
+    with does_not_raise():
+        instance = TrunkVpcHostPolicyModel(peer2_member_ports=value)
+    assert instance.peer2_member_ports == expected
+
+
+# =============================================================================
+# Test: TrunkVpcHostPolicyModel — bounds + frozen
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("native_vlan", 0),
+        ("native_vlan", 4095),
+        ("peer1_port_channel_id", 0),
+        ("peer1_port_channel_id", 4097),
+        ("peer2_port_channel_id", 0),
+        ("peer2_port_channel_id", 4097),
+    ],
+    ids=[
+        "native_vlan_below_min",
+        "native_vlan_above_max",
+        "peer1_pc_id_below_min",
+        "peer1_pc_id_above_max",
+        "peer2_pc_id_below_min",
+        "peer2_pc_id_above_max",
+    ],
+)
+def test_vpc_trunk_host_interface_00200_range(field, value):
+    """
+    # Summary
+
+    Verify VLAN (1-4094) and port-channel-id (1-4096) range validation.
+
+    ## Test
+
+    - Values outside the valid range raise ValidationError
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel (Pydantic Field constraints)
+    """
+    with pytest.raises(ValidationError):
+        TrunkVpcHostPolicyModel(**{field: value})
+
+
+def test_vpc_trunk_host_interface_00210_policy_type_frozen():
+    """
+    # Summary
+
+    Verify `policy_type` cannot be reassigned to a different value (frozen=True).
+
+    ## Test
+
+    - Construct with default policy_type
+    - Attempt to assign a different value raises ValidationError
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel (frozen Field)
+    """
+    instance = TrunkVpcHostPolicyModel()
+    with pytest.raises(ValidationError):
+        instance.policy_type = "accessVpcHost"
+
+
+# =============================================================================
+# Test: TrunkVpcHostVlanMappingEntryModel
+# =============================================================================
+
+
+def test_vpc_trunk_host_interface_00250_vlan_mapping_entry_construction():
+    """
+    # Summary
+
+    Verify VLAN mapping entry accepts customer/provider ids with valid shape.
+
+    ## Test
+
+    - Construction with mixed scalar / range customer ids
+    - Optional dot1q_tunnel and customer_inner_vlan_id
+
+    ## Classes and Methods
+
+    - TrunkVpcHostVlanMappingEntryModel.__init__()
+    """
+    entry = TrunkVpcHostVlanMappingEntryModel(
+        customer_vlan_id=["100", "200-300"],
+        provider_vlan_id=1000,
+        dot1q_tunnel=True,
+        customer_inner_vlan_id=510,
+    )
+    assert entry.customer_vlan_id == ["100", "200-300"]
+    assert entry.provider_vlan_id == 1000
+    assert entry.dot1q_tunnel is True
+    assert entry.customer_inner_vlan_id == 510
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ["abc"],
+        ["100", ""],
+        [""],
+        ["200-100"],
+        ["0"],
+        ["5000"],
+    ],
+    ids=["non_numeric", "empty_token", "single_empty", "reversed_range", "low_oob", "high_oob"],
+)
+def test_vpc_trunk_host_interface_00255_customer_vlan_id_rejects(value):
+    """
+    # Summary
+
+    Verify customer_vlan_id list validator rejects invalid entries.
+
+    ## Test
+
+    - Non-string / empty / out-of-bounds / reversed-range entries raise ValueError
+
+    ## Classes and Methods
+
+    - TrunkVpcHostPolicyModel._validate_customer_vlan_id_list()
+    """
+    with pytest.raises(ValidationError):
+        TrunkVpcHostVlanMappingEntryModel(customer_vlan_id=value)
+
+
+# =============================================================================
+# Test: TrunkVpcHostInterfaceModel — identifier behavior
+# =============================================================================
+
+
+def test_vpc_trunk_host_interface_00300_identifier():
+    """
+    # Summary
+
+    Verify the identifier is `interface_name` only (single strategy). A vPC interface is one fabric-level resource;
+    ND echoes it from both peers but it must collapse to one identity for diff/override-deletion correctness.
+
+    ## Test
+
+    - Identifier is `["interface_name"]`
+    - Identifier strategy is `"single"`
+    - get_identifier_value returns the interface name string
+    - `switch_ip` is excluded from the diff dict (routing-only field)
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceModel.get_identifier_value()
+    - TrunkVpcHostInterfaceModel.to_diff_dict()
+    """
+    instance = TrunkVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc500")
+    assert instance.identifiers == ["interface_name"]
+    assert instance.identifier_strategy == "single"
+    assert instance.get_identifier_value() == "vpc500"
+    # switch_ip is for routing only; it must not appear in the diff dict so two peers' echoes diff-equal.
+    assert "switchIp" not in instance.to_diff_dict()
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("Vpc500", "vpc500"),
+        ("VPC500", "vpc500"),
+        ("vpc500", "vpc500"),
+        ("vPC500", "vpc500"),
+    ],
+    ids=["title_case", "upper_case", "lower_case_passthrough", "mixed_case"],
+)
+def test_vpc_trunk_host_interface_00310_normalize_name(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` lowercases interface names.
+
+    ## Test
+
+    - Various casings are normalized to lowercase
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceModel.normalize_interface_name()
+    """
+    instance = TrunkVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name=value)
+    assert instance.interface_name == expected
+
+
+# =============================================================================
+# Test: TrunkVpcHostInterfaceModel — round-trip
+# =============================================================================
+
+
+def test_vpc_trunk_host_interface_00400_round_trip_from_api():
+    """
+    # Summary
+
+    Verify the model accepts the camelCase API response shape and exposes values via Python attributes.
+
+    ## Test
+
+    - Construct from SAMPLE_API_RESPONSE
+    - Nested values accessible
+    - peerSwitchId reads through
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceModel.__init__()
+    """
+    instance = TrunkVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.interface_name == "vpc500"
+    assert instance.interface_type == "vpc"
+    policy = instance.config_data.network_os.policy
+    assert policy.policy_type == "trunkVpcHost"
+    assert policy.peer_switch_id == "FDOPEER0001"
+    assert policy.allowed_vlans == "100-200"
+    assert policy.native_vlan == 99
+    assert policy.peer1_member_ports == ["Ethernet1/1"]
+    assert policy.peer2_member_ports == ["Ethernet1/2"]
+    assert policy.admin_state is True
+
+
+def test_vpc_trunk_host_interface_00410_round_trip_from_ansible():
+    """
+    # Summary
+
+    Verify the model accepts the snake_case Ansible config shape.
+
+    ## Test
+
+    - Construct from SAMPLE_ANSIBLE_CONFIG
+    - Nested values accessible
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceModel.__init__()
+    """
+    instance = TrunkVpcHostInterfaceModel(**copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    assert instance.switch_ip == "192.168.1.1"
+    policy = instance.config_data.network_os.policy
+    assert policy.peer1_port_channel_id == 500
+    assert policy.peer2_port_channel_id == 500
+    assert policy.allowed_vlans == "100-200"
+    assert policy.native_vlan == 99
+    assert policy.policy_type == "trunkVpcHost"
+
+
+def test_vpc_trunk_host_interface_00420_to_payload():
+    """
+    # Summary
+
+    Verify `to_payload()` serializes the model back to camelCase, drops the `switch_ip` identifier, and splits the
+    user-facing single `allowed_vlans` and `native_vlan` into the per-peer write keys that ND's create schema requires.
+
+    ## Test
+
+    - to_payload() returns wire-shaped dict
+    - switchIp is excluded (Ansible-facing only)
+    - interfaceType is present
+    - Nested policy aliases are camelCase
+    - allowedVlans and nativeVlan are absent from the payload (split into per-peer keys)
+    - peer1/peer2 AllowedVlans + NativeVlan are present with the same value
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceModel.to_payload()
+    - TrunkVpcHostPolicyModel.expand_per_peer_fields()
+    """
+    instance = TrunkVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+    assert "switchIp" not in payload
+    assert payload["interfaceName"] == "vpc500"
+    assert payload["interfaceType"] == "vpc"
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert policy["policyType"] == "trunkVpcHost"
+    assert policy["peer1MemberPorts"] == ["Ethernet1/1"]
+    assert policy["peer2MemberPorts"] == ["Ethernet1/2"]
+    assert policy["peer1PortChannelId"] == 500
+    assert policy["peer2PortChannelId"] == 500
+    # allowed_vlans split to both per-peer keys; the single-valued allowedVlans key is removed on payload.
+    assert "allowedVlans" not in policy
+    assert policy["peer1AllowedVlans"] == "100-200"
+    assert policy["peer2AllowedVlans"] == "100-200"
+    # native_vlan split as well.
+    assert "nativeVlan" not in policy
+    assert policy["peer1NativeVlan"] == 99
+    assert policy["peer2NativeVlan"] == 99
+
+
+def test_vpc_trunk_host_interface_00425_to_config_keeps_single_vlan():
+    """
+    # Summary
+
+    Verify `to_config()` keeps `allowed_vlans` and `native_vlan` as single fields (does NOT expand to per-peer) and
+    drops the frozen, argspec-excluded `policy_type` so it does not leak into before/after/gathered output.
+    The expansion only happens for payload mode; config / diff modes use the wire-echo (single) shape so idempotency works.
+
+    ## Test
+
+    - to_config() returns the snake_case fields `allowed_vlans` and `native_vlan`
+    - `peer1_allowed_vlans` / `peer2_allowed_vlans` / `peer1_native_vlan` / `peer2_native_vlan` are NOT in the config
+    - `policy_type` / `policyType` are NOT in the config (frozen scaffolding suppressed)
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceModel.to_config()
+    - TrunkVpcHostPolicyModel.expand_per_peer_fields()
+    """
+    instance = TrunkVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    config = instance.to_config()
+    policy = config["config_data"]["network_os"]["policy"]
+    assert policy["allowed_vlans"] == "100-200"
+    assert policy["native_vlan"] == 99
+    assert "peer1_allowed_vlans" not in policy
+    assert "peer2_allowed_vlans" not in policy
+    assert "peer1_native_vlan" not in policy
+    assert "peer2_native_vlan" not in policy
+    assert "policy_type" not in policy
+    assert "policyType" not in policy
+
+
+def test_vpc_trunk_host_interface_00430_payload_with_vlan_mapping():
+    """
+    # Summary
+
+    Verify VLAN mapping entries serialize through `to_payload()` with their camelCase aliases intact.
+
+    ## Test
+
+    - vlan_mapping=True and a single entry are present in the payload
+    - Entry keys are camelCase (customerVlanId, providerVlanId, etc.)
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceModel.to_payload()
+    - TrunkVpcHostVlanMappingEntryModel
+    """
+    cfg = copy.deepcopy(SAMPLE_ANSIBLE_CONFIG)
+    cfg["config_data"]["network_os"]["policy"]["vlan_mapping"] = True
+    cfg["config_data"]["network_os"]["policy"]["vlan_mapping_entries"] = [
+        {
+            "customer_vlan_id": ["100", "200-300"],
+            "provider_vlan_id": 1000,
+            "dot1q_tunnel": False,
+        },
+    ]
+    instance = TrunkVpcHostInterfaceModel(**cfg)
+    payload = instance.to_payload()
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert policy["vlanMapping"] is True
+    assert len(policy["vlanMappingEntries"]) == 1
+    entry = policy["vlanMappingEntries"][0]
+    assert entry["customerVlanId"] == ["100", "200-300"]
+    assert entry["providerVlanId"] == 1000
+    assert entry["dot1qTunnel"] is False
+
+
+# =============================================================================
+# Test: Argument spec exposure
+# =============================================================================
+
+
+def test_vpc_trunk_host_interface_00500_argument_spec_shape():
+    """
+    # Summary
+
+    Verify the argument spec exposes the right shape: fabric_name, config list, state choices.
+
+    ## Test
+
+    - top-level keys: fabric_name, config, state
+    - state choices contain merged/replaced/overridden/deleted
+    - config has nested policy options including peer1_/peer2_ fields and trunk-specific fields
+    - Frozen scaffolding (interface_type, mode, network_os_type, policy_type) is NOT exposed
+    - peer_switch_id (orchestrator-injected) is NOT exposed
+    - Per-peer AllowedVlans / NativeVlan are NOT exposed (ND collapses to single fields on read)
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceModel.get_argument_spec()
+    """
+    spec = TrunkVpcHostInterfaceModel.get_argument_spec()
+    assert set(spec) == {"fabric_name", "config", "state"}
+    assert spec["fabric_name"]["required"] is True
+    assert set(spec["state"]["choices"]) == {"merged", "replaced", "overridden", "deleted"}
+
+    config_options = spec["config"]["options"]
+    assert "switch_ip" in config_options
+    assert "interface_name" in config_options
+    assert "config_data" in config_options
+
+    policy_options = config_options["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    # Trunk-specific single fields
+    assert "allowed_vlans" in policy_options
+    assert "native_vlan" in policy_options
+    assert "vlan_mapping" in policy_options
+    assert "vlan_mapping_entries" in policy_options
+    # Per-peer presence
+    assert "peer1_port_channel_id" in policy_options
+    assert "peer1_member_ports" in policy_options
+    assert "peer2_port_channel_id" in policy_options
+    assert "peer2_member_ports" in policy_options
+    # Shared field samples
+    assert "admin_state" in policy_options
+    assert "lacp_rate" in policy_options
+    assert "port_channel_mode" in policy_options
+    assert "port_type_edge_trunk" in policy_options
+    # Frozen/injected exclusions
+    assert "interface_type" not in config_options
+    assert "policy_type" not in policy_options
+    assert "mode" not in policy_options
+    assert "network_os_type" not in policy_options
+    assert "peer_switch_id" not in policy_options
+    # Per-peer VLAN/Native explicitly NOT exposed (ND collapses on read; user sets single fields).
+    assert "peer1_allowed_vlans" not in policy_options
+    assert "peer2_allowed_vlans" not in policy_options
+    assert "peer1_native_vlan" not in policy_options
+    assert "peer2_native_vlan" not in policy_options
+
+
+def test_vpc_trunk_host_interface_00510_argument_spec_vlan_mapping_entries_shape():
+    """
+    # Summary
+
+    Verify `vlan_mapping_entries` argspec exposes the four nested options.
+
+    ## Test
+
+    - vlan_mapping_entries is a list of dicts with options: customer_vlan_id, customer_inner_vlan_id, dot1q_tunnel, provider_vlan_id
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceModel.get_argument_spec()
+    """
+    spec = TrunkVpcHostInterfaceModel.get_argument_spec()
+    policy_options = spec["config"]["options"]["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    entries = policy_options["vlan_mapping_entries"]
+    assert entries["type"] == "list"
+    assert entries["elements"] == "dict"
+    assert set(entries["options"]) == {"customer_vlan_id", "customer_inner_vlan_id", "dot1q_tunnel", "provider_vlan_id"}
+
+
+# =============================================================================
+# Test: Nested-model sanity (Config / NetworkOS)
+# =============================================================================
+
+
+def test_vpc_trunk_host_interface_00600_nested_defaults():
+    """
+    # Summary
+
+    Verify ConfigData and NetworkOS containers default their frozen discriminators.
+
+    ## Test
+
+    - TrunkVpcHostConfigDataModel.mode defaults to "trunk"
+    - TrunkVpcHostNetworkOSModel.network_os_type defaults to "nx-os"
+
+    ## Classes and Methods
+
+    - TrunkVpcHostConfigDataModel
+    - TrunkVpcHostNetworkOSModel
+    """
+    network_os = TrunkVpcHostNetworkOSModel(policy=TrunkVpcHostPolicyModel())
+    config = TrunkVpcHostConfigDataModel(network_os=network_os)
+    assert config.mode == "trunk"
+    assert config.network_os.network_os_type == "nx-os"

--- a/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
@@ -199,7 +199,6 @@ def test_port_channel_access_orchestrator_00400() -> None:
 
     def responses():
         yield responses_pc_access("test_query_all_happy_path_00400a")
-        yield responses_pc_access("test_query_all_happy_path_00400_freeze")
         yield responses_pc_access("test_query_all_happy_path_00400b")
         yield responses_pc_access("test_query_all_happy_path_00400c")
         yield responses_pc_access("test_query_all_happy_path_00400d")
@@ -247,7 +246,6 @@ def test_port_channel_access_orchestrator_00410() -> None:
 
     def responses():
         yield responses_pc_access("test_query_all_no_match_00410a")
-        yield responses_pc_access("test_query_all_no_match_00410_freeze")
         yield responses_pc_access("test_query_all_no_match_00410b")
         yield responses_pc_access("test_query_all_no_match_00410c")
 
@@ -306,7 +304,6 @@ def test_port_channel_access_orchestrator_00430() -> None:
 
     def responses():
         yield responses_pc_access("test_query_all_switch_404_00430a")
-        yield responses_pc_access("test_query_all_switch_404_00430_freeze")
         yield responses_pc_access("test_query_all_switch_404_00430b")
         yield responses_pc_access("test_query_all_switch_404_00430c")
 

--- a/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
@@ -55,8 +55,17 @@ def responses_pc_access(key: str):
     return load_fixture("test_port_channel_access_interface")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
-    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    """
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
@@ -66,7 +75,13 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -74,9 +89,14 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     return rest_send
 
 
-def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> PortChannelAccessInterfaceOrchestrator:
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> PortChannelAccessInterfaceOrchestrator:
     """Construct an orchestrator with the file-based RestSend injected."""
-    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
     return PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
 
 
@@ -227,7 +247,8 @@ def test_port_channel_access_orchestrator_00400() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        orchestrator = _build_orchestrator(gen_responses)
+        # state=overridden keeps query_all fabric-wide so this test exercises cross-switch filtering.
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
         result = orchestrator.query_all()
 
     assert isinstance(result, list)
@@ -273,7 +294,8 @@ def test_port_channel_access_orchestrator_00410() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        orchestrator = _build_orchestrator(gen_responses)
+        # state=overridden keeps query_all fabric-wide so every switch is scanned.
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
         result = orchestrator.query_all()
 
     assert result == []
@@ -331,10 +353,52 @@ def test_port_channel_access_orchestrator_00430() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        orchestrator = _build_orchestrator(gen_responses)
+        # state=overridden keeps query_all fabric-wide so the 404 switch is still visited and skipped.
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
         result = orchestrator.query_all()
 
     assert result == []
+
+
+def test_port_channel_access_orchestrator_00440() -> None:
+    """
+    # Summary
+
+    Verify `query_all` scopes its per-switch interface-list fan-out to switches named in the user config when
+    `state` is not `overridden`, rather than querying every switch in the fabric.
+
+    ## Test
+
+    - Fabric has two switches (192.168.1.1, 192.168.1.2), but config names only 192.168.1.1
+    - state is `merged` (non-overridden), so `_switches_to_query` returns only the config switch
+    - Only the config switch's interfaces are fetched; the second switch is never queried (the response
+      generator yields exactly three responses — summary, switch list, switch-1 interfaces — and would raise
+      if a second per-switch GET were issued)
+    - Result contains only the accessPoHost port-channel on the config switch
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator._switches_to_query()
+    - PortChannelBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_pc_access("test_query_all_config_scoped_00440a")
+        yield responses_pc_access("test_query_all_config_scoped_00440b")
+        yield responses_pc_access("test_query_all_config_scoped_00440c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "port-channel501"}]
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="merged", config=config)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "port-channel501"
+    assert result[0]["switchIp"] == "192.168.1.1"
 
 
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
@@ -23,6 +23,8 @@ Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as th
 # pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
 # pylint: disable=too-many-lines
+# pylint: disable=assignment-from-no-return
+# pylint: disable=use-implicit-booleaness-not-comparison
 
 from __future__ import annotations
 
@@ -31,7 +33,10 @@ import inspect
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import (
+    PortChannelAccessConfigDataModel,
     PortChannelAccessInterfaceModel,
+    PortChannelAccessNetworkOSModel,
+    PortChannelAccessPolicyModel,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_access_interface import (
     PortChannelAccessInterfaceOrchestrator,
@@ -73,6 +78,22 @@ def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fa
     """Construct an orchestrator with the file-based RestSend injected."""
     rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
     return PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+
+
+def _build_pc_model(
+    switch_ip: str = "192.168.1.1",
+    interface_name: str = "port-channel501",
+    include_config: bool = True,
+) -> PortChannelAccessInterfaceModel:
+    """Build a minimal `PortChannelAccessInterfaceModel` instance for CRUD tests."""
+    kwargs: dict = {"switch_ip": switch_ip, "interface_name": interface_name}
+    if include_config:
+        kwargs["config_data"] = PortChannelAccessConfigDataModel(
+            network_os=PortChannelAccessNetworkOSModel(
+                policy=PortChannelAccessPolicyModel(admin_state=True, access_vlan=100, port_channel_mode="active", ports=["Ethernet1/1"]),
+            ),
+        )
+    return PortChannelAccessInterfaceModel(**kwargs)
 
 
 # =============================================================================
@@ -314,3 +335,571 @@ def test_port_channel_access_orchestrator_00430() -> None:
         result = orchestrator.query_all()
 
     assert result == []
+
+
+# =============================================================================
+# Test: create
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00200() -> None:
+    """
+    # Summary
+
+    Verify `create` resolves the switch IP, wraps the payload in `{"interfaces": [...]}`, injects `switchId`,
+    emits the hardcoded `policyType`, and queues a deploy.
+
+    ## Test
+
+    - First `_resolve_switch_id` triggers a switches-list fetch
+    - POST is issued against `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces`
+    - Request body is `{"interfaces": [{...payload..., "switchId": "FDO11111AAA"}]}`
+    - Payload carries `policyType: accessPoHost` and omits `switchIp`
+    - `_pending_deploys` contains a single `(interface_name, switch_id)` pair
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.create()
+    - NDBaseInterfaceOrchestrator._resolve_switch_id()
+    - NDBaseInterfaceOrchestrator._queue_deploy()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model()
+
+    with does_not_raise():
+        instance.create(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert "interfaces" in body
+    assert len(body["interfaces"]) == 1
+    payload_item = body["interfaces"][0]
+    assert payload_item["interfaceName"] == "port-channel501"
+    assert payload_item["interfaceType"] == "portChannel"
+    assert payload_item["switchId"] == "FDO11111AAA"
+    assert "switchIp" not in payload_item
+    assert payload_item["configData"]["networkOS"]["policy"]["policyType"] == "accessPoHost"
+    assert instance._pending_deploys == [("port-channel501", "FDO11111AAA")]
+
+
+def test_port_channel_access_orchestrator_00210() -> None:
+    """
+    # Summary
+
+    Verify `create` wraps a `_request` failure in `RuntimeError` mentioning the identifier.
+
+    ## Test
+
+    - switches-list returns 200
+    - POST returns 500
+    - `RuntimeError` matches `Create failed for .*port-channel501`
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.create()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model()
+
+    match = r"Create failed for .*port-channel501"
+    with pytest.raises(RuntimeError, match=match):
+        instance.create(model)
+
+    assert instance._pending_deploys == []
+
+
+def test_port_channel_access_orchestrator_00220() -> None:
+    """
+    # Summary
+
+    Verify `create` wraps an unknown-switch-IP `RuntimeError` from `_resolve_switch_id`.
+
+    ## Test
+
+    - switches-list returns a different IP than the model's `switch_ip`
+    - `create` re-raises as `RuntimeError` matching `Create failed for .*port-channel501.*No switch found with fabricManagementIp '192\\.168\\.99\\.99'`
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.create()
+    - NDBaseInterfaceOrchestrator._resolve_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model(switch_ip="192.168.99.99")
+
+    match = r"Create failed for .*port-channel501.*No switch found with fabricManagementIp '192\.168\.99\.99'"
+    with pytest.raises(RuntimeError, match=match):
+        instance.create(model)
+
+    assert instance._pending_deploys == []
+
+
+# =============================================================================
+# Test: update
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00300() -> None:
+    """
+    # Summary
+
+    Verify `update` issues a PUT against the per-interface URL, injects `switchId` into the payload, and queues a deploy.
+
+    ## Test
+
+    - switches-list fetched on first switch_id resolution
+    - PUT is issued against `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/port-channel501`
+    - `switchId` is present in the payload; `switchIp` is not
+    - `_pending_deploys` contains the `(port-channel501, FDO11111AAA)` pair
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model()
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/port-channel501"
+    assert rest_send.verb == HttpVerbEnum.PUT.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert body["interfaceName"] == "port-channel501"
+    assert body["switchId"] == "FDO11111AAA"
+    assert "switchIp" not in body
+    assert instance._pending_deploys == [("port-channel501", "FDO11111AAA")]
+
+
+def test_port_channel_access_orchestrator_00310() -> None:
+    """
+    # Summary
+
+    Verify `update` wraps a `_request` failure in `RuntimeError` mentioning the identifier.
+
+    ## Test
+
+    - PUT returns 500
+    - `RuntimeError` matches `Update failed for .*port-channel501`
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model()
+
+    match = r"Update failed for .*port-channel501"
+    with pytest.raises(RuntimeError, match=match):
+        instance.update(model)
+
+    assert instance._pending_deploys == []
+
+
+# =============================================================================
+# Test: delete
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00320() -> None:
+    """
+    # Summary
+
+    Verify `delete` queues a remove + deploy without making any API call beyond the switches-list fetch.
+
+    ## Test
+
+    - Only the switches-list response is consumed (one HTTP call to resolve switch_id)
+    - `_pending_removes` contains `(port-channel501, FDO11111AAA)`
+    - `_pending_deploys` contains `(port-channel501, FDO11111AAA)`
+    - `delete` returns None
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.delete()
+    - NDBaseInterfaceOrchestrator._queue_remove()
+    - NDBaseInterfaceOrchestrator._queue_deploy()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model(include_config=False)
+
+    with does_not_raise():
+        result = instance.delete(model)
+
+    assert result is None
+    assert instance._pending_removes == [("port-channel501", "FDO11111AAA")]
+    assert instance._pending_deploys == [("port-channel501", "FDO11111AAA")]
+
+
+def test_port_channel_access_orchestrator_00330() -> None:
+    """
+    # Summary
+
+    Verify `delete` propagates the raw `RuntimeError` from `_resolve_switch_id` when the IP is unknown.
+
+    Unlike `create`/`update`, `delete` does not wrap exceptions, so the underlying
+    `No switch found with fabricManagementIp ...` message surfaces directly.
+
+    ## Test
+
+    - switches-list returns a different IP
+    - `RuntimeError` matches `No switch found with fabricManagementIp '192\\.168\\.99\\.99'`
+    - No queues are populated
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.delete()
+    - NDBaseInterfaceOrchestrator._resolve_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model(switch_ip="192.168.99.99", include_config=False)
+
+    match = r"No switch found with fabricManagementIp '192\.168\.99\.99'"
+    with pytest.raises(RuntimeError, match=match):
+        instance.delete(model)
+
+    assert instance._pending_removes == []
+    assert instance._pending_deploys == []
+
+
+# =============================================================================
+# Test: create_bulk
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00500() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` groups interfaces by switch and issues one POST per switch with the per-switch subset
+    wrapped in `{"interfaces": [...]}`.
+
+    ## Test
+
+    - Three port-channels across two switches: port-channel501/502 on switch A, port-channel601 on switch B
+    - Two POSTs are issued (one per switch)
+    - All three pairs are queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+        yield responses_pc_access(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    models = [
+        _build_pc_model(switch_ip="192.168.1.1", interface_name="port-channel501"),
+        _build_pc_model(switch_ip="192.168.1.1", interface_name="port-channel502"),
+        _build_pc_model(switch_ip="192.168.1.2", interface_name="port-channel601"),
+    ]
+
+    with does_not_raise():
+        instance.create_bulk(models)
+
+    assert rest_send.path in (
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+    )
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert sorted(instance._pending_deploys) == sorted(
+        [
+            ("port-channel501", "FDO11111AAA"),
+            ("port-channel502", "FDO11111AAA"),
+            ("port-channel601", "FDO22222BBB"),
+        ]
+    )
+
+
+def test_port_channel_access_orchestrator_00510() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` wraps a per-switch `_request` failure in `RuntimeError` matching `Bulk create failed`.
+
+    ## Test
+
+    - switches-list succeeds
+    - First per-switch POST succeeds, second returns 500
+    - `RuntimeError` matches `Bulk create failed`
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+        yield responses_pc_access(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    models = [
+        _build_pc_model(switch_ip="192.168.1.1", interface_name="port-channel501"),
+        _build_pc_model(switch_ip="192.168.1.2", interface_name="port-channel601"),
+    ]
+
+    match = r"Bulk create failed"
+    with pytest.raises(RuntimeError, match=match):
+        instance.create_bulk(models)
+
+
+def test_port_channel_access_orchestrator_00520() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` works with a single interface on a single switch (degenerate case).
+
+    ## Test
+
+    - One port-channel on switch A
+    - One POST is issued
+    - `_pending_deploys` contains a single pair
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    models = [_build_pc_model(interface_name="port-channel501")]
+
+    with does_not_raise():
+        instance.create_bulk(models)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces"
+    assert instance._pending_deploys == [("port-channel501", "FDO11111AAA")]
+
+
+# =============================================================================
+# Test: delete_bulk
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00600() -> None:
+    """
+    # Summary
+
+    Verify `delete_bulk` queues remove + deploy entries for each instance without issuing any API call beyond the
+    switches-list fetch.
+
+    ## Test
+
+    - Two port-channels on two switches
+    - Only switches-list response is consumed
+    - `_pending_removes` and `_pending_deploys` each contain both pairs
+    - `delete_bulk` returns None
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.delete_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    models = [
+        _build_pc_model(switch_ip="192.168.1.1", interface_name="port-channel501", include_config=False),
+        _build_pc_model(switch_ip="192.168.1.2", interface_name="port-channel601", include_config=False),
+    ]
+
+    with does_not_raise():
+        result = instance.delete_bulk(models)
+
+    assert result is None
+    expected = [("port-channel501", "FDO11111AAA"), ("port-channel601", "FDO22222BBB")]
+    assert sorted(instance._pending_removes) == sorted(expected)
+    assert sorted(instance._pending_deploys) == sorted(expected)
+
+
+# =============================================================================
+# Test: query_one
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00700() -> None:
+    """
+    # Summary
+
+    Verify `query_one` issues a GET against the per-interface URL and returns the DATA dict.
+
+    ## Test
+
+    - switches-list fetched on first switch_id resolution
+    - GET hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/port-channel501`
+    - Returned DATA matches the fixture (accessPoHost port-channel)
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model(include_config=False)
+
+    with does_not_raise():
+        result = instance.query_one(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/port-channel501"
+    assert rest_send.verb == HttpVerbEnum.GET.value
+    assert result["interfaceName"] == "port-channel501"
+    assert result["interfaceType"] == "portChannel"
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "accessPoHost"
+
+
+def test_port_channel_access_orchestrator_00710() -> None:
+    """
+    # Summary
+
+    Verify `query_one` wraps a `_request` failure in `RuntimeError` mentioning the identifier.
+
+    ## Test
+
+    - switches-list succeeds, GET returns 500
+    - `RuntimeError` matches `Query failed for .*port-channel501`
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model(include_config=False)
+
+    match = r"Query failed for .*port-channel501"
+    with pytest.raises(RuntimeError, match=match):
+        instance.query_one(model)
+
+
+# =============================================================================
+# Test: deploy queue de-duplication
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00800() -> None:
+    """
+    # Summary
+
+    Verify that calling `create` twice for the same `(interface_name, switch_id)` does not queue a duplicate deploy entry.
+
+    ## Test
+
+    - Two consecutive `create` calls with identical model
+    - Both POSTs succeed (response generator consumes both responses)
+    - `_pending_deploys` contains exactly one entry
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.create()
+    - NDBaseInterfaceOrchestrator._queue_deploy()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+        yield responses_pc_access(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+    model = _build_pc_model()
+
+    with does_not_raise():
+        instance.create(model)
+        instance.create(model)
+
+    assert instance._pending_deploys == [("port-channel501", "FDO11111AAA")]

--- a/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for port_channel_access_interface orchestrator.
+
+Verifies that `PortChannelAccessInterfaceOrchestrator` correctly:
+- declares the right `model_class` and `_managed_policy_types`
+- inherits bulk-support flags from `PortChannelBaseOrchestrator`
+- filters fabric-wide interface results to `interfaceType: "portChannel"` plus the managed
+  policy types (so non-port-channel and other-flavor port-channels are excluded)
+- propagates `RuntimeError` from the inherited `validate_prerequisites` path
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as the
+`sender` dependency injected into a real `RestSend`. Responses are read from
+`tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json`.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import (
+    PortChannelAccessInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_access_interface import (
+    PortChannelAccessInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_pc_access(key: str):
+    """Load fixture data for the orchestrator's test_port_channel_access_interface.json file."""
+    return load_fixture("test_port_channel_access_interface")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> PortChannelAccessInterfaceOrchestrator:
+    """Construct an orchestrator with the file-based RestSend injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    return PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+
+
+# =============================================================================
+# Test: ClassVar / model_class
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00010() -> None:
+    """
+    # Summary
+
+    Verify `model_class` points to `PortChannelAccessInterfaceModel`.
+
+    ## Test
+
+    - model_class is PortChannelAccessInterfaceModel
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceOrchestrator.model_class
+    """
+    assert PortChannelAccessInterfaceOrchestrator.model_class is PortChannelAccessInterfaceModel
+
+
+def test_port_channel_access_orchestrator_00020() -> None:
+    """
+    # Summary
+
+    Verify bulk-support flags inherited from `PortChannelBaseOrchestrator`.
+
+    ## Test
+
+    - supports_bulk_create is True
+    - supports_bulk_delete is True
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceOrchestrator
+    """
+    assert PortChannelAccessInterfaceOrchestrator.supports_bulk_create is True
+    assert PortChannelAccessInterfaceOrchestrator.supports_bulk_delete is True
+
+
+# =============================================================================
+# Test: _managed_policy_types
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00100() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns the single `"accessPoHost"` API value.
+
+    ## Test
+
+    - Returned set contains exactly "accessPoHost"
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    assert orchestrator._managed_policy_types() == {"accessPoHost"}
+
+
+def test_port_channel_access_orchestrator_00110() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns a set (supports set membership for `in` checks).
+
+    ## Test
+
+    - Return type is set
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    result = orchestrator._managed_policy_types()
+    assert isinstance(result, set)
+    assert "accessPoHost" in result
+
+
+# =============================================================================
+# Test: query_all — happy path with filtering
+# =============================================================================
+
+
+def test_port_channel_access_orchestrator_00400() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=="portChannel"
+    and policyType=="accessPoHost", and injects `switchIp` onto each kept interface.
+
+    ## Test
+
+    - Fabric summary (validate_prerequisites) returns 200
+    - Switches list returns two switches
+    - Switch 1 returns: configured accessPoHost portChannel, trunkPoHost portChannel, ethernet trunkHost
+    - Switch 2 returns: one configured accessPoHost portChannel
+    - Result contains exactly the two accessPoHost port-channels
+    - Each has switchIp injected with the fabricManagementIp
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceOrchestrator._managed_policy_types()
+    - PortChannelBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access("test_query_all_happy_path_00400a")
+        yield responses_pc_access("test_query_all_happy_path_00400_freeze")
+        yield responses_pc_access("test_query_all_happy_path_00400b")
+        yield responses_pc_access("test_query_all_happy_path_00400c")
+        yield responses_pc_access("test_query_all_happy_path_00400d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    by_name = {iface["interfaceName"]: iface for iface in result}
+    assert set(by_name) == {"port-channel501", "port-channel601"}
+
+    # switchIp is injected by the base query_all
+    assert by_name["port-channel501"]["switchIp"] == "192.168.1.1"
+    assert by_name["port-channel601"]["switchIp"] == "192.168.1.2"
+
+    # Filtered out: trunkPoHost (port-channel502) and ethernet trunkHost (Ethernet1/1)
+    assert "port-channel502" not in by_name
+    assert "Ethernet1/1" not in by_name
+
+    # method_name is used for clearer pytest failure messages; keep as a sanity reference
+    assert method_name.endswith("00400")
+
+
+def test_port_channel_access_orchestrator_00410() -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty list when no switch reports any accessPoHost port-channel.
+
+    ## Test
+
+    - Switch returns only non-port-channel and non-accessPoHost port-channel interfaces
+    - Result is an empty list
+
+    ## Classes and Methods
+
+    - PortChannelAccessInterfaceOrchestrator._managed_policy_types()
+    - PortChannelBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_pc_access("test_query_all_no_match_00410a")
+        yield responses_pc_access("test_query_all_no_match_00410_freeze")
+        yield responses_pc_access("test_query_all_no_match_00410b")
+        yield responses_pc_access("test_query_all_no_match_00410c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_port_channel_access_orchestrator_00420() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - query_all raises RuntimeError with "Query all failed" (wrapping the inner "Fabric ... not found")
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.query_all()
+    - FabricContext.validate_for_mutation()
+    """
+
+    def responses():
+        yield responses_pc_access("test_query_all_fabric_not_found_00420a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        orchestrator.query_all()
+
+
+def test_port_channel_access_orchestrator_00430() -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty list when a switch's interfaces endpoint returns no body
+    (the `not_found_ok=True` branch in `PortChannelBaseOrchestrator.query_all`).
+
+    ## Test
+
+    - Switch's interface list returns 404 (treated as no interfaces present)
+    - query_all skips the switch and yields []
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_pc_access("test_query_all_switch_404_00430a")
+        yield responses_pc_access("test_query_all_switch_404_00430_freeze")
+        yield responses_pc_access("test_query_all_switch_404_00430b")
+        yield responses_pc_access("test_query_all_switch_404_00430c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        result = orchestrator.query_all()
+
+    assert result == []

--- a/tests/unit/module_utils/orchestrators/test_port_channel_trunk_host_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_port_channel_trunk_host_interface.py
@@ -1,0 +1,381 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for port_channel_trunk_host_interface orchestrator.
+
+Verifies that `PortChannelTrunkHostInterfaceOrchestrator` correctly:
+- declares the right `model_class` and `_managed_policy_types`
+- inherits bulk-support flags from `PortChannelBaseOrchestrator`
+- filters fabric-wide interface results to `interfaceType: "portChannel"` plus the managed
+  policy types (so non-port-channel and accessPoHost port-channels are excluded)
+- propagates `RuntimeError` from the inherited `validate_prerequisites` path
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as the
+`sender` dependency injected into a real `RestSend`. Responses are read from
+`tests/unit/module_utils/fixtures/fixture_data/test_port_channel_trunk_host_interface.json`.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_pc_trunk_host(key: str):
+    """Load fixture data for the orchestrator's test_port_channel_trunk_host_interface.json file."""
+    return load_fixture("test_port_channel_trunk_host_interface")[key]
+
+
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    """
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> PortChannelTrunkHostInterfaceOrchestrator:
+    """Construct an orchestrator with the file-based RestSend injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
+    return PortChannelTrunkHostInterfaceOrchestrator(rest_send=rest_send)
+
+
+# =============================================================================
+# Test: ClassVar / model_class
+# =============================================================================
+
+
+def test_port_channel_trunk_host_orchestrator_00010() -> None:
+    """
+    # Summary
+
+    Verify `model_class` points to `PortChannelTrunkHostInterfaceModel`.
+
+    ## Test
+
+    - model_class is PortChannelTrunkHostInterfaceModel
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceOrchestrator.model_class
+    """
+    assert PortChannelTrunkHostInterfaceOrchestrator.model_class is PortChannelTrunkHostInterfaceModel
+
+
+def test_port_channel_trunk_host_orchestrator_00020() -> None:
+    """
+    # Summary
+
+    Verify bulk-support flags inherited from `PortChannelBaseOrchestrator`.
+
+    ## Test
+
+    - supports_bulk_create is True
+    - supports_bulk_delete is True
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceOrchestrator
+    """
+    assert PortChannelTrunkHostInterfaceOrchestrator.supports_bulk_create is True
+    assert PortChannelTrunkHostInterfaceOrchestrator.supports_bulk_delete is True
+
+
+# =============================================================================
+# Test: _managed_policy_types
+# =============================================================================
+
+
+def test_port_channel_trunk_host_orchestrator_00100() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns the single `"trunkPoHost"` API value.
+
+    ## Test
+
+    - Returned set contains exactly "trunkPoHost"
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    assert orchestrator._managed_policy_types() == {"trunkPoHost"}
+
+
+def test_port_channel_trunk_host_orchestrator_00110() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns a set (supports set membership for `in` checks).
+
+    ## Test
+
+    - Return type is set
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    result = orchestrator._managed_policy_types()
+    assert isinstance(result, set)
+    assert "trunkPoHost" in result
+
+
+# =============================================================================
+# Test: query_all — happy path with filtering
+# =============================================================================
+
+
+def test_port_channel_trunk_host_orchestrator_00400() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=="portChannel"
+    and policyType=="trunkPoHost", and injects `switchIp` onto each kept interface. accessPoHost
+    port-channels and ethernet interfaces are excluded.
+
+    ## Test
+
+    - Fabric summary (validate_prerequisites) returns 200
+    - Switches list returns two switches
+    - Switch 1 returns: configured trunkPoHost portChannel, accessPoHost portChannel, ethernet trunkHost
+    - Switch 2 returns: one configured trunkPoHost portChannel
+    - Result contains exactly the two trunkPoHost port-channels
+    - Each has switchIp injected with the fabricManagementIp
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceOrchestrator._managed_policy_types()
+    - PortChannelBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_trunk_host("test_query_all_happy_path_00400a")
+        yield responses_pc_trunk_host("test_query_all_happy_path_00400b")
+        yield responses_pc_trunk_host("test_query_all_happy_path_00400c")
+        yield responses_pc_trunk_host("test_query_all_happy_path_00400d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        # state=overridden keeps query_all fabric-wide so this test exercises cross-switch filtering.
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    by_name = {iface["interfaceName"]: iface for iface in result}
+    assert set(by_name) == {"port-channel501", "port-channel601"}
+
+    # switchIp is injected by the base query_all
+    assert by_name["port-channel501"]["switchIp"] == "192.168.1.1"
+    assert by_name["port-channel601"]["switchIp"] == "192.168.1.2"
+
+    # Filtered out: accessPoHost (port-channel502) and ethernet trunkHost (Ethernet1/1)
+    assert "port-channel502" not in by_name
+    assert "Ethernet1/1" not in by_name
+
+    # method_name is used for clearer pytest failure messages; keep as a sanity reference
+    assert method_name.endswith("00400")
+
+
+def test_port_channel_trunk_host_orchestrator_00410() -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty list when no switch reports any trunkPoHost port-channel.
+
+    ## Test
+
+    - Switch returns only non-port-channel and non-trunkPoHost port-channel interfaces
+    - Result is an empty list
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostInterfaceOrchestrator._managed_policy_types()
+    - PortChannelBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_pc_trunk_host("test_query_all_no_match_00410a")
+        yield responses_pc_trunk_host("test_query_all_no_match_00410b")
+        yield responses_pc_trunk_host("test_query_all_no_match_00410c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        # state=overridden keeps query_all fabric-wide so every switch is scanned for the no-match assertion.
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_port_channel_trunk_host_orchestrator_00420() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - query_all raises RuntimeError with "Query all failed" (wrapping the inner "Fabric ... not found")
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.query_all()
+    - FabricContext.validate_for_mutation()
+    """
+
+    def responses():
+        yield responses_pc_trunk_host("test_query_all_fabric_not_found_00420a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        orchestrator.query_all()
+
+
+def test_port_channel_trunk_host_orchestrator_00430() -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty list when a switch's interfaces endpoint returns no body
+    (the `not_found_ok=True` branch in `PortChannelBaseOrchestrator.query_all`).
+
+    ## Test
+
+    - Switch's interface list returns 404 (treated as no interfaces present)
+    - query_all skips the switch and yields []
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_pc_trunk_host("test_query_all_switch_404_00430a")
+        yield responses_pc_trunk_host("test_query_all_switch_404_00430b")
+        yield responses_pc_trunk_host("test_query_all_switch_404_00430c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        # state=overridden keeps query_all fabric-wide so the 404 switch is still visited and skipped.
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_port_channel_trunk_host_orchestrator_00440() -> None:
+    """
+    # Summary
+
+    Verify `query_all` scopes its per-switch interface-list fan-out to switches named in the user config when
+    `state` is not `overridden`, rather than querying every switch in the fabric.
+
+    ## Test
+
+    - Fabric has two switches (192.168.1.1, 192.168.1.2), but config names only 192.168.1.1
+    - state is `merged` (non-overridden), so `_switches_to_query` returns only the config switch
+    - Only the config switch's interfaces are fetched; the second switch is never queried (the response
+      generator yields exactly three responses — summary, switch list, switch-1 interfaces — and would raise
+      if a second per-switch GET were issued)
+    - Result contains only the trunkPoHost port-channel on the config switch
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator._switches_to_query()
+    - PortChannelBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_pc_trunk_host("test_query_all_config_scoped_00440a")
+        yield responses_pc_trunk_host("test_query_all_config_scoped_00440b")
+        yield responses_pc_trunk_host("test_query_all_config_scoped_00440c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "port-channel501"}]
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="merged", config=config)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "port-channel501"
+    assert result[0]["switchIp"] == "192.168.1.1"

--- a/tests/unit/module_utils/orchestrators/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_access_interface.py
@@ -1,0 +1,519 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for vpc_access_interface orchestrator.
+
+Verifies that `AccessVpcHostInterfaceOrchestrator` correctly:
+- declares the right `model_class` and `_managed_policy_types`
+- inherits bulk-support flags from `VpcInterfaceBaseOrchestrator`
+- resolves the peer switch's serial via the vPC pair GET endpoint
+- raises a clear `RuntimeError` when the primary switch is not in a vPC pair
+- caches peer-serial lookups per orchestrator instance
+- filters fabric-wide interface results to `interfaceType: "vpc"` plus the managed
+  policy types (so non-vPC interfaces and other-flavor vPCs are excluded)
+- propagates `RuntimeError` from the inherited `validate_prerequisites` path
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as the
+`sender` dependency injected into a real `RestSend`. Responses are read from
+`tests/unit/module_utils/fixtures/fixture_data/test_vpc_access_interface_orchestrator.json`.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+    AccessVpcHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_access_interface import (
+    AccessVpcHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_vpc_access(key: str):
+    """Load fixture data for the orchestrator's test_vpc_access_interface_orchestrator.json file."""
+    return load_fixture("test_vpc_access_interface_orchestrator")[key]
+
+
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list | None = None,
+) -> RestSend:
+    """
+    Build a RestSend wired to the file-based Sender and the real ResponseHandler.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    """
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list | None = None,
+) -> AccessVpcHostInterfaceOrchestrator:
+    """Construct an orchestrator with the file-based RestSend injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
+    return AccessVpcHostInterfaceOrchestrator(rest_send=rest_send)
+
+
+# =============================================================================
+# Test: ClassVar / model_class
+# =============================================================================
+
+
+def test_vpc_access_orchestrator_00010() -> None:
+    """
+    # Summary
+
+    Verify `model_class` points to `AccessVpcHostInterfaceModel`.
+
+    ## Test
+
+    - model_class is AccessVpcHostInterfaceModel
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator.model_class
+    """
+    assert AccessVpcHostInterfaceOrchestrator.model_class is AccessVpcHostInterfaceModel
+
+
+def test_vpc_access_orchestrator_00020() -> None:
+    """
+    # Summary
+
+    Verify bulk-support flags inherited from `VpcInterfaceBaseOrchestrator`. Bulk-create is enabled (POST /interfaces accepts
+    an array); bulk-delete is disabled because ND 4.2.1's `interfaceActions/remove` returns `Invalid Interface` for
+    vPC entries — we use per-interface `DELETE` instead via the state machine's individual delete path.
+
+    ## Test
+
+    - supports_bulk_create is True
+    - supports_bulk_delete is False
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator
+    """
+    assert AccessVpcHostInterfaceOrchestrator.supports_bulk_create is True
+    assert AccessVpcHostInterfaceOrchestrator.supports_bulk_delete is False
+
+
+# =============================================================================
+# Test: _managed_policy_types
+# =============================================================================
+
+
+def test_vpc_access_orchestrator_00100() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns the single `"accessVpcHost"` API value.
+
+    ## Test
+
+    - Returned set contains exactly "accessVpcHost"
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    assert orchestrator._managed_policy_types() == {"accessVpcHost"}
+
+
+def test_vpc_access_orchestrator_00110() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns a set.
+
+    ## Test
+
+    - Return type is set
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    result = orchestrator._managed_policy_types()
+    assert isinstance(result, set)
+    assert "accessVpcHost" in result
+
+
+# =============================================================================
+# Test: _resolve_peer_switch_id
+# =============================================================================
+
+
+def test_vpc_access_orchestrator_00500_peer_resolve_happy() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` returns the peer serial when the primary is in a vPC pair.
+
+    ## Test
+
+    - GET /vpcPair returns peerSwitchId
+    - Helper returns that value
+    - Result is cached on the orchestrator
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_peer_resolve_happy_path_00500a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        peer = orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+    assert peer == "FDO22222BBB"
+    assert orchestrator._peer_serial_cache == {"FDO11111AAA": "FDO22222BBB"}
+
+
+def test_vpc_access_orchestrator_00505_peer_resolve_cached() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` returns the cached value without issuing a second GET.
+
+    ## Test
+
+    - First call fetches and caches
+    - Second call returns the cached value (no additional response is yielded)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_peer_resolve_happy_path_00500a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    first = orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+    second = orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+    assert first == second == "FDO22222BBB"
+
+
+def test_vpc_access_orchestrator_00510_peer_resolve_not_paired() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises a clear RuntimeError when the primary switch is not in a vPC pair.
+
+    ## Test
+
+    - GET /vpcPair returns 404 (live-lab structured error body)
+    - Helper raises RuntimeError mentioning the switch_ip and pointing the user at nd_manage_vpc_pair
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_peer_resolve_not_paired_00510a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with pytest.raises(RuntimeError, match=r"192\.168\.1\.1.*not in a vPC pair.*nd_manage_vpc_pair"):
+        orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+
+def test_vpc_access_orchestrator_00520_peer_resolve_missing_field() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises RuntimeError when the vPC pair record is missing `peerSwitchId`.
+
+    ## Test
+
+    - GET /vpcPair returns 200 but body omits peerSwitchId
+    - Helper raises RuntimeError mentioning the missing field
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_peer_resolve_missing_field_00520a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with pytest.raises(RuntimeError, match=r"missing 'peerSwitchId'"):
+        orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+
+# =============================================================================
+# Test: query_all — happy path with filtering
+# =============================================================================
+
+
+def test_vpc_access_orchestrator_00600_delete_uses_per_interface_endpoint() -> None:
+    """
+    # Summary
+
+    Verify `delete()` calls the per-interface `DELETE /interfaces/{name}` endpoint (not the bulk
+    `interfaceActions/remove` which silently fails for vPC on ND 4.2.1) and queues a deploy for the same
+    `(interface_name, switch_id)` pair.
+
+    ## Test
+
+    - Switch-map fixture resolves switch_ip -> switch_id
+    - DELETE call returns 204 (no body)
+    - delete() does not raise
+    - Deploy queue contains exactly one entry: (vpc100, FDOAAAAAAAA)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.delete()
+    """
+    method_name = "test_delete_per_interface_00600"
+
+    def responses():
+        yield {
+            "RETURN_CODE": 200,
+            "METHOD": "GET",
+            "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+            "MESSAGE": "OK",
+            "DATA": {"switches": [{"fabricManagementIp": "192.168.1.1", "switchId": "FDOAAAAAAAA"}]},
+        }
+        yield {
+            "RETURN_CODE": 204,
+            "METHOD": "DELETE",
+            "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces/vpc100",
+            "MESSAGE": "No Content",
+            "DATA": {},
+        }
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+        AccessVpcHostInterfaceModel,
+    )
+
+    model = AccessVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc100")
+    with does_not_raise():
+        orchestrator.delete(model)
+
+    assert orchestrator._pending_deploys == [("vpc100", "FDOAAAAAAAA")]
+    # Bulk-remove queue stays untouched because we use per-interface DELETE.
+    assert orchestrator._pending_removes == []
+    # Sanity reference
+    assert method_name.endswith("00600")
+
+
+def test_vpc_access_orchestrator_00400_query_all_happy() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=="vpc"
+    and policyType=="accessVpcHost", and injects `switchIp` onto each kept interface.
+
+    `state=overridden` keeps `query_all` fabric-wide so every switch is scanned (config-scoped states only
+    visit switches named in the user config — see `_switches_to_query`).
+
+    ## Test
+
+    - Fabric summary (validate_prerequisites) returns 200
+    - Switches list returns two switches
+    - Switch 1 returns: configured accessVpcHost vpc, trunkVpcHost vpc, ethernet trunkHost
+    - Switch 2 returns: one configured accessVpcHost vpc
+    - Result contains exactly the two accessVpcHost vPC interfaces
+    - Each has switchIp injected with the fabricManagementIp
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator._managed_policy_types()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_query_all_happy_path_00400a")
+        yield responses_vpc_access("test_query_all_happy_path_00400b")
+        yield responses_vpc_access("test_query_all_happy_path_00400c")
+        yield responses_vpc_access("test_query_all_happy_path_00400d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    by_name = {iface["interfaceName"]: iface for iface in result}
+    assert set(by_name) == {"vpc100", "vpc200"}
+
+    assert by_name["vpc100"]["switchIp"] == "192.168.1.1"
+    assert by_name["vpc200"]["switchIp"] == "192.168.1.2"
+
+    # Filtered out: trunkVpcHost (vpc101) and ethernet trunkHost (Ethernet1/1)
+    assert "vpc101" not in by_name
+    assert "Ethernet1/1" not in by_name
+
+
+def test_vpc_access_orchestrator_00410_query_all_no_match() -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty list when no switch reports any accessVpcHost vPC.
+
+    `state=overridden` keeps `query_all` fabric-wide so the switch is scanned and the policy-type filter is exercised.
+
+    ## Test
+
+    - Switch returns only non-vPC and non-accessVpcHost vPC interfaces
+    - Result is an empty list
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator._managed_policy_types()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_query_all_no_match_00410a")
+        yield responses_vpc_access("test_query_all_no_match_00410b")
+        yield responses_vpc_access("test_query_all_no_match_00410c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_vpc_access_orchestrator_00430_query_all_dedup() -> None:
+    """
+    # Summary
+
+    Verify `query_all` dedupes vPC interfaces that appear on both peers. ND returns each vPC interface twice
+    (once per peer GET) with identical configData; without dedupe, `_manage_override_deletions` would treat the
+    peer-side copy as "not in proposed" and queue a spurious delete.
+
+    `state=overridden` keeps `query_all` fabric-wide so both peers are scanned and the per-peer dedup is exercised.
+
+    ## Test
+
+    - Two switches in the fabric, both return the same `vpc100` configuration
+    - Result contains exactly ONE entry for `vpc100`
+    - Canonical representative is the entry with the alphabetically-lower `switchId`
+      (FDOAAAAAAAA = 192.168.1.1 is kept; FDOBBBBBBBB = 192.168.1.2 is dropped)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all() dedupe logic
+    """
+
+    def responses():
+        yield responses_vpc_access("test_query_all_dedup_00430a")
+        yield responses_vpc_access("test_query_all_dedup_00430b")
+        yield responses_vpc_access("test_query_all_dedup_00430c")
+        yield responses_vpc_access("test_query_all_dedup_00430d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc100"
+    # Canonical representative is the lower-switchId one
+    assert result[0]["switchIp"] == "192.168.1.1"
+    assert result[0]["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDOBBBBBBBB"
+
+
+def test_vpc_access_orchestrator_00420_query_all_fabric_not_found() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - query_all raises RuntimeError with "Query all failed"
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - FabricContext.validate_for_mutation()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_query_all_fabric_not_found_00420a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        orchestrator.query_all()

--- a/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
@@ -1,0 +1,1176 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for `VpcInterfaceBaseOrchestrator`.
+
+`VpcInterfaceBaseOrchestrator` is an abstract base shared by every vPC interface module (access, trunk-host, ...).
+The concrete per-type orchestrators and models live on the branches stacked above this one, so these tests exercise
+the base directly through `_StubVpcOrchestrator` / `_StubVpcInterfaceModel` -- minimal concrete subclasses that
+bind `model_class` and `_managed_policy_types` without coupling to any per-feature module.
+
+Coverage (per PR #334 review):
+- `_resolve_peer_switch_id`: success, per-instance caching, missing-pair, and missing-`peerSwitchId`.
+- `_inject_peer_switch_id`: injection into `configData.networkOS.policy`, and no-op when no policy is present.
+- `create` / `update`: `switchId` + `peerSwitchId` injection, endpoint path/verb, deploy queuing, error wrapping.
+- `delete`: per-interface DELETE path construction, deploy queuing (no bulk remove), error wrapping.
+- `create_bulk`: per-switch grouping with a single peer lookup per primary switch (cache).
+- `query_one`: per-interface GET path construction and error wrapping.
+- `query_all`: fabric validation, `interfaceType`/`policyType` filtering, `switchIp` enrichment, per-peer dedup,
+  and an explicit request-count lock (2 + one GET per switch) for the fabric-wide scan flagged in review.
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` injected into a real `RestSend`.
+Responses are read from `tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json`.
+"""
+
+# pylint: disable=disallowed-name
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-few-public-methods
+# pylint: disable=too-many-lines
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+from __future__ import annotations
+
+import inspect
+from typing import ClassVar, Literal, Type
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesDelete,
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import VpcInterfaceBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+# =============================================================================
+# Stub model + orchestrator: minimal concrete subclasses of the abstract base
+# =============================================================================
+
+
+class _StubVpcPolicyModel(NDNestedModel):
+    """Minimal vPC policy block mapping to `configData.networkOS.policy`."""
+
+    policy_type: Literal["accessVpcHost"] = Field(default="accessVpcHost", alias="policyType", frozen=True)
+    access_vlan: int | None = Field(default=None, alias="accessVlan")
+    peer_switch_id: str | None = Field(default=None, alias="peerSwitchId")
+
+
+class _StubVpcNetworkOSModel(NDNestedModel):
+    """Minimal networkOS container mapping to `configData.networkOS`."""
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: _StubVpcPolicyModel | None = Field(default=None, alias="policy")
+
+
+class _StubVpcConfigDataModel(NDNestedModel):
+    """Minimal config-data container mapping to `configData`."""
+
+    mode: Literal["access"] = Field(default="access", alias="mode", frozen=True)
+    network_os: _StubVpcNetworkOSModel = Field(default_factory=_StubVpcNetworkOSModel, alias="networkOS")
+
+
+class _StubVpcInterfaceModel(NDBaseModel):
+    """Minimal vPC interface model: composite identifier, nested config mirroring the ND wire shape."""
+
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["vpc"] = Field(default="vpc", alias="interfaceType", frozen=True)
+    config_data: _StubVpcConfigDataModel | None = Field(default=None, alias="configData")
+
+
+class _StubVpcOrchestrator(VpcInterfaceBaseOrchestrator):
+    """Concrete subclass binding `model_class` and the managed policy type for the abstract base."""
+
+    model_class: ClassVar[Type[NDBaseModel]] = _StubVpcInterfaceModel
+
+    def _managed_policy_types(self) -> set[str]:
+        return {"accessVpcHost"}
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def responses_vpc_base(key: str):
+    """Load fixture data for the test_vpc_interface_base.json file."""
+    return load_fixture("test_vpc_interface_base")[key]
+
+
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> RestSend:
+    """Build a `RestSend` wired to the file-based `Sender` and the real `ResponseHandler`.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) and its config-preference dedup can be exercised.
+    """
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> _StubVpcOrchestrator:
+    """Construct a `_StubVpcOrchestrator` with the file-based `RestSend` injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
+    return _StubVpcOrchestrator(rest_send=rest_send)
+
+
+def _build_model(
+    switch_ip: str = "192.168.1.1",
+    interface_name: str = "vpc501",
+    include_config: bool = True,
+) -> _StubVpcInterfaceModel:
+    """Build a minimal `_StubVpcInterfaceModel` instance for CRUD tests."""
+    kwargs: dict = {"switch_ip": switch_ip, "interface_name": interface_name}
+    if include_config:
+        kwargs["config_data"] = _StubVpcConfigDataModel(
+            network_os=_StubVpcNetworkOSModel(policy=_StubVpcPolicyModel(access_vlan=100)),
+        )
+    return _StubVpcInterfaceModel(**kwargs)
+
+
+# =============================================================================
+# Test: ClassVars / endpoint wiring
+# =============================================================================
+
+
+def test_vpc_interface_base_00010() -> None:
+    """
+    # Summary
+
+    Verify the bulk-support flags: vPC supports bulk create but NOT bulk delete (the `interfaceActions/remove`
+    endpoint returns `Invalid Interface` for vPC entries on ND 4.2.1, so delete goes per-interface).
+
+    ## Test
+
+    - `supports_bulk_create` is True
+    - `supports_bulk_delete` is False
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator
+    """
+    assert VpcInterfaceBaseOrchestrator.supports_bulk_create is True
+    assert VpcInterfaceBaseOrchestrator.supports_bulk_delete is False
+
+
+def test_vpc_interface_base_00020() -> None:
+    """
+    # Summary
+
+    Verify the per-verb endpoint classes are wired to the ND Manage Interfaces endpoints, including the
+    per-interface DELETE endpoint added by this PR.
+
+    The `*_endpoint` attributes are Pydantic instance fields (they hold the endpoint *type*), so they are read
+    off an instance, not the class.
+
+    ## Test
+
+    - create/update/query_one/query_all endpoints point at the expected `EpManageInterfaces*` classes
+    - `delete_endpoint` is the per-interface `EpManageInterfacesDelete`
+    - `delete_bulk_endpoint` is None (bulk delete disabled)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    assert instance.create_endpoint is EpManageInterfacesPost
+    assert instance.update_endpoint is EpManageInterfacesPut
+    assert instance.delete_endpoint is EpManageInterfacesDelete
+    assert instance.query_one_endpoint is EpManageInterfacesGet
+    assert instance.query_all_endpoint is EpManageInterfacesListGet
+    assert instance.delete_bulk_endpoint is None
+
+
+# =============================================================================
+# Test: _managed_policy_types
+# =============================================================================
+
+
+def test_vpc_interface_base_00100() -> None:
+    """
+    # Summary
+
+    Verify the abstract base raises `NotImplementedError` for `_managed_policy_types` and the concrete stub overrides it.
+
+    ## Test
+
+    - Calling `VpcInterfaceBaseOrchestrator._managed_policy_types` (unbound) raises `NotImplementedError`
+    - `_StubVpcOrchestrator._managed_policy_types()` returns `{"accessVpcHost"}`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with pytest.raises(NotImplementedError, match=r"Subclasses must implement _managed_policy_types"):
+        VpcInterfaceBaseOrchestrator._managed_policy_types(orchestrator)
+
+    assert orchestrator._managed_policy_types() == {"accessVpcHost"}
+
+
+# =============================================================================
+# Test: _resolve_peer_switch_id
+# =============================================================================
+
+
+def test_vpc_interface_base_00200() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` reads the per-switch `vpcPair` endpoint and returns the peer serial.
+
+    ## Test
+
+    - vpcPair GET returns `peerSwitchId: FDO22222BBB`
+    - `_resolve_peer_switch_id` returns `"FDO22222BBB"` and caches it under the primary serial
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        peer = instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert peer == "FDO22222BBB"
+    assert instance._peer_serial_cache == {"FDO11111AAA": "FDO22222BBB"}
+
+
+def test_vpc_interface_base_00210() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` caches per primary serial: a second call for the same switch does NOT
+    issue another `vpcPair` GET (only one response is provided).
+
+    ## Test
+
+    - First call consumes the single vpcPair response and returns the peer
+    - Second call returns the cached peer without consuming another response (generator would be exhausted)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        first = instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+        second = instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert first == "FDO22222BBB"
+    assert second == "FDO22222BBB"
+
+
+def test_vpc_interface_base_00220() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises `RuntimeError` when the switch is not in a vPC pair (vpcPair GET 404).
+
+    ## Test
+
+    - vpcPair GET returns 404 (empty body via `not_found_ok`)
+    - `RuntimeError` mentions the switch IP, the serial, and points the user at `nd_manage_vpc_pair`
+    - Nothing is cached
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    match = r"Switch 192\.168\.1\.1 \(serial FDO11111AAA\) is not in a vPC pair.*nd_manage_vpc_pair"
+    with pytest.raises(RuntimeError, match=match):
+        instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert instance._peer_serial_cache == {}
+
+
+def test_vpc_interface_base_00230() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises `RuntimeError` when the vpcPair record omits `peerSwitchId`.
+
+    ## Test
+
+    - vpcPair GET returns 200 but the body has no `peerSwitchId`
+    - `RuntimeError` matches `missing 'peerSwitchId'`
+    - Nothing is cached
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    match = r"missing 'peerSwitchId'"
+    with pytest.raises(RuntimeError, match=match):
+        instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert instance._peer_serial_cache == {}
+
+
+# =============================================================================
+# Test: _inject_peer_switch_id
+# =============================================================================
+
+
+def test_vpc_interface_base_00300() -> None:
+    """
+    # Summary
+
+    Verify `_inject_peer_switch_id` sets `peerSwitchId` inside `configData.networkOS.policy`.
+
+    ## Test
+
+    - Payload with a nested policy gets `peerSwitchId` injected
+    - The same dict object is returned (in-place mutation)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._inject_peer_switch_id()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    payload = {"configData": {"networkOS": {"policy": {"policyType": "accessVpcHost"}}}}
+    result = instance._inject_peer_switch_id(payload, "FDO22222BBB")
+
+    assert result is payload
+    assert payload["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+
+
+def test_vpc_interface_base_00310() -> None:
+    """
+    # Summary
+
+    Verify `_inject_peer_switch_id` raises `RuntimeError` when there is no nested `policy` block to inject into. A
+    vPC interface always needs a peer serial, so a policy-less payload is structurally invalid and must fail fast
+    rather than be silently sent to ND as a one-sided vPC.
+
+    ## Test
+
+    - Payload with no `policy` key raises `RuntimeError` matching `missing the 'configData.networkOS.policy' block`
+    - Payload with no `configData` key raises the same `RuntimeError`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._inject_peer_switch_id()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    match = r"missing the 'configData\.networkOS\.policy' block"
+
+    no_policy: dict = {"configData": {"networkOS": {}}}
+    with pytest.raises(RuntimeError, match=match):
+        instance._inject_peer_switch_id(no_policy, "FDO22222BBB")
+
+    no_config: dict = {"interfaceName": "vpc501"}
+    with pytest.raises(RuntimeError, match=match):
+        instance._inject_peer_switch_id(no_config, "FDO22222BBB")
+
+
+# =============================================================================
+# Test: create
+# =============================================================================
+
+
+def test_vpc_interface_base_00400() -> None:
+    """
+    # Summary
+
+    Verify `create` resolves the switch and peer serials, injects `switchId` and `peerSwitchId`, wraps the payload
+    in `{"interfaces": [...]}`, POSTs to the per-switch interfaces URL, and queues a deploy.
+
+    ## Test
+
+    - POST hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces`
+    - Request body is `{"interfaces": [ {...} ]}` with one element
+    - The element carries `interfaceType: vpc`, `switchId: FDO11111AAA`, no `switchIp`
+    - `configData.networkOS.policy.peerSwitchId` is the resolved peer serial
+    - `_pending_deploys` contains the single `(interface_name, switch_id)` pair
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    - VpcInterfaceBaseOrchestrator._inject_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with does_not_raise():
+        instance.create(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert len(body["interfaces"]) == 1
+    payload_item = body["interfaces"][0]
+    assert payload_item["interfaceName"] == "vpc501"
+    assert payload_item["interfaceType"] == "vpc"
+    assert payload_item["switchId"] == "FDO11111AAA"
+    assert "switchIp" not in payload_item
+    assert payload_item["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+    assert instance._pending_deploys == [("vpc501", "FDO11111AAA")]
+
+
+def test_vpc_interface_base_00410() -> None:
+    """
+    # Summary
+
+    Verify `create` wraps a `_request` failure in `RuntimeError` and queues no deploy.
+
+    ## Test
+
+    - switches-list and vpcPair succeed; POST returns 500
+    - `RuntimeError` matches `Create failed for`
+    - `_pending_deploys` stays empty
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with pytest.raises(RuntimeError, match=r"Create failed for"):
+        instance.create(model)
+
+    assert instance._pending_deploys == []
+
+
+def test_vpc_interface_base_00420() -> None:
+    """
+    # Summary
+
+    Verify `create` surfaces the not-in-a-vPC-pair error (wrapped as `Create failed`) when the primary switch
+    has no vpcPair record.
+
+    ## Test
+
+    - switches-list succeeds; vpcPair GET returns 404
+    - `RuntimeError` matches `Create failed for .*is not in a vPC pair`
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with pytest.raises(RuntimeError, match=r"Create failed for .*is not in a vPC pair"):
+        instance.create(model)
+
+    assert instance._pending_deploys == []
+
+
+# =============================================================================
+# Test: update
+# =============================================================================
+
+
+def test_vpc_interface_base_00500() -> None:
+    """
+    # Summary
+
+    Verify `update` issues a PUT to the per-interface URL, injects `switchId` + `peerSwitchId`, and queues a deploy.
+
+    ## Test
+
+    - PUT hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501`
+    - Body carries `switchId`, no `switchIp`, and the injected `peerSwitchId`
+    - `_pending_deploys` contains the `(vpc501, FDO11111AAA)` pair
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501"
+    assert rest_send.verb == HttpVerbEnum.PUT.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert body["interfaceName"] == "vpc501"
+    assert body["switchId"] == "FDO11111AAA"
+    assert "switchIp" not in body
+    assert body["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+    assert instance._pending_deploys == [("vpc501", "FDO11111AAA")]
+
+
+def test_vpc_interface_base_00510() -> None:
+    """
+    # Summary
+
+    Verify `update` wraps a `_request` failure in `RuntimeError` and queues no deploy.
+
+    ## Test
+
+    - switches-list and vpcPair succeed; PUT returns 500
+    - `RuntimeError` matches `Update failed for`
+    - `_pending_deploys` stays empty
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with pytest.raises(RuntimeError, match=r"Update failed for"):
+        instance.update(model)
+
+    assert instance._pending_deploys == []
+
+
+# =============================================================================
+# Test: delete (per-interface DELETE)
+# =============================================================================
+
+
+def test_vpc_interface_base_00600() -> None:
+    """
+    # Summary
+
+    Verify `delete` issues a per-interface DELETE (not a bulk remove) and queues a deploy.
+
+    ## Test
+
+    - DELETE hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501`
+    - The DELETE returns 204
+    - `_pending_deploys` contains `(vpc501, FDO11111AAA)`; `_pending_removes` stays empty (bulk remove unused)
+    - `delete` returns None
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.delete()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with does_not_raise():
+        result = instance.delete(model)
+
+    assert result is None
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501"
+    assert rest_send.verb == HttpVerbEnum.DELETE.value
+    assert instance._pending_deploys == [("vpc501", "FDO11111AAA")]
+    assert instance._pending_removes == []
+
+
+def test_vpc_interface_base_00610() -> None:
+    """
+    # Summary
+
+    Verify `delete` wraps a DELETE failure in `RuntimeError` and queues no deploy.
+
+    ## Test
+
+    - switches-list succeeds; per-interface DELETE returns 500
+    - `RuntimeError` matches `Delete failed for`
+    - Both queues stay empty
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.delete()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with pytest.raises(RuntimeError, match=r"Delete failed for"):
+        instance.delete(model)
+
+    assert instance._pending_deploys == []
+    assert instance._pending_removes == []
+
+
+# =============================================================================
+# Test: create_bulk (peer lookup cached per primary switch)
+# =============================================================================
+
+
+def test_vpc_interface_base_00700() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` groups interfaces by primary switch and resolves the peer serial only ONCE per primary
+    switch (cache), issuing a single POST carrying both interfaces.
+
+    ## Test
+
+    - Two vPC interfaces on the same primary switch (192.168.1.1)
+    - Only one switches-list, one vpcPair GET, and one POST are consumed (cache prevents a second peer lookup)
+    - Both interfaces carry the injected `peerSwitchId`
+    - Both `(interface_name, switch_id)` pairs are queued for deploy
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create_bulk()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    models = [
+        _build_model(interface_name="vpc501"),
+        _build_model(interface_name="vpc502"),
+    ]
+
+    with does_not_raise():
+        instance.create_bulk(models)
+
+    # A single vpcPair lookup served both interfaces on the same primary switch.
+    assert instance._peer_serial_cache == {"FDO11111AAA": "FDO22222BBB"}
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert len(body["interfaces"]) == 2
+    for item in body["interfaces"]:
+        assert item["switchId"] == "FDO11111AAA"
+        assert item["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+    assert sorted(instance._pending_deploys) == sorted([("vpc501", "FDO11111AAA"), ("vpc502", "FDO11111AAA")])
+
+
+def test_vpc_interface_base_00710() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` wraps a per-switch `_request` failure in `RuntimeError` matching `Bulk create failed`.
+
+    ## Test
+
+    - switches-list and vpcPair succeed; the per-switch POST returns 500
+    - `RuntimeError` matches `Bulk create failed`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    models = [_build_model(interface_name="vpc501")]
+
+    with pytest.raises(RuntimeError, match=r"Bulk create failed"):
+        instance.create_bulk(models)
+
+
+# =============================================================================
+# Test: query_one
+# =============================================================================
+
+
+def test_vpc_interface_base_00800() -> None:
+    """
+    # Summary
+
+    Verify `query_one` issues a GET against the per-interface URL and returns the DATA dict.
+
+    ## Test
+
+    - GET hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501`
+    - Returned dict carries the vPC interface (`interfaceType: vpc`, `policyType: accessVpcHost`)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with does_not_raise():
+        result = instance.query_one(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501"
+    assert rest_send.verb == HttpVerbEnum.GET.value
+    assert result["interfaceName"] == "vpc501"
+    assert result["interfaceType"] == "vpc"
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "accessVpcHost"
+
+
+def test_vpc_interface_base_00810() -> None:
+    """
+    # Summary
+
+    Verify `query_one` wraps a `_request` failure in `RuntimeError` mentioning the identifier.
+
+    ## Test
+
+    - switches-list succeeds; GET returns 500
+    - `RuntimeError` matches `Query failed for`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with pytest.raises(RuntimeError, match=r"Query failed for"):
+        instance.query_one(model)
+
+
+# =============================================================================
+# Test: query_all (fabric-wide scan, filtering, dedup, request count)
+# =============================================================================
+
+
+def test_vpc_interface_base_00900() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, scans every switch, filters to vPC interfaces with managed policy
+    types, injects `switchIp`, de-duplicates the per-peer copies, and -- per PR #334 review -- issues exactly
+    one request per switch plus the fabric summary and switches-list (no N+1 beyond the documented per-switch scan).
+
+    ## Test
+
+    - Switch A returns: managed `accessVpcHost` vpc501, other-policy `trunkVpcHost` vpc502, non-vPC ethernet
+    - Switch B returns: the peer-side copy of vpc501
+    - Result contains exactly vpc501 (vpc502 and the ethernet are filtered out; the peer copy is deduped)
+    - The kept entry carries `switchIp` of the lower-`switchId` peer (192.168.1.1 / FDO11111AAA)
+    - Request count is exactly 4: summary + switches-list + one interface GET per switch (locks the scan cost)
+
+    `state=overridden` keeps `query_all` fabric-wide so both peers are scanned and the per-peer dedup is exercised.
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._managed_policy_types()
+    """
+    method_name = inspect.stack()[0][3]
+    calls: list[str] = []
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            calls.append(suffix)
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden")
+        result = instance.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    iface = result[0]
+    assert iface["interfaceName"] == "vpc501"
+    assert iface["switchIp"] == "192.168.1.1"
+
+    by_name = {entry["interfaceName"] for entry in result}
+    assert "vpc502" not in by_name  # other-policy vPC filtered out
+    assert "Ethernet1/5" not in by_name  # non-vPC filtered out
+
+    # Request-count lock: 1 summary (validate) + 1 switches-list + 1 GET per switch (2 switches) = 4.
+    # This pins the fabric-wide scan cost flagged in review so a regression to N+1 fails the test.
+    assert len(calls) == 4
+
+
+def test_vpc_interface_base_00910() -> None:
+    """
+    # Summary
+
+    Verify `query_all` skips a managed vPC interface that has no `interfaceName` (it cannot be keyed for dedup).
+
+    ## Test
+
+    - The single switch returns one managed `accessVpcHost` vPC interface with no `interfaceName`
+    - `query_all` returns `[]` (the nameless entry is skipped, not raised on)
+
+    `state=overridden` keeps `query_all` fabric-wide so the switch is scanned.
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden")
+        result = instance.query_all()
+
+    assert result == []
+
+
+def test_vpc_interface_base_00930() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` (wrapping the validation failure) when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - `query_all` raises `RuntimeError` matching `Query all failed.*missing_fabric`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        instance.query_all()
+
+
+def test_vpc_interface_base_00940() -> None:
+    """
+    # Summary
+
+    Verify `query_all` skips a switch whose interfaces endpoint returns no body (the `not_found_ok` branch) and
+    yields an empty list when no managed vPC interfaces are found.
+
+    ## Test
+
+    - Fabric summary and switches-list succeed (one switch)
+    - The switch's interfaces endpoint returns 404 (no body)
+    - `query_all` returns `[]`
+
+    `state=overridden` keeps `query_all` fabric-wide so the 404 switch is still visited and skipped.
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden")
+        result = instance.query_all()
+
+    assert result == []
+
+
+def test_vpc_interface_base_00920() -> None:
+    """
+    # Summary
+
+    Verify `query_all` scopes its per-switch interface-list fan-out to switches named in the user config when
+    `state` is not `overridden`, rather than querying every switch in the fabric (CLAUDE.md performance rule).
+
+    ## Test
+
+    - Fabric has two switches (192.168.1.1, 192.168.1.2), but config names only 192.168.1.1
+    - state is `merged` (non-overridden), so `_switches_to_query` returns only the config switch
+    - Only the config switch's interfaces are fetched; the second switch is never queried (the response generator
+      yields exactly three responses — summary, switch list, switch-1 interfaces — and would raise if a second
+      per-switch GET were issued)
+    - Result contains only the `accessVpcHost` vPC on the config switch, stamped with the config `switchIp`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._switches_to_query()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "vpc501"}]
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="merged", config=config)
+        result = instance.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc501"
+    assert result[0]["switchIp"] == "192.168.1.1"
+
+
+def test_vpc_interface_base_00950() -> None:
+    """
+    # Summary
+
+    Verify the per-peer dedup keeps the peer whose `switchIp` the user actually configured, so idempotency holds
+    even when the user names the HIGHER-`switchId` peer. A vPC is returned on both peers; without this preference
+    the dedup would canonicalize to the lower-`switchId` peer (192.168.1.1) and the existing-state identifier would
+    never match a config naming 192.168.1.2, churning a spurious delete + recreate under `overridden`.
+
+    ## Test
+
+    - `state=overridden` so both peers are scanned (192.168.1.1 / FDO11111AAA and 192.168.1.2 / FDO22222BBB)
+    - Config names vpc501 on the higher-`switchId` peer 192.168.1.2
+    - The deduped entry carries `switchIp` 192.168.1.2 (the configured peer), not the lower-`switchId` default
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._prefers_candidate()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.2", "interface_name": "vpc501"}]
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden", config=config)
+        result = instance.query_all()
+
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc501"
+    assert result[0]["switchIp"] == "192.168.1.2"
+
+
+def test_vpc_interface_base_00960() -> None:
+    """
+    # Summary
+
+    Verify `query_all` tolerates malformed per-switch bodies without aborting the whole run: a `configData: null`
+    interface is filtered out via the null-safe policy-type accessor, and a non-dict interfaces body is skipped via
+    the `isinstance(result, dict)` guard. Neither raises `AttributeError`.
+
+    ## Test
+
+    - `state=overridden` so both switches are scanned
+    - Switch A returns a vPC interface with `configData: null` (policy type resolves to None → filtered out)
+    - Switch B returns a bare list as its DATA body (non-dict → skipped by the isinstance guard)
+    - `query_all` returns `[]` rather than raising
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._policy_type()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden")
+        result = instance.query_all()
+
+    assert result == []

--- a/tests/unit/module_utils/orchestrators/test_vpc_trunk_host_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_trunk_host_interface.py
@@ -1,0 +1,516 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for vpc_trunk_host_interface orchestrator.
+
+Verifies that `TrunkVpcHostInterfaceOrchestrator` correctly:
+- declares the right `model_class` and `_managed_policy_types`
+- inherits bulk-support flags from `VpcInterfaceBaseOrchestrator`
+- resolves the peer switch's serial via the vPC pair GET endpoint
+- raises a clear `RuntimeError` when the primary switch is not in a vPC pair
+- caches peer-serial lookups per orchestrator instance
+- filters fabric-wide interface results to `interfaceType: "vpc"` plus the managed
+  policy types (so non-vPC interfaces and other-flavor vPCs are excluded)
+- dedupes vPC interfaces that appear on both peers (ND query_all duplicate quirk)
+- propagates `RuntimeError` from the inherited `validate_prerequisites` path
+- uses per-interface `DELETE` (workaround for ND 4.2.1 bulk-remove silent fail)
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as the
+`sender` dependency injected into a real `RestSend`. Responses are read from
+`tests/unit/module_utils/fixtures/fixture_data/test_vpc_trunk_host_interface_orchestrator.json`.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import (
+    TrunkVpcHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_trunk_host_interface import (
+    TrunkVpcHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_vpc_trunk_host(key: str):
+    """Load fixture data for the orchestrator's test_vpc_trunk_host_interface_orchestrator.json file."""
+    return load_fixture("test_vpc_trunk_host_interface_orchestrator")[key]
+
+
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list | None = None,
+) -> RestSend:
+    """
+    Build a RestSend wired to the file-based Sender and the real ResponseHandler.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    """
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list | None = None,
+) -> TrunkVpcHostInterfaceOrchestrator:
+    """Construct an orchestrator with the file-based RestSend injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
+    return TrunkVpcHostInterfaceOrchestrator(rest_send=rest_send)
+
+
+# =============================================================================
+# Test: ClassVar / model_class
+# =============================================================================
+
+
+def test_vpc_trunk_host_orchestrator_00010() -> None:
+    """
+    # Summary
+
+    Verify `model_class` points to `TrunkVpcHostInterfaceModel`.
+
+    ## Test
+
+    - model_class is TrunkVpcHostInterfaceModel
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceOrchestrator.model_class
+    """
+    assert TrunkVpcHostInterfaceOrchestrator.model_class is TrunkVpcHostInterfaceModel
+
+
+def test_vpc_trunk_host_orchestrator_00020() -> None:
+    """
+    # Summary
+
+    Verify bulk-support flags inherited from `VpcInterfaceBaseOrchestrator`. Bulk-create is enabled (POST /interfaces accepts
+    an array); bulk-delete is disabled because ND 4.2.1's `interfaceActions/remove` returns `Invalid Interface` for
+    vPC entries — we use per-interface `DELETE` instead via the state machine's individual delete path.
+
+    ## Test
+
+    - supports_bulk_create is True
+    - supports_bulk_delete is False
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceOrchestrator
+    """
+    assert TrunkVpcHostInterfaceOrchestrator.supports_bulk_create is True
+    assert TrunkVpcHostInterfaceOrchestrator.supports_bulk_delete is False
+
+
+# =============================================================================
+# Test: _managed_policy_types
+# =============================================================================
+
+
+def test_vpc_trunk_host_orchestrator_00100() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns the single `"trunkVpcHost"` API value.
+
+    ## Test
+
+    - Returned set contains exactly "trunkVpcHost"
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    assert orchestrator._managed_policy_types() == {"trunkVpcHost"}
+
+
+def test_vpc_trunk_host_orchestrator_00110() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns a set.
+
+    ## Test
+
+    - Return type is set
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    result = orchestrator._managed_policy_types()
+    assert isinstance(result, set)
+    assert "trunkVpcHost" in result
+
+
+# =============================================================================
+# Test: _resolve_peer_switch_id
+# =============================================================================
+
+
+def test_vpc_trunk_host_orchestrator_00500_peer_resolve_happy() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` returns the peer serial when the primary is in a vPC pair.
+
+    ## Test
+
+    - GET /vpcPair returns peerSwitchId
+    - Helper returns that value
+    - Result is cached on the orchestrator
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_trunk_host("test_peer_resolve_happy_path_00500a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        peer = orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+    assert peer == "FDO22222BBB"
+    assert orchestrator._peer_serial_cache == {"FDO11111AAA": "FDO22222BBB"}
+
+
+def test_vpc_trunk_host_orchestrator_00505_peer_resolve_cached() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` returns the cached value without issuing a second GET.
+
+    ## Test
+
+    - First call fetches and caches
+    - Second call returns the cached value (no additional response is yielded)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_trunk_host("test_peer_resolve_happy_path_00500a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    first = orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+    second = orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+    assert first == second == "FDO22222BBB"
+
+
+def test_vpc_trunk_host_orchestrator_00510_peer_resolve_not_paired() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises a clear RuntimeError when the primary switch is not in a vPC pair.
+
+    ## Test
+
+    - GET /vpcPair returns 404 (live-lab structured error body)
+    - Helper raises RuntimeError mentioning the switch_ip and pointing the user at nd_manage_vpc_pair
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_trunk_host("test_peer_resolve_not_paired_00510a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with pytest.raises(RuntimeError, match=r"192\.168\.1\.1.*not in a vPC pair.*nd_manage_vpc_pair"):
+        orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+
+def test_vpc_trunk_host_orchestrator_00520_peer_resolve_missing_field() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises RuntimeError when the vPC pair record is missing `peerSwitchId`.
+
+    ## Test
+
+    - GET /vpcPair returns 200 but body omits peerSwitchId
+    - Helper raises RuntimeError mentioning the missing field
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_trunk_host("test_peer_resolve_missing_field_00520a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with pytest.raises(RuntimeError, match=r"missing 'peerSwitchId'"):
+        orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+
+# =============================================================================
+# Test: query_all — happy path with filtering
+# =============================================================================
+
+
+def test_vpc_trunk_host_orchestrator_00400_query_all_happy() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=="vpc"
+    and policyType=="trunkVpcHost", and injects `switchIp` onto each kept interface.
+
+    ## Test
+
+    - Fabric summary (validate_prerequisites) returns 200
+    - Switches list returns two switches
+    - Switch 1 returns: configured trunkVpcHost vpc, accessVpcHost vpc, ethernet trunkHost
+    - Switch 2 returns: one configured trunkVpcHost vpc
+    - Result contains exactly the two trunkVpcHost vPC interfaces
+    - Each has switchIp injected with the fabricManagementIp
+    - `state=overridden` keeps `query_all` fabric-wide so every switch is scanned (config-scoped states only query the configured switches)
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceOrchestrator._managed_policy_types()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_vpc_trunk_host("test_query_all_happy_path_00400a")
+        yield responses_vpc_trunk_host("test_query_all_happy_path_00400b")
+        yield responses_vpc_trunk_host("test_query_all_happy_path_00400c")
+        yield responses_vpc_trunk_host("test_query_all_happy_path_00400d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    by_name = {iface["interfaceName"]: iface for iface in result}
+    assert set(by_name) == {"vpc500", "vpc600"}
+
+    assert by_name["vpc500"]["switchIp"] == "192.168.1.1"
+    assert by_name["vpc600"]["switchIp"] == "192.168.1.2"
+
+    # Filtered out: accessVpcHost (vpc100) and ethernet trunkHost (Ethernet1/1)
+    assert "vpc100" not in by_name
+    assert "Ethernet1/1" not in by_name
+
+
+def test_vpc_trunk_host_orchestrator_00410_query_all_no_match() -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty list when no switch reports any trunkVpcHost vPC.
+
+    ## Test
+
+    - Switch returns only non-vPC and non-trunkVpcHost vPC interfaces
+    - Result is an empty list
+    - `state=overridden` keeps `query_all` fabric-wide so the switch is scanned and the policy-type filter is exercised
+
+    ## Classes and Methods
+
+    - TrunkVpcHostInterfaceOrchestrator._managed_policy_types()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_vpc_trunk_host("test_query_all_no_match_00410a")
+        yield responses_vpc_trunk_host("test_query_all_no_match_00410b")
+        yield responses_vpc_trunk_host("test_query_all_no_match_00410c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_vpc_trunk_host_orchestrator_00420_query_all_fabric_not_found() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - query_all raises RuntimeError with "Query all failed"
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - FabricContext.validate_for_mutation()
+    """
+
+    def responses():
+        yield responses_vpc_trunk_host("test_query_all_fabric_not_found_00420a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        orchestrator.query_all()
+
+
+def test_vpc_trunk_host_orchestrator_00430_query_all_dedup() -> None:
+    """
+    # Summary
+
+    Verify `query_all` dedupes vPC interfaces that appear on both peers. ND returns each vPC interface twice
+    (once per peer GET) with identical configData; without dedupe, `_manage_override_deletions` would treat the
+    peer-side copy as "not in proposed" and queue a spurious delete.
+
+    ## Test
+
+    - Two switches in the fabric, both return the same `vpc500` configuration
+    - Result contains exactly ONE entry for `vpc500`
+    - Canonical representative is the entry with the alphabetically-lower `switchId`
+      (FDOAAAAAAAA = 192.168.1.1 is kept; FDOBBBBBBBB = 192.168.1.2 is dropped)
+    - `state=overridden` keeps `query_all` fabric-wide so both peers are scanned and the per-peer dedup is exercised
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all() dedupe logic
+    """
+
+    def responses():
+        yield responses_vpc_trunk_host("test_query_all_dedup_00430a")
+        yield responses_vpc_trunk_host("test_query_all_dedup_00430b")
+        yield responses_vpc_trunk_host("test_query_all_dedup_00430c")
+        yield responses_vpc_trunk_host("test_query_all_dedup_00430d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc500"
+    # Canonical representative is the lower-switchId one
+    assert result[0]["switchIp"] == "192.168.1.1"
+    assert result[0]["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDOBBBBBBBB"
+
+
+# =============================================================================
+# Test: delete uses per-interface endpoint
+# =============================================================================
+
+
+def test_vpc_trunk_host_orchestrator_00600_delete_uses_per_interface_endpoint() -> None:
+    """
+    # Summary
+
+    Verify `delete()` calls the per-interface `DELETE /interfaces/{name}` endpoint (not the bulk
+    `interfaceActions/remove` which silently fails for vPC on ND 4.2.1) and queues a deploy for the same
+    `(interface_name, switch_id)` pair.
+
+    ## Test
+
+    - Switch-map fixture resolves switch_ip -> switch_id
+    - DELETE call returns 204 (no body)
+    - delete() does not raise
+    - Deploy queue contains exactly one entry: (vpc500, FDOAAAAAAAA)
+    - Bulk-remove queue stays untouched (per-interface DELETE path)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.delete()
+    """
+
+    def responses():
+        yield {
+            "RETURN_CODE": 200,
+            "METHOD": "GET",
+            "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+            "MESSAGE": "OK",
+            "DATA": {"switches": [{"fabricManagementIp": "192.168.1.1", "switchId": "FDOAAAAAAAA"}]},
+        }
+        yield {
+            "RETURN_CODE": 204,
+            "METHOD": "DELETE",
+            "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces/vpc500",
+            "MESSAGE": "No Content",
+            "DATA": {},
+        }
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    model = TrunkVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc500")
+    with does_not_raise():
+        orchestrator.delete(model)
+
+    assert orchestrator._pending_deploys == [("vpc500", "FDOAAAAAAAA")]
+    # Bulk-remove queue stays untouched because we use per-interface DELETE.
+    assert orchestrator._pending_removes == []


### PR DESCRIPTION
## Related Issue(s)

- CiscoDevNet/ansible-nd#320

### Deferred follow-ups (tracked)

- #348 — interface orchestrator CRUD + policy-type serializer dedup (cross-cutting)
- #349 — query_all per-switch fan-out / no fabric-wide interface endpoint (cross-cutting)
- #350 — create accepts a policy-less config item (config_data optional, no create-time validator)
- #351 — storm-control percentage vs pps not mutually exclusive
- #295 — HTTP 207 multi-status silent success (shared RestSend infra; 207 guard deferred on this branch)

## Proposed Changes

Adds `nd_interface_port_channel_access` for managing accessPoHost port-channel interfaces on ND 4.2 fabrics. The PC policy is the single source of truth for members (the `ports` list); ND propagates access-mode configuration to member interfaces — users do not pre-configure members.

- `PortChannelAccessInterfaceModel` — Pydantic policy/payload model targeting `accessPoHost`, composite identifier `(switch_ip, interface_name)`, all access-mode policy fields plus port-channel specifics (`ports`, `copy_description`, `port_channel_mode`, `lacp_rate`, `lacp_port_priority`, `lacp_suspend`).
- `PortChannelBaseOrchestrator` — shared CRUD base extending `NDBaseInterfaceOrchestrator`. Uses `EpManageInterfacesRemove` for delete (PCs are virtual/deletable like loopbacks). Filters `query_all` by `interfaceType="portChannel"` and per-subclass policy-type set.
- `PortChannelAccessInterfaceOrchestrator` — concrete subclass binding `model_class` and the `accessPoHost` policy-type filter.
- `plugins/module_utils/models/interfaces/enums.py` — first introduction on this branch; contains `AccessPoHostPolicyTypeEnum`, `PortChannelModeEnum`, `LacpRateEnum`, plus access-mode enums that will be shared with future trunk-host work (`BpduFilter`, `BpduGuard`, `DuplexMode`, `Mtu`, `Speed`, `StormControlAction`).

Branch base: stacked on `nd_interface_loopback` for the base interface infrastructure (`NDBaseInterfaceOrchestrator`, `FabricContext`, `manage_interfaces` endpoints, base interface models).

## Test Notes

### Unit tests

Adapted from the ethernet_trunk_host unit-test trio:

- `tests/unit/module_utils/models/test_port_channel_access_interface.py` — 114 cases covering policy/network_os/config_data/interface model defaults, alias population, `normalize_policy_type`, `normalize_ports`, range/enum validation, `AsciiDescription`, serializer modes, `to_payload` / `to_config` / `from_response` / `from_config` round-trips, composite identifier, `get_diff`, `merge`, and `get_argument_spec`.
- `tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py` — 8 cases covering `model_class`, bulk-support flags, `_managed_policy_types == {"accessPoHost"}`, and `PortChannelBaseOrchestrator.query_all` filtering by `interfaceType` and `policyType`, plus fabric-not-found and per-switch 404 paths.
- `tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json` — fabric summary, deploymentFreeze, switches, and per-switch interfaces fixtures for the orchestrator tests.

To run:

```
python -m pytest tests/unit/module_utils/models/test_port_channel_access_interface.py tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
```

122/122 pass. Full unit suite (558 tests) green; black/isort clean.

### Integration tests

Cover: create / multi-create across switches, idempotency, update access_vlan and description, add member to PC, remove member from PC, `state: replaced`, `state: overridden` (incl. interfaceType filter check), `state: deleted` with member-revert path, `deploy: false` staging, and non-existent delete no-op.

Tests passed end-to-end on a 9000v testbed against ND 4.2 (192.168.7.8 / fabric_1 / leaf at 192.168.12.151).

The test target uses `module_defaults: { cisco.nd.nd_interface_port_channel_access: { timeout: 300 } }` to scope a 300s timeout to PC tests — port-channel deploys (build bundle, pull members, apply LACP) routinely exceed the default 30s on slower testbeds. Scoped at the test target level so we don't touch shared `nd_argument_spec` defaults.

To run:

```
ansible-test network-integration nd_interface_port_channel_access -v
```

Required `[nd:vars]` entries (in `tests/integration/inventory.networking`):

```
nd_test_fabric_name=<fabric>
nd_test_switch_ip=<switch IP>
nd_test_pc_member_a=Ethernet1/10
nd_test_pc_member_b=Ethernet1/11
nd_test_pc_member_c=Ethernet1/12
nd_test_pc_member_d=Ethernet1/13
```

The four member ethernets must exist on the target switch and not currently belong to any other port-channel (the SETUP cleanup at the start of each state file resets them).

## Cisco Nexus Dashboard Version

4.2

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from base branch with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
