### PR TITLE
interface capability preflight (#273)

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_fabric_capable_switches.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabric_capable_switches.py
@@ -24,12 +24,9 @@ from __future__ import annotations
 from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import _EpManageFabricsBase
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
-from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
 
 class CapableSwitchesEndpointParams(EndpointQueryParams):
@@ -72,7 +69,7 @@ class CapableSwitchesEndpointParams(EndpointQueryParams):
     )
 
 
-class EpManageFabricsCapableSwitchesGet(FabricNameMixin, NDEndpointBaseModel):
+class EpManageFabricsCapableSwitchesGet(_EpManageFabricsBase):
     """
     # Summary
 
@@ -115,41 +112,34 @@ class EpManageFabricsCapableSwitchesGet(FabricNameMixin, NDEndpointBaseModel):
         description="Class name for backward compatibility",
     )
 
-    _require_fabric_name: ClassVar[bool] = True
-    _path_suffix: ClassVar[str] = "capableSwitches"
+    _path_suffix: ClassVar[str | None] = "capableSwitches"
 
     endpoint_params: CapableSwitchesEndpointParams = Field(
         default_factory=CapableSwitchesEndpointParams,
         description="Endpoint-specific query parameters (interface_type, mode).",
     )
 
-    def set_identifiers(self, identifier: IdentifierKey = None):
-        """Set the fabric_name from the identifier value."""
-        self.fabric_name = identifier
-
     @property
     def path(self) -> str:
         """
         # Summary
 
-        Build the endpoint path with fabric name, capableSwitches suffix, and required query string.
+        Validate the required query parameters, then delegate to `_EpManageFabricsBase.path` to build the path with the
+        fabric name, `capableSwitches` suffix, and query string.
 
         ## Raises
 
         ### ValueError
 
-        - If `fabric_name` is not set
         - If `interface_type` is not set
         - If `mode` is not set
+        - If `fabric_name` is not set
         """
-        if self.fabric_name is None:
-            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
         if self.endpoint_params.interface_type is None:
             raise ValueError(f"{type(self).__name__}.path: endpoint_params.interface_type must be set before accessing path.")
         if self.endpoint_params.mode is None:
             raise ValueError(f"{type(self).__name__}.path: endpoint_params.mode must be set before accessing path.")
-        base_path = BasePath.path("fabrics", self.fabric_name, self._path_suffix)
-        return f"{base_path}?{self.endpoint_params.to_query_string()}"
+        return super().path
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabric_capable_switches.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabric_capable_switches.py
@@ -21,7 +21,7 @@ stable for the lifetime of ND 4.2.x. See GitHub issue #273 for context and risk 
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal, Optional
+from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
@@ -60,12 +60,12 @@ class CapableSwitchesEndpointParams(EndpointQueryParams):
     None
     """
 
-    interface_type: Optional[str] = Field(
+    interface_type: str | None = Field(
         default=None,
         min_length=1,
         description="Interface type (e.g. loopback, ethernet, portChannel, svi, tunnel). Sent as interfaceType.",
     )
-    mode: Optional[str] = Field(
+    mode: str | None = Field(
         default=None,
         min_length=1,
         description="Interface mode (e.g. managed, trunk, access, routed).",

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabric_capable_switches.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabric_capable_switches.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel) <arobel@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+ND Manage Fabrics capableSwitches endpoint model.
+
+Endpoint definition for the unpublished but stable
+``GET /api/v1/manage/fabrics/{fabric_name}/capableSwitches`` resource.
+
+## Endpoints
+
+- ``EpManageFabricsCapableSwitchesGet`` - Get switches in a fabric capable of hosting a given
+  ``interfaceType`` and ``mode``
+  (``GET /api/v1/manage/fabrics/{fabric_name}/capableSwitches?interfaceType={type}&mode={mode}``)
+
+This endpoint is not present in the ND OpenAPI spec. Cisco ND developers have confirmed it is
+stable for the lifetime of ND 4.2.x. See GitHub issue #273 for context and risk discussion.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal, Optional
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
+
+
+class CapableSwitchesEndpointParams(EndpointQueryParams):
+    """
+    # Summary
+
+    Endpoint-specific query parameters for the capableSwitches endpoint.
+
+    ## Parameters
+
+    - interface_type: Interface type to query for capable switches (e.g. `loopback`, `ethernet`, `portChannel`, `svi`, `tunnel`).
+      Sent to the API as `interfaceType` (camelCase).
+    - mode: Mode for the given interface type (e.g. `managed`, `trunk`, `access`, `routed`).
+
+    Valid `(interface_type, mode)` pairs are enforced by `InterfaceCapabilityPreflight`, not by this model — the endpoint layer
+    is intentionally a thin wire-format adapter.
+
+    ## Usage
+
+    ```python
+    params = CapableSwitchesEndpointParams(interface_type="loopback", mode="managed")
+    query_string = params.to_query_string()
+    # Returns: "interfaceType=loopback&mode=managed"
+    ```
+
+    ## Raises
+
+    None
+    """
+
+    interface_type: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="Interface type (e.g. loopback, ethernet, portChannel, svi, tunnel). Sent as interfaceType.",
+    )
+    mode: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="Interface mode (e.g. managed, trunk, access, routed).",
+    )
+
+
+class EpManageFabricsCapableSwitchesGet(FabricNameMixin, NDEndpointBaseModel):
+    """
+    # Summary
+
+    ND Manage Fabrics capableSwitches GET Endpoint
+
+    ## Description
+
+    Endpoint to retrieve the list of switches in a fabric that are capable of hosting interfaces of a given `interface_type` and
+    `mode`. Used by `InterfaceCapabilityPreflight` to fail fast with a clear aggregate error before per-switch configuration calls.
+
+    ## Path
+
+    - `/api/v1/manage/fabrics/{fabric_name}/capableSwitches?interfaceType={type}&mode={mode}`
+
+    ## Verb
+
+    - GET
+
+    ## Raises
+
+    ### ValueError
+
+    - If `fabric_name`, `interface_type`, or `mode` is not set when accessing `path`
+
+    ## Usage
+
+    ```python
+    ep = EpManageFabricsCapableSwitchesGet()
+    ep.fabric_name = "my-fabric"
+    ep.endpoint_params.interface_type = "loopback"
+    ep.endpoint_params.mode = "managed"
+    rest_send.path = ep.path
+    rest_send.verb = ep.verb
+    # Path: /api/v1/manage/fabrics/my-fabric/capableSwitches?interfaceType=loopback&mode=managed
+    ```
+    """
+
+    class_name: Literal["EpManageFabricsCapableSwitchesGet"] = Field(
+        default="EpManageFabricsCapableSwitchesGet",
+        description="Class name for backward compatibility",
+    )
+
+    _require_fabric_name: ClassVar[bool] = True
+    _path_suffix: ClassVar[str] = "capableSwitches"
+
+    endpoint_params: CapableSwitchesEndpointParams = Field(
+        default_factory=CapableSwitchesEndpointParams,
+        description="Endpoint-specific query parameters (interface_type, mode).",
+    )
+
+    def set_identifiers(self, identifier: IdentifierKey = None):
+        """Set the fabric_name from the identifier value."""
+        self.fabric_name = identifier
+
+    @property
+    def path(self) -> str:
+        """
+        # Summary
+
+        Build the endpoint path with fabric name, capableSwitches suffix, and required query string.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `fabric_name` is not set
+        - If `interface_type` is not set
+        - If `mode` is not set
+        """
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        if self.endpoint_params.interface_type is None:
+            raise ValueError(f"{type(self).__name__}.path: endpoint_params.interface_type must be set before accessing path.")
+        if self.endpoint_params.mode is None:
+            raise ValueError(f"{type(self).__name__}.path: endpoint_params.mode must be set before accessing path.")
+        base_path = BasePath.path("fabrics", self.fabric_name, self._path_suffix)
+        return f"{base_path}?{self.endpoint_params.to_query_string()}"
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.GET

--- a/plugins/module_utils/interface_capability_preflight.py
+++ b/plugins/module_utils/interface_capability_preflight.py
@@ -1,0 +1,272 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel) <arobel@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Interface capability preflight for per-policy interface orchestrators.
+
+Provides `InterfaceCapabilityPreflight`, a lazy-loaded cache + validator that pre-flights
+which switches in a fabric are capable of hosting a given `interface_type` and `mode`. Used
+by `NDBaseInterfaceOrchestrator.validate_switches_capable` to convert confusing ND HTTP 400s
+on incapable switches into a single aggregate error naming the offending switches.
+
+Uses the unpublished `/api/v1/manage/fabrics/{fabric_name}/capableSwitches?interfaceType=...&mode=...`
+endpoint. See GitHub issue #273 for stability/risk discussion.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_capable_switches import (
+    EpManageFabricsCapableSwitchesGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+
+
+class InterfaceCapabilityPreflight:
+    """
+    # Summary
+
+    Cached interface capability validator for per-policy interface orchestrators.
+
+    Lazily fetches the set of switches capable of hosting a given `(interface_type, mode)` pair from
+    the ND Manage `capableSwitches` endpoint, caches by `(interface_type, mode)`, and validates a
+    user-supplied set of switch IDs against that capable set. On failure, raises `RuntimeError` with a
+    single aggregate message naming the offending switches (`switch_ip` / `switch_name` / `model` when
+    `fabric_context` is injected).
+
+    The `(interface_type, mode)` taxonomy is captured experimentally (ND 4.2, 2026-05-11) and enforced
+    client-side before any API call — invalid combos raise `ValueError` without consuming a round trip.
+
+    ## Taxonomy (captured ND 4.2, 2026-05-11)
+
+    | interface_type | valid modes                                                              |
+    |----------------|--------------------------------------------------------------------------|
+    | `loopback`     | `managed`                                                                |
+    | `svi`          | `managed`                                                                |
+    | `tunnel`       | `managed`                                                                |
+    | `ethernet`     | `trunk`, `access`, `routed`, `fex`, `pvlan`, `dot1qTunnel`, `unmanaged`  |
+    | `portChannel`  | `trunk`, `access`, `routed`, `fex`, `pvlan`, `dot1qTunnel`, `unmanaged`  |
+
+    `vpc` interfaces use a separate endpoint (`/api/v1/manage/fabrics/{fabric}/vpcPairs?view=intendedPairs`)
+    and are handled by a sibling validator, not this class. `breakout` and `subinterface` have no
+    pre-check endpoint and are out of scope.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate` when one or more switch IDs are not in the capable set for `(interface_type, mode)`.
+    - Via `get_capable_switches` if the underlying GET request fails (other than 404).
+
+    ### ValueError
+
+    - Via any method that takes `(interface_type, mode)` when the pair is not in the supported taxonomy.
+    """
+
+    _TAXONOMY: ClassVar[dict[str, frozenset[str]]] = {
+        "loopback": frozenset({"managed"}),
+        "svi": frozenset({"managed"}),
+        "tunnel": frozenset({"managed"}),
+        "ethernet": frozenset({"trunk", "access", "routed", "fex", "pvlan", "dot1qTunnel", "unmanaged"}),
+        "portChannel": frozenset({"trunk", "access", "routed", "fex", "pvlan", "dot1qTunnel", "unmanaged"}),
+    }
+
+    def __init__(self, rest_send: RestSend, fabric_name: str, fabric_context: FabricContext | None = None):
+        """
+        # Summary
+
+        Initialize the preflight with a `RestSend` instance, fabric name, and optional `FabricContext` for error enrichment.
+
+        ## Parameters
+
+        - rest_send: configured `RestSend` (sender, response handler, params already wired).
+        - fabric_name: target fabric for the capability query.
+        - fabric_context: optional `FabricContext` used to enrich error messages with `switch_ip` / `switch_name` / `model`.
+
+        ## Raises
+
+        None
+        """
+        self._rest_send = rest_send
+        self._fabric_name = fabric_name
+        self._fabric_context = fabric_context
+        self._cache: dict[tuple[str, str], list[dict]] = {}
+
+    @classmethod
+    def supported_modes(cls, interface_type: str) -> frozenset[str]:
+        """
+        # Summary
+
+        Return the set of valid modes for a given `interface_type` from the taxonomy.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `interface_type` is not present in the taxonomy.
+        """
+        try:
+            return cls._TAXONOMY[interface_type]
+        except KeyError as e:
+            supported = ", ".join(sorted(cls._TAXONOMY))
+            raise ValueError(f"Unsupported interface_type '{interface_type}'. Supported interface types: {supported}.") from e
+
+    @classmethod
+    def _check_taxonomy(cls, interface_type: str, mode: str) -> None:
+        """
+        # Summary
+
+        Validate that `(interface_type, mode)` is a supported pair in the taxonomy. Raises before any API call.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `interface_type` is not in the taxonomy.
+        - If `mode` is not valid for the given `interface_type`.
+        """
+        valid_modes = cls.supported_modes(interface_type)
+        if mode not in valid_modes:
+            modes = ", ".join(sorted(valid_modes))
+            raise ValueError(f"Unsupported mode '{mode}' for interface_type '{interface_type}'. Supported modes: {modes}.")
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        # Summary
+
+        Return the fabric name this preflight was created for.
+
+        ## Raises
+
+        None
+        """
+        return self._fabric_name
+
+    def _query_get(self, path: str) -> dict:
+        """
+        # Summary
+
+        Issue a GET request via `RestSend` and return the `DATA` dict. Returns `{}` on HTTP 404.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the request fails with any non-success status other than 404.
+        """
+        self._rest_send.path = path
+        self._rest_send.verb = HttpVerbEnum.GET
+        self._rest_send.commit()
+        if self._rest_send.return_code == 404:
+            return {}
+        if not self._rest_send.success:
+            raise RuntimeError(f"GET {path} failed {self._rest_send.error_summary}")
+        return self._rest_send.response_current.get("DATA", {})
+
+    def get_capable_switches(self, interface_type: str, mode: str) -> list[dict]:
+        """
+        # Summary
+
+        Return the list of switch records capable of hosting `(interface_type, mode)` in this fabric. Each record contains
+        at least `switchId`, `switchName`, and `model`. Lazily fetched and cached per `(interface_type, mode)`.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `(interface_type, mode)` is not a supported pair in the taxonomy.
+
+        ### RuntimeError
+
+        - If the underlying GET request fails (other than 404).
+        """
+        self._check_taxonomy(interface_type, mode)
+        key = (interface_type, mode)
+        if key in self._cache:
+            return self._cache[key]
+        ep = EpManageFabricsCapableSwitchesGet()
+        ep.fabric_name = self._fabric_name
+        ep.endpoint_params.interface_type = interface_type
+        ep.endpoint_params.mode = mode
+        result = self._query_get(ep.path)
+        switches = (result.get("switches") or []) if result else []
+        self._cache[key] = switches
+        return switches
+
+    def get_capable_switch_ids(self, interface_type: str, mode: str) -> set[str]:
+        """
+        # Summary
+
+        Return the set of `switchId` values capable of hosting `(interface_type, mode)`. Derived from `get_capable_switches`.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `(interface_type, mode)` is not a supported pair in the taxonomy.
+
+        ### RuntimeError
+
+        - If the underlying GET request fails (other than 404).
+        """
+        return {sw["switchId"] for sw in self.get_capable_switches(interface_type, mode) if sw.get("switchId")}
+
+    def validate(self, interface_type: str, mode: str, switch_ids: set[str]) -> None:
+        """
+        # Summary
+
+        Verify that every `switch_id` in `switch_ids` is in the capable set for `(interface_type, mode)`. On failure, raise
+        `RuntimeError` with a single aggregate message naming the offending switches.
+
+        When `fabric_context` was injected at construction, the error message enriches each offender with its
+        `switch_ip`, `switch_name`, and `model`. When `fabric_context` is not available, the message names only the
+        offending `switchId` values.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `(interface_type, mode)` is not a supported pair in the taxonomy.
+
+        ### RuntimeError
+
+        - If one or more switches in `switch_ids` are not in the capable set for `(interface_type, mode)`.
+        - If the underlying GET request fails (other than 404).
+        """
+        capable_ids = self.get_capable_switch_ids(interface_type, mode)
+        offenders = {sid for sid in switch_ids if sid not in capable_ids}
+        if not offenders:
+            return
+
+        offender_descriptions: list[str] = []
+        for sid in sorted(offenders):
+            parts = [f"switchId={sid}"]
+            if self._fabric_context is not None:
+                switch_ip = self._fabric_context.switch_map_by_id.get(sid)
+                if switch_ip:
+                    parts.append(f"switch_ip={switch_ip}")
+            offender_descriptions.append("(" + ", ".join(parts) + ")")
+
+        endpoint_path = f"/api/v1/manage/fabrics/{self._fabric_name}/capableSwitches?interfaceType={interface_type}&mode={mode}"
+        raise RuntimeError(
+            f"The following switches are not capable of hosting interface_type='{interface_type}' "
+            f"mode='{mode}' in fabric '{self._fabric_name}': {', '.join(offender_descriptions)}. "
+            f"Verify via GET {endpoint_path}."
+        )
+
+    def invalidate(self) -> None:
+        """
+        # Summary
+
+        Drop all cached capability data so the next access re-fetches from the API.
+
+        ## Raises
+
+        None
+        """
+        self._cache.clear()

--- a/plugins/module_utils/interface_capability_preflight.py
+++ b/plugins/module_utils/interface_capability_preflight.py
@@ -169,6 +169,23 @@ class InterfaceCapabilityPreflight:
             raise RuntimeError(f"GET {path} failed {self._rest_send.error_summary}")
         return self._rest_send.response_current.get("DATA", {})
 
+    def _build_endpoint(self, interface_type: str, mode: str) -> EpManageFabricsCapableSwitchesGet:
+        """
+        # Summary
+
+        Build a populated `EpManageFabricsCapableSwitchesGet` for `(interface_type, mode)` in this fabric. Single source of
+        truth for the `capableSwitches` URL — used both for the live request and for the verification hint in error messages.
+
+        ## Raises
+
+        None
+        """
+        ep = EpManageFabricsCapableSwitchesGet()
+        ep.fabric_name = self._fabric_name
+        ep.endpoint_params.interface_type = interface_type
+        ep.endpoint_params.mode = mode
+        return ep
+
     def get_capable_switches(self, interface_type: str, mode: str) -> list[dict]:
         """
         # Summary
@@ -190,11 +207,7 @@ class InterfaceCapabilityPreflight:
         key = (interface_type, mode)
         if key in self._cache:
             return self._cache[key]
-        ep = EpManageFabricsCapableSwitchesGet()
-        ep.fabric_name = self._fabric_name
-        ep.endpoint_params.interface_type = interface_type
-        ep.endpoint_params.mode = mode
-        result = self._query_get(ep.path)
+        result = self._query_get(self._build_endpoint(interface_type, mode).path)
         switches = (result.get("switches") or []) if result else []
         self._cache[key] = switches
         return switches
@@ -258,7 +271,7 @@ class InterfaceCapabilityPreflight:
                     parts.append(f"switch_ip={switch_ip}")
             offender_descriptions.append("(" + ", ".join(parts) + ")")
 
-        endpoint_path = f"/api/v1/manage/fabrics/{self._fabric_name}/capableSwitches?interfaceType={interface_type}&mode={mode}"
+        endpoint_path = self._build_endpoint(interface_type, mode).path
         raise RuntimeError(
             f"The following switches are not capable of hosting interface_type='{interface_type}' "
             f"mode='{mode}' in fabric '{self._fabric_name}': {', '.join(offender_descriptions)}. "

--- a/plugins/module_utils/interface_capability_preflight.py
+++ b/plugins/module_utils/interface_capability_preflight.py
@@ -95,6 +95,7 @@ class InterfaceCapabilityPreflight:
         self._fabric_name = fabric_name
         self._fabric_context = fabric_context
         self._cache: dict[tuple[str, str], list[dict]] = {}
+        self._id_cache: dict[tuple[str, str], set[str]] = {}
 
     @classmethod
     def supported_modes(cls, interface_type: str) -> frozenset[str]:
@@ -214,7 +215,12 @@ class InterfaceCapabilityPreflight:
 
         - If the underlying GET request fails (other than 404).
         """
-        return {sw["switchId"] for sw in self.get_capable_switches(interface_type, mode) if sw.get("switchId")}
+        key = (interface_type, mode)
+        if key in self._id_cache:
+            return self._id_cache[key]
+        switch_ids = {sw["switchId"] for sw in self.get_capable_switches(interface_type, mode) if sw.get("switchId")}
+        self._id_cache[key] = switch_ids
+        return switch_ids
 
     def validate(self, interface_type: str, mode: str, switch_ids: set[str]) -> None:
         """
@@ -270,3 +276,4 @@ class InterfaceCapabilityPreflight:
         None
         """
         self._cache.clear()
+        self._id_cache.clear()

--- a/plugins/module_utils/interface_capability_preflight.py
+++ b/plugins/module_utils/interface_capability_preflight.py
@@ -208,7 +208,7 @@ class InterfaceCapabilityPreflight:
         if key in self._cache:
             return self._cache[key]
         result = self._query_get(self._build_endpoint(interface_type, mode).path)
-        switches = (result.get("switches") or []) if result else []
+        switches = result.get("switches") or []
         self._cache[key] = switches
         return switches
 
@@ -265,6 +265,8 @@ class InterfaceCapabilityPreflight:
         for sid in sorted(offenders):
             parts = [f"switchId={sid}"]
             if self._fabric_context is not None:
+                # Soft lookup: FabricContext.get_switch_ip() raises on miss; here a missing IP should
+                # only yield a less-detailed message, not mask the capability error being reported.
                 switch_ip = self._fabric_context.switch_map_by_id.get(sid)
                 if switch_ip:
                     parts.append(f"switch_ip={switch_ip}")

--- a/plugins/module_utils/interface_capability_preflight.py
+++ b/plugins/module_utils/interface_capability_preflight.py
@@ -16,6 +16,7 @@ endpoint. See GitHub issue #273 for stability/risk discussion.
 
 from __future__ import annotations
 
+import copy
 from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_capable_switches import (
@@ -201,7 +202,7 @@ class InterfaceCapabilityPreflight:
 
         Return the list of switch records capable of hosting `(interface_type, mode)` in this fabric. Each record contains
         at least `switchId`, `switchName`, and `model`. Lazily fetched and cached per `(interface_type, mode)`. Returns a
-        fresh list per call; callers may mutate the returned list without affecting cached state.
+        deep copy per call; callers may mutate the returned list *and its record dicts* without affecting cached state.
 
         ## Raises
 
@@ -218,7 +219,10 @@ class InterfaceCapabilityPreflight:
         if key not in self._cache:
             result = self._query_get(self._build_endpoint(interface_type, mode).path)
             self._cache[key] = result.get("switches") or []
-        return list(self._cache[key])
+        # Deep copy so callers can mutate returned records without corrupting the cache. A shallow
+        # list() copy would still share the record dicts by reference, letting a caller alter
+        # cached switchId/switchName/model (and so the derived id cache built later).
+        return copy.deepcopy(self._cache[key])
 
     def get_capable_switch_ids(self, interface_type: str, mode: str) -> set[str]:
         """

--- a/plugins/module_utils/interface_capability_preflight.py
+++ b/plugins/module_utils/interface_capability_preflight.py
@@ -35,8 +35,8 @@ class InterfaceCapabilityPreflight:
     Lazily fetches the set of switches capable of hosting a given `(interface_type, mode)` pair from
     the ND Manage `capableSwitches` endpoint, caches by `(interface_type, mode)`, and validates a
     user-supplied set of switch IDs against that capable set. On failure, raises `RuntimeError` with a
-    single aggregate message naming the offending switches (`switch_ip` / `switch_name` / `model` when
-    `fabric_context` is injected).
+    single aggregate message naming the offending switches (enriched with `switch_ip` when `fabric_context`
+    is injected).
 
     The `(interface_type, mode)` taxonomy is captured experimentally (ND 4.2, 2026-05-11) and enforced
     client-side before any API call — invalid combos raise `ValueError` without consuming a round trip.
@@ -85,7 +85,7 @@ class InterfaceCapabilityPreflight:
 
         - rest_send: configured `RestSend` (sender, response handler, params already wired).
         - fabric_name: target fabric for the capability query.
-        - fabric_context: optional `FabricContext` used to enrich error messages with `switch_ip` / `switch_name` / `model`.
+        - fabric_context: optional `FabricContext` used to enrich error messages with each offending switch's `switch_ip`.
 
         ## Raises
 
@@ -243,8 +243,7 @@ class InterfaceCapabilityPreflight:
         `RuntimeError` with a single aggregate message naming the offending switches.
 
         When `fabric_context` was injected at construction, the error message enriches each offender with its
-        `switch_ip`, `switch_name`, and `model`. When `fabric_context` is not available, the message names only the
-        offending `switchId` values.
+        `switch_ip`. When `fabric_context` is not available, the message names only the offending `switchId` values.
 
         ## Raises
 

--- a/plugins/module_utils/interface_capability_preflight.py
+++ b/plugins/module_utils/interface_capability_preflight.py
@@ -60,7 +60,7 @@ class InterfaceCapabilityPreflight:
     ### RuntimeError
 
     - Via `validate` when one or more switch IDs are not in the capable set for `(interface_type, mode)`.
-    - Via `get_capable_switches` if the underlying GET request fails (other than 404).
+    - Via `get_capable_switches` if the underlying GET request fails.
 
     ### ValueError
 
@@ -152,21 +152,30 @@ class InterfaceCapabilityPreflight:
         """
         # Summary
 
-        Issue a GET request via `RestSend` and return the `DATA` dict. Returns `{}` on HTTP 404.
+        Issue a GET request via `RestSend` and return the `DATA` dict.
 
         ## Raises
 
         ### RuntimeError
 
-        - If the request fails with any non-success status other than 404.
+        - If the request fails with any non-success status, including 404. A 404 here is treated
+          as a hard failure rather than an empty result, because the unpublished `capableSwitches`
+          endpoint may move or be removed in a future ND release (see issue #273); silently caching
+          an empty capable set would mislabel every requested switch as "not capable".
         """
         self._rest_send.path = path
         self._rest_send.verb = HttpVerbEnum.GET
         self._rest_send.commit()
-        if self._rest_send.return_code == 404:
-            return {}
-        if not self._rest_send.success:
-            raise RuntimeError(f"GET {path} failed {self._rest_send.error_summary}")
+        # ResponseHandler treats 404 GETs as success=True, so check return_code explicitly.
+        # A 404 here means the endpoint is gone or the fabric_name is wrong; either way we
+        # must raise rather than caching an empty capable set that would mislabel every
+        # requested switch as "not capable".
+        if not self._rest_send.success or self._rest_send.return_code == 404:
+            raise RuntimeError(
+                f"GET {path} failed {self._rest_send.error_summary}. "
+                "The capableSwitches endpoint is unpublished and may be unavailable on this "
+                "ND release; see GitHub issue #273."
+            )
         return self._rest_send.response_current.get("DATA", {})
 
     def _build_endpoint(self, interface_type: str, mode: str) -> EpManageFabricsCapableSwitchesGet:
@@ -191,7 +200,8 @@ class InterfaceCapabilityPreflight:
         # Summary
 
         Return the list of switch records capable of hosting `(interface_type, mode)` in this fabric. Each record contains
-        at least `switchId`, `switchName`, and `model`. Lazily fetched and cached per `(interface_type, mode)`.
+        at least `switchId`, `switchName`, and `model`. Lazily fetched and cached per `(interface_type, mode)`. Returns a
+        fresh list per call; callers may mutate the returned list without affecting cached state.
 
         ## Raises
 
@@ -201,22 +211,21 @@ class InterfaceCapabilityPreflight:
 
         ### RuntimeError
 
-        - If the underlying GET request fails (other than 404).
+        - If the underlying GET request fails.
         """
         self._check_taxonomy(interface_type, mode)
         key = (interface_type, mode)
-        if key in self._cache:
-            return self._cache[key]
-        result = self._query_get(self._build_endpoint(interface_type, mode).path)
-        switches = result.get("switches") or []
-        self._cache[key] = switches
-        return switches
+        if key not in self._cache:
+            result = self._query_get(self._build_endpoint(interface_type, mode).path)
+            self._cache[key] = result.get("switches") or []
+        return list(self._cache[key])
 
     def get_capable_switch_ids(self, interface_type: str, mode: str) -> set[str]:
         """
         # Summary
 
         Return the set of `switchId` values capable of hosting `(interface_type, mode)`. Derived from `get_capable_switches`.
+        Returns a fresh set per call; callers may mutate the returned set without affecting cached state.
 
         ## Raises
 
@@ -226,14 +235,12 @@ class InterfaceCapabilityPreflight:
 
         ### RuntimeError
 
-        - If the underlying GET request fails (other than 404).
+        - If the underlying GET request fails.
         """
         key = (interface_type, mode)
-        if key in self._id_cache:
-            return self._id_cache[key]
-        switch_ids = {sw["switchId"] for sw in self.get_capable_switches(interface_type, mode) if sw.get("switchId")}
-        self._id_cache[key] = switch_ids
-        return switch_ids
+        if key not in self._id_cache:
+            self._id_cache[key] = {sw["switchId"] for sw in self.get_capable_switches(interface_type, mode) if sw.get("switchId")}
+        return set(self._id_cache[key])
 
     def validate(self, interface_type: str, mode: str, switch_ids: set[str]) -> None:
         """

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -6,6 +6,7 @@
 from __future__ import absolute_import, annotations, division, print_function
 
 from typing import Any, Callable
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
@@ -88,12 +89,17 @@ class NDStateMachine:
         Manage state according to desired configuration.
         """
         if self.state in ["merged", "replaced", "overridden"]:
+            # Capability preflight runs here -- before _manage_create_update_state, whose mutations are
+            # skipped in check mode -- so dry-runs surface incapable switches (PR #275 / issue #273).
+            self.model_orchestrator.preflight(list(self.proposed))
             self._manage_create_update_state()
 
             if self.state == "overridden":
                 self._manage_override_deletions()
 
         elif self.state == "deleted":
+            # Capability preflight intentionally NOT run for deletes: removing configuration does not
+            # depend on a switch's capability to host the interface type (PR #275 scope decision).
             self._manage_delete_state()
 
         else:

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, annotations, division, print_function
 
+from collections.abc import Sequence
 from functools import wraps
 from typing import Any, ClassVar, Dict, Generic, Optional, TypeVar
 
@@ -117,6 +118,20 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
             raise Exception(f"Request failed {self.rest_send.error_summary}")
 
         return self.rest_send.response_current.get("DATA", {})
+
+    def preflight(self, model_instances: Sequence[ModelType]) -> None:
+        """
+        # Summary
+
+        Pre-mutation hook invoked by `NDStateMachine` before create/update operations — which are skipped in check
+        mode — so subclasses can validate the proposed set during a dry-run. Base implementation is a no-op;
+        interface orchestrators override to run capability preflight.
+
+        ## Raises
+
+        None
+        """
+        return
 
     # NOTE: Generic CRUD API operations for simple endpoints with single identifier (e.g. "api/v1/infra/aaa/LocalUsers/{loginID}")
     def create(self, model_instance: ModelType, **kwargs) -> ResponseType:

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -16,7 +16,6 @@ with interface-type-specific payload construction and query filtering.
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Iterable
 from typing import ClassVar
 
@@ -55,9 +54,11 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
     deploy: bool = True
 
-    # Subclasses override to enable capability preflight (e.g. `interface_type: ClassVar[str] = "loopback"`).
-    # An empty string opts out — used by interface types with no capability endpoint (e.g. future breakout).
+    # Subclasses opt in to capability preflight by setting BOTH ClassVars (e.g. loopback sets
+    # `interface_type = "loopback"` and `interface_mode = "managed"`). Leaving `interface_type` as ""
+    # opts out — used by interface types with no capability endpoint (e.g. future breakout).
     interface_type: ClassVar[str] = ""
+    interface_mode: ClassVar[str] = ""
 
     _fabric_context: FabricContext | None = None
     _capability_preflight: InterfaceCapabilityPreflight | None = None
@@ -138,59 +139,36 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
             )
         return self._capability_preflight
 
-    def _resolve_mode(self, model_instance: ModelType) -> str:
-        """
-        # Summary
-
-        Return the `mode` string for a model instance, used to key the capability preflight cache. Defaults to
-        `model_instance.mode`. Subclasses override only when the model has no `mode` attribute or the mapping is non-trivial.
-
-        ## Raises
-
-        ### AttributeError
-
-        - If the model has no `mode` attribute and the subclass has not overridden this method.
-        """
-        # getattr (not direct access): ModelType is bound to NDBaseModel, which has no `mode`. The
-        # attribute is duck-typed -- present on most interface models, absent on some (e.g. loopback).
-        return getattr(model_instance, "mode")
-
     def validate_switches_capable(self, model_instances: Iterable[ModelType]) -> None:
         """
         # Summary
 
         Pre-flight the set of target switches against the ND `capableSwitches` endpoint for this orchestrator's
-        `interface_type` and the per-instance `mode`. Groups instances by `(interface_type, mode)` so a single GET covers
-        all instances sharing the same pair. On failure, raises a single aggregate `RuntimeError` naming every offending
-        switch across all groups.
+        `interface_type` and `interface_mode` ClassVars. A single GET covers every target switch. On failure, raises a
+        `RuntimeError` naming every offending switch.
 
         When `interface_type` is `""` (default on the base class) this method is a no-op — subclasses opt in by setting
-        the `ClassVar`.
+        both the `interface_type` and `interface_mode` ClassVars.
 
         ## Raises
 
         ### RuntimeError
 
-        - If one or more switches are not capable of hosting the requested `(interface_type, mode)` pair.
+        - If one or more switches are not capable of hosting the requested `(interface_type, interface_mode)` pair.
+        - If the orchestrator sets `interface_type` but leaves `interface_mode` empty.
         - If no switch matches a given `switch_ip` in the fabric.
         - If the underlying capability GET request fails.
         """
         if not self.interface_type:
             return
-        groups: dict[tuple[str, str], set[str]] = defaultdict(set)
-        for model_instance in model_instances:
-            mode = self._resolve_mode(model_instance)
-            switch_id = self._resolve_switch_id(model_instance.switch_ip)
-            groups[(self.interface_type, mode)].add(switch_id)
-
-        errors: list[str] = []
-        for (interface_type, mode), switch_ids in groups.items():
-            try:
-                self.capability_preflight.validate(interface_type, mode, switch_ids)
-            except RuntimeError as e:
-                errors.append(str(e))
-        if errors:
-            raise RuntimeError(" | ".join(errors))
+        if not self.interface_mode:
+            raise RuntimeError(
+                f"{type(self).__name__} sets interface_type but not interface_mode; both ClassVars are required to enable capability preflight."
+            )
+        switch_ids = {self._resolve_switch_id(model_instance.switch_ip) for model_instance in model_instances}
+        if not switch_ids:
+            return
+        self.capability_preflight.validate(self.interface_type, self.interface_mode, switch_ids)
 
     def validate_prerequisites(self) -> None:
         """

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -154,14 +154,20 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         `RuntimeError` names every unknown IP so a typo on one entry does not mask resolution or capability problems on
         the remaining entries (issue #301).
 
+        In `--check` mode the capability GET is still issued, but a failure of the capability check itself — whether an
+        endpoint outage or one or more incapable switches — is downgraded to a warning rather than re-raised, so dry-runs
+        stay green when the unpublished endpoint is unavailable (issue #302). Unresolvable `switch_ip` values are always
+        raised, including in check mode, because they reflect user input errors rather than environmental flakiness.
+
         ## Raises
 
         ### RuntimeError
 
-        - If one or more switches are not capable of hosting the requested `(interface_type, interface_mode)` pair.
+        - If one or more switches are not capable of hosting the requested `(interface_type, interface_mode)` pair
+          (outside `--check` mode).
         - If the orchestrator sets `interface_type` but leaves `interface_mode` empty.
         - If one or more `switch_ip` values do not match any switch in the fabric (aggregated into a single message).
-        - If the underlying capability GET request fails.
+        - If the underlying capability GET request fails (outside `--check` mode).
         """
         if not self.interface_type:
             return
@@ -181,7 +187,25 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
             raise RuntimeError(f"Cannot resolve switch_ip to switchId in fabric '{self.fabric_name}' for: {', '.join(sorted(set(unresolved)))}.")
         if not switch_ids:
             return
-        self.capability_preflight.validate(self.interface_type, self.interface_mode, switch_ids)
+        try:
+            self.capability_preflight.validate(self.interface_type, self.interface_mode, switch_ids)
+        except RuntimeError as e:
+            if not self.rest_send.check_mode:
+                raise
+            self._warn(f"Capability preflight skipped in check mode: {e}")
+
+    def _warn(self, message: str) -> None:
+        """
+        # Summary
+
+        Emit a warning through the underlying `AnsibleModule` so it surfaces in `ansible-playbook` output. Used to soften
+        non-fatal preflight failures (see `validate_switches_capable`) without converting them into module errors.
+
+        ## Raises
+
+        None
+        """
+        self.rest_send.sender.ansible_module.warn(message)  # type: ignore[attr-defined]
 
     def validate_prerequisites(self) -> None:
         """

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -16,7 +16,7 @@ with interface-type-specific payload construction and query filtering.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Sequence
 from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
@@ -139,7 +139,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
             )
         return self._capability_preflight
 
-    def validate_switches_capable(self, model_instances: Iterable[ModelType]) -> None:
+    def validate_switches_capable(self, model_instances: Sequence[ModelType]) -> None:
         """
         # Summary
 

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -139,6 +139,23 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
             )
         return self._capability_preflight
 
+    def preflight(self, model_instances: Sequence[ModelType]) -> None:
+        """
+        # Summary
+
+        Run capability preflight for the proposed interfaces. Delegates to `validate_switches_capable`, which is a
+        no-op unless the orchestrator opts in via the `interface_type`/`interface_mode` ClassVars. Invoked by
+        `NDStateMachine.manage_state` before create/update operations so the check runs in `--check` mode, where the
+        underlying mutations are skipped.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Propagated from `validate_switches_capable` (see its docstring).
+        """
+        self.validate_switches_capable(model_instances)
+
     def validate_switches_capable(self, model_instances: Sequence[ModelType]) -> None:
         """
         # Summary

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -16,11 +16,15 @@ with interface-type-specific payload construction and query filtering.
 
 from __future__ import annotations
 
+from collections import defaultdict
+from typing import ClassVar, Iterable
+
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesDeploy,
     EpManageInterfacesRemove,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.interface_capability_preflight import InterfaceCapabilityPreflight
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import ModelType, NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
@@ -50,7 +54,12 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
     deploy: bool = True
 
+    # Subclasses override to enable capability preflight (e.g. `interface_type: ClassVar[str] = "loopback"`).
+    # An empty string opts out — used by interface types with no capability endpoint (e.g. future breakout).
+    interface_type: ClassVar[str] = ""
+
     _fabric_context: FabricContext | None = None
+    _capability_preflight: InterfaceCapabilityPreflight | None = None
 
     def model_post_init(self, __context) -> None:
         """
@@ -107,6 +116,78 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         - If no switch matches the given IP in the fabric.
         """
         return self.fabric_context.get_switch_id(switch_ip)
+
+    @property
+    def capability_preflight(self) -> InterfaceCapabilityPreflight:
+        """
+        # Summary
+
+        Return a lazily-initialized `InterfaceCapabilityPreflight` for this orchestrator's fabric. Shares the orchestrator's
+        `FabricContext` so error messages for incapable switches are enriched with `switch_ip`.
+
+        ## Raises
+
+        None
+        """
+        if self._capability_preflight is None:
+            self._capability_preflight = InterfaceCapabilityPreflight(
+                rest_send=self.rest_send,
+                fabric_name=self.fabric_name,
+                fabric_context=self.fabric_context,
+            )
+        return self._capability_preflight
+
+    def _resolve_mode(self, model_instance: ModelType) -> str:
+        """
+        # Summary
+
+        Return the `mode` string for a model instance, used to key the capability preflight cache. Defaults to
+        `model_instance.mode`. Subclasses override only when the model has no `mode` attribute or the mapping is non-trivial.
+
+        ## Raises
+
+        ### AttributeError
+
+        - If the model has no `mode` attribute and the subclass has not overridden this method.
+        """
+        return getattr(model_instance, "mode")
+
+    def validate_switches_capable(self, model_instances: Iterable[ModelType]) -> None:
+        """
+        # Summary
+
+        Pre-flight the set of target switches against the ND `capableSwitches` endpoint for this orchestrator's
+        `interface_type` and the per-instance `mode`. Groups instances by `(interface_type, mode)` so a single GET covers
+        all instances sharing the same pair. On failure, raises a single aggregate `RuntimeError` naming every offending
+        switch across all groups.
+
+        When `interface_type` is `""` (default on the base class) this method is a no-op — subclasses opt in by setting
+        the `ClassVar`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If one or more switches are not capable of hosting the requested `(interface_type, mode)` pair.
+        - If no switch matches a given `switch_ip` in the fabric.
+        - If the underlying capability GET request fails.
+        """
+        if not self.interface_type:
+            return
+        groups: dict[tuple[str, str], set[str]] = defaultdict(set)
+        for model_instance in model_instances:
+            mode = self._resolve_mode(model_instance)
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            groups[(self.interface_type, mode)].add(switch_id)
+
+        errors: list[str] = []
+        for (interface_type, mode), switch_ids in groups.items():
+            try:
+                self.capability_preflight.validate(interface_type, mode, switch_ids)
+            except RuntimeError as e:
+                errors.append(str(e))
+        if errors:
+            raise RuntimeError(" | ".join(errors))
 
     def validate_prerequisites(self) -> None:
         """

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -150,13 +150,17 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         When `interface_type` is `""` (default on the base class) this method is a no-op — subclasses opt in by setting
         both the `interface_type` and `interface_mode` ClassVars.
 
+        All `switch_ip` values are resolved before the capability check runs; if any are unresolvable, a single aggregate
+        `RuntimeError` names every unknown IP so a typo on one entry does not mask resolution or capability problems on
+        the remaining entries (issue #301).
+
         ## Raises
 
         ### RuntimeError
 
         - If one or more switches are not capable of hosting the requested `(interface_type, interface_mode)` pair.
         - If the orchestrator sets `interface_type` but leaves `interface_mode` empty.
-        - If no switch matches a given `switch_ip` in the fabric.
+        - If one or more `switch_ip` values do not match any switch in the fabric (aggregated into a single message).
         - If the underlying capability GET request fails.
         """
         if not self.interface_type:
@@ -165,7 +169,16 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
             raise RuntimeError(
                 f"{type(self).__name__} sets interface_type but not interface_mode; both ClassVars are required to enable capability preflight."
             )
-        switch_ids = {self._resolve_switch_id(model_instance.switch_ip) for model_instance in model_instances}
+        switch_ids: set[str] = set()
+        unresolved: list[str] = []
+        for model_instance in model_instances:
+            switch_ip = model_instance.switch_ip
+            try:
+                switch_ids.add(self._resolve_switch_id(switch_ip))
+            except RuntimeError:
+                unresolved.append(switch_ip)
+        if unresolved:
+            raise RuntimeError(f"Cannot resolve switch_ip to switchId in fabric '{self.fabric_name}' for: {', '.join(sorted(set(unresolved)))}.")
         if not switch_ids:
             return
         self.capability_preflight.validate(self.interface_type, self.interface_mode, switch_ids)

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -17,7 +17,8 @@ with interface-type-specific payload construction and query filtering.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import ClassVar, Iterable
+from collections.abc import Iterable
+from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesDeploy,
@@ -150,6 +151,8 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         - If the model has no `mode` attribute and the subclass has not overridden this method.
         """
+        # getattr (not direct access): ModelType is bound to NDBaseModel, which has no `mode`. The
+        # attribute is duck-typed -- present on most interface models, absent on some (e.g. loopback).
         return getattr(model_instance, "mode")
 
     def validate_switches_capable(self, model_instances: Iterable[ModelType]) -> None:

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -198,14 +198,15 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         """
         # Summary
 
-        Emit a warning through the underlying `AnsibleModule` so it surfaces in `ansible-playbook` output. Used to soften
-        non-fatal preflight failures (see `validate_switches_capable`) without converting them into module errors.
+        Emit a warning through `RestSend.warn`, which routes to the underlying `AnsibleModule.warn` so it surfaces in
+        `ansible-playbook` output. Used to soften non-fatal preflight failures (see `validate_switches_capable`) without
+        converting them into module errors.
 
         ## Raises
 
         None
         """
-        self.rest_send.sender.ansible_module.warn(message)  # type: ignore[attr-defined]
+        self.rest_send.warn(message)
 
     def validate_prerequisites(self) -> None:
         """

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -192,21 +192,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         except RuntimeError as e:
             if not self.rest_send.check_mode:
                 raise
-            self._warn(f"Capability preflight skipped in check mode: {e}")
-
-    def _warn(self, message: str) -> None:
-        """
-        # Summary
-
-        Emit a warning through `RestSend.warn`, which routes to the underlying `AnsibleModule.warn` so it surfaces in
-        `ansible-playbook` output. Used to soften non-fatal preflight failures (see `validate_switches_capable`) without
-        converting them into module errors.
-
-        ## Raises
-
-        None
-        """
-        self.rest_send.warn(message)
+            self.rest_send.warn(f"Capability preflight skipped in check mode: {e}")
 
     def validate_prerequisites(self) -> None:
         """

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -99,7 +99,6 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         - If the create API request fails.
         """
         try:
-            self.validate_switches_capable([model_instance])
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
             payload = model_instance.to_payload()
@@ -125,7 +124,6 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         - If the update API request fails.
         """
         try:
-            self.validate_switches_capable([model_instance])
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
             api_endpoint.set_identifiers(model_instance.interface_name)
@@ -169,7 +167,6 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         - If any create API request fails.
         """
         try:
-            self.validate_switches_capable(model_instances)
             groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
             for model_instance in model_instances:
                 switch_id = self._resolve_switch_id(model_instance.switch_ip)

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -74,6 +74,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     model_class: ClassVar[type[NDBaseModel]] = LoopbackInterfaceModel
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
+    interface_type: ClassVar[str] = "loopback"
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -82,6 +83,19 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
     create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
     delete_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesRemove
+
+    def _resolve_mode(self, model_instance: LoopbackInterfaceModel) -> str:
+        """
+        # Summary
+
+        Return the capability-preflight mode for a loopback interface. `LoopbackInterfaceModel` has no top-level `mode`
+        field -- `mode` is hardcoded to `managed` on the nested `LoopbackConfigDataModel` -- so this always returns `managed`.
+
+        ## Raises
+
+        None
+        """
+        return "managed"
 
     def create(self, model_instance: LoopbackInterfaceModel, **kwargs) -> ResponseType:
         """
@@ -97,6 +111,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         - If the create API request fails.
         """
         try:
+            self.validate_switches_capable([model_instance])
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
             payload = model_instance.to_payload()
@@ -122,6 +137,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         - If the update API request fails.
         """
         try:
+            self.validate_switches_capable([model_instance])
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
             api_endpoint.set_identifiers(model_instance.interface_name)
@@ -165,6 +181,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         - If any create API request fails.
         """
         try:
+            self.validate_switches_capable(model_instances)
             groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
             for model_instance in model_instances:
                 switch_id = self._resolve_switch_id(model_instance.switch_ip)

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -75,6 +75,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
     interface_type: ClassVar[str] = "loopback"
+    interface_mode: ClassVar[str] = "managed"
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -83,19 +84,6 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
     create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
     delete_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesRemove
-
-    def _resolve_mode(self, model_instance: LoopbackInterfaceModel) -> str:
-        """
-        # Summary
-
-        Return the capability-preflight mode for a loopback interface. `LoopbackInterfaceModel` has no top-level `mode`
-        field -- `mode` is hardcoded to `managed` on the nested `LoopbackConfigDataModel` -- so this always returns `managed`.
-
-        ## Raises
-
-        None
-        """
-        return "managed"
 
     def create(self, model_instance: LoopbackInterfaceModel, **kwargs) -> ResponseType:
         """

--- a/plugins/module_utils/rest/rest_send.py
+++ b/plugins/module_utils/rest/rest_send.py
@@ -24,7 +24,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.rest.protocols.sender imp
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
 
-class RestSend:
+class RestSend:  # pylint: disable=too-many-public-methods
     """
     # Summary
 
@@ -195,6 +195,22 @@ class RestSend:
             self.saved_check_mode = self.check_mode
         if self.timeout is not None:
             self.saved_timeout = self.timeout
+
+    def warn(self, message: str) -> None:
+        """
+        # Summary
+
+        Emit a user-visible warning through the underlying `AnsibleModule`. Used by orchestrators to surface non-fatal
+        preflight failures (e.g. capability preflight in check mode) without converting them into module errors.
+
+        Encapsulates the `sender.ansible_module.warn(...)` reach so callers don't need to know about the sender's
+        internals; one localized `# type: ignore` here keeps the orchestrator call sites clean.
+
+        ## Raises
+
+        None
+        """
+        self.sender.ansible_module.warn(message)  # type: ignore[attr-defined]
 
     def commit(self) -> None:
         """

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_capable_switches.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_capable_switches.py
@@ -1,0 +1,236 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel) <arobel@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for manage_fabric_capable_switches.py
+
+Tests the ND Manage Fabrics capableSwitches endpoint classes.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_capable_switches import (
+    CapableSwitchesEndpointParams,
+    EpManageFabricsCapableSwitchesGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+
+# =============================================================================
+# Test: CapableSwitchesEndpointParams
+# =============================================================================
+
+
+def test_endpoints_api_v1_manage_fabric_capable_switches_00010():
+    """
+    # Summary
+
+    Verify `CapableSwitchesEndpointParams` defaults all fields to None and produces an empty query string.
+
+    ## Test
+
+    - Instance can be created with no arguments
+    - interface_type and mode default to None
+    - to_query_string() returns ""
+    - is_empty() returns True
+
+    ## Classes and Methods
+
+    - CapableSwitchesEndpointParams.__init__()
+    - CapableSwitchesEndpointParams.to_query_string()
+    - CapableSwitchesEndpointParams.is_empty()
+    """
+    with does_not_raise():
+        instance = CapableSwitchesEndpointParams()
+    assert instance.interface_type is None
+    assert instance.mode is None
+    assert instance.to_query_string() == ""
+    assert instance.is_empty() is True
+
+
+def test_endpoints_api_v1_manage_fabric_capable_switches_00020():
+    """
+    # Summary
+
+    Verify `CapableSwitchesEndpointParams` snake_case fields convert to camelCase in the query string.
+
+    ## Test
+
+    - interface_type="loopback" and mode="managed" -> "interfaceType=loopback&mode=managed"
+
+    ## Classes and Methods
+
+    - CapableSwitchesEndpointParams.to_query_string()
+    """
+    with does_not_raise():
+        instance = CapableSwitchesEndpointParams(interface_type="loopback", mode="managed")
+        result = instance.to_query_string()
+    assert result == "interfaceType=loopback&mode=managed"
+
+
+def test_endpoints_api_v1_manage_fabric_capable_switches_00030():
+    """
+    # Summary
+
+    Verify `CapableSwitchesEndpointParams` preserves camelCase values verbatim (e.g. `dot1qTunnel`) in the query string.
+
+    ## Test
+
+    - interface_type="portChannel" and mode="dot1qTunnel" -> "interfaceType=portChannel&mode=dot1qTunnel"
+
+    ## Classes and Methods
+
+    - CapableSwitchesEndpointParams.to_query_string()
+    """
+    with does_not_raise():
+        instance = CapableSwitchesEndpointParams(interface_type="portChannel", mode="dot1qTunnel")
+        result = instance.to_query_string()
+    assert result == "interfaceType=portChannel&mode=dot1qTunnel"
+
+
+# =============================================================================
+# Test: EpManageFabricsCapableSwitchesGet
+# =============================================================================
+
+
+def test_endpoints_api_v1_manage_fabric_capable_switches_00100():
+    """
+    # Summary
+
+    Verify `EpManageFabricsCapableSwitchesGet` basic instantiation.
+
+    ## Test
+
+    - Instance can be created
+    - class_name is set correctly
+    - verb is GET
+    - fabric_name, interface_type, and mode default to None
+
+    ## Classes and Methods
+
+    - EpManageFabricsCapableSwitchesGet.__init__()
+    - EpManageFabricsCapableSwitchesGet.verb
+    - EpManageFabricsCapableSwitchesGet.class_name
+    """
+    with does_not_raise():
+        instance = EpManageFabricsCapableSwitchesGet()
+    assert instance.class_name == "EpManageFabricsCapableSwitchesGet"
+    assert instance.verb == HttpVerbEnum.GET
+    assert instance.fabric_name is None
+    assert instance.endpoint_params.interface_type is None
+    assert instance.endpoint_params.mode is None
+
+
+def test_endpoints_api_v1_manage_fabric_capable_switches_00110():
+    """
+    # Summary
+
+    Verify `EpManageFabricsCapableSwitchesGet.path` builds the correct URL when all required values are set.
+
+    ## Test
+
+    - fabric_name, interface_type, and mode all set -> path is "/api/v1/manage/fabrics/{fabric}/capableSwitches?interfaceType={t}&mode={m}"
+
+    ## Classes and Methods
+
+    - EpManageFabricsCapableSwitchesGet.path
+    """
+    with does_not_raise():
+        instance = EpManageFabricsCapableSwitchesGet()
+        instance.fabric_name = "fabric_1"
+        instance.endpoint_params.interface_type = "loopback"
+        instance.endpoint_params.mode = "managed"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed"
+
+
+def test_endpoints_api_v1_manage_fabric_capable_switches_00120():
+    """
+    # Summary
+
+    Verify `EpManageFabricsCapableSwitchesGet.path` raises ValueError when fabric_name is not set.
+
+    ## Test
+
+    - interface_type and mode set, fabric_name not set -> ValueError mentioning fabric_name
+
+    ## Classes and Methods
+
+    - EpManageFabricsCapableSwitchesGet.path
+    """
+    instance = EpManageFabricsCapableSwitchesGet()
+    instance.endpoint_params.interface_type = "loopback"
+    instance.endpoint_params.mode = "managed"
+    match = r"fabric_name must be set"
+    with pytest.raises(ValueError, match=match):
+        result = instance.path  # pylint: disable=pointless-statement  # noqa: F841
+
+
+def test_endpoints_api_v1_manage_fabric_capable_switches_00130():
+    """
+    # Summary
+
+    Verify `EpManageFabricsCapableSwitchesGet.path` raises ValueError when interface_type is not set.
+
+    ## Test
+
+    - fabric_name and mode set, interface_type not set -> ValueError mentioning interface_type
+
+    ## Classes and Methods
+
+    - EpManageFabricsCapableSwitchesGet.path
+    """
+    instance = EpManageFabricsCapableSwitchesGet()
+    instance.fabric_name = "fabric_1"
+    instance.endpoint_params.mode = "managed"
+    match = r"interface_type must be set"
+    with pytest.raises(ValueError, match=match):
+        result = instance.path  # pylint: disable=pointless-statement  # noqa: F841
+
+
+def test_endpoints_api_v1_manage_fabric_capable_switches_00140():
+    """
+    # Summary
+
+    Verify `EpManageFabricsCapableSwitchesGet.path` raises ValueError when mode is not set.
+
+    ## Test
+
+    - fabric_name and interface_type set, mode not set -> ValueError mentioning mode
+
+    ## Classes and Methods
+
+    - EpManageFabricsCapableSwitchesGet.path
+    """
+    instance = EpManageFabricsCapableSwitchesGet()
+    instance.fabric_name = "fabric_1"
+    instance.endpoint_params.interface_type = "loopback"
+    match = r"mode must be set"
+    with pytest.raises(ValueError, match=match):
+        result = instance.path  # pylint: disable=pointless-statement  # noqa: F841
+
+
+def test_endpoints_api_v1_manage_fabric_capable_switches_00150():
+    """
+    # Summary
+
+    Verify `set_identifiers` populates the fabric_name on the endpoint.
+
+    ## Test
+
+    - set_identifiers("fabric_1") sets fabric_name to "fabric_1"
+
+    ## Classes and Methods
+
+    - EpManageFabricsCapableSwitchesGet.set_identifiers
+    """
+    with does_not_raise():
+        instance = EpManageFabricsCapableSwitchesGet()
+        instance.set_identifiers("fabric_1")
+    assert instance.fabric_name == "fabric_1"

--- a/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
@@ -93,5 +93,21 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/remove",
         "MESSAGE": "Internal Server Error",
         "DATA": {"error": "boom"}
+    },
+
+    "test_base_interface_00820a": {
+        "TEST_NOTES": [
+            "Issue #301: switches list returns only 192.168.12.151; the two other model_instances (10.1.1.99, 10.1.1.100)",
+            "are unresolvable and must be aggregated into a single RuntimeError without consuming a capableSwitches response."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
@@ -172,5 +172,34 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
         "MESSAGE": "OK",
         "DATA": {"switches": []}
+    },
+    "test_base_interface_00860a": {
+        "TEST_NOTES": [
+            "preflight() delegation: switches list resolves the target IP before the capability GET."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.12.151",
+                    "switchId": "FDO12345ABC"
+                }
+            ]
+        }
+    },
+    "test_base_interface_00860b": {
+        "TEST_NOTES": [
+            "preflight() delegation: capableSwitches returns 200 with empty switches; offender warning in check_mode proves preflight() routed to validate_switches_capable."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": []
+        }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
@@ -109,5 +109,68 @@
                 {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
             ]
         }
+    },
+
+    "test_base_interface_00830a": {
+        "TEST_NOTES": ["Issue #302: switches list resolves the target IP before the capability GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_base_interface_00830b": {
+        "TEST_NOTES": ["Issue #302: capableSwitches GET returns 404; in check_mode the failure is softened to a warning."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_base_interface_00840a": {
+        "TEST_NOTES": ["Issue #302: switches list resolves the target IP before the capability GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_base_interface_00840b": {
+        "TEST_NOTES": ["Issue #302: capableSwitches returns 200 with empty switches; offender warning in check_mode."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {"switches": []}
+    },
+
+    "test_base_interface_00850a": {
+        "TEST_NOTES": ["Issue #302 regression guard: switches list resolves the target IP before the capability GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"}
+            ]
+        }
+    },
+    "test_base_interface_00850b": {
+        "TEST_NOTES": ["Issue #302 regression guard: capability mismatch must still raise outside check_mode."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {"switches": []}
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_interface_capability_preflight.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_interface_capability_preflight.json
@@ -153,5 +153,28 @@
                 {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
             ]
         }
+    },
+    "test_interface_capability_preflight_00320a": {
+        "TEST_NOTES": [
+            "capableSwitches for (loopback, managed): two capable switches; used to verify returned RECORD dicts are deep copies (mutating a returned record must not corrupt the cache)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "model": "N9K-C9300v",
+                    "switchId": "FDO12345ABC",
+                    "switchName": "BG1"
+                },
+                {
+                    "model": "N9K-C9300v",
+                    "switchId": "FDO12345ABD",
+                    "switchName": "BG2"
+                }
+            ]
+        }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_interface_capability_preflight.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_interface_capability_preflight.json
@@ -132,5 +132,26 @@
                 {"fabricManagementIp": "10.0.0.99", "switchId": "FDO99999XYZ"}
             ]
         }
+    },
+    "test_interface_capability_preflight_00300a": {
+        "TEST_NOTES": ["capableSwitches GET returns 404; preflight must raise rather than caching an empty capable set"],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_interface_capability_preflight_00310a": {
+        "TEST_NOTES": ["capableSwitches for (loopback, managed): two capable switches; used to verify returned collections are defensive copies"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
+            ]
+        }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_interface_capability_preflight.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_interface_capability_preflight.json
@@ -1,0 +1,136 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for test_interface_capability_preflight.py",
+        "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
+        "Responses mirror what ND returns for /api/v1/manage/fabrics/{fabric}/capableSwitches?interfaceType=...&mode=...",
+        "Switch record shape: {model, switchId, switchName}. Taxonomy captured from ND 4.2 GUI 2026-05-11."
+    ],
+    "test_interface_capability_preflight_00100a": {
+        "TEST_NOTES": ["capableSwitches for (loopback, managed): two capable switches"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
+            ]
+        }
+    },
+    "test_interface_capability_preflight_00110a": {
+        "TEST_NOTES": ["capableSwitches for (loopback, managed): first fetch, two switches (cache hit test - only one response yielded)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
+            ]
+        }
+    },
+    "test_interface_capability_preflight_00120a": {
+        "TEST_NOTES": ["capableSwitches for (loopback, managed) - first call in 00120 dual-cache test"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
+            ]
+        }
+    },
+    "test_interface_capability_preflight_00120b": {
+        "TEST_NOTES": ["capableSwitches for (ethernet, trunk) - second call in 00120 dual-cache test"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=ethernet&mode=trunk",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C93180YC-EX", "switchId": "FDO12345ABC", "switchName": "LE1"},
+                {"model": "N9K-C93180YC-EX", "switchId": "FDO12345ABD", "switchName": "LE2"},
+                {"model": "N9K-C9504", "switchId": "FDO12345ABE", "switchName": "SP1"}
+            ]
+        }
+    },
+    "test_interface_capability_preflight_00130a": {
+        "TEST_NOTES": ["capableSwitches for (loopback, managed) before invalidate(): one capable switch"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
+            ]
+        }
+    },
+    "test_interface_capability_preflight_00130b": {
+        "TEST_NOTES": ["capableSwitches for (loopback, managed) after invalidate(): two capable switches"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
+            ]
+        }
+    },
+    "test_interface_capability_preflight_00200a": {
+        "TEST_NOTES": ["validate success: all requested switch_ids are in the capable set"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
+            ]
+        }
+    },
+    "test_interface_capability_preflight_00210a": {
+        "TEST_NOTES": ["validate failure: one switch_id is not in the capable set; no fabric_context for enrichment"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
+            ]
+        }
+    },
+    "test_interface_capability_preflight_00220a": {
+        "TEST_NOTES": ["validate failure with fabric_context enrichment: capableSwitches response (incapable switch FDO99999XYZ not present)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
+            ]
+        }
+    },
+    "test_interface_capability_preflight_00220b": {
+        "TEST_NOTES": ["validate failure with fabric_context enrichment: fabric switches list (FDO99999XYZ -> 10.0.0.99)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"},
+                {"fabricManagementIp": "10.0.0.99", "switchId": "FDO99999XYZ"}
+            ]
+        }
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_loopback_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_loopback_interface.json
@@ -6,7 +6,8 @@
         "Tests that resolve a switch IP consume one switches-list response first (FabricContext lazy fetch).",
         "Tests that call validate_prerequisites consume one fabric-summary response first.",
         "Switch A: fabricManagementIp=192.168.12.151, switchId=FDO12345ABC.",
-        "Switch B: fabricManagementIp=192.168.12.152, switchId=FDO12345ABD."
+        "Switch B: fabricManagementIp=192.168.12.152, switchId=FDO12345ABD.",
+        "Mutating tests (create/update/create_bulk) consume one capableSwitches response after the switches-list (interface capability preflight)."
     ],
 
     "test_loopback_interface_00100a": {
@@ -22,6 +23,18 @@
         }
     },
     "test_loopback_interface_00100b": {
+        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
+            ]
+        }
+    },
+    "test_loopback_interface_00100c": {
         "TEST_NOTES": ["create happy path: POST /interfaces (200)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -43,6 +56,18 @@
         }
     },
     "test_loopback_interface_00110b": {
+        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
+            ]
+        }
+    },
+    "test_loopback_interface_00110c": {
         "TEST_NOTES": ["create _request failure: POST returns 500"],
         "RETURN_CODE": 500,
         "METHOD": "POST",
@@ -77,6 +102,18 @@
         }
     },
     "test_loopback_interface_00200b": {
+        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
+            ]
+        }
+    },
+    "test_loopback_interface_00200c": {
         "TEST_NOTES": ["update happy path: PUT /interfaces/loopback10"],
         "RETURN_CODE": 200,
         "METHOD": "PUT",
@@ -98,6 +135,18 @@
         }
     },
     "test_loopback_interface_00210b": {
+        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
+            ]
+        }
+    },
+    "test_loopback_interface_00210c": {
         "TEST_NOTES": ["update _request failure: PUT returns 500"],
         "RETURN_CODE": 500,
         "METHOD": "PUT",
@@ -146,6 +195,19 @@
         }
     },
     "test_loopback_interface_00400b": {
+        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC, FDO12345ABD capable"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
+            ]
+        }
+    },
+    "test_loopback_interface_00400c": {
         "TEST_NOTES": ["create_bulk: POST switch A (loopback10+loopback11)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -153,7 +215,7 @@
         "MESSAGE": "OK",
         "DATA": {"status": "ok"}
     },
-    "test_loopback_interface_00400c": {
+    "test_loopback_interface_00400d": {
         "TEST_NOTES": ["create_bulk: POST switch B (loopback20)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -176,6 +238,19 @@
         }
     },
     "test_loopback_interface_00410b": {
+        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC, FDO12345ABD capable"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
+            ]
+        }
+    },
+    "test_loopback_interface_00410c": {
         "TEST_NOTES": ["create_bulk failure: POST switch A succeeds"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -183,7 +258,7 @@
         "MESSAGE": "OK",
         "DATA": {"status": "ok"}
     },
-    "test_loopback_interface_00410c": {
+    "test_loopback_interface_00410d": {
         "TEST_NOTES": ["create_bulk failure: POST switch B fails"],
         "RETURN_CODE": 500,
         "METHOD": "POST",
@@ -205,6 +280,18 @@
         }
     },
     "test_loopback_interface_00420b": {
+        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
+            ]
+        }
+    },
+    "test_loopback_interface_00420c": {
         "TEST_NOTES": ["create_bulk single: POST switch A (loopback10)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -481,6 +568,18 @@
         }
     },
     "test_loopback_interface_00800b": {
+        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
+            ]
+        }
+    },
+    "test_loopback_interface_00800c": {
         "TEST_NOTES": ["deploy queue de-dup: first POST"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -488,7 +587,7 @@
         "MESSAGE": "OK",
         "DATA": {"status": "ok"}
     },
-    "test_loopback_interface_00800c": {
+    "test_loopback_interface_00800d": {
         "TEST_NOTES": ["deploy queue de-dup: second POST (same identifier — should NOT add a second queue entry)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",

--- a/tests/unit/module_utils/fixtures/fixture_data/test_loopback_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_loopback_interface.json
@@ -6,8 +6,7 @@
         "Tests that resolve a switch IP consume one switches-list response first (FabricContext lazy fetch).",
         "Tests that call validate_prerequisites consume one fabric-summary response first.",
         "Switch A: fabricManagementIp=192.168.12.151, switchId=FDO12345ABC.",
-        "Switch B: fabricManagementIp=192.168.12.152, switchId=FDO12345ABD.",
-        "Mutating tests (create/update/create_bulk) consume one capableSwitches response after the switches-list (interface capability preflight)."
+        "Switch B: fabricManagementIp=192.168.12.152, switchId=FDO12345ABD."
     ],
 
     "test_loopback_interface_00100a": {
@@ -23,18 +22,6 @@
         }
     },
     "test_loopback_interface_00100b": {
-        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switches": [
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
-            ]
-        }
-    },
-    "test_loopback_interface_00100c": {
         "TEST_NOTES": ["create happy path: POST /interfaces (200)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -56,18 +43,6 @@
         }
     },
     "test_loopback_interface_00110b": {
-        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switches": [
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
-            ]
-        }
-    },
-    "test_loopback_interface_00110c": {
         "TEST_NOTES": ["create _request failure: POST returns 500"],
         "RETURN_CODE": 500,
         "METHOD": "POST",
@@ -102,18 +77,6 @@
         }
     },
     "test_loopback_interface_00200b": {
-        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switches": [
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
-            ]
-        }
-    },
-    "test_loopback_interface_00200c": {
         "TEST_NOTES": ["update happy path: PUT /interfaces/loopback10"],
         "RETURN_CODE": 200,
         "METHOD": "PUT",
@@ -135,18 +98,6 @@
         }
     },
     "test_loopback_interface_00210b": {
-        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switches": [
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
-            ]
-        }
-    },
-    "test_loopback_interface_00210c": {
         "TEST_NOTES": ["update _request failure: PUT returns 500"],
         "RETURN_CODE": 500,
         "METHOD": "PUT",
@@ -195,19 +146,6 @@
         }
     },
     "test_loopback_interface_00400b": {
-        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC, FDO12345ABD capable"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switches": [
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
-            ]
-        }
-    },
-    "test_loopback_interface_00400c": {
         "TEST_NOTES": ["create_bulk: POST switch A (loopback10+loopback11)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -215,7 +153,7 @@
         "MESSAGE": "OK",
         "DATA": {"status": "ok"}
     },
-    "test_loopback_interface_00400d": {
+    "test_loopback_interface_00400c": {
         "TEST_NOTES": ["create_bulk: POST switch B (loopback20)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -238,19 +176,6 @@
         }
     },
     "test_loopback_interface_00410b": {
-        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC, FDO12345ABD capable"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switches": [
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"}
-            ]
-        }
-    },
-    "test_loopback_interface_00410c": {
         "TEST_NOTES": ["create_bulk failure: POST switch A succeeds"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -258,7 +183,7 @@
         "MESSAGE": "OK",
         "DATA": {"status": "ok"}
     },
-    "test_loopback_interface_00410d": {
+    "test_loopback_interface_00410c": {
         "TEST_NOTES": ["create_bulk failure: POST switch B fails"],
         "RETURN_CODE": 500,
         "METHOD": "POST",
@@ -280,18 +205,6 @@
         }
     },
     "test_loopback_interface_00420b": {
-        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switches": [
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
-            ]
-        }
-    },
-    "test_loopback_interface_00420c": {
         "TEST_NOTES": ["create_bulk single: POST switch A (loopback10)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -568,18 +481,6 @@
         }
     },
     "test_loopback_interface_00800b": {
-        "TEST_NOTES": ["capableSwitches GET (loopback, managed): FDO12345ABC capable"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/capableSwitches?interfaceType=loopback&mode=managed",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switches": [
-                {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"}
-            ]
-        }
-    },
-    "test_loopback_interface_00800c": {
         "TEST_NOTES": ["deploy queue de-dup: first POST"],
         "RETURN_CODE": 200,
         "METHOD": "POST",
@@ -587,7 +488,7 @@
         "MESSAGE": "OK",
         "DATA": {"status": "ok"}
     },
-    "test_loopback_interface_00800d": {
+    "test_loopback_interface_00800c": {
         "TEST_NOTES": ["deploy queue de-dup: second POST (same identifier — should NOT add a second queue entry)"],
         "RETURN_CODE": 200,
         "METHOD": "POST",

--- a/tests/unit/module_utils/mock_ansible_module.py
+++ b/tests/unit/module_utils/mock_ansible_module.py
@@ -53,6 +53,7 @@ class MockAnsibleModule:
     ## Methods
 
     - fail_json: Raises AnsibleFailJson exception with the provided message
+    - warn: Records the warning on the instance for later assertion
     """
 
     check_mode = False
@@ -64,6 +65,9 @@ class MockAnsibleModule:
         "check_mode": False,
     }
     supports_check_mode = True
+
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
 
     @staticmethod
     def fail_json(msg, **kwargs) -> AnsibleFailJson:
@@ -82,6 +86,19 @@ class MockAnsibleModule:
         - AnsibleFailJson: Always raised with the provided message
         """
         raise AnsibleFailJson(msg)
+
+    def warn(self, message: str) -> None:
+        """
+        # Summary
+
+        Mock the `AnsibleModule.warn` method. Records the warning on `self.warnings` so unit tests can assert the
+        warning surfaced.
+
+        ## Raises
+
+        None
+        """
+        self.warnings.append(message)
 
     def public_method_for_pylint(self):
         """

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -8,9 +8,9 @@
 Unit tests for `NDBaseInterfaceOrchestrator`.
 
 Verifies the shared interface-orchestrator infrastructure: lazy `FabricContext`, switch IP-to-serial
-resolution, fabric pre-flight validation, endpoint configuration, deploy/remove queue de-duplication,
-and bulk `deploy_pending` / `remove_pending` flush against the `interfaceActions/deploy` and
-`interfaceActions/remove` endpoints.
+resolution, fabric pre-flight validation, capability-preflight gating, endpoint configuration,
+deploy/remove queue de-duplication, and bulk `deploy_pending` / `remove_pending` flush against the
+`interfaceActions/deploy` and `interfaceActions/remove` endpoints.
 
 Uses `_StubInterfaceOrchestrator`, a minimal concrete subclass, to satisfy `NDBaseOrchestrator`'s
 Pydantic field requirements without coupling these tests to any per-feature orchestrator.
@@ -24,6 +24,7 @@ from __future__ import absolute_import, annotations, division, print_function
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import inspect
+from types import SimpleNamespace
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
@@ -59,6 +60,15 @@ class _StubInterfaceOrchestrator(NDBaseInterfaceOrchestrator):
     delete_endpoint: type[NDEndpointBaseModel] = NDEndpointBaseModel
     query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
     query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+
+
+class _StubOptedInOrchestrator(_StubInterfaceOrchestrator):
+    """Stub that opts in to capability preflight via `interface_type` but omits `interface_mode`.
+
+    Used to verify `validate_switches_capable` raises a clear error for a half-configured subclass.
+    """
+
+    interface_type = "loopback"
 
 
 def responses_base_interface(key: str):
@@ -766,3 +776,63 @@ def test_base_interface_00720() -> None:
         instance.remove_pending()
 
     assert instance._pending_removes == [("loopback10", "FDO12345ABC")]
+
+
+# =============================================================================
+# Test: validate_switches_capable
+# =============================================================================
+
+
+def test_base_interface_00800() -> None:
+    """
+    # Summary
+
+    Verify `validate_switches_capable` is a no-op when `interface_type` is `""` (the opted-out base default).
+
+    ## Test
+
+    - `_StubInterfaceOrchestrator` leaves `interface_type` as `""`
+    - `validate_switches_capable` returns without resolving switches or raising, even for a non-empty input
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.validate_switches_capable()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.validate_switches_capable([SimpleNamespace(switch_ip="192.168.12.151")])
+
+
+def test_base_interface_00810() -> None:
+    """
+    # Summary
+
+    Verify `validate_switches_capable` raises a clear `RuntimeError` when a subclass sets `interface_type` but leaves `interface_mode` empty.
+
+    ## Test
+
+    - `_StubOptedInOrchestrator` sets `interface_type` but inherits the empty `interface_mode`
+    - `validate_switches_capable` raises `RuntimeError` naming the class and both ClassVars
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.validate_switches_capable()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubOptedInOrchestrator(rest_send=rest_send)
+
+    match = r"_StubOptedInOrchestrator sets interface_type but not interface_mode"
+    with pytest.raises(RuntimeError, match=match):
+        instance.validate_switches_capable([SimpleNamespace(switch_ip="192.168.12.151")])

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -71,6 +71,16 @@ class _StubOptedInOrchestrator(_StubInterfaceOrchestrator):
     interface_type = "loopback"
 
 
+class _StubCapableOrchestrator(_StubInterfaceOrchestrator):
+    """Stub that fully opts in to capability preflight via both `interface_type` and `interface_mode`.
+
+    Used to drive `validate_switches_capable` through the resolution + capability-endpoint code path.
+    """
+
+    interface_type = "loopback"
+    interface_mode = "managed"
+
+
 def responses_base_interface(key: str):
     """Load fixture data for test_base_interface tests."""
     return load_fixture("test_base_interface")[key]
@@ -836,3 +846,40 @@ def test_base_interface_00810() -> None:
     match = r"_StubOptedInOrchestrator sets interface_type but not interface_mode"
     with pytest.raises(RuntimeError, match=match):
         instance.validate_switches_capable([SimpleNamespace(switch_ip="192.168.12.151")])
+
+
+def test_base_interface_00820() -> None:
+    """
+    # Summary
+
+    Verify `validate_switches_capable` aggregates multiple unresolvable `switch_ip` values into a single `RuntimeError`
+    (issue #301), so one typo cannot mask resolution or capability problems on the remaining entries.
+
+    ## Test
+
+    - Switches inventory contains only `192.168.12.151`
+    - Three model_instances are passed: the valid IP and two distinct unknown IPs
+    - `validate_switches_capable` raises `RuntimeError` naming BOTH unknown IPs in a single message
+    - The capability endpoint is NOT contacted (no second fixture consumed)
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.validate_switches_capable()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubCapableOrchestrator(rest_send=rest_send)
+
+    model_instances = [
+        SimpleNamespace(switch_ip="192.168.12.151"),
+        SimpleNamespace(switch_ip="10.1.1.99"),
+        SimpleNamespace(switch_ip="10.1.1.100"),
+    ]
+    match = r"Cannot resolve switch_ip to switchId in fabric 'fabric_1' for: 10\.1\.1\.100, 10\.1\.1\.99"
+    with pytest.raises(RuntimeError, match=match):
+        instance.validate_switches_capable(model_instances)

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -883,3 +883,118 @@ def test_base_interface_00820() -> None:
     match = r"Cannot resolve switch_ip to switchId in fabric 'fabric_1' for: 10\.1\.1\.100, 10\.1\.1\.99"
     with pytest.raises(RuntimeError, match=match):
         instance.validate_switches_capable(model_instances)
+
+
+def test_base_interface_00830() -> None:
+    """
+    # Summary
+
+    Verify `validate_switches_capable` downgrades a capability endpoint failure to a warning in `--check` mode
+    (issue #302), so dry-runs stay green when the unpublished `capableSwitches` endpoint is unavailable.
+
+    ## Test
+
+    - `rest_send.check_mode` is True
+    - Switches inventory resolves the one target IP to `FDO12345ABC`
+    - `capableSwitches` GET returns 404 -> `InterfaceCapabilityPreflight._query_get` raises `RuntimeError`
+    - `validate_switches_capable` does NOT raise
+    - A warning containing `Capability preflight skipped in check mode` is recorded on the mock module
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.validate_switches_capable()
+    - NDBaseInterfaceOrchestrator._warn()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+        yield responses_base_interface(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    rest_send.check_mode = True
+    instance = _StubCapableOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.validate_switches_capable([SimpleNamespace(switch_ip="192.168.12.151")])
+
+    warnings = rest_send.sender.ansible_module.warnings
+    assert len(warnings) == 1
+    assert "Capability preflight skipped in check mode" in warnings[0]
+
+
+def test_base_interface_00840() -> None:
+    """
+    # Summary
+
+    Verify `validate_switches_capable` downgrades a capability MISMATCH (offending switch) to a warning in `--check`
+    mode (issue #302), so dry-runs still surface the information without failing the run.
+
+    ## Test
+
+    - `rest_send.check_mode` is True
+    - Switches inventory resolves the target IP to `FDO12345ABC`
+    - `capableSwitches` returns 200 with an empty `switches` list -> `validate` raises with offender details
+    - `validate_switches_capable` does NOT raise
+    - A warning is recorded mentioning the offending `switchId`
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.validate_switches_capable()
+    - NDBaseInterfaceOrchestrator._warn()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+        yield responses_base_interface(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    rest_send.check_mode = True
+    instance = _StubCapableOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.validate_switches_capable([SimpleNamespace(switch_ip="192.168.12.151")])
+
+    warnings = rest_send.sender.ansible_module.warnings
+    assert len(warnings) == 1
+    assert "Capability preflight skipped in check mode" in warnings[0]
+    assert "FDO12345ABC" in warnings[0]
+
+
+def test_base_interface_00850() -> None:
+    """
+    # Summary
+
+    Verify `validate_switches_capable` still raises a capability mismatch OUTSIDE `--check` mode (issue #302 regression
+    guard): the softening behavior must be gated on `check_mode`.
+
+    ## Test
+
+    - `rest_send.check_mode` is False
+    - Switches inventory resolves the target IP
+    - `capableSwitches` returns 200 with an empty `switches` list
+    - `validate_switches_capable` raises `RuntimeError` naming the offending `switchId`
+    - No warning is recorded
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.validate_switches_capable()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+        yield responses_base_interface(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubCapableOrchestrator(rest_send=rest_send)
+
+    match = r"not capable of hosting interface_type='loopback' mode='managed'"
+    with pytest.raises(RuntimeError, match=match):
+        instance.validate_switches_capable([SimpleNamespace(switch_ip="192.168.12.151")])
+
+    assert rest_send.sender.ansible_module.warnings == []

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -996,3 +996,44 @@ def test_base_interface_00850() -> None:
         instance.validate_switches_capable([SimpleNamespace(switch_ip="192.168.12.151")])
 
     assert rest_send.sender.ansible_module.warnings == []
+
+
+def test_base_interface_00860() -> None:
+    """
+    # Summary
+
+    Verify `preflight` delegates to `validate_switches_capable`. `NDStateMachine` calls `preflight` (the generic
+    pre-mutation hook) rather than `validate_switches_capable` directly, so this guards the interface override that
+    wires the two together.
+
+    ## Test
+
+    - `rest_send.check_mode` is True
+    - Switches inventory resolves the target IP to `FDO12345ABC`
+    - `capableSwitches` returns 200 with an empty `switches` list (the target is incapable)
+    - `preflight` does NOT raise (check-mode softening, inherited from `validate_switches_capable`)
+    - A warning mentioning the offending `switchId` is recorded -> proves `preflight` routed through `validate_switches_capable`
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.preflight()
+    - NDBaseInterfaceOrchestrator.validate_switches_capable()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+        yield responses_base_interface(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    rest_send.check_mode = True
+    instance = _StubCapableOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.preflight([SimpleNamespace(switch_ip="192.168.12.151")])
+
+    warnings = rest_send.sender.ansible_module.warnings
+    assert len(warnings) == 1
+    assert "Capability preflight skipped in check mode" in warnings[0]
+    assert "FDO12345ABC" in warnings[0]

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -903,7 +903,6 @@ def test_base_interface_00830() -> None:
     ## Classes and Methods
 
     - NDBaseInterfaceOrchestrator.validate_switches_capable()
-    - NDBaseInterfaceOrchestrator._warn()
     """
     method_name = inspect.stack()[0][3]
 
@@ -942,7 +941,6 @@ def test_base_interface_00840() -> None:
     ## Classes and Methods
 
     - NDBaseInterfaceOrchestrator.validate_switches_capable()
-    - NDBaseInterfaceOrchestrator._warn()
     """
     method_name = inspect.stack()[0][3]
 

--- a/tests/unit/module_utils/orchestrators/test_base_orchestrator.py
+++ b/tests/unit/module_utils/orchestrators/test_base_orchestrator.py
@@ -559,3 +559,34 @@ class TestRequestDefaultOperationType:
         task = results._tasks[0]
         assert task.metadata["action"] == "query"
         assert task.verbosity_level == 3
+
+
+# =============================================================================
+# Test: preflight() generic no-op hook
+# =============================================================================
+
+
+class TestPreflightNoOp:
+    """Tests for the generic preflight() pre-mutation hook on NDBaseOrchestrator.
+
+    NDStateMachine invokes preflight() over the proposed set before create/update operations.
+    The base implementation must be a no-op so non-interface orchestrators (local_user, fabric_*)
+    are unaffected; interface orchestrators override it to run capability preflight.
+    """
+
+    def test_preflight_returns_none_and_issues_no_request(self):
+        """preflight() on the generic base returns None and makes no API call."""
+        # No responses seeded: any HTTP attempt would StopIteration.
+        rest_send = _make_rest_send([])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        assert orch.preflight([StubModel(name="a"), StubModel(name="b")]) is None
+        assert results._tasks == []
+
+    def test_preflight_accepts_empty_sequence(self):
+        """preflight() tolerates an empty proposed set."""
+        rest_send = _make_rest_send([])
+        orch = _make_orchestrator(rest_send, results=None)
+
+        assert orch.preflight([]) is None

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -238,18 +238,18 @@ def test_loopback_interface_00120() -> None:
     """
     # Summary
 
-    Verify `create` wraps an unknown-switch-IP `RuntimeError` from `_resolve_switch_id`.
+    Verify `create` wraps an unknown-switch-IP `RuntimeError` raised by the capability preflight's switch resolution.
 
     ## Test
 
     - switches-list returns a different IP than the model's `switch_ip`
-    - `_resolve_switch_id` raises `RuntimeError` with `No switch found with fabricManagementIp '192.168.12.151'`
+    - `validate_switches_capable` aggregates the unresolvable IP into a single `RuntimeError`
     - `create` re-raises as `RuntimeError` matching `Create failed for .*loopback10`
 
     ## Classes and Methods
 
     - LoopbackInterfaceOrchestrator.create()
-    - NDBaseInterfaceOrchestrator._resolve_switch_id()
+    - NDBaseInterfaceOrchestrator.validate_switches_capable()
     """
     method_name = inspect.stack()[0][3]
 
@@ -261,7 +261,7 @@ def test_loopback_interface_00120() -> None:
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
     model = _build_loopback_model(switch_ip="192.168.12.151")
 
-    match = r"Create failed for .*loopback10.*No switch found with fabricManagementIp '192\.168\.12\.151'"
+    match = r"Create failed for .*loopback10.*Cannot resolve switch_ip to switchId in fabric 'fabric_1' for: 192\.168\.12\.151"
     with pytest.raises(RuntimeError, match=match):
         instance.create(model)
 

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -174,6 +174,7 @@ def test_loopback_interface_00100() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
+        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -219,6 +220,7 @@ def test_loopback_interface_00110() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
+        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -293,6 +295,7 @@ def test_loopback_interface_00200() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
+        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -333,6 +336,7 @@ def test_loopback_interface_00210() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
+        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -453,6 +457,7 @@ def test_loopback_interface_00400() -> None:
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
         yield responses_loopback_interface(f"{method_name}c")
+        yield responses_loopback_interface(f"{method_name}d")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -504,6 +509,7 @@ def test_loopback_interface_00410() -> None:
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
         yield responses_loopback_interface(f"{method_name}c")
+        yield responses_loopback_interface(f"{method_name}d")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -539,6 +545,7 @@ def test_loopback_interface_00420() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
+        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -875,6 +882,7 @@ def test_loopback_interface_00800() -> None:
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
         yield responses_loopback_interface(f"{method_name}c")
+        yield responses_loopback_interface(f"{method_name}d")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -174,7 +174,6 @@ def test_loopback_interface_00100() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
-        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -220,7 +219,6 @@ def test_loopback_interface_00110() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
-        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -238,18 +236,20 @@ def test_loopback_interface_00120() -> None:
     """
     # Summary
 
-    Verify `create` wraps an unknown-switch-IP `RuntimeError` raised by the capability preflight's switch resolution.
+    Verify `create` wraps an unknown-switch-IP `RuntimeError` raised by `_resolve_switch_id`.
+
+    Capability preflight now runs centrally in `NDStateMachine` (not inside `create`), so an unresolvable
+    `switch_ip` reaching `create` directly surfaces the raw `_resolve_switch_id` failure, wrapped by `create`.
 
     ## Test
 
     - switches-list returns a different IP than the model's `switch_ip`
-    - `validate_switches_capable` aggregates the unresolvable IP into a single `RuntimeError`
-    - `create` re-raises as `RuntimeError` matching `Create failed for .*loopback10`
+    - `_resolve_switch_id` raises; `create` re-raises as `RuntimeError` matching `Create failed for .*loopback10`
 
     ## Classes and Methods
 
     - LoopbackInterfaceOrchestrator.create()
-    - NDBaseInterfaceOrchestrator.validate_switches_capable()
+    - NDBaseInterfaceOrchestrator._resolve_switch_id()
     """
     method_name = inspect.stack()[0][3]
 
@@ -261,7 +261,7 @@ def test_loopback_interface_00120() -> None:
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
     model = _build_loopback_model(switch_ip="192.168.12.151")
 
-    match = r"Create failed for .*loopback10.*Cannot resolve switch_ip to switchId in fabric 'fabric_1' for: 192\.168\.12\.151"
+    match = r"Create failed for .*loopback10.*No switch found with fabricManagementIp '192\.168\.12\.151'"
     with pytest.raises(RuntimeError, match=match):
         instance.create(model)
 
@@ -295,7 +295,6 @@ def test_loopback_interface_00200() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
-        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -336,7 +335,6 @@ def test_loopback_interface_00210() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
-        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -457,7 +455,6 @@ def test_loopback_interface_00400() -> None:
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
         yield responses_loopback_interface(f"{method_name}c")
-        yield responses_loopback_interface(f"{method_name}d")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -509,7 +506,6 @@ def test_loopback_interface_00410() -> None:
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
         yield responses_loopback_interface(f"{method_name}c")
-        yield responses_loopback_interface(f"{method_name}d")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -545,7 +541,6 @@ def test_loopback_interface_00420() -> None:
     def responses():
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
-        yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
@@ -882,7 +877,6 @@ def test_loopback_interface_00800() -> None:
         yield responses_loopback_interface(f"{method_name}a")
         yield responses_loopback_interface(f"{method_name}b")
         yield responses_loopback_interface(f"{method_name}c")
-        yield responses_loopback_interface(f"{method_name}d")
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)

--- a/tests/unit/module_utils/test_interface_capability_preflight.py
+++ b/tests/unit/module_utils/test_interface_capability_preflight.py
@@ -224,7 +224,8 @@ def test_interface_capability_preflight_00110() -> None:
 
     - Single response yielded by the generator
     - First call to `get_capable_switches("loopback", "managed")` consumes the response
-    - Second call returns the same data from cache without consuming another response
+    - Second call returns equal data from cache without consuming another response
+    - Each call returns a fresh list object (defensive copy; see test_00310)
 
     ## Classes and Methods
 
@@ -245,7 +246,7 @@ def test_interface_capability_preflight_00110() -> None:
         cached = instance.get_capable_switches("loopback", "managed")
 
     assert first == cached
-    assert cached is first
+    assert cached is not first
 
 
 def test_interface_capability_preflight_00120() -> None:
@@ -439,3 +440,91 @@ def test_interface_capability_preflight_00230() -> None:
     match = r"Unsupported mode 'trunk' for interface_type 'loopback'"
     with pytest.raises(ValueError, match=match):
         instance.validate("loopback", "trunk", {"FDO12345ABC"})
+
+
+# =============================================================================
+# Test: HTTP 404 from the capableSwitches endpoint
+# =============================================================================
+
+
+def test_interface_capability_preflight_00300() -> None:
+    """
+    # Summary
+
+    Verify a 404 response from the capableSwitches endpoint raises `RuntimeError` rather than caching
+    an empty capable set (which would mislabel every requested switch as "not capable").
+
+    ## Test
+
+    - GET capableSwitches returns 404
+    - `get_capable_switches` raises RuntimeError mentioning the path and issue #273
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight._query_get
+    - InterfaceCapabilityPreflight.get_capable_switches
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    def responses():
+        yield responses_preflight(key)
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+    match = r"GET /api/v1/manage/fabrics/fabric_1/capableSwitches.*failed.*issue #273"
+    with pytest.raises(RuntimeError, match=match):
+        instance.get_capable_switches("loopback", "managed")
+
+
+# =============================================================================
+# Test: returned collections are defensive copies
+# =============================================================================
+
+
+def test_interface_capability_preflight_00310() -> None:
+    """
+    # Summary
+
+    Verify `get_capable_switches` and `get_capable_switch_ids` return fresh collections per call so a caller
+    that mutates the result cannot corrupt cached state for subsequent callers.
+
+    ## Test
+
+    - First `get_capable_switches` returns two-switch list; mutate the returned list (`.append(...)`)
+    - Second `get_capable_switches` returns the original (un-mutated) two-switch list from cache
+    - Same for `get_capable_switch_ids` (mutate the returned set)
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.get_capable_switches
+    - InterfaceCapabilityPreflight.get_capable_switch_ids
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    def responses():
+        yield responses_preflight(key)
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+        first_list = instance.get_capable_switches("loopback", "managed")
+        first_list.append({"switchId": "BOGUS", "switchName": "BOGUS", "model": "BOGUS"})
+        first_list.clear()
+        second_list = instance.get_capable_switches("loopback", "managed")
+
+        first_ids = instance.get_capable_switch_ids("loopback", "managed")
+        first_ids.add("BOGUS")
+        first_ids.clear()
+        second_ids = instance.get_capable_switch_ids("loopback", "managed")
+
+    assert second_list == [
+        {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+        {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"},
+    ]
+    assert second_ids == {"FDO12345ABC", "FDO12345ABD"}

--- a/tests/unit/module_utils/test_interface_capability_preflight.py
+++ b/tests/unit/module_utils/test_interface_capability_preflight.py
@@ -528,3 +528,51 @@ def test_interface_capability_preflight_00310() -> None:
         {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"},
     ]
     assert second_ids == {"FDO12345ABC", "FDO12345ABD"}
+
+
+def test_interface_capability_preflight_00320() -> None:
+    """
+    # Summary
+
+    Verify `get_capable_switches` deep-copies cached records, so mutating a returned record dict cannot corrupt
+    cached state or the derived `get_capable_switch_ids` set. Regression guard for the shallow-copy defect: a
+    `list(self._cache[key])` copy shares the record dicts by reference (PR #275 review).
+
+    ## Test
+
+    - First `get_capable_switches` call returns two records; mutate a returned record in place (`["switchId"] = "HACKED"`)
+    - Second `get_capable_switches` returns the original, un-mutated records from cache
+    - `get_capable_switch_ids` (built after the mutation) yields the original IDs, proving the mutation did not
+      leak into the cache used to derive them
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.get_capable_switches
+    - InterfaceCapabilityPreflight.get_capable_switch_ids
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    def responses():
+        yield responses_preflight(key)
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+        first_list = instance.get_capable_switches("loopback", "managed")
+        # Mutate the returned record dicts in place -- must not touch the cache.
+        first_list[0]["switchId"] = "HACKED"
+        first_list[1]["switchName"] = "HACKED"
+        del first_list[0]["model"]
+
+        second_list = instance.get_capable_switches("loopback", "managed")
+        # ids are derived from the cache *after* the mutation above
+        ids = instance.get_capable_switch_ids("loopback", "managed")
+
+    assert second_list == [
+        {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+        {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"},
+    ]
+    assert ids == {"FDO12345ABC", "FDO12345ABD"}

--- a/tests/unit/module_utils/test_interface_capability_preflight.py
+++ b/tests/unit/module_utils/test_interface_capability_preflight.py
@@ -1,0 +1,441 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for interface_capability_preflight.py.
+
+Verifies that `InterfaceCapabilityPreflight` drives `RestSend` correctly for the capableSwitches endpoint,
+caches results per `(interface_type, mode)`, enforces the taxonomy table client-side, and raises
+`RuntimeError` from `validate` with an aggregate message listing offending switches.
+"""
+
+# pylint: disable=disallowed-name,protected-access,redefined-outer-name,too-many-lines
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+import inspect
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.interface_capability_preflight import InterfaceCapabilityPreflight
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_preflight(key: str):
+    """Load fixture data for interface_capability_preflight tests."""
+    return load_fixture("test_interface_capability_preflight")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator) -> RestSend:
+    """Build a RestSend instance wired to a file-based Sender and ResponseHandler."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+# =============================================================================
+# Test: Initialization
+# =============================================================================
+
+
+def test_interface_capability_preflight_00010() -> None:
+    """
+    # Summary
+
+    Verify `InterfaceCapabilityPreflight` initializes with `rest_send` and `fabric_name` without fetching.
+
+    ## Test
+
+    - `fabric_name` returns the value passed at construction
+    - Internal cache is empty
+    - No HTTP calls are made during `__init__`
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.__init__()
+    - InterfaceCapabilityPreflight.fabric_name
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+
+    assert instance.fabric_name == "fabric_1"
+    assert instance._cache == {}  # pylint: disable=protected-access
+
+
+# =============================================================================
+# Test: Taxonomy enforcement
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "interface_type,mode",
+    [
+        ("loopback", "managed"),
+        ("svi", "managed"),
+        ("tunnel", "managed"),
+        ("ethernet", "trunk"),
+        ("ethernet", "access"),
+        ("ethernet", "routed"),
+        ("ethernet", "fex"),
+        ("ethernet", "pvlan"),
+        ("ethernet", "dot1qTunnel"),
+        ("ethernet", "unmanaged"),
+        ("portChannel", "trunk"),
+        ("portChannel", "access"),
+        ("portChannel", "routed"),
+        ("portChannel", "fex"),
+        ("portChannel", "pvlan"),
+        ("portChannel", "dot1qTunnel"),
+        ("portChannel", "unmanaged"),
+    ],
+    ids=lambda v: v,
+)
+def test_interface_capability_preflight_00050_taxonomy_valid(interface_type: str, mode: str) -> None:
+    """
+    # Summary
+
+    Verify `_check_taxonomy` accepts every valid `(interface_type, mode)` pair from the captured ND 4.2 taxonomy.
+
+    ## Test
+
+    - Each parametrized pair raises nothing when passed to `_check_taxonomy`
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight._check_taxonomy
+    """
+    with does_not_raise():
+        InterfaceCapabilityPreflight._check_taxonomy(interface_type, mode)  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize(
+    "interface_type,mode,match",
+    [
+        ("vpc", "managed", r"Unsupported interface_type 'vpc'"),
+        ("breakout", "managed", r"Unsupported interface_type 'breakout'"),
+        ("subinterface", "routed", r"Unsupported interface_type 'subinterface'"),
+        ("loopback", "trunk", r"Unsupported mode 'trunk' for interface_type 'loopback'"),
+        ("svi", "access", r"Unsupported mode 'access' for interface_type 'svi'"),
+        ("ethernet", "managed", r"Unsupported mode 'managed' for interface_type 'ethernet'"),
+        ("portChannel", "bogusMode", r"Unsupported mode 'bogusMode' for interface_type 'portChannel'"),
+    ],
+    ids=lambda v: v if isinstance(v, str) and "Unsupported" not in v else "",
+)
+def test_interface_capability_preflight_00060_taxonomy_invalid(interface_type: str, mode: str, match: str) -> None:
+    """
+    # Summary
+
+    Verify `_check_taxonomy` raises `ValueError` for unsupported interface types and unsupported modes.
+
+    ## Test
+
+    - Unsupported interface_type raises ValueError mentioning the type
+    - Unsupported mode for a known type raises ValueError mentioning the mode and the type
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight._check_taxonomy
+    """
+    with pytest.raises(ValueError, match=match):
+        InterfaceCapabilityPreflight._check_taxonomy(interface_type, mode)  # pylint: disable=protected-access
+
+
+# =============================================================================
+# Test: get_capable_switches / get_capable_switch_ids
+# =============================================================================
+
+
+def test_interface_capability_preflight_00100() -> None:
+    """
+    # Summary
+
+    Verify `get_capable_switches` fetches and caches the switch list for `(loopback, managed)`.
+
+    ## Test
+
+    - GET to `/api/v1/manage/fabrics/{fabric}/capableSwitches?interfaceType=loopback&mode=managed` returns 200 with two switches
+    - `get_capable_switches` returns the full record list
+    - `get_capable_switch_ids` derives the set of switchIds
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.get_capable_switches
+    - InterfaceCapabilityPreflight.get_capable_switch_ids
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    def responses():
+        yield responses_preflight(key)
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+        records = instance.get_capable_switches("loopback", "managed")
+        ids = instance.get_capable_switch_ids("loopback", "managed")
+
+    assert records == [
+        {"model": "N9K-C9300v", "switchId": "FDO12345ABC", "switchName": "BG1"},
+        {"model": "N9K-C9300v", "switchId": "FDO12345ABD", "switchName": "BG2"},
+    ]
+    assert ids == {"FDO12345ABC", "FDO12345ABD"}
+
+
+def test_interface_capability_preflight_00110() -> None:
+    """
+    # Summary
+
+    Verify a second access to `get_capable_switches` for the same `(interface_type, mode)` is a cache hit (does not re-fetch).
+
+    ## Test
+
+    - Single response yielded by the generator
+    - First call to `get_capable_switches("loopback", "managed")` consumes the response
+    - Second call returns the same data from cache without consuming another response
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.get_capable_switches
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    def responses():
+        yield responses_preflight(key)
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+        first = instance.get_capable_switches("loopback", "managed")
+        cached = instance.get_capable_switches("loopback", "managed")
+
+    assert first == cached
+    assert cached is first
+
+
+def test_interface_capability_preflight_00120() -> None:
+    """
+    # Summary
+
+    Verify `get_capable_switches` issues a separate request per `(interface_type, mode)` pair and caches each independently.
+
+    ## Test
+
+    - First call for `(loopback, managed)` and second call for `(ethernet, trunk)` produce two different cache entries
+    - Each is a separate API call
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.get_capable_switches
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_preflight(f"{method_name}a")
+        yield responses_preflight(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+        loopback_switches = instance.get_capable_switches("loopback", "managed")
+        ethernet_switches = instance.get_capable_switches("ethernet", "trunk")
+
+    assert {sw["switchId"] for sw in loopback_switches} == {"FDO12345ABC", "FDO12345ABD"}
+    assert {sw["switchId"] for sw in ethernet_switches} == {"FDO12345ABC", "FDO12345ABD", "FDO12345ABE"}
+
+
+def test_interface_capability_preflight_00130() -> None:
+    """
+    # Summary
+
+    Verify `invalidate` drops cached state so the next access re-fetches.
+
+    ## Test
+
+    - First `get_capable_switches("loopback", "managed")` returns one-switch response and caches it
+    - `invalidate()` clears the cache
+    - Second `get_capable_switches("loopback", "managed")` returns two-switch response
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.invalidate
+    - InterfaceCapabilityPreflight.get_capable_switches
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_preflight(f"{method_name}a")
+        yield responses_preflight(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+    with does_not_raise():
+        first = instance.get_capable_switch_ids("loopback", "managed")
+        instance.invalidate()
+        second = instance.get_capable_switch_ids("loopback", "managed")
+
+    assert first == {"FDO12345ABC"}
+    assert second == {"FDO12345ABC", "FDO12345ABD"}
+
+
+# =============================================================================
+# Test: validate()
+# =============================================================================
+
+
+def test_interface_capability_preflight_00200() -> None:
+    """
+    # Summary
+
+    Verify `validate` returns silently when every requested switch_id is in the capable set.
+
+    ## Test
+
+    - capableSwitches returns two switches: FDO12345ABC, FDO12345ABD
+    - `validate("loopback", "managed", {"FDO12345ABC"})` does not raise
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.validate
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    def responses():
+        yield responses_preflight(key)
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+        instance.validate("loopback", "managed", {"FDO12345ABC"})
+
+
+def test_interface_capability_preflight_00210() -> None:
+    """
+    # Summary
+
+    Verify `validate` raises `RuntimeError` listing the offending switch_id when `fabric_context` is not injected.
+
+    ## Test
+
+    - capableSwitches returns one switch: FDO12345ABC
+    - `validate("loopback", "managed", {"FDO12345ABC", "FDO99999XYZ"})` raises with FDO99999XYZ named
+    - Error message references the fabric, the (interface_type, mode), and the endpoint path
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.validate
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    def responses():
+        yield responses_preflight(key)
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+    match = r"interface_type='loopback'.*mode='managed'.*fabric_1.*switchId=FDO99999XYZ"
+    with pytest.raises(RuntimeError, match=match):
+        instance.validate("loopback", "managed", {"FDO12345ABC", "FDO99999XYZ"})
+
+
+def test_interface_capability_preflight_00220() -> None:
+    """
+    # Summary
+
+    Verify `validate` enriches the offender description with `switch_ip` when `fabric_context` is injected.
+
+    ## Test
+
+    - capableSwitches returns one switch: FDO12345ABC
+    - fabric_context maps FDO99999XYZ -> 10.0.0.99 (via fabric switches list)
+    - `validate("loopback", "managed", {"FDO99999XYZ"})` raises with "switch_ip=10.0.0.99" in the message
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.validate
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        # First: capableSwitches GET
+        yield responses_preflight(f"{method_name}a")
+        # Second: fabric switches list GET (driven by FabricContext.switch_map_by_id lookup)
+        yield responses_preflight(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    fabric_context = FabricContext(rest_send=rest_send, fabric_name="fabric_1")
+    instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1", fabric_context=fabric_context)
+    match = r"switchId=FDO99999XYZ, switch_ip=10\.0\.0\.99"
+    with pytest.raises(RuntimeError, match=match):
+        instance.validate("loopback", "managed", {"FDO99999XYZ"})
+
+
+def test_interface_capability_preflight_00230() -> None:
+    """
+    # Summary
+
+    Verify `validate` raises `ValueError` on an unsupported `(interface_type, mode)` pair before any HTTP call.
+
+    ## Test
+
+    - No response yielded (no HTTP call should be made)
+    - `validate("loopback", "trunk", {"FDO12345ABC"})` raises ValueError mentioning the unsupported mode
+
+    ## Classes and Methods
+
+    - InterfaceCapabilityPreflight.validate
+    - InterfaceCapabilityPreflight._check_taxonomy
+    """
+    gen_responses = ResponseGenerator(iter([]))
+    rest_send = _build_rest_send(gen_responses)
+
+    instance = InterfaceCapabilityPreflight(rest_send=rest_send, fabric_name="fabric_1")
+    match = r"Unsupported mode 'trunk' for interface_type 'loopback'"
+    with pytest.raises(ValueError, match=match):
+        instance.validate("loopback", "trunk", {"FDO12345ABC"})

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for `NDStateMachine` capability-preflight wiring.
+
+Verifies that `manage_state` invokes the orchestrator's `preflight` hook at a point that runs BEFORE
+mutation operations are gated by check mode (PR #275 / issue #273):
+
+- For create/update states (merged/replaced/overridden) `preflight` is called over the proposed set,
+  in check mode as well as normal mode, even though the underlying create/update calls are skipped in
+  check mode.
+- For `deleted` state `preflight` is NOT called (removing configuration does not depend on a switch's
+  capability to host the interface type -- the documented out-of-scope decision).
+
+These drive the full `NDStateMachine.manage_state` path with a spy orchestrator instance, so they cover
+the seam the per-method capability tests in `test_base_interface.py` cannot: the check-mode skip lives in
+`NDStateMachine._execute_operation`, not in the orchestrator.
+"""
+
+# pylint: disable=disallowed-name,protected-access,redefined-outer-name,unused-argument
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+class _SpyLoopbackOrchestrator(LoopbackInterfaceOrchestrator):
+    """Spy subclass that records mutation/preflight calls instead of issuing HTTP.
+
+    `query_all` returns an empty inventory (so `before`/`existing` start empty), and every CRUD plus
+    `preflight` method records `(name, args)` on `self._calls`. This lets a test assert exactly which
+    orchestrator entry points `manage_state` reached, without driving real REST traffic.
+    """
+
+    def model_post_init(self, __context) -> None:
+        super().model_post_init(__context)
+        self._calls: list[tuple] = []
+
+    def query_all(self, model_instance=None, **kwargs) -> ResponseType:
+        return []
+
+    def preflight(self, model_instances) -> None:
+        self._calls.append(("preflight", list(model_instances)))
+
+    def create(self, model_instance, **kwargs) -> ResponseType:
+        self._calls.append(("create", model_instance))
+        return {}
+
+    def create_bulk(self, model_instances, **kwargs) -> ResponseType:
+        self._calls.append(("create_bulk", list(model_instances)))
+        return {}
+
+    def update(self, model_instance, **kwargs) -> ResponseType:
+        self._calls.append(("update", model_instance))
+        return {}
+
+    def delete(self, model_instance, **kwargs) -> None:
+        self._calls.append(("delete", model_instance))
+
+    def delete_bulk(self, model_instances, **kwargs) -> None:
+        self._calls.append(("delete_bulk", list(model_instances)))
+
+
+def _build_rest_send() -> RestSend:
+    """Build a minimal `RestSend` for spy construction; the spy never exercises it."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = ResponseGenerator(iter(()))
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": "fabric_1"})
+    rest_send.sender = sender
+    rest_send.response_handler = ResponseHandler()
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_module(state: str, check_mode: bool, config: list[dict]) -> MockAnsibleModule:
+    """Build a `MockAnsibleModule` with the params `NDStateMachine` reads."""
+    module = MockAnsibleModule()
+    module.check_mode = check_mode
+    module.params = {
+        "state": state,
+        "config": config,
+        "output_level": "normal",
+        "ignore_errors": False,
+        "fabric_name": "fabric_1",
+    }
+    return module
+
+
+def _build_state_machine(state: str, check_mode: bool, config: list[dict]) -> NDStateMachine:
+    """Construct an `NDStateMachine` wired to the spy orchestrator instance."""
+    spy = _SpyLoopbackOrchestrator(rest_send=_build_rest_send())
+    module = _build_module(state=state, check_mode=check_mode, config=config)
+    return NDStateMachine(module=module, model_orchestrator=spy)
+
+
+_CONFIG = [{"switch_ip": "192.168.12.151", "interface_name": "loopback10"}]
+
+
+def test_nd_state_machine_00100() -> None:
+    """
+    # Summary
+
+    Verify `manage_state` runs `preflight` in check mode for `merged`, while the mutation (`create_bulk`)
+    is skipped -- proving the preflight executes ahead of the check-mode gate in `_execute_operation`.
+
+    ## Test
+
+    - `state: merged`, `check_mode: True`, one proposed interface (new vs empty inventory)
+    - `preflight` is recorded exactly once, with the single proposed model
+    - No `create`/`create_bulk` call is recorded (skipped in check mode)
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDBaseInterfaceOrchestrator.preflight()
+    """
+    instance = _build_state_machine(state="merged", check_mode=True, config=_CONFIG)
+
+    with does_not_raise():
+        instance.manage_state()
+
+    calls = instance.model_orchestrator._calls
+    names = [name for name, _ in calls]
+    assert names == ["preflight"]
+    assert len(calls[0][1]) == 1
+    assert calls[0][1][0].get_identifier_value() == ("192.168.12.151", "loopback10")
+
+
+def test_nd_state_machine_00110() -> None:
+    """
+    # Summary
+
+    Verify `manage_state` runs `preflight` AND the mutation in NORMAL mode for `merged` -- the contrast to
+    `test_nd_state_machine_00100` that proves the skipped mutation there is driven by check mode, not by an
+    empty work set. `preflight` precedes the mutation.
+
+    ## Test
+
+    - `state: merged`, `check_mode: False`, one proposed interface
+    - `preflight` is recorded, then `create_bulk` is recorded (loopback supports bulk create)
+    - `preflight` appears before `create_bulk`
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_create_update_state()
+    - NDBaseInterfaceOrchestrator.preflight()
+    """
+    instance = _build_state_machine(state="merged", check_mode=False, config=_CONFIG)
+
+    with does_not_raise():
+        instance.manage_state()
+
+    names = [name for name, _ in instance.model_orchestrator._calls]
+    assert names == ["preflight", "create_bulk"]
+
+
+def test_nd_state_machine_00120() -> None:
+    """
+    # Summary
+
+    Verify `manage_state` does NOT call `preflight` for `deleted` state, documenting the out-of-scope decision:
+    removing configuration does not depend on a switch's capability to host the interface type.
+
+    ## Test
+
+    - `state: deleted`, `check_mode: True`, one proposed interface
+    - No `preflight` call is recorded
+    - No mutation is recorded either (nothing matches the empty inventory, and check mode skips mutations)
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_delete_state()
+    """
+    instance = _build_state_machine(state="deleted", check_mode=True, config=_CONFIG)
+
+    with does_not_raise():
+        instance.manage_state()
+
+    names = [name for name, _ in instance.model_orchestrator._calls]
+    assert "preflight" not in names
+
+
+def test_nd_state_machine_00130() -> None:
+    """
+    # Summary
+
+    Verify `manage_state` runs `preflight` over the proposed (desired-config) set for `overridden` state in check
+    mode. The delete half of `overridden` (`_manage_override_deletions`) is intentionally not preflighted, matching
+    the `deleted` scope decision.
+
+    ## Test
+
+    - `state: overridden`, `check_mode: True`, one proposed interface
+    - `preflight` is recorded exactly once, with the proposed model
+    - No mutation is recorded (check mode)
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDBaseInterfaceOrchestrator.preflight()
+    """
+    instance = _build_state_machine(state="overridden", check_mode=True, config=_CONFIG)
+
+    with does_not_raise():
+        instance.manage_state()
+
+    calls = instance.model_orchestrator._calls
+    names = [name for name, _ in calls]
+    assert names.count("preflight") == 1
+    assert names[0] == "preflight"
+    assert len(calls[0][1]) == 1


### PR DESCRIPTION
## Related Issue(s)

Closes #273, #300, #301, #302

## Proposed Changes

Pre-flights ND's unpublished `/api/v1/manage/fabrics/{fabric}/capableSwitches` endpoint before per-switch configuration calls, converting confusing HTTP 400s on incapable switches into a single aggregate error that names the offending switches.

- **Endpoint model** `EpManageFabricsCapableSwitchesGet`, inheriting `_EpManageFabricsBase` for path construction, with required `interfaceType` / `mode` query params.
- **`InterfaceCapabilityPreflight`** class (`plugins/module_utils/interface_capability_preflight.py`) mirroring `FabricContext` shape:
  - `(interface_type, mode)` cache (switch records + derived switch-id set); one GET per pair per task run
  - Client-side taxonomy enforcement (captured from the ND 4.2 GUI 2026-05-11) — invalid combos raise `ValueError` without consuming a round trip
  - Optional `FabricContext` injection enriches error messages with `switch_ip`
  - `invalidate()` for cache reset
  - Treats HTTP 404 from `capableSwitches` as a hard failure (rather than caching an empty capable set that would mislabel every requested switch); returns defensive copies from `get_capable_switches` / `get_capable_switch_ids` so callers can't corrupt cached state.
- **Orchestrator wiring** on `NDBaseInterfaceOrchestrator`:
  - `interface_type` / `interface_mode` ClassVars (both default `""`) — subclasses opt in by setting **both** to a valid taxonomy pair
  - Lazy `capability_preflight` property
  - `validate_switches_capable(model_instances)` — resolves the target switch-id set, issues a single `capableSwitches` GET, and raises one `RuntimeError` naming every incapable switch; also raises a clear `RuntimeError` if a subclass sets `interface_type` without `interface_mode`. Parameter typed `Sequence[ModelType]` so static analysis rejects generator callers (commit `0157f2f`, fixes #300). Resolves all `switch_ip` values up front and aggregates unresolvable ones into a single `RuntimeError` so a typo on one entry no longer masks problems on the rest (commit `8835915`, fixes #301). In `--check` mode, downgrades capability-endpoint failures and capability mismatches to warnings via `AnsibleModule.warn` so dry-runs stay green when the unpublished endpoint is unavailable (commit `215601a`, fixes #302).
- **State-machine wiring** — `NDStateMachine.manage_state()` invokes the preflight once per run, over the proposed (desired-config) set, **before** the create/update operations (which are skipped in `--check` mode). This is what makes preflight fire during a dry-run; see "Modifies existing files on `develop`" below.
- **Loopback as reference impl** — `interface_type = "loopback"`, `interface_mode = "managed"`. Preflight is driven centrally by the state machine (above), not from loopback's per-op CRUD methods. Delete and read paths intentionally skip preflight.

### Taxonomy embedded in `InterfaceCapabilityPreflight` docstring

| interface_type | valid modes                                                              |
|----------------|--------------------------------------------------------------------------|
| `loopback`     | `managed`                                                                |
| `svi`          | `managed`                                                                |
| `tunnel`       | `managed`                                                                |
| `ethernet`     | `trunk`, `access`, `routed`, `fex`, `pvlan`, `dot1qTunnel`, `unmanaged`  |
| `portChannel`  | `trunk`, `access`, `routed`, `fex`, `pvlan`, `dot1qTunnel`, `unmanaged`  |

VPC uses a different endpoint (`/vpcPairs?view=intendedPairs`) and is handled separately (follow-up). Breakout and subinterface are out of scope (no pre-check available / absent from taxonomy).

## Modifies existing files on `develop` (merge-conflict surface)

This PR is **not purely additive** — it modifies several files that already exist on `develop` (from PRs #220 / loopback). They are the merge-conflict surface; anyone rebasing an in-flight branch onto this work should expect touch-points here, and conflict resolution should preserve the intent noted per file:

**Core base files (shared by every Gen-3 / interface module):**

- `plugins/module_utils/orchestrators/base.py` — adds a no-op `preflight(model_instances)` hook on `NDBaseOrchestrator`. Polymorphic seam so `NDStateMachine` can call preflight on any orchestrator; no-op for non-interface orchestrators (local_user, fabric_*), so behavior there is unchanged. **Conflict intent:** keep the new method; it has no interaction with existing CRUD.
- `plugins/module_utils/nd_state_machine.py` — `manage_state()` now calls `self.model_orchestrator.preflight(list(self.proposed))` before `_manage_create_update_state()` (i.e. ahead of the check-mode skip in `_execute_operation`). The `deleted` branch is intentionally left without a preflight call. **Conflict intent:** the preflight call must stay above the create/update path and out of the delete path.
- `plugins/module_utils/orchestrators/base_interface.py` — overrides `preflight()` to delegate to the existing `validate_switches_capable()`, plus the `interface_type`/`interface_mode` ClassVars and `validate_switches_capable()` itself (from the original feature commits).

**Loopback reference impl (already merged):**

- `plugins/module_utils/orchestrators/loopback_interface.py` — sets the `interface_type`/`interface_mode` ClassVars. The earlier per-op `validate_switches_capable()` calls in `create`/`update`/`create_bulk` were **removed** once preflight moved to the state machine.
- `tests/unit/module_utils/orchestrators/test_loopback_interface.py` and `tests/unit/module_utils/fixtures/fixture_data/test_loopback_interface.json` — mutating tests no longer consume a per-op `capableSwitches` GET (those fixture responses were removed; capability is now covered at the state-machine and base-interface level).

No change to `plugins/modules/nd_interface_loopback.py`, the loopback model, or loopback's user-facing behavior — preflight is internal and runs ahead of the existing API calls.

## Code-review follow-ups resolved in this PR

A high-effort `/code-review` pass on this branch surfaced three additional findings whose fixes touch files originating in `develop` (`base_interface.py`, `loopback_interface.py`, both from PR #220). All three are now resolved in this PR rather than deferred:

- **#300** — Resolved (commit `0157f2f`). `validate_switches_capable` accepted `Iterable` but bulk callers iterate the same parameter twice; a generator caller would have become a silent no-op. Narrowed the base-class signature to `Sequence[ModelType]` so mypy rejects generator callers at the boundary. The method body and all existing call sites (`list[...]`) are unchanged.
- **#301** — Resolved (commit `8835915`). A single unresolvable `switch_ip` masked aggregate capability problems for the rest of the batch. Now resolves every `switch_ip` up front, collects the unresolvable ones, and raises a single aggregate `RuntimeError` naming every unknown IP; the capability GET only runs on the resolved subset.
- **#302** — Resolved (commit `215601a`). Capability preflight issues a live GET in `--check` mode; a 404 (post-#273-merge) would now fail a dry-run that previously succeeded. In `--check` mode, capability-endpoint failures and capability mismatches are downgraded to warnings via `AnsibleModule.warn` so dry-runs stay green and the information still surfaces. Unresolvable `switch_ip` values still raise even in check mode because they reflect user input errors.

Two further in-branch findings in `interface_capability_preflight.py`: the 404-silently-cached-as-empty-set and an initial collection-level defensive copy are in commit `7a130c4`. A later review (gmicol, discussion_r3429267935) found that copy was only shallow — `get_capable_switches()` still shared the cached record dicts by reference, so a caller could mutate a returned record and corrupt the cache (and the derived id set). Completed in commit `8c1ce044`: `get_capable_switches()` now returns a `copy.deepcopy` of the cached list, with a regression test that mutates returned record dicts and asserts the cache is unaffected.

## Adopting preflight in downstream interface modules

Once this lands, each new interface orchestrator (svi, ethernet access / trunk-host, port-channel, ...) opts in with no boilerplate beyond two ClassVars:

1. **Inherit `NDBaseInterfaceOrchestrator`** — already standard for interface orchestrators; nothing new.
2. **Set both ClassVars** to a valid taxonomy pair from the table above:
   - `interface_type: ClassVar[str] = "..."` (e.g. `"ethernet"`, `"portChannel"`, `"svi"`)
   - `interface_mode: ClassVar[str] = "..."` (e.g. `"access"`, `"trunk"`, `"routed"`, `"managed"`)

   One orchestrator = one `(interface_type, interface_mode)` pair; per-mode variants (e.g. ethernet access vs. trunk-host) each set their own `interface_mode`.
3. **Nothing to call per-op.** Preflight is driven centrally by `NDStateMachine.manage_state()` over the proposed set, before create/update; orchestrators no longer call `validate_switches_capable(...)` from their CRUD methods. Setting the two ClassVars is the entire opt-in.
4. **Nothing else to override.** `_resolve_mode()` no longer exists — mode is the `interface_mode` ClassVar. If a subclass sets `interface_type` but omits `interface_mode`, `validate_switches_capable` raises a clear `RuntimeError` naming the class.
5. **Opt out** by leaving `interface_type` as `""` (the base default) — for interface types with no `capableSwitches` coverage (breakout, subinterface).
6. **VPC is separate** — vpc orchestrators use a different endpoint (`/vpcPairs?view=intendedPairs`) and must not set these ClassVars; vpc preflight is a follow-up.
7. **Tests** — no per-op fixture changes needed; capability behavior is covered once at the state-machine level (`test_nd_state_machine.py`) and base-interface level (`test_base_interface.py`). Orchestrator tests no longer carry a per-op `capableSwitches` response.

## Test Notes

- 50 new unit tests for the preflight feature pass:
  - `tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_capable_switches.py` — 9 tests
  - `tests/unit/module_utils/test_interface_capability_preflight.py` — 35 tests (incl. 24 parametrized taxonomy cases, plus 404-failure and defensive-copy tests added in commit `7a130c4`)
  - `tests/unit/module_utils/orchestrators/test_base_interface.py` — 6 tests covering `validate_switches_capable`: opted-out no-op, half-configured `RuntimeError`, aggregate unresolved-IP error (#301), check-mode soften on endpoint failure (#302), check-mode soften on capability mismatch (#302), and the regression guard ensuring mismatches still raise outside check mode (#302)
- **State-machine wiring coverage** — new `tests/unit/module_utils/test_nd_state_machine.py` drives the full `manage_state()` path and proves: check-mode `merged` calls `preflight` while the mutation (`create_bulk`) is skipped; the normal-mode contrast calls both (preflight first); `deleted` does not preflight; `overridden` preflights the proposed set. Plus a `preflight` delegation test in `test_base_interface.py` and generic no-op tests in `test_base_orchestrator.py`.
- `test_loopback_interface.py` / `test_loopback_interface.json` — the per-op `capableSwitches` responses were **removed** (preflight no longer runs inside loopback CRUD); fixtures renumbered to keep the documented contiguous order. Loopback suite green.
- `MockAnsibleModule` gains a `warn()` method that records to `self.warnings` so the check-mode soften tests can assert on emitted warnings.
- Full local unit suite: **1210 passed**, no regressions
- `nd_interface_loopback` integration tests green (happy path unchanged)
- `ansible-test sanity --docker` passes on all changed files (compile / import / pep8 / pylint / validate-modules / empty-init / yamllint / ... across Python 3.8–3.13)
- `black` + `isort` clean
- Integration smoke against the ND 4.2 lab is deferred to a follow-up — depends on having a reproducer for an incapable switch.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)


