### PR TITLE
nd_vpc_pair

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_fabric_switch_actions_deploy.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabric_switch_actions_deploy.py
@@ -1,0 +1,81 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+ND Manage Fabric Switch Actions Deploy endpoint.
+
+This module contains the fabric-level switch deploy endpoint used to push pending
+switch-scoped intent (e.g. vPC pair configuration) to the wire.
+
+## Endpoints
+
+- `EpManageFabricSwitchActionsDeployPost` - Deploy switch-level configuration changes
+  (POST /api/v1/manage/fabrics/{fabric_name}/switchActions/deploy)
+  Body: `{"switchIds": ["serial1", "serial2", ...]}`
+  Response: 207 multi-status with per-switch `status` enum.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import quote
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+class EpManageFabricSwitchActionsDeployPost(FabricNameMixin, NDEndpointBaseModel):
+    """
+    # Summary
+
+    Deploy queued switch-level configuration to the wire. Used by `nd_vpc_pair` to push pair intent created via
+    `EpManageFabricSwitchVpcPairPut`. The 207 multi-status response carries per-switch results under the `switchIds`
+    key (note: not `results` — that key is reserved for `interfaceActions/remove`).
+
+    - Path: `/api/v1/manage/fabrics/{fabric_name}/switchActions/deploy`
+    - Verb: POST
+    - Body: `{"switchIds": ["serial1", "serial2"]}`
+
+    ## Raises
+
+    ### ValueError
+
+    - Via `path` property if `fabric_name` is not set.
+    """
+
+    class_name: Literal["EpManageFabricSwitchActionsDeployPost"] = Field(
+        default="EpManageFabricSwitchActionsDeployPost", frozen=True, description="Class name for backward compatibility"
+    )
+
+    @property
+    def path(self) -> str:
+        """
+        # Summary
+
+        Build the fabric switch-actions deploy path.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `fabric_name` is not set before accessing `path`.
+        """
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "switchActions", "deploy")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """
+        # Summary
+
+        Return `HttpVerbEnum.POST`.
+
+        ## Raises
+
+        None
+        """
+        return HttpVerbEnum.POST

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabric_switch_vpc_pair.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabric_switch_vpc_pair.py
@@ -1,0 +1,146 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+ND Manage Fabric Switch vPC Pair endpoint models.
+
+This module contains endpoint definitions for per-switch vPC pair operations
+in the ND Manage API.
+
+## Endpoints
+
+- `EpManageFabricSwitchVpcPairGet` - Retrieve the vPC pair config attached to a switch
+  (GET /api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/vpcPair)
+- `EpManageFabricSwitchVpcPairPut` - Create, update, or unpair a vPC pair on a switch
+  (PUT /api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/vpcPair)
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import quote
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin, SwitchSerialNumberMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
+
+
+class _EpManageFabricSwitchVpcPairBase(FabricNameMixin, SwitchSerialNumberMixin, NDEndpointBaseModel):
+    """
+    # Summary
+
+    Base class for the per-switch vPC pair endpoint. The path resolves to
+    `/api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/vpcPair`. Subclasses define the HTTP verb.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `fabric_name` is not set before accessing `path`.
+    - If `switch_sn` is not set before accessing `path`.
+    """
+
+    @property
+    def path(self) -> str:
+        """
+        # Summary
+
+        Build the per-switch vPC pair endpoint path. Path-segment values are percent-encoded with `safe=""` for parity
+        with the manage_interfaces endpoint family.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `fabric_name` is not set before accessing `path`.
+        - If `switch_sn` is not set before accessing `path`.
+        """
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        if self.switch_sn is None:
+            raise ValueError(f"{type(self).__name__}.path: switch_sn must be set before accessing path.")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "switches", quote(self.switch_sn, safe=""), "vpcPair")
+
+    def set_identifiers(self, identifier: IdentifierKey = None):
+        """
+        # Summary
+
+        Set `switch_sn` from `identifier`. `fabric_name` must be set separately via `_configure_endpoint` in the orchestrator.
+
+        ## Raises
+
+        None
+        """
+        self.switch_sn = identifier
+
+
+class EpManageFabricSwitchVpcPairGet(_EpManageFabricSwitchVpcPairBase):
+    """
+    # Summary
+
+    Retrieve the vPC pair configuration attached to a switch.
+
+    - Path: `/api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/vpcPair`
+    - Verb: GET
+
+    ## Raises
+
+    ### ValueError
+
+    - Via inherited `path` property if `fabric_name` or `switch_sn` is not set.
+    """
+
+    class_name: Literal["EpManageFabricSwitchVpcPairGet"] = Field(
+        default="EpManageFabricSwitchVpcPairGet", frozen=True, description="Class name for backward compatibility"
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """
+        # Summary
+
+        Return `HttpVerbEnum.GET`.
+
+        ## Raises
+
+        None
+        """
+        return HttpVerbEnum.GET
+
+
+class EpManageFabricSwitchVpcPairPut(_EpManageFabricSwitchVpcPairBase):
+    """
+    # Summary
+
+    Create, update, or unpair a vPC pair on a switch. The body carries `vpcAction: "pair" | "unPair"` plus pair-detail
+    fields (peer, domain ID, keepalive, role priority, etc.).
+
+    - Path: `/api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/vpcPair`
+    - Verb: PUT
+
+    ## Raises
+
+    ### ValueError
+
+    - Via inherited `path` property if `fabric_name` or `switch_sn` is not set.
+    """
+
+    class_name: Literal["EpManageFabricSwitchVpcPairPut"] = Field(
+        default="EpManageFabricSwitchVpcPairPut", frozen=True, description="Class name for backward compatibility"
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """
+        # Summary
+
+        Return `HttpVerbEnum.PUT`.
+
+        ## Raises
+
+        None
+        """
+        return HttpVerbEnum.PUT

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabric_vpc_pairs.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabric_vpc_pairs.py
@@ -1,0 +1,78 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+ND Manage Fabric vPC Pairs endpoint models.
+
+This module contains the fabric-wide vPC pairs list endpoint.
+
+## Endpoints
+
+- `EpManageFabricVpcPairsListGet` - List all vPC pairs in a fabric
+  (GET /api/v1/manage/fabrics/{fabric_name}/vpcPairs)
+
+The fabric-wide list reflects deployed/operational pairs only; per-switch intent state
+is exposed by `EpManageFabricSwitchVpcPairGet` in `manage_fabric_switch_vpc_pair.py`.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import quote
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+class EpManageFabricVpcPairsListGet(FabricNameMixin, NDEndpointBaseModel):
+    """
+    # Summary
+
+    List all vPC pairs in a fabric. Response shape: `{"vpcPairs": [...], "meta": {"counts": {...}}}`.
+
+    - Path: `/api/v1/manage/fabrics/{fabric_name}/vpcPairs`
+    - Verb: GET
+
+    ## Raises
+
+    ### ValueError
+
+    - Via `path` property if `fabric_name` is not set.
+    """
+
+    class_name: Literal["EpManageFabricVpcPairsListGet"] = Field(
+        default="EpManageFabricVpcPairsListGet", frozen=True, description="Class name for backward compatibility"
+    )
+
+    @property
+    def path(self) -> str:
+        """
+        # Summary
+
+        Build the fabric-wide vPC pairs list path.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `fabric_name` is not set before accessing `path`.
+        """
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "vpcPairs")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """
+        # Summary
+
+        Return `HttpVerbEnum.GET`.
+
+        ## Raises
+
+        None
+        """
+        return HttpVerbEnum.GET

--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -275,6 +275,44 @@ class EpManageInterfacesPut(_EpManageInterfacesBase):
         return HttpVerbEnum.PUT
 
 
+class EpManageInterfacesDelete(_EpManageInterfacesBase):
+    """
+    # Summary
+
+    Delete a specific interface via the per-interface endpoint.
+
+    - Path: `/api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/interfaces/{interface_name}`
+    - Verb: DELETE
+
+    Used by vPC interface orchestrators because the `interfaceActions/remove` bulk endpoint returns
+    `Invalid Interface` for vPC entries on ND 4.2.1 (lab-verified). The per-interface DELETE returns 204
+    on success and a subsequent GET returns 404.
+
+    ## Raises
+
+    ### ValueError
+
+    - Via inherited `path` property if `fabric_name`, `switch_sn`, or `interface_name` is not set.
+    """
+
+    class_name: Literal["EpManageInterfacesDelete"] = Field(
+        default="EpManageInterfacesDelete", frozen=True, description="Class name for backward compatibility"
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """
+        # Summary
+
+        Return `HttpVerbEnum.DELETE`.
+
+        ## Raises
+
+        None
+        """
+        return HttpVerbEnum.DELETE
+
+
 class EpManageInterfacesDeploy(FabricNameMixin, NDEndpointBaseModel):
     """
     # Summary

--- a/plugins/module_utils/models/vpc/vpc_pair.py
+++ b/plugins/module_utils/models/vpc/vpc_pair.py
@@ -1,0 +1,293 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+vPC pair Pydantic model for Nexus Dashboard.
+
+Models the pair-level resource exposed at
+`/api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/vpcPair`. The pair owns
+peer-link, keepalive, domain ID, and role-priority configuration; vPC member
+interfaces (`accessVpcHost`, `trunkVpcHost`) live in a separate per-interface model
+family.
+
+## v1 scope
+
+Direct peering only — `useVirtualPeerLink` is frozen to `False`. Fabric peering
+(`useVirtualPeerLink=True`) will be a v2 follow-up that unfreezes the field; the
+discriminated-union extension is non-breaking.
+
+## Composite identifier
+
+`(fabric_name, switch_ip, peer_switch_ip)` — `get_identifier_value()` canonicalizes
+the peer pair via sort so user-supplied `(A, B)` and `(B, A)` collapse to the same
+logical pair (a single switch can only ever be in at most one vPC pair per fabric).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    model_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+
+
+class VpcPairModel(NDBaseModel):
+    """
+    # Summary
+
+    vPC pair configuration for Nexus Dashboard. Composite identifier `(fabric_name, switch_ip, peer_switch_ip)`. v1 freezes
+    `useVirtualPeerLink=False` (direct peering). Pair-detail fields are nested under `vpcPairDetails` on the wire via
+    `payload_nested_fields`.
+
+    The orchestrator resolves `switch_ip` / `peer_switch_ip` (Ansible-facing) into wire serials (`switch_id`, `peer_switch_id`)
+    before calling `to_payload()`.
+
+    ## Raises
+
+    ### ValidationError
+
+    - If `fabric_name`, `switch_ip`, `peer_switch_ip`, or `domain_id` is missing.
+    - If `domain_id` is outside `1..1000`.
+    - If `switch_ip == peer_switch_ip` (peers must differ).
+    - If `use_virtual_peer_link` is set to `True` (frozen, v1 direct peering only).
+    - If `keep_alive_vrf` is not one of `"default"` or `"management"`.
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[list[str] | None] = ["fabric_name", "switch_ip", "peer_switch_ip"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"fabric_name", "switch_ip", "peer_switch_ip"}
+
+    payload_nested_fields: ClassVar[dict[str, list[str]]] = {
+        "vpcPairDetails": [
+            "pair_details_type",
+            "domain_id",
+            "keep_alive_vrf",
+            "keep_alive_hold_timeout",
+            "switch_keep_alive_local_ip",
+            "peer_switch_keep_alive_local_ip",
+            "switch_po_id",
+            "peer_switch_po_id",
+            "switch_member_interfaces",
+            "peer_switch_member_interfaces",
+            "enable_mirror_config",
+            "is_vpc_plus",
+            "is_vteps",
+            "nve_interface",
+            "po_mode",
+            "admin_state",
+            "allowed_vlans",
+        ],
+    }
+
+    # --- Ansible-facing identifiers (not on the wire) ---
+
+    fabric_name: str = Field(min_length=1)
+    switch_ip: str = Field(min_length=1)
+    peer_switch_ip: str = Field(min_length=1)
+
+    # --- Wire-facing serial fields (orchestrator-injected) ---
+
+    switch_id: str | None = Field(default=None, alias="switchId", description="Wire serial for the primary peer (resolved from switch_ip)")
+    peer_switch_id: str | None = Field(default=None, alias="peerSwitchId", description="Wire serial for the secondary peer (resolved from peer_switch_ip)")
+
+    # --- Discriminators ---
+
+    use_virtual_peer_link: Literal[False] = Field(
+        default=False,
+        alias="useVirtualPeerLink",
+        frozen=True,
+        description="Direct peering (False, v1). Fabric peering (True) is a v2 follow-up; field will become bool at that time.",
+    )
+    vpc_action: Literal["pair", "unPair"] = Field(
+        default="pair",
+        alias="vpcAction",
+        description="Pair lifecycle action carried in PUT body",
+    )
+    pair_details_type: Literal["default"] = Field(
+        default="default",
+        alias="type",
+        frozen=True,
+        description="vpcPairDetails discriminator. v1 supports only the default template; custom templates are a v2 follow-up.",
+    )
+
+    # --- Pair-detail fields (nested under vpcPairDetails on the wire) ---
+
+    domain_id: int = Field(ge=1, le=1000, alias="domainId", description="vPC domain ID (1-1000)")
+    keep_alive_vrf: Literal["default", "management"] = Field(
+        default="management",
+        alias="keepAliveVrf",
+        description="VRF used for vPC peer keepalive",
+    )
+    keep_alive_hold_timeout: int | None = Field(default=None, alias="keepAliveHoldTimeout", description="Peer keepalive hold timeout in seconds")
+    switch_keep_alive_local_ip: str | None = Field(
+        default=None,
+        alias="switchKeepAliveLocalIp",
+        description="Peer-keepalive source IP on peer 1. Defaults to switch_ip when keep_alive_vrf is 'management'.",
+    )
+    peer_switch_keep_alive_local_ip: str | None = Field(
+        default=None,
+        alias="peerSwitchKeepAliveLocalIp",
+        description="Peer-keepalive source IP on peer 2. Defaults to peer_switch_ip when keep_alive_vrf is 'management'.",
+    )
+    switch_po_id: int | None = Field(
+        default=None,
+        ge=1,
+        le=4096,
+        alias="switchPoId",
+        description="Peer-link port-channel ID on peer 1",
+    )
+    peer_switch_po_id: int | None = Field(
+        default=None,
+        ge=1,
+        le=4096,
+        alias="peerSwitchPoId",
+        description="Peer-link port-channel ID on peer 2",
+    )
+    switch_member_interfaces: list[str] | None = Field(default=None, alias="switchMemberInterfaces", description="Peer-link member ports on peer 1")
+    peer_switch_member_interfaces: list[str] | None = Field(default=None, alias="peerSwitchMemberInterfaces", description="Peer-link member ports on peer 2")
+    enable_mirror_config: bool | None = Field(default=None, alias="enableMirrorConfig", description="Mirror peer-1 config onto peer-2")
+    is_vpc_plus: bool | None = Field(default=None, alias="isVpcPlus", description="Enable vPC+")
+    is_vteps: bool | None = Field(default=None, alias="isVteps", description="Both peers act as VTEPs")
+    nve_interface: int | None = Field(default=None, alias="nveInterface", description="NVE interface ID for VXLAN")
+    po_mode: str | None = Field(default=None, alias="poMode", description="Peer-link port-channel mode (active/passive/on)")
+    admin_state: bool | None = Field(default=None, alias="adminState", description="Peer-link admin state")
+    allowed_vlans: str | None = Field(default=None, alias="allowedVlans", description="VLAN list permitted across the peer link")
+
+    # --- Validators ---
+
+    @model_validator(mode="before")
+    @classmethod
+    def flatten_vpc_pair_details(cls, data):
+        """
+        # Summary
+
+        Lift `vpcPairDetails` nested fields up to the top level on input so that the round-trip between `to_payload()`
+        (which nests under `vpcPairDetails`) and `from_response()` (which receives the nested wire shape) works
+        through standard Pydantic validation. Top-level fields take precedence if both shapes are present.
+
+        ## Raises
+
+        None
+        """
+        if isinstance(data, dict) and isinstance(data.get("vpcPairDetails"), dict):
+            details = data.pop("vpcPairDetails")
+            for key, value in details.items():
+                data.setdefault(key, value)
+        return data
+
+    @model_validator(mode="after")
+    def default_keepalive_local_ips(self) -> "VpcPairModel":
+        """
+        # Summary
+
+        Default `switch_keep_alive_local_ip` / `peer_switch_keep_alive_local_ip` to the corresponding management IPs
+        when they are unset and `keep_alive_vrf == "management"`. ND requires both keepalive local IPs in the PUT
+        body even though the OpenAPI schema marks them optional; for the management-VRF case, the management IP is
+        the standard value and the user should not have to repeat it.
+
+        ## Raises
+
+        None
+        """
+        if self.keep_alive_vrf == "management":
+            if self.switch_keep_alive_local_ip is None and self.switch_ip:
+                self.switch_keep_alive_local_ip = self.switch_ip
+            if self.peer_switch_keep_alive_local_ip is None and self.peer_switch_ip:
+                self.peer_switch_keep_alive_local_ip = self.peer_switch_ip
+        return self
+
+    @model_validator(mode="after")
+    def validate_peers_differ(self) -> "VpcPairModel":
+        """
+        # Summary
+
+        Reject configurations where `switch_ip` and `peer_switch_ip` are the same — a switch cannot vPC-pair with itself.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `switch_ip == peer_switch_ip`.
+        """
+        if self.switch_ip == self.peer_switch_ip:
+            raise ValueError("switch_ip and peer_switch_ip must differ - a switch cannot vPC-pair with itself")
+        return self
+
+    # --- Identifier ---
+
+    def get_identifier_value(self) -> tuple:
+        """
+        # Summary
+
+        Return the composite identifier as `(fabric_name, low_ip, high_ip)`. The peer IPs are sorted so that
+        user-supplied `(A, B)` and `(B, A)` orderings collapse to the same logical pair (a switch can only ever
+        be in one vPC pair per fabric).
+
+        ## Raises
+
+        ### ValueError
+
+        - If any of `fabric_name`, `switch_ip`, `peer_switch_ip` is `None`.
+        """
+        for field in ("fabric_name", "switch_ip", "peer_switch_ip"):
+            if getattr(self, field, None) is None:
+                raise ValueError(f"Composite identifier field '{field}' is None")
+        low, high = sorted([self.switch_ip, self.peer_switch_ip])
+        return (self.fabric_name, low, high)
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_vpc_pair` module. Frozen / internal fields
+        (`use_virtual_peer_link`, `vpc_action`) are intentionally NOT exposed.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=False,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    peer_switch_ip=dict(type="str", required=True),
+                    domain_id=dict(type="int", required=True),
+                    keep_alive_vrf=dict(type="str", default="management", choices=["default", "management"]),
+                    keep_alive_hold_timeout=dict(type="int"),
+                    switch_keep_alive_local_ip=dict(type="str"),
+                    peer_switch_keep_alive_local_ip=dict(type="str"),
+                    switch_po_id=dict(type="int"),
+                    peer_switch_po_id=dict(type="int"),
+                    switch_member_interfaces=dict(type="list", elements="str"),
+                    peer_switch_member_interfaces=dict(type="list", elements="str"),
+                    enable_mirror_config=dict(type="bool"),
+                    is_vpc_plus=dict(type="bool"),
+                    is_vteps=dict(type="bool"),
+                    nve_interface=dict(type="int"),
+                    po_mode=dict(type="str"),
+                    admin_state=dict(type="bool"),
+                    allowed_vlans=dict(type="str"),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted", "query"],
+            ),
+        )

--- a/plugins/module_utils/orchestrators/vpc_base.py
+++ b/plugins/module_utils/orchestrators/vpc_base.py
@@ -1,0 +1,366 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# pyright: reportAttributeAccessIssue=false
+# ModelType is NDBaseModel which lacks interface-specific fields (switch_ip,
+# interface_name, config_data). Concrete subclasses always bind ModelType to a
+# model that provides these fields, so the accesses are safe at runtime.
+
+"""
+Base orchestrator for vPC interface modules on Nexus Dashboard.
+
+This module provides `VpcBaseOrchestrator`, which implements shared CRUD operations for all vPC interface
+types (`accessVpcHost`, `trunkVpcHost`, etc.) via the ND Manage Interfaces API. Type-specific orchestrators
+inherit from this base and provide their own `model_class` and `_managed_policy_types()`.
+
+Inherits shared interface lifecycle operations (deploy queuing, fabric validation, switch resolution) from
+`NDBaseInterfaceOrchestrator` and adds vPC-specific functionality:
+
+- Peer-serial auto-resolution: each create/update reads the per-switch `vpcPair` endpoint to obtain the peer
+  serial, then injects it as `peerSwitchId` in the payload. Results are cached per orchestrator instance so
+  bulk operations make at most one lookup per primary switch.
+- Standard remove-based deletion (vPC interfaces are virtual and deletable).
+- Fabric-wide `query_all()` filtered by `interfaceType: "vpc"` and per-type policy filtering.
+
+A vPC interface spans two switches in a vPC pair; the user supplies one peer's management IP as `switch_ip`.
+If the supplied switch is not in a vPC pair the orchestrator raises a clear `RuntimeError` instructing the
+user to create the pair first via `nd_vpc_pair`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_switch_vpc_pair import (
+    EpManageFabricSwitchVpcPairGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesDelete,
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+ModelType = NDBaseModel
+
+
+class VpcBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
+    """
+    # Summary
+
+    Base orchestrator for vPC interface CRUD operations on Nexus Dashboard.
+
+    Provides shared logic for all vPC interface types. Subclasses must set `model_class` and implement
+    `_managed_policy_types()` to define which policy types they manage.
+
+    Each create/update reads the `vpcPair` record for the primary switch to obtain the peer serial, which is
+    then injected as `peerSwitchId` in the payload. Lookups are cached per orchestrator instance.
+
+    Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` queues vPC interfaces for
+    bulk removal via `interfaceActions/remove` and bulk deploy. Call `remove_pending` and `deploy_pending` after
+    all mutations are complete.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
+    - Via `_resolve_peer_switch_id` if the switch is not in a vPC pair.
+    - Via `create` if the create API request fails.
+    - Via `update` if the update API request fails.
+    - Via `remove_pending` if the bulk remove API request fails.
+    - Via `deploy_pending` if the bulk deploy API request fails.
+    - Via `query_one` if the query API request fails.
+    - Via `query_all` if the query API request fails.
+    """
+
+    # TODO(4.2.1) The bulk `/api/v1/manage/fabrics/{fabric}/interfaceActions/remove` endpoint returns
+    # `{"status":"Failed","message":"Invalid Interface"}` inside a 207 for vPC interfaces (lab-verified). The
+    # per-interface `DELETE /interfaces/{name}` endpoint works (returns 204). We therefore disable bulk delete and
+    # use the per-interface DELETE via `delete_endpoint`.
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = False
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] | None = None
+
+    def model_post_init(self, __context) -> None:
+        """
+        # Summary
+
+        Initialize mutable private state. Extends `NDBaseInterfaceOrchestrator.model_post_init` with a
+        per-instance peer-serial cache so bulk operations make at most one `vpcPair` GET per primary switch.
+
+        ## Raises
+
+        None
+        """
+        super().model_post_init(__context)
+        self._peer_serial_cache: dict[str, str] = {}
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator. Subclasses must override this method
+        to return their specific policy types (e.g., `{"accessVpcHost"}` for the access orchestrator).
+
+        ## Raises
+
+        ### NotImplementedError
+
+        - Always, if not overridden by a subclass.
+        """
+        raise NotImplementedError("Subclasses must implement _managed_policy_types()")
+
+    def _resolve_peer_switch_id(self, switch_ip: str, primary_serial: str) -> str:
+        """
+        # Summary
+
+        Resolve the peer switch's serial number for the vPC pair containing `primary_serial`. Reads the per-switch
+        `vpcPair` endpoint. Caches the result per orchestrator instance so bulk operations issue at most one lookup
+        per primary switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the switch is not in a vPC pair (the `vpcPair` GET returns 404 / empty body).
+        - If the `vpcPair` GET returns success but omits `peerSwitchId`.
+        """
+        cached = self._peer_serial_cache.get(primary_serial)
+        if cached:
+            return cached
+        api_endpoint = EpManageFabricSwitchVpcPairGet()
+        api_endpoint.fabric_name = self.fabric_name
+        api_endpoint.switch_sn = primary_serial
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        if not result:
+            raise RuntimeError(
+                f"Switch {switch_ip} (serial {primary_serial}) is not in a vPC pair; " f"create the pair via nd_vpc_pair before configuring vPC interfaces."
+            )
+        peer_serial = result.get("peerSwitchId")
+        if not peer_serial:
+            raise RuntimeError(f"vPC pair record for switch {switch_ip} (serial {primary_serial}) is missing 'peerSwitchId'; " f"received: {result!r}")
+        self._peer_serial_cache[primary_serial] = peer_serial
+        return peer_serial
+
+    def _inject_peer_switch_id(self, payload: dict, peer_serial: str) -> dict:
+        """
+        # Summary
+
+        Inject `peerSwitchId` into the nested `configData.networkOS.policy` block of an interface payload. The model
+        already nests `peer_switch_id` under `policy`, so this just sets the value if not already present.
+
+        ## Raises
+
+        None
+        """
+        policy = payload.get("configData", {}).get("networkOS", {}).get("policy")
+        if policy is not None:
+            policy["peerSwitchId"] = peer_serial
+        return payload
+
+    def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create a vPC interface configuration. Resolves `switch_ip` to a primary serial, resolves the peer serial via
+        the vPC pair record, injects both into the payload, and POSTs the wrapped `interfaces` array. Queues a deploy
+        for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails.
+        - If the primary switch is not in a vPC pair.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+            api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            self._inject_peer_switch_id(payload, peer_serial)
+            request_body = {"interfaces": [payload]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update a vPC interface configuration. Resolves `switch_ip` to a primary serial, resolves the peer serial via
+        the vPC pair record, injects both into the payload, and PUTs the updated configuration. Queues a deploy for
+        later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails.
+        - If the primary switch is not in a vPC pair.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+            api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            self._inject_peer_switch_id(payload, peer_serial)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: ModelType, **kwargs) -> None:
+        """
+        # Summary
+
+        Delete a vPC interface immediately via the per-interface `DELETE /interfaces/{name}` endpoint, then queue
+        a deploy for later bulk execution via `deploy_pending`. The DELETE returns 204 on success; a subsequent GET
+        returns 404. The deploy pushes the removal to both peers and reverts member interfaces to their fabric
+        default configuration.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the DELETE API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.delete_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+        except Exception as e:
+            raise RuntimeError(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def create_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create multiple vPC interfaces in bulk. Groups by primary switch, resolves the peer serial once per group, and
+        sends one POST per primary switch with all vPC interfaces in the `interfaces` array. Queues deploys for all
+        created interfaces for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create API request fails.
+        - If any primary switch is not in a vPC pair.
+        """
+        try:
+            groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+            for model_instance in model_instances:
+                switch_id = self._resolve_switch_id(model_instance.switch_ip)
+                peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+                payload = model_instance.to_payload()
+                payload["switchId"] = switch_id
+                self._inject_peer_switch_id(payload, peer_serial)
+                groups[switch_id].append((model_instance.interface_name, payload))
+
+            results = []
+            for switch_id, items in groups.items():
+                # Guarded at runtime by @requires_bulk_support("supports_bulk_create")
+                api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
+                request_body = {"interfaces": [payload for interface_name, payload in items]}
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+                results.append(result)
+                for interface_name, payload in items:
+                    self._queue_deploy(interface_name, switch_id)
+            return results
+        except Exception as e:
+            raise RuntimeError(f"Bulk create failed: {e}") from e
+
+    def query_one(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Query a single vPC interface by name on a specific switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
+        vPC interfaces with policy types managed by this orchestrator (as defined by `_managed_policy_types()`).
+
+        Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
+
+        Each returned interface dict is enriched with a `switch_ip` field so that the model has routing context.
+        vPC interfaces are de-duplicated by `interfaceName` (ND returns each vPC twice — once per peer); the entry
+        with the alphabetically-lower `switchId` is kept as the canonical representative.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist on the target ND node.
+        - If the fabric is in deployment-freeze mode.
+        - If the query API request fails.
+        """
+        managed_types = self._managed_policy_types()
+        try:
+            self.validate_prerequisites()
+            # TODO(4.2.1) ND returns each vPC interface TWICE — once per peer switch — with identical configData.
+            # Dedupe by interfaceName, keeping the entry whose URL-path `switchId` is alphabetically lower so the
+            # chosen representative is stable across runs. Without this dedupe, `_manage_override_deletions` would
+            # see the peer-side copy as "not in proposed" and queue a spurious delete.
+            interfaces_by_name: dict[str, tuple[str, dict]] = {}
+            for switch_ip, switch_id in self.fabric_context.switch_map.items():
+                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                if not result:
+                    continue
+                interfaces = result.get("interfaces", []) or []
+                vpc_interfaces = [iface for iface in interfaces if iface.get("interfaceType") == "vpc"]
+                managed = [
+                    iface for iface in vpc_interfaces if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
+                ]
+                for iface in managed:
+                    iface["switchIp"] = switch_ip
+                    name = iface.get("interfaceName")
+                    if name is None:
+                        continue
+                    existing = interfaces_by_name.get(name)
+                    if existing is None or switch_id < existing[0]:
+                        interfaces_by_name[name] = (switch_id, iface)
+            return [entry for _, entry in interfaces_by_name.values()]
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/vpc_pair.py
+++ b/plugins/module_utils/orchestrators/vpc_pair.py
@@ -1,0 +1,388 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+vPC pair orchestrator for Nexus Dashboard.
+
+Direct subclass of `NDBaseOrchestrator` (a vPC pair is not an interface, so this orchestrator does NOT inherit
+from `NDBaseInterfaceOrchestrator` or `PortChannelBaseOrchestrator`).
+
+## Two-stage lifecycle
+
+ND models pair lifecycle as a two-stage operation:
+
+1. **Intent**: `PUT /api/v1/manage/fabrics/{fabric}/switches/{switch_sn}/vpcPair` — sets the pair config (or unpair).
+   Returns 204 No Content. Visible at the per-switch GET endpoint immediately.
+2. **Deploy**: `POST /api/v1/manage/fabrics/{fabric}/switchActions/deploy` body `{"switchIds":[le1,le2]}` — pushes the
+   intent to the wire. Returns 207 multi-status. ND switch poller propagates discovery state ~30-40s later.
+
+This orchestrator queues both peer serials for deploy after every mutation (`create` / `update` / `delete`) and
+flushes the queue via `deploy_pending` at the end of the module run.
+
+## 207 status parsing
+
+The `switchActions/deploy` response key is `switchIds` (NOT `results` — that key is reserved for `interfaceActions/remove`).
+Per-switch `status` is compared case-insensitively because lab observation showed mixed casing across endpoints.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, List, Type
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_switch_actions_deploy import (
+    EpManageFabricSwitchActionsDeployPost,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_switch_vpc_pair import (
+    EpManageFabricSwitchVpcPairGet,
+    EpManageFabricSwitchVpcPairPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_vpc_pairs import (
+    EpManageFabricVpcPairsListGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.vpc.vpc_pair import VpcPairModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class VpcPairOrchestrator(NDBaseOrchestrator[VpcPairModel]):
+    """
+    # Summary
+
+    Orchestrator for vPC pair CRUD on Nexus Dashboard. PUT vpcPair sets intent; switchActions/deploy pushes to the wire.
+    Both peer serials are queued for deploy after every mutation and flushed via `deploy_pending` at module-end.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `_resolve_switch_id` if `switch_ip` or `peer_switch_ip` cannot be mapped to a switch in the fabric.
+    - Via `create` / `update` / `delete` if the underlying API request fails.
+    - Via `query_one` if the per-switch GET fails (404 maps to `None`, not an error).
+    - Via `query_all` if the fabric-wide list GET fails.
+    - Via `deploy_pending` if the deploy POST fails or any per-switch status is not "success" (case-insensitive).
+    """
+
+    model_class: ClassVar[Type[NDBaseModel]] = VpcPairModel
+
+    create_endpoint: Type[NDEndpointBaseModel] = EpManageFabricSwitchVpcPairPut
+    update_endpoint: Type[NDEndpointBaseModel] = EpManageFabricSwitchVpcPairPut
+    delete_endpoint: Type[NDEndpointBaseModel] = EpManageFabricSwitchVpcPairPut
+    query_one_endpoint: Type[NDEndpointBaseModel] = EpManageFabricSwitchVpcPairGet
+    query_all_endpoint: Type[NDEndpointBaseModel] = EpManageFabricVpcPairsListGet
+
+    deploy_endpoint: ClassVar[Type[NDEndpointBaseModel]] = EpManageFabricSwitchActionsDeployPost
+
+    deploy: bool = True
+
+    _fabric_context: FabricContext | None = None
+
+    def model_post_init(self, __context) -> None:
+        """
+        # Summary
+
+        Initialize per-instance mutable state after Pydantic construction. Pydantic disallows `Field()` on
+        underscore-prefixed names, so private state is set here.
+
+        ## Raises
+
+        None
+        """
+        self._pending_deploy_switch_ids: List[str] = []
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        # Summary
+
+        Return `fabric_name` from module params (sourced via the `RestSend` `params` dict).
+
+        ## Raises
+
+        None
+        """
+        return self.rest_send.params.get("fabric_name")
+
+    @property
+    def fabric_context(self) -> FabricContext:
+        """
+        # Summary
+
+        Return a lazily-initialized `FabricContext` for this orchestrator's fabric.
+
+        ## Raises
+
+        None
+        """
+        if self._fabric_context is None:
+            self._fabric_context = FabricContext(rest_send=self.rest_send, fabric_name=self.fabric_name)
+        return self._fabric_context
+
+    def _resolve_switch_id(self, switch_ip: str) -> str:
+        """
+        # Summary
+
+        Resolve a `switch_ip` to its `switchId` via `FabricContext`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If no switch matches the given IP in the fabric.
+        """
+        return self.fabric_context.get_switch_id(switch_ip)
+
+    def _configure_switch_endpoint(self, api_endpoint, switch_sn: str):
+        """
+        # Summary
+
+        Set `fabric_name` and `switch_sn` on a per-switch endpoint instance before path generation.
+
+        ## Raises
+
+        None
+        """
+        api_endpoint.fabric_name = self.fabric_name
+        api_endpoint.switch_sn = switch_sn
+        return api_endpoint
+
+    def _queue_deploy_switch(self, switch_id: str) -> None:
+        """
+        # Summary
+
+        Queue a `switch_id` for deferred deployment. Idempotent — re-queueing the same serial is a no-op.
+
+        ## Raises
+
+        None
+        """
+        if switch_id not in self._pending_deploy_switch_ids:
+            self._pending_deploy_switch_ids.append(switch_id)
+
+    def _resolve_and_queue_pair(self, model_instance: VpcPairModel) -> tuple[str, str]:
+        """
+        # Summary
+
+        Resolve both peer IPs to serials, populate them on the model (so `to_payload()` emits the correct
+        `switchId` / `peerSwitchId` values), and queue both for deploy. Returns the resolved (peer1, peer2) serials.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If either peer IP cannot be resolved to a switch in the fabric.
+        """
+        switch_id = self._resolve_switch_id(model_instance.switch_ip)
+        peer_switch_id = self._resolve_switch_id(model_instance.peer_switch_ip)
+        model_instance.switch_id = switch_id
+        model_instance.peer_switch_id = peer_switch_id
+        self._queue_deploy_switch(switch_id)
+        self._queue_deploy_switch(peer_switch_id)
+        return switch_id, peer_switch_id
+
+    def create(self, model_instance: VpcPairModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create a vPC pair via PUT vpcPair (vpcAction=pair). Resolves both peer IPs to serials, configures the
+        per-switch endpoint, and queues both serials for deferred deploy.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails or peer resolution fails.
+        """
+        try:
+            model_instance.vpc_action = "pair"
+            switch_id, _ = self._resolve_and_queue_pair(model_instance)
+            api_endpoint = self._configure_switch_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload())
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: VpcPairModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update an existing vPC pair via PUT vpcPair (vpcAction=pair). PUT is idempotent at the intent layer.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails or peer resolution fails.
+        """
+        try:
+            model_instance.vpc_action = "pair"
+            switch_id, _ = self._resolve_and_queue_pair(model_instance)
+            api_endpoint = self._configure_switch_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload())
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: VpcPairModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Tear down a vPC pair via PUT vpcPair with `{"vpcAction": "unPair"}`. ND cascades the unpair to all member
+        vPC interfaces — the orchestrator does NOT need to pre-delete `nd_interface_vpc_*` members.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the delete API request fails or peer resolution fails.
+        """
+        try:
+            model_instance.vpc_action = "unPair"
+            switch_id, _ = self._resolve_and_queue_pair(model_instance)
+            api_endpoint = self._configure_switch_endpoint(self.delete_endpoint(), switch_sn=switch_id)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data={"vpcAction": "unPair"})
+        except Exception as e:
+            raise RuntimeError(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_one(self, model_instance: VpcPairModel, **kwargs) -> VpcPairModel | None:
+        """
+        # Summary
+
+        Query the per-switch vPC pair intent for the model's `switch_ip`. Returns `None` when ND returns 404
+        (no pair exists). Otherwise returns a populated `VpcPairModel`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails for any reason other than 404.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_switch_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            response = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            if not response:
+                return None
+            enriched = dict(response)
+            enriched["fabric_name"] = self.fabric_name
+            enriched["switch_ip"] = model_instance.switch_ip
+            enriched["peer_switch_ip"] = model_instance.peer_switch_ip
+            return VpcPairModel.from_response(enriched)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Walk the user-proposed `config` items and call the per-switch vPC pair GET endpoint for each unique
+        peer pair. Each existing pair's wire response is enriched with `fabric_name`, `switch_ip`, and
+        `peer_switch_ip` so that `VpcPairModel.from_response()` can populate the composite identifier.
+
+        The fabric-wide `vpcPairs` list endpoint is intentionally NOT used here — it lags or omits recently
+        deployed pairs in practice. The per-switch GET is authoritative.
+
+        Returns an empty list when `config` is empty (e.g. `state=query` with no specified peers).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If a per-switch query API request fails (404 from the GET is treated as "no pair", not an error).
+        """
+        try:
+            config_items = self.rest_send.params.get("config") or []
+            pairs: List[dict] = []
+            seen_keys: set[tuple[str, str]] = set()
+            for item in config_items:
+                if not isinstance(item, dict):
+                    continue
+                switch_ip = item.get("switch_ip")
+                peer_switch_ip = item.get("peer_switch_ip")
+                if not switch_ip or not peer_switch_ip:
+                    continue
+                key = tuple(sorted([switch_ip, peer_switch_ip]))
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                switch_id = self._resolve_switch_id(switch_ip)
+                api_endpoint = self._configure_switch_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+                response = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                if not response:
+                    continue
+                enriched = dict(response)
+                enriched["fabric_name"] = self.fabric_name
+                enriched["switch_ip"] = switch_ip
+                enriched["peer_switch_ip"] = peer_switch_ip
+                pairs.append(enriched)
+            return pairs
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e
+
+    def deploy_pending(self) -> ResponseType | None:
+        """
+        # Summary
+
+        Flush queued switch deploys via `switchActions/deploy`. Parses the 207 multi-status response under the
+        `switchIds` key (not `results`); per-switch status is compared case-insensitively because ND returns
+        mixed casing across deploy endpoints.
+
+        Returns `None` (without making any API call) when the queue is empty or `deploy` is False.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the deploy POST fails.
+        - If any per-switch entry has `status != "success"` (case-insensitive); the failed switch's `message`
+          is included in the exception text.
+        """
+        if not self.deploy or not self._pending_deploy_switch_ids:
+            return None
+        try:
+            api_endpoint = self.deploy_endpoint()
+            api_endpoint.fabric_name = self.fabric_name
+            payload = {"switchIds": list(self._pending_deploy_switch_ids)}
+            response = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._validate_deploy_response(response)
+            self._pending_deploy_switch_ids = []
+            return response
+        except Exception as e:
+            raise RuntimeError(f"Bulk deploy failed for switches {self._pending_deploy_switch_ids}: {e}") from e
+
+    # Deploy-response messages that ND uses for idempotent no-op deploys. These do not indicate a deploy
+    # failure — ND just had nothing to push because the intent already matches the switch state.
+    _BENIGN_DEPLOY_MESSAGE_FRAGMENTS: ClassVar[tuple[str, ...]] = ("no commands to execute",)
+
+    @classmethod
+    def _validate_deploy_response(cls, response: ResponseType) -> None:
+        """
+        # Summary
+
+        Inspect the 207 multi-status response from `switchActions/deploy`. Raise on any per-switch entry whose
+        status is not `"success"` (case-insensitive), EXCEPT entries whose `message` matches one of
+        `_BENIGN_DEPLOY_MESSAGE_FRAGMENTS` — those represent ND no-ops (already in sync) and are treated as
+        success.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any per-switch entry under the `switchIds` key has a non-success status and the message is not
+          a known benign no-op.
+        """
+        if not isinstance(response, dict):
+            return
+        entries = response.get("switchIds", []) or []
+        failures = []
+        for entry in entries:
+            status = str(entry.get("status", "")).lower()
+            if status == "success":
+                continue
+            message = str(entry.get("message", ""))
+            if any(fragment in message.lower() for fragment in cls._BENIGN_DEPLOY_MESSAGE_FRAGMENTS):
+                continue
+            failures.append(f"{entry.get('switchId', '<unknown>')}: {message or '<no message>'}")
+        if failures:
+            raise RuntimeError("; ".join(failures))

--- a/plugins/modules/nd_vpc_pair.py
+++ b/plugins/modules/nd_vpc_pair.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_vpc_pair
-version_added: "1.4.0"
+version_added: "2.0.0"
 short_description: Manage vPC pairs on Cisco Nexus Dashboard
 description:
 - Manage virtual Port-Channel (vPC) pairs on Cisco Nexus Dashboard.

--- a/plugins/modules/nd_vpc_pair.py
+++ b/plugins/modules/nd_vpc_pair.py
@@ -1,0 +1,281 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Ansible module for managing vPC pairs on Cisco Nexus Dashboard."""
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_vpc_pair
+version_added: "1.4.0"
+short_description: Manage vPC pairs on Cisco Nexus Dashboard
+description:
+- Manage virtual Port-Channel (vPC) pairs on Cisco Nexus Dashboard.
+- Supports creating, updating, querying, and tearing down vPC pairs between two leaf switches in a fabric.
+- This module manages the pair-level lifecycle only (peer-link, keepalive, domain ID, role priority).
+  Member vPC interfaces are managed by the C(nd_interface_vpc_access) and C(nd_interface_vpc_trunk_host) modules.
+- Tearing down a pair (O(state=deleted)) cascades on the ND side and removes all member vPC interfaces on both peers.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target switches.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of vPC pairs to configure.
+    - Each item specifies the two peer switches by management IP and the pair-level configuration.
+    type: list
+    elements: dict
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of the first peer switch.
+        - Resolved to the switch serial number internally.
+        type: str
+        required: true
+      peer_switch_ip:
+        description:
+        - The management IP address of the second peer switch.
+        - Resolved to the switch serial number internally.
+        - Must differ from O(config.switch_ip).
+        type: str
+        required: true
+      domain_id:
+        description:
+        - The vPC domain ID. Must be in the range 1-1000.
+        type: int
+        required: true
+      keep_alive_vrf:
+        description:
+        - The VRF used for vPC peer keepalive.
+        - Defaults to C(management) to align with the typical SITE1 fabric setting.
+        type: str
+        default: management
+        choices: [ default, management ]
+      keep_alive_hold_timeout:
+        description:
+        - The peer keepalive hold timeout in seconds.
+        type: int
+      switch_po_id:
+        description:
+        - The peer-link port-channel ID on peer 1. Range 1-4096.
+        type: int
+      peer_switch_po_id:
+        description:
+        - The peer-link port-channel ID on peer 2. Range 1-4096.
+        type: int
+      switch_member_interfaces:
+        description:
+        - List of peer-link member interfaces on peer 1 (e.g. C(["Ethernet1/3"])).
+        type: list
+        elements: str
+      peer_switch_member_interfaces:
+        description:
+        - List of peer-link member interfaces on peer 2.
+        type: list
+        elements: str
+      enable_mirror_config:
+        description:
+        - Mirror peer-1 configuration onto peer-2.
+        type: bool
+      is_vpc_plus:
+        description:
+        - Enable vPC+ (FabricPath).
+        type: bool
+      is_vteps:
+        description:
+        - Both peers act as VTEPs.
+        type: bool
+      nve_interface:
+        description:
+        - The NVE interface ID for VXLAN.
+        type: int
+      po_mode:
+        description:
+        - The peer-link port-channel mode (e.g. C(active), C(passive), C(on)).
+        type: str
+      admin_state:
+        description:
+        - The administrative state of the peer link.
+        type: bool
+      allowed_vlans:
+        description:
+        - VLAN list permitted across the peer link.
+        type: str
+  deploy:
+    description:
+    - Whether to deploy pair changes to the switches after the intent is configured.
+    - When V(true), both peer serials are queued and pushed via C(switchActions/deploy) at the end of module execution.
+    - When V(false), the pair intent is configured on ND but not pushed to the switches.
+    type: bool
+    default: true
+  state:
+    description:
+    - The desired state of the vPC pair on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new pairs and update existing ones.
+    - Use O(state=replaced) to replace the pairs specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+    - Use O(state=deleted) to unpair the switches. This cascades and also removes member vPC interfaces on both peers.
+    - Use O(state=query) to retrieve the current pair state without making changes.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted, query ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This release supports direct vPC peering only (C(useVirtualPeerLink=false)).
+  Fabric peering will be added in a follow-up release.
+- ND deploy returns when the intent has been handed off to the switches; switch-side discovery converges
+  asynchronously (typically 30-40 seconds on virtual switches).
+"""
+
+EXAMPLES = r"""
+- name: Create a vPC pair between two leafs
+  cisco.nd.nd_vpc_pair:
+    fabric_name: SITE1
+    config:
+      - switch_ip: 192.168.12.151
+        peer_switch_ip: 192.168.12.155
+        domain_id: 1
+        keep_alive_vrf: management
+        switch_po_id: 1
+        peer_switch_po_id: 1
+        switch_member_interfaces:
+          - Ethernet1/3
+        peer_switch_member_interfaces:
+          - Ethernet1/2
+    state: merged
+
+- name: Query the current vPC pair state for two switches
+  cisco.nd.nd_vpc_pair:
+    fabric_name: SITE1
+    config:
+      - switch_ip: 192.168.12.151
+        peer_switch_ip: 192.168.12.155
+        domain_id: 1
+    state: query
+  register: result
+
+- name: Unpair two switches (cascades to all member vPC interfaces)
+  cisco.nd.nd_vpc_pair:
+    fabric_name: SITE1
+    config:
+      - switch_ip: 192.168.12.151
+        peer_switch_ip: 192.168.12.155
+        domain_id: 1
+    state: deleted
+
+- name: Configure pair intent without deploying (stage for batched deploy)
+  cisco.nd.nd_vpc_pair:
+    fabric_name: SITE1
+    config:
+      - switch_ip: 192.168.12.151
+        peer_switch_ip: 192.168.12.155
+        domain_id: 1
+    deploy: false
+    state: merged
+"""
+
+RETURN = r"""
+"""
+# pylint: disable=wrong-import-position
+
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.vpc.vpc_pair import VpcPairModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_pair import VpcPairOrchestrator
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_vpc_pair` Ansible module. Initializes the `NDStateMachine` with `VpcPairOrchestrator`
+    and executes the requested state operation, then flushes any queued switch deploys.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(VpcPairModel.get_argument_spec())
+    argument_spec.update(
+        deploy=dict(type="bool", default=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_vpc_pair")
+
+    # fabric_name is module-level in the argspec but a per-item field on VpcPairModel
+    # (composite identifier includes fabric_name). Inject it into each config item
+    # so model validation sees a complete record.
+    fabric_name = module.params.get("fabric_name")
+    for item in module.params.get("config") or []:
+        if isinstance(item, dict):
+            item.setdefault("fabric_name", fabric_name)
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=VpcPairOrchestrator,
+        )
+        if not isinstance(nd_state_machine.model_orchestrator, VpcPairOrchestrator):
+            raise AssertionError(f"Expected VpcPairOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        nd_state_machine.model_orchestrator.deploy = module.params["deploy"]
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            module.params["deploy"],
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/nd_vpc_pair_module/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_vpc_pair_module/tasks/deleted.yaml
@@ -1,0 +1,43 @@
+---
+# Deleted state tests for nd_vpc_pair
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Tear down the pair created in merged.yaml. Per project_vpc_module_design.md, ND cascades unpair
+# to all member vPC interfaces — no need to pre-delete those.
+
+- name: "DELETED: Unpair peers (check mode)"
+  cisco.nd.nd_vpc_pair: &delete_pair
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip_peer1 }}"
+        peer_switch_ip: "{{ test_switch_ip_peer2 }}"
+        domain_id: 1
+    state: deleted
+  check_mode: true
+  register: cm_deleted
+
+- name: "DELETED: Unpair peers (normal mode)"
+  cisco.nd.nd_vpc_pair: *delete_pair
+  register: nm_deleted
+
+- name: "DELETED: Verify unpair produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted is changed
+      - nm_deleted is changed
+
+- name: "DELETED IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "DELETED IDEMPOTENT: Re-apply unpair (normal mode)"
+  cisco.nd.nd_vpc_pair: *delete_pair
+  register: nm_deleted_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change after second unpair"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_idem is not changed

--- a/tests/integration/targets/nd_vpc_pair_module/tasks/main.yaml
+++ b/tests/integration/targets/nd_vpc_pair_module/tasks/main.yaml
@@ -1,0 +1,45 @@
+---
+# Test code for the nd_vpc_pair module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#
+#   ansible-test integration nd_vpc_pair
+#
+# Lab pre-conditions (verified in reference_nd_lab.md):
+#   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.155) reachable
+#   - Both switches start UNPAIRED (vpcConfigured: false)
+#   - Peer-link cable: peer1 Ethernet1/3 <-> peer2 Ethernet1/2
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_vpc_pair state tests
+  block:
+    - name: Pre-test cleanup (ensure unpaired baseline)
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run nd_vpc_pair merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run nd_vpc_pair replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run nd_vpc_pair deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  module_defaults:
+    cisco.nd.nd_vpc_pair:
+      timeout: 300
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_vpc_pair_module/tasks/main.yaml
+++ b/tests/integration/targets/nd_vpc_pair_module/tasks/main.yaml
@@ -8,7 +8,7 @@
 #
 # Run the test suite with ansible-test:
 #
-#   ansible-test integration nd_vpc_pair
+#   ansible-test integration nd_vpc_pair_module
 #
 # Lab pre-conditions (verified in reference_nd_lab.md):
 #   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.155) reachable

--- a/tests/integration/targets/nd_vpc_pair_module/tasks/merged.yaml
+++ b/tests/integration/targets/nd_vpc_pair_module/tasks/merged.yaml
@@ -1,0 +1,50 @@
+---
+# Merged state tests for nd_vpc_pair
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- MERGED CREATE ---
+
+- name: "MERGED CREATE: Pair peer1 + peer2 (check mode)"
+  cisco.nd.nd_vpc_pair: &merge_pair
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_pair_baseline }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create
+
+- name: "MERGED CREATE: Pair peer1 + peer2 (normal mode)"
+  cisco.nd.nd_vpc_pair: *merge_pair
+  register: nm_merged_create
+
+- name: "MERGED CREATE: Verify pair creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create is changed
+      - nm_merged_create is changed
+
+# --- MERGED IDEMPOTENCY ---
+# Pause to allow switch-side discovery before the second apply, otherwise the
+# diff calculation may compare against still-pending intent state.
+
+- name: "MERGED IDEMPOTENT: Pause for switch convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "MERGED IDEMPOTENT: Re-apply pair (check mode)"
+  cisco.nd.nd_vpc_pair: *merge_pair
+  check_mode: true
+  register: cm_merged_idem
+
+- name: "MERGED IDEMPOTENT: Re-apply pair (normal mode)"
+  cisco.nd.nd_vpc_pair: *merge_pair
+  register: nm_merged_idem
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem is not changed
+      - nm_merged_idem is not changed

--- a/tests/integration/targets/nd_vpc_pair_module/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_vpc_pair_module/tasks/replaced.yaml
@@ -1,0 +1,40 @@
+---
+# Replaced state tests for nd_vpc_pair
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Pair was created in merged.yaml. Replace the keepalive hold timeout and verify the change is reflected.
+
+- name: "REPLACED: Update keepalive hold timeout (check mode)"
+  cisco.nd.nd_vpc_pair: &replace_pair
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_pair_updated }}"
+    state: replaced
+  check_mode: true
+  register: cm_replaced
+
+- name: "REPLACED: Update keepalive hold timeout (normal mode)"
+  cisco.nd.nd_vpc_pair: *replace_pair
+  register: nm_replaced
+
+- name: "REPLACED: Verify replace produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced is changed
+      - nm_replaced is changed
+
+- name: "REPLACED IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "REPLACED IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_vpc_pair: *replace_pair
+  register: nm_replaced_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on re-apply"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_idem is not changed

--- a/tests/integration/targets/nd_vpc_pair_module/tasks/setup.yaml
+++ b/tests/integration/targets/nd_vpc_pair_module/tasks/setup.yaml
@@ -1,0 +1,26 @@
+---
+# Pre-test cleanup for nd_vpc_pair
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Ensures the two test switches are NOT paired before the state tests run.
+# Per project_vpc_module_design.md: PUT vpcAction=unPair returns 204 even when no pair exists,
+# but ND treats nothing-to-do gracefully. The teardown also waits for switch convergence.
+
+- name: "SETUP: Tear down any existing vPC pair on test peers"
+  cisco.nd.nd_vpc_pair:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip_peer1 }}"
+        peer_switch_ip: "{{ test_switch_ip_peer2 }}"
+        domain_id: 1
+    state: deleted
+  ignore_errors: true
+  tags: always
+
+- name: "SETUP: Allow ND switch poller to reflect baseline state"
+  ansible.builtin.pause:
+    seconds: 30
+  tags: always

--- a/tests/integration/targets/nd_vpc_pair_module/vars/main.yaml
+++ b/tests/integration/targets/nd_vpc_pair_module/vars/main.yaml
@@ -1,0 +1,36 @@
+---
+# Variables for nd_vpc_pair integration tests.
+#
+# Override the defaults in your inventory or extra-vars to match a real ND 4.2 testbed.
+# The defaults below match the SITE1 lab documented in reference_nd_lab.md.
+
+test_fabric_name: "{{ nd_test_vpc_fabric_name | default(nd_test_fabric_name | default('SITE1')) }}"
+test_switch_ip_peer1: "{{ nd_test_vpc_peer1_ip | default('192.168.12.151') }}"
+test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.155') }}"
+
+# Baseline pair config used by merged + idempotent tests.
+vpc_pair_baseline:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  peer_switch_ip: "{{ test_switch_ip_peer2 }}"
+  domain_id: 1
+  keep_alive_vrf: management
+  switch_po_id: 1
+  peer_switch_po_id: 1
+  switch_member_interfaces:
+    - Ethernet1/3
+  peer_switch_member_interfaces:
+    - Ethernet1/2
+
+# Updated pair config used by replaced tests (different keepalive hold timeout).
+vpc_pair_updated:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  peer_switch_ip: "{{ test_switch_ip_peer2 }}"
+  domain_id: 1
+  keep_alive_vrf: management
+  keep_alive_hold_timeout: 5
+  switch_po_id: 1
+  peer_switch_po_id: 1
+  switch_member_interfaces:
+    - Ethernet1/3
+  peer_switch_member_interfaces:
+    - Ethernet1/2

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_switch_actions_deploy.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_switch_actions_deploy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Cisco Systems, Inc.
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -10,11 +10,7 @@ Unit tests for manage_fabric_switch_actions_deploy.py
 Tests the fabric-level switch deploy endpoint.
 """
 
-from __future__ import absolute_import, annotations, division, print_function
-
-# pylint: disable=invalid-name
-__metaclass__ = type
-# pylint: enable=invalid-name
+from __future__ import annotations
 
 from contextlib import contextmanager
 

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_switch_actions_deploy.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_switch_actions_deploy.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for manage_fabric_switch_actions_deploy.py
+
+Tests the fabric-level switch deploy endpoint.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+from contextlib import contextmanager
+
+import pytest  # pylint: disable=unused-import
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_switch_actions_deploy import (
+    EpManageFabricSwitchActionsDeployPost,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+def test_ep_manage_fabric_switch_actions_deploy_00010():
+    """
+    # Summary
+
+    Verify EpManageFabricSwitchActionsDeployPost basic instantiation.
+
+    ## Test
+
+    - Instance can be created
+    - class_name is set correctly
+    - verb is POST
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchActionsDeployPost.__init__()
+    - EpManageFabricSwitchActionsDeployPost.verb
+    """
+    with does_not_raise():
+        instance = EpManageFabricSwitchActionsDeployPost()
+    assert instance.class_name == "EpManageFabricSwitchActionsDeployPost"
+    assert instance.verb == HttpVerbEnum.POST
+    assert instance.fabric_name is None
+
+
+def test_ep_manage_fabric_switch_actions_deploy_00020():
+    """
+    # Summary
+
+    Verify path raises ValueError when fabric_name is None.
+
+    ## Test
+
+    - fabric_name not set
+    - Accessing path raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchActionsDeployPost.path
+    """
+    instance = EpManageFabricSwitchActionsDeployPost()
+    with pytest.raises(ValueError, match="fabric_name must be set"):
+        result = instance.path  # pylint: disable=unused-variable
+
+
+def test_ep_manage_fabric_switch_actions_deploy_00030():
+    """
+    # Summary
+
+    Verify path returns the fabric switch-actions deploy URL.
+
+    ## Test
+
+    - fabric_name set
+    - path returns /api/v1/manage/fabrics/{fabric_name}/switchActions/deploy
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchActionsDeployPost.path
+    """
+    with does_not_raise():
+        instance = EpManageFabricSwitchActionsDeployPost()
+        instance.fabric_name = "SITE1"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/SITE1/switchActions/deploy"
+
+
+def test_ep_manage_fabric_switch_actions_deploy_00040():
+    """
+    # Summary
+
+    Verify endpoint has only FabricNameMixin (no switch_sn / interface_name).
+
+    ## Test
+
+    - Accessing switch_sn or interface_name returns False from hasattr
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchActionsDeployPost.__init__()
+    """
+    instance = EpManageFabricSwitchActionsDeployPost()
+    assert not hasattr(instance, "switch_sn")
+    assert not hasattr(instance, "interface_name")
+
+
+def test_ep_manage_fabric_switch_actions_deploy_00050():
+    """
+    # Summary
+
+    Verify fabric_name="" raises ValueError (Pydantic min_length=1).
+
+    ## Test
+
+    - Setting fabric_name to empty string raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchActionsDeployPost.__init__()
+    """
+    with pytest.raises(ValueError):
+        EpManageFabricSwitchActionsDeployPost(fabric_name="")
+
+
+def test_ep_manage_fabric_switch_actions_deploy_00060():
+    """
+    # Summary
+
+    Verify fabric_name with reserved characters is percent-encoded in the path.
+
+    ## Test
+
+    - fabric_name = "fab/odd"
+    - path encodes the slash
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchActionsDeployPost.path
+    """
+    instance = EpManageFabricSwitchActionsDeployPost()
+    instance.fabric_name = "fab/odd"
+    assert instance.path == "/api/v1/manage/fabrics/fab%2Fodd/switchActions/deploy"

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_switch_vpc_pair.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_switch_vpc_pair.py
@@ -1,0 +1,333 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for manage_fabric_switch_vpc_pair.py
+
+Tests the per-switch vPC pair endpoint classes (GET, PUT).
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+from contextlib import contextmanager
+
+import pytest  # pylint: disable=unused-import
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_switch_vpc_pair import (
+    EpManageFabricSwitchVpcPairGet,
+    EpManageFabricSwitchVpcPairPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test: EpManageFabricSwitchVpcPairGet
+# =============================================================================
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00010():
+    """
+    # Summary
+
+    Verify EpManageFabricSwitchVpcPairGet basic instantiation.
+
+    ## Test
+
+    - Instance can be created
+    - class_name is set correctly
+    - verb is GET
+    - All mixin params default to None
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.__init__()
+    - EpManageFabricSwitchVpcPairGet.verb
+    """
+    with does_not_raise():
+        instance = EpManageFabricSwitchVpcPairGet()
+    assert instance.class_name == "EpManageFabricSwitchVpcPairGet"
+    assert instance.verb == HttpVerbEnum.GET
+    assert instance.fabric_name is None
+    assert instance.switch_sn is None
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00020():
+    """
+    # Summary
+
+    Verify path raises ValueError when fabric_name is None.
+
+    ## Test
+
+    - fabric_name is not set
+    - Accessing path raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.path
+    """
+    instance = EpManageFabricSwitchVpcPairGet()
+    with pytest.raises(ValueError, match="fabric_name must be set"):
+        result = instance.path  # pylint: disable=unused-variable
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00030():
+    """
+    # Summary
+
+    Verify path raises ValueError when switch_sn is None.
+
+    ## Test
+
+    - fabric_name is set, switch_sn is not
+    - Accessing path raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.path
+    """
+    instance = EpManageFabricSwitchVpcPairGet()
+    instance.fabric_name = "SITE1"
+    with pytest.raises(ValueError, match="switch_sn must be set"):
+        result = instance.path  # pylint: disable=unused-variable
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00040():
+    """
+    # Summary
+
+    Verify path returns correct URL with all params set.
+
+    ## Test
+
+    - fabric_name and switch_sn set
+    - path ends with /vpcPair literal segment
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.path
+    """
+    with does_not_raise():
+        instance = EpManageFabricSwitchVpcPairGet()
+        instance.fabric_name = "SITE1"
+        instance.switch_sn = "9ASNKH8T9DJ"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ/vpcPair"
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00050():
+    """
+    # Summary
+
+    Verify set_identifiers sets switch_sn.
+
+    ## Test
+
+    - set_identifiers("9ASNKH8T9DJ") sets switch_sn
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.set_identifiers()
+    """
+    with does_not_raise():
+        instance = EpManageFabricSwitchVpcPairGet()
+        instance.set_identifiers("9ASNKH8T9DJ")
+    assert instance.switch_sn == "9ASNKH8T9DJ"
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00060():
+    """
+    # Summary
+
+    Verify set_identifiers(None) clears switch_sn.
+
+    ## Test
+
+    - set_identifiers(None) sets switch_sn to None
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.set_identifiers()
+    """
+    with does_not_raise():
+        instance = EpManageFabricSwitchVpcPairGet()
+        instance.switch_sn = "9ASNKH8T9DJ"
+        instance.set_identifiers(None)
+    assert instance.switch_sn is None
+
+
+# =============================================================================
+# Test: EpManageFabricSwitchVpcPairPut
+# =============================================================================
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00100():
+    """
+    # Summary
+
+    Verify EpManageFabricSwitchVpcPairPut basic instantiation.
+
+    ## Test
+
+    - Instance can be created
+    - class_name is set correctly
+    - verb is PUT
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairPut.__init__()
+    - EpManageFabricSwitchVpcPairPut.verb
+    """
+    with does_not_raise():
+        instance = EpManageFabricSwitchVpcPairPut()
+    assert instance.class_name == "EpManageFabricSwitchVpcPairPut"
+    assert instance.verb == HttpVerbEnum.PUT
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00110():
+    """
+    # Summary
+
+    Verify Put produces same path as Get for identical params.
+
+    ## Test
+
+    - Put and Get with same identifiers produce identical URLs
+    - Verbs differ
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairPut.path
+    - EpManageFabricSwitchVpcPairGet.path
+    """
+    params = {"fabric_name": "SITE1", "switch_sn": "9ASNKH8T9DJ"}
+    expected = "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ/vpcPair"
+
+    with does_not_raise():
+        get_ep = EpManageFabricSwitchVpcPairGet(**params)
+        put_ep = EpManageFabricSwitchVpcPairPut(**params)
+
+    assert get_ep.path == expected
+    assert put_ep.path == expected
+    assert get_ep.verb == HttpVerbEnum.GET
+    assert put_ep.verb == HttpVerbEnum.PUT
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00120():
+    """
+    # Summary
+
+    Verify Put path raises ValueError when switch_sn is None.
+
+    ## Test
+
+    - fabric_name set, switch_sn missing
+    - Accessing path raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairPut.path
+    """
+    instance = EpManageFabricSwitchVpcPairPut()
+    instance.fabric_name = "SITE1"
+    with pytest.raises(ValueError, match="switch_sn must be set"):
+        result = instance.path  # pylint: disable=unused-variable
+
+
+# =============================================================================
+# Test: Validation of empty identifiers
+# =============================================================================
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00200():
+    """
+    # Summary
+
+    Verify fabric_name="" raises ValueError (Pydantic min_length=1).
+
+    ## Test
+
+    - Setting fabric_name to empty string raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.__init__()
+    """
+    with pytest.raises(ValueError):
+        EpManageFabricSwitchVpcPairGet(fabric_name="")
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00210():
+    """
+    # Summary
+
+    Verify switch_sn="" raises ValueError (Pydantic min_length=1).
+
+    ## Test
+
+    - Setting switch_sn to empty string raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.__init__()
+    """
+    with pytest.raises(ValueError):
+        EpManageFabricSwitchVpcPairGet(switch_sn="")
+
+
+# =============================================================================
+# Test: URL encoding of path-segment values
+# =============================================================================
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00300():
+    """
+    # Summary
+
+    Verify slashes in fabric_name are percent-encoded in the path.
+
+    ## Test
+
+    - fabric_name = "fab/odd"
+    - path encodes the slash
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.path
+    """
+    instance = EpManageFabricSwitchVpcPairGet()
+    instance.fabric_name = "fab/odd"
+    instance.switch_sn = "9ASNKH8T9DJ"
+    assert instance.path == "/api/v1/manage/fabrics/fab%2Fodd/switches/9ASNKH8T9DJ/vpcPair"
+
+
+def test_ep_manage_fabric_switch_vpc_pair_00310():
+    """
+    # Summary
+
+    Verify alphanumeric segment values are unchanged by encoding.
+
+    ## Test
+
+    - All alphanumeric inputs survive untouched
+
+    ## Classes and Methods
+
+    - EpManageFabricSwitchVpcPairGet.path
+    """
+    instance = EpManageFabricSwitchVpcPairGet()
+    instance.fabric_name = "SITE1"
+    instance.switch_sn = "9ASNKH8T9DJ"
+    assert instance.path == "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ/vpcPair"

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_switch_vpc_pair.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_switch_vpc_pair.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Cisco Systems, Inc.
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -10,11 +10,7 @@ Unit tests for manage_fabric_switch_vpc_pair.py
 Tests the per-switch vPC pair endpoint classes (GET, PUT).
 """
 
-from __future__ import absolute_import, annotations, division, print_function
-
-# pylint: disable=invalid-name
-__metaclass__ = type
-# pylint: enable=invalid-name
+from __future__ import annotations
 
 from contextlib import contextmanager
 

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_vpc_pairs.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_vpc_pairs.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for manage_fabric_vpc_pairs.py
+
+Tests the fabric-wide vPC pairs list endpoint.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+from contextlib import contextmanager
+
+import pytest  # pylint: disable=unused-import
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_vpc_pairs import (
+    EpManageFabricVpcPairsListGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+def test_ep_manage_fabric_vpc_pairs_00010():
+    """
+    # Summary
+
+    Verify EpManageFabricVpcPairsListGet basic instantiation.
+
+    ## Test
+
+    - Instance can be created
+    - class_name is set correctly
+    - verb is GET
+
+    ## Classes and Methods
+
+    - EpManageFabricVpcPairsListGet.__init__()
+    - EpManageFabricVpcPairsListGet.verb
+    """
+    with does_not_raise():
+        instance = EpManageFabricVpcPairsListGet()
+    assert instance.class_name == "EpManageFabricVpcPairsListGet"
+    assert instance.verb == HttpVerbEnum.GET
+    assert instance.fabric_name is None
+
+
+def test_ep_manage_fabric_vpc_pairs_00020():
+    """
+    # Summary
+
+    Verify path raises ValueError when fabric_name is None.
+
+    ## Test
+
+    - fabric_name not set
+    - Accessing path raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageFabricVpcPairsListGet.path
+    """
+    instance = EpManageFabricVpcPairsListGet()
+    with pytest.raises(ValueError, match="fabric_name must be set"):
+        result = instance.path  # pylint: disable=unused-variable
+
+
+def test_ep_manage_fabric_vpc_pairs_00030():
+    """
+    # Summary
+
+    Verify path returns correct URL when fabric_name is set.
+
+    ## Test
+
+    - fabric_name set
+    - path returns /api/v1/manage/fabrics/{fabric_name}/vpcPairs
+
+    ## Classes and Methods
+
+    - EpManageFabricVpcPairsListGet.path
+    """
+    with does_not_raise():
+        instance = EpManageFabricVpcPairsListGet()
+        instance.fabric_name = "SITE1"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/SITE1/vpcPairs"
+
+
+def test_ep_manage_fabric_vpc_pairs_00040():
+    """
+    # Summary
+
+    Verify endpoint has only FabricNameMixin (no switch_sn / interface_name).
+
+    ## Test
+
+    - Accessing switch_sn or interface_name returns False from hasattr
+
+    ## Classes and Methods
+
+    - EpManageFabricVpcPairsListGet.__init__()
+    """
+    instance = EpManageFabricVpcPairsListGet()
+    assert not hasattr(instance, "switch_sn")
+    assert not hasattr(instance, "interface_name")
+
+
+def test_ep_manage_fabric_vpc_pairs_00050():
+    """
+    # Summary
+
+    Verify fabric_name="" raises ValueError (Pydantic min_length=1).
+
+    ## Test
+
+    - Setting fabric_name to empty string raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageFabricVpcPairsListGet.__init__()
+    """
+    with pytest.raises(ValueError):
+        EpManageFabricVpcPairsListGet(fabric_name="")
+
+
+def test_ep_manage_fabric_vpc_pairs_00060():
+    """
+    # Summary
+
+    Verify fabric_name with reserved characters is percent-encoded in the path.
+
+    ## Test
+
+    - fabric_name = "fab/odd"
+    - path encodes the slash
+
+    ## Classes and Methods
+
+    - EpManageFabricVpcPairsListGet.path
+    """
+    instance = EpManageFabricVpcPairsListGet()
+    instance.fabric_name = "fab/odd"
+    assert instance.path == "/api/v1/manage/fabrics/fab%2Fodd/vpcPairs"

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_vpc_pairs.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabric_vpc_pairs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Cisco Systems, Inc.
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -10,11 +10,7 @@ Unit tests for manage_fabric_vpc_pairs.py
 Tests the fabric-wide vPC pairs list endpoint.
 """
 
-from __future__ import absolute_import, annotations, division, print_function
-
-# pylint: disable=invalid-name
-__metaclass__ = type
-# pylint: enable=invalid-name
+from __future__ import annotations
 
 from contextlib import contextmanager
 

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_pair_orchestrator.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_pair_orchestrator.json
@@ -1,0 +1,214 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for tests/unit/module_utils/orchestrators/test_vpc_pair.py",
+        "Each key matches a test function + suffix per CLAUDE.md unit-test conventions.",
+        "Fixtures simulate ND responses for:",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches  (FabricContext IP -> serial map)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/vpcPair  (per-switch intent)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/vpcPairs  (fabric-wide list)",
+        "  - PUT /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/vpcPair  (create / update / unpair)",
+        "  - POST /api/v1/manage/fabrics/{fabric_name}/switchActions/deploy (deploy 207 multi-status)"
+    ],
+    "_switches_lab_baseline": {
+        "TEST_NOTES": [
+            "Reusable switch-list response: SITE1 with the two leafs lab-paired in project_vpc_module_design.md.",
+            "Test functions reference this via responses_helper to avoid duplication."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "9ASNKH8T9DJ"},
+                {"fabricManagementIp": "192.168.12.155", "switchId": "9SJKCSQND07"}
+            ]
+        }
+    },
+    "test_vpc_pair_orch_00100a_switches": {
+        "TEST_NOTES": ["query_one 404 — switches list (one-time IP->serial load)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "9ASNKH8T9DJ"},
+                {"fabricManagementIp": "192.168.12.155", "switchId": "9SJKCSQND07"}
+            ]
+        }
+    },
+    "test_vpc_pair_orch_00100b_get_404": {
+        "TEST_NOTES": ["query_one 404: no pair exists yet for switch"],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {
+            "code": 404,
+            "description": "",
+            "message": "No vPC Pair found for switch serial number: 9ASNKH8T9DJ"
+        }
+    },
+    "test_vpc_pair_orch_00110a_switches": {
+        "TEST_NOTES": ["query_one 200 — switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "9ASNKH8T9DJ"},
+                {"fabricManagementIp": "192.168.12.155", "switchId": "9SJKCSQND07"}
+            ]
+        }
+    },
+    "test_vpc_pair_orch_00110b_get_200": {
+        "TEST_NOTES": [
+            "query_one 200: lab-captured per-switch GET response (project_vpc_module_design.md)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9ASNKH8T9DJ",
+            "peerSwitchId": "9SJKCSQND07",
+            "useVirtualPeerLink": false,
+            "vpcAction": "pair",
+            "vpcPairDetails": {
+                "domainId": 1,
+                "keepAliveVrf": "management",
+                "keepAliveHoldTimeout": 3,
+                "enableMirrorConfig": false,
+                "isVpcPlus": false,
+                "isVteps": false,
+                "nveInterface": 1,
+                "poMode": "active",
+                "adminState": true,
+                "allowedVlans": "all",
+                "fabricName": "SITE1"
+            }
+        }
+    },
+    "test_vpc_pair_orch_00200a_list_empty": {
+        "TEST_NOTES": ["query_all empty: fabric has no pairs"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/vpcPairs",
+        "MESSAGE": "OK",
+        "DATA": {
+            "meta": {"counts": {"remaining": 0, "total": 0}},
+            "vpcPairs": []
+        }
+    },
+    "test_vpc_pair_orch_00210a_list_populated": {
+        "TEST_NOTES": ["query_all populated: one paired entry"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/vpcPairs",
+        "MESSAGE": "OK",
+        "DATA": {
+            "meta": {"counts": {"remaining": 0, "total": 1}},
+            "vpcPairs": [
+                {
+                    "switchId": "9ASNKH8T9DJ",
+                    "peerSwitchId": "9SJKCSQND07",
+                    "useVirtualPeerLink": false,
+                    "vpcPairDetails": {
+                        "domainId": 1,
+                        "keepAliveVrf": "management",
+                        "fabricName": "SITE1"
+                    }
+                }
+            ]
+        }
+    },
+    "test_vpc_pair_orch_00300a_switches": {
+        "TEST_NOTES": ["create — switch list for IP->serial"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "9ASNKH8T9DJ"},
+                {"fabricManagementIp": "192.168.12.155", "switchId": "9SJKCSQND07"}
+            ]
+        }
+    },
+    "test_vpc_pair_orch_00300b_put_204": {
+        "TEST_NOTES": ["create — PUT vpcPair returns 204 No Content"],
+        "RETURN_CODE": 204,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ/vpcPair",
+        "MESSAGE": "No Content",
+        "DATA": {}
+    },
+    "test_vpc_pair_orch_00500a_switches": {
+        "TEST_NOTES": ["delete — switch list for IP->serial"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "9ASNKH8T9DJ"},
+                {"fabricManagementIp": "192.168.12.155", "switchId": "9SJKCSQND07"}
+            ]
+        }
+    },
+    "test_vpc_pair_orch_00500b_put_unpair_204": {
+        "TEST_NOTES": ["delete — PUT vpcPair body vpcAction=unPair returns 204"],
+        "RETURN_CODE": 204,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ/vpcPair",
+        "MESSAGE": "No Content",
+        "DATA": {}
+    },
+    "test_vpc_pair_orch_00600a_deploy_207_all_success": {
+        "TEST_NOTES": [
+            "deploy_pending — 207 multi-status, both switches success (lowercase per OpenAPI)."
+        ],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switchActions/deploy",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "switchIds": [
+                {"switchId": "9ASNKH8T9DJ", "switchName": "S1_LE1", "status": "success", "message": "Deployed Successfully"},
+                {"switchId": "9SJKCSQND07", "switchName": "S1_LE2", "status": "success", "message": "Deployed Successfully"}
+            ]
+        }
+    },
+    "test_vpc_pair_orch_00610a_deploy_207_mixed_case": {
+        "TEST_NOTES": [
+            "deploy_pending — 207 with mixed-case status (Success vs success).",
+            "Lab observed: interfaceActions returns 'Success' (capital), switchActions returns 'success' (lower).",
+            "Orchestrator must compare case-insensitively."
+        ],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switchActions/deploy",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "switchIds": [
+                {"switchId": "9ASNKH8T9DJ", "switchName": "S1_LE1", "status": "Success", "message": "Deployed Successfully"},
+                {"switchId": "9SJKCSQND07", "switchName": "S1_LE2", "status": "success", "message": "Deployed Successfully"}
+            ]
+        }
+    },
+    "test_vpc_pair_orch_00620a_deploy_207_one_failed": {
+        "TEST_NOTES": ["deploy_pending — 207 with one failed switch must raise."],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switchActions/deploy",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "switchIds": [
+                {"switchId": "9ASNKH8T9DJ", "switchName": "S1_LE1", "status": "success", "message": "Deployed Successfully"},
+                {"switchId": "9SJKCSQND07", "switchName": "S1_LE2", "status": "failed", "message": "Switch unreachable"}
+            ]
+        }
+    }
+}

--- a/tests/unit/module_utils/models/test_vpc_pair.py
+++ b/tests/unit/module_utils/models/test_vpc_pair.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Cisco Systems, Inc.
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -10,13 +10,10 @@ Unit tests for plugins/module_utils/models/vpc/vpc_pair.py
 Tests the VpcPairModel Pydantic model.
 """
 
-from __future__ import absolute_import, annotations, division, print_function
-
-# pylint: disable=invalid-name
 # pylint: disable=line-too-long
 # pylint: disable=too-many-lines
-__metaclass__ = type
-# pylint: enable=invalid-name
+
+from __future__ import annotations
 
 import copy
 from contextlib import contextmanager

--- a/tests/unit/module_utils/models/test_vpc_pair.py
+++ b/tests/unit/module_utils/models/test_vpc_pair.py
@@ -1,0 +1,675 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for plugins/module_utils/models/vpc/vpc_pair.py
+
+Tests the VpcPairModel Pydantic model.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+# pylint: disable=invalid-name
+# pylint: disable=line-too-long
+# pylint: disable=too-many-lines
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+import copy
+from contextlib import contextmanager
+
+import pytest  # pylint: disable=unused-import
+from ansible_collections.cisco.nd.plugins.module_utils.models.vpc.vpc_pair import VpcPairModel
+from pydantic import ValidationError  # pylint: disable=unused-import
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# Lab-captured PUT payload (minimal direct-peering pair) — see project_vpc_module_design.md
+SAMPLE_ANSIBLE_CONFIG = {
+    "fabric_name": "SITE1",
+    "switch_ip": "192.168.12.151",
+    "peer_switch_ip": "192.168.12.155",
+    "domain_id": 1,
+    "keep_alive_vrf": "management",
+}
+
+# Lab-captured GET response from /api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ/vpcPair
+SAMPLE_API_RESPONSE = {
+    "switchId": "9ASNKH8T9DJ",
+    "peerSwitchId": "9SJKCSQND07",
+    "useVirtualPeerLink": False,
+    "vpcAction": "pair",
+    "vpcPairDetails": {
+        "domainId": 1,
+        "keepAliveVrf": "management",
+        "keepAliveHoldTimeout": 3,
+        "enableMirrorConfig": False,
+        "isVpcPlus": False,
+        "isVteps": False,
+        "nveInterface": 1,
+        "poMode": "active",
+        "adminState": True,
+        "allowedVlans": "all",
+        "fabricName": "SITE1",
+    },
+}
+
+
+# =============================================================================
+# Test 00000-00009: Instantiation defaults
+# =============================================================================
+
+
+def test_vpc_pair_00000():
+    """
+    # Summary
+
+    Verify minimal instantiation with required fields succeeds and defaults are applied.
+
+    ## Test
+
+    - VpcPairModel can be created with required fields
+    - use_virtual_peer_link defaults to False (v1 direct peering)
+    - keep_alive_vrf defaults to "management"
+    - vpc_action defaults to "pair"
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with does_not_raise():
+        instance = VpcPairModel(
+            fabric_name="SITE1",
+            switch_ip="192.168.12.151",
+            peer_switch_ip="192.168.12.155",
+            domain_id=1,
+        )
+    assert instance.fabric_name == "SITE1"
+    assert instance.switch_ip == "192.168.12.151"
+    assert instance.peer_switch_ip == "192.168.12.155"
+    assert instance.domain_id == 1
+    assert instance.use_virtual_peer_link is False
+    assert instance.keep_alive_vrf == "management"
+    assert instance.vpc_action == "pair"
+
+
+def test_vpc_pair_00001():
+    """
+    # Summary
+
+    Verify model has correct ClassVar configuration for composite identifier.
+
+    ## Test
+
+    - identifiers ClassVar is ["fabric_name", "switch_ip", "peer_switch_ip"]
+    - identifier_strategy is "composite"
+
+    ## Classes and Methods
+
+    - VpcPairModel
+    """
+    assert VpcPairModel.identifiers == ["fabric_name", "switch_ip", "peer_switch_ip"]
+    assert VpcPairModel.identifier_strategy == "composite"
+
+
+# =============================================================================
+# Test 00010-00099: Validation
+# =============================================================================
+
+
+def test_vpc_pair_00010():
+    """
+    # Summary
+
+    Verify missing fabric_name raises ValidationError.
+
+    ## Test
+
+    - Missing fabric_name field raises ValidationError
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        VpcPairModel(switch_ip="192.168.12.151", peer_switch_ip="192.168.12.155", domain_id=1)
+
+
+def test_vpc_pair_00020():
+    """
+    # Summary
+
+    Verify missing switch_ip raises ValidationError.
+
+    ## Test
+
+    - Missing switch_ip raises ValidationError
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        VpcPairModel(fabric_name="SITE1", peer_switch_ip="192.168.12.155", domain_id=1)
+
+
+def test_vpc_pair_00030():
+    """
+    # Summary
+
+    Verify missing peer_switch_ip raises ValidationError.
+
+    ## Test
+
+    - Missing peer_switch_ip raises ValidationError
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        VpcPairModel(fabric_name="SITE1", switch_ip="192.168.12.151", domain_id=1)
+
+
+def test_vpc_pair_00040():
+    """
+    # Summary
+
+    Verify missing domain_id raises ValidationError.
+
+    ## Test
+
+    - Missing domain_id raises ValidationError
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        VpcPairModel(fabric_name="SITE1", switch_ip="192.168.12.151", peer_switch_ip="192.168.12.155")
+
+
+@pytest.mark.parametrize(
+    "domain_id",
+    [0, -1, 1001, 9999],
+    ids=["zero", "negative", "above_max", "well_above_max"],
+)
+def test_vpc_pair_00050(domain_id):
+    """
+    # Summary
+
+    Verify domain_id outside 1-1000 raises ValidationError.
+
+    ## Test
+
+    - domain_id values outside [1, 1000] are rejected
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        VpcPairModel(
+            fabric_name="SITE1",
+            switch_ip="192.168.12.151",
+            peer_switch_ip="192.168.12.155",
+            domain_id=domain_id,
+        )
+
+
+@pytest.mark.parametrize("domain_id", [1, 100, 1000], ids=["min", "mid", "max"])
+def test_vpc_pair_00060(domain_id):
+    """
+    # Summary
+
+    Verify domain_id boundary values 1, 100, 1000 are accepted.
+
+    ## Test
+
+    - domain_id boundary values are accepted
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with does_not_raise():
+        instance = VpcPairModel(
+            fabric_name="SITE1",
+            switch_ip="192.168.12.151",
+            peer_switch_ip="192.168.12.155",
+            domain_id=domain_id,
+        )
+    assert instance.domain_id == domain_id
+
+
+def test_vpc_pair_00070():
+    """
+    # Summary
+
+    Verify switch_ip == peer_switch_ip raises a ValueError indicating peers must differ.
+
+    ## Test
+
+    - peer_switch_ip identical to switch_ip is rejected
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__() (model_validator)
+    """
+    with pytest.raises(ValidationError, match=r"switch_ip.*peer_switch_ip.*differ"):
+        VpcPairModel(
+            fabric_name="SITE1",
+            switch_ip="192.168.12.151",
+            peer_switch_ip="192.168.12.151",
+            domain_id=1,
+        )
+
+
+def test_vpc_pair_00080():
+    """
+    # Summary
+
+    Verify use_virtual_peer_link is frozen (cannot mutate after construction).
+
+    ## Test
+
+    - Attempting to set use_virtual_peer_link to True raises ValidationError
+
+    ## Classes and Methods
+
+    - VpcPairModel.use_virtual_peer_link (frozen field)
+    """
+    instance = VpcPairModel(
+        fabric_name="SITE1",
+        switch_ip="192.168.12.151",
+        peer_switch_ip="192.168.12.155",
+        domain_id=1,
+    )
+    with pytest.raises(ValidationError):
+        instance.use_virtual_peer_link = True
+
+
+def test_vpc_pair_00090():
+    """
+    # Summary
+
+    Verify use_virtual_peer_link cannot be constructed with True (frozen + default).
+
+    ## Test
+
+    - Constructing with use_virtual_peer_link=True raises ValidationError because the field is frozen with default False
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        VpcPairModel(
+            fabric_name="SITE1",
+            switch_ip="192.168.12.151",
+            peer_switch_ip="192.168.12.155",
+            domain_id=1,
+            use_virtual_peer_link=True,
+        )
+
+
+@pytest.mark.parametrize("vrf", ["default", "management"])
+def test_vpc_pair_00100(vrf):
+    """
+    # Summary
+
+    Verify keep_alive_vrf accepts the two enum values.
+
+    ## Test
+
+    - "default" and "management" are accepted
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with does_not_raise():
+        instance = VpcPairModel(
+            fabric_name="SITE1",
+            switch_ip="192.168.12.151",
+            peer_switch_ip="192.168.12.155",
+            domain_id=1,
+            keep_alive_vrf=vrf,
+        )
+    assert instance.keep_alive_vrf == vrf
+
+
+def test_vpc_pair_00110():
+    """
+    # Summary
+
+    Verify keep_alive_vrf rejects unknown values.
+
+    ## Test
+
+    - keep_alive_vrf="bogus" raises ValidationError
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        VpcPairModel(
+            fabric_name="SITE1",
+            switch_ip="192.168.12.151",
+            peer_switch_ip="192.168.12.155",
+            domain_id=1,
+            keep_alive_vrf="bogus",
+        )
+
+
+@pytest.mark.parametrize("action", ["pair", "unPair"])
+def test_vpc_pair_00120(action):
+    """
+    # Summary
+
+    Verify vpc_action accepts the two enum values.
+
+    ## Test
+
+    - "pair" and "unPair" are accepted
+
+    ## Classes and Methods
+
+    - VpcPairModel.__init__()
+    """
+    with does_not_raise():
+        instance = VpcPairModel(
+            fabric_name="SITE1",
+            switch_ip="192.168.12.151",
+            peer_switch_ip="192.168.12.155",
+            domain_id=1,
+            vpc_action=action,
+        )
+    assert instance.vpc_action == action
+
+
+# =============================================================================
+# Test 00200-00299: Composite identifier (canonical sort)
+# =============================================================================
+
+
+def test_vpc_pair_00200():
+    """
+    # Summary
+
+    Verify get_identifier_value returns a 3-tuple with canonical-sorted peer IPs.
+
+    ## Test
+
+    - get_identifier_value() returns (fabric_name, sorted_low_ip, sorted_high_ip)
+
+    ## Classes and Methods
+
+    - VpcPairModel.get_identifier_value()
+    """
+    instance = VpcPairModel(
+        fabric_name="SITE1",
+        switch_ip="192.168.12.155",
+        peer_switch_ip="192.168.12.151",
+        domain_id=1,
+    )
+    assert instance.get_identifier_value() == ("SITE1", "192.168.12.151", "192.168.12.155")
+
+
+def test_vpc_pair_00210():
+    """
+    # Summary
+
+    Verify (A, B) and (B, A) produce the same identifier (canonical sort collapses ordering).
+
+    ## Test
+
+    - Two instances with peer IPs swapped have identical get_identifier_value()
+
+    ## Classes and Methods
+
+    - VpcPairModel.get_identifier_value()
+    """
+    a = VpcPairModel(
+        fabric_name="SITE1",
+        switch_ip="192.168.12.151",
+        peer_switch_ip="192.168.12.155",
+        domain_id=1,
+    )
+    b = VpcPairModel(
+        fabric_name="SITE1",
+        switch_ip="192.168.12.155",
+        peer_switch_ip="192.168.12.151",
+        domain_id=1,
+    )
+    assert a.get_identifier_value() == b.get_identifier_value()
+
+
+# =============================================================================
+# Test 00300-00399: to_payload (alias + nesting)
+# =============================================================================
+
+
+def test_vpc_pair_00300():
+    """
+    # Summary
+
+    Verify to_payload uses camelCase aliases at the top level.
+
+    ## Test
+
+    - to_payload returns switchId, peerSwitchId, useVirtualPeerLink, vpcAction at top level
+
+    ## Classes and Methods
+
+    - VpcPairModel.to_payload()
+    """
+    instance = VpcPairModel(
+        fabric_name="SITE1",
+        switch_ip="192.168.12.151",
+        peer_switch_ip="192.168.12.155",
+        switch_id="9ASNKH8T9DJ",
+        peer_switch_id="9SJKCSQND07",
+        domain_id=1,
+    )
+    result = instance.to_payload()
+    assert "switchId" in result
+    assert "peerSwitchId" in result
+    assert "useVirtualPeerLink" in result
+    assert "vpcAction" in result
+    assert result["switchId"] == "9ASNKH8T9DJ"
+    assert result["peerSwitchId"] == "9SJKCSQND07"
+    assert result["useVirtualPeerLink"] is False
+    assert result["vpcAction"] == "pair"
+
+
+def test_vpc_pair_00310():
+    """
+    # Summary
+
+    Verify to_payload nests pair-detail fields under vpcPairDetails.
+
+    ## Test
+
+    - to_payload places domainId, keepAliveVrf under vpcPairDetails
+
+    ## Classes and Methods
+
+    - VpcPairModel.to_payload()
+    """
+    instance = VpcPairModel(
+        fabric_name="SITE1",
+        switch_ip="192.168.12.151",
+        peer_switch_ip="192.168.12.155",
+        switch_id="9ASNKH8T9DJ",
+        peer_switch_id="9SJKCSQND07",
+        domain_id=1,
+        keep_alive_vrf="management",
+    )
+    result = instance.to_payload()
+    assert "vpcPairDetails" in result
+    details = result["vpcPairDetails"]
+    assert details["domainId"] == 1
+    assert details["keepAliveVrf"] == "management"
+    # Top-level keys must NOT also contain the nested fields
+    assert "domainId" not in result
+    assert "keepAliveVrf" not in result
+
+
+def test_vpc_pair_00320():
+    """
+    # Summary
+
+    Verify to_payload excludes ansible-only fields (fabric_name, switch_ip, peer_switch_ip) from the wire payload.
+
+    ## Test
+
+    - fabric_name, switch_ip, peer_switch_ip aliases NOT present in payload
+
+    ## Classes and Methods
+
+    - VpcPairModel.to_payload()
+    """
+    instance = VpcPairModel(
+        fabric_name="SITE1",
+        switch_ip="192.168.12.151",
+        peer_switch_ip="192.168.12.155",
+        switch_id="9ASNKH8T9DJ",
+        peer_switch_id="9SJKCSQND07",
+        domain_id=1,
+    )
+    result = instance.to_payload()
+    # These three are Ansible-facing identifiers, not wire fields
+    assert "fabric_name" not in result
+    assert "fabricName" not in result
+    assert "switch_ip" not in result
+    assert "switchIp" not in result
+    assert "peer_switch_ip" not in result
+    assert "peerSwitchIp" not in result
+
+
+def test_vpc_pair_00330():
+    """
+    # Summary
+
+    Verify to_payload(vpc_action="unPair") produces a minimal unPair body.
+
+    ## Test
+
+    - When vpc_action is "unPair", vpcAction key is present in payload
+
+    ## Classes and Methods
+
+    - VpcPairModel.to_payload()
+    """
+    instance = VpcPairModel(
+        fabric_name="SITE1",
+        switch_ip="192.168.12.151",
+        peer_switch_ip="192.168.12.155",
+        switch_id="9ASNKH8T9DJ",
+        peer_switch_id="9SJKCSQND07",
+        domain_id=1,
+        vpc_action="unPair",
+    )
+    result = instance.to_payload()
+    assert result["vpcAction"] == "unPair"
+
+
+# =============================================================================
+# Test 00400-00499: from_response (wire -> model)
+# =============================================================================
+
+
+def test_vpc_pair_00400():
+    """
+    # Summary
+
+    Verify from_response parses a lab-captured GET shape into a populated model.
+
+    ## Test
+
+    - from_response constructs an instance from the SAMPLE_API_RESPONSE shape
+    - Top-level wire fields are accessible via Python field names
+    - Nested vpcPairDetails fields are accessible via Python field names
+
+    ## Classes and Methods
+
+    - VpcPairModel.from_response()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    # from_response needs the orchestrator to also inject ansible identifiers
+    # The orchestrator does this; we mimic it here.
+    response["fabric_name"] = "SITE1"
+    response["switch_ip"] = "192.168.12.151"
+    response["peer_switch_ip"] = "192.168.12.155"
+    with does_not_raise():
+        instance = VpcPairModel.from_response(response)
+    assert instance.switch_id == "9ASNKH8T9DJ"
+    assert instance.peer_switch_id == "9SJKCSQND07"
+    assert instance.use_virtual_peer_link is False
+    assert instance.vpc_action == "pair"
+    assert instance.domain_id == 1
+    assert instance.keep_alive_vrf == "management"
+    assert instance.keep_alive_hold_timeout == 3
+
+
+# =============================================================================
+# Test 00500-00599: get_argument_spec
+# =============================================================================
+
+
+def test_vpc_pair_00500():
+    """
+    # Summary
+
+    Verify get_argument_spec returns a dict with fabric_name + config + state keys.
+
+    ## Test
+
+    - argument_spec has fabric_name, config, state at top level
+    - state choices include merged/replaced/overridden/deleted/query
+
+    ## Classes and Methods
+
+    - VpcPairModel.get_argument_spec()
+    """
+    spec = VpcPairModel.get_argument_spec()
+    assert "fabric_name" in spec
+    assert "config" in spec
+    assert "state" in spec
+    state_choices = spec["state"]["choices"]
+    for required_state in ("merged", "replaced", "overridden", "deleted", "query"):
+        assert required_state in state_choices
+
+
+def test_vpc_pair_00510():
+    """
+    # Summary
+
+    Verify get_argument_spec exposes pair fields under config.options but does NOT expose
+    use_virtual_peer_link or vpc_action (those are internal/frozen).
+
+    ## Test
+
+    - config.options contains switch_ip, peer_switch_ip, domain_id, keep_alive_vrf
+    - config.options does NOT contain use_virtual_peer_link or vpc_action
+
+    ## Classes and Methods
+
+    - VpcPairModel.get_argument_spec()
+    """
+    spec = VpcPairModel.get_argument_spec()
+    options = spec["config"]["options"]
+    for required_field in ("switch_ip", "peer_switch_ip", "domain_id", "keep_alive_vrf"):
+        assert required_field in options, f"Expected {required_field} in config.options"
+    assert "use_virtual_peer_link" not in options, "Frozen field should not be exposed in argspec"
+    assert "vpc_action" not in options, "Internal action discriminator should not be exposed in argspec"

--- a/tests/unit/module_utils/orchestrators/test_vpc_pair.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_pair.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Cisco Systems, Inc.
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/tests/unit/module_utils/orchestrators/test_vpc_pair.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_pair.py
@@ -1,0 +1,537 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for VpcPairOrchestrator.
+
+Verifies that VpcPairOrchestrator correctly:
+- declares VpcPairModel as model_class and the expected endpoints
+- maps query_one 404 -> None via not_found_ok
+- parses fabric-wide vpcPairs list
+- runs create / update / delete via PUT vpcPair (with vpcAction = pair | unPair)
+- queues both peer serials for switchActions/deploy after each mutation
+- treats 207 deploy responses case-insensitively (Success / success both pass)
+- raises on per-switch failure status
+
+Uses the file-based Sender from tests/unit/module_utils/sender_file.py and the real
+ResponseHandler / RestSend; fixtures in
+tests/unit/module_utils/fixtures/fixture_data/test_vpc_pair_orchestrator.json.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_switch_actions_deploy import (
+    EpManageFabricSwitchActionsDeployPost,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_switch_vpc_pair import (
+    EpManageFabricSwitchVpcPairGet,
+    EpManageFabricSwitchVpcPairPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabric_vpc_pairs import (
+    EpManageFabricVpcPairsListGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.vpc.vpc_pair import VpcPairModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_pair import VpcPairOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_vpc_pair_orch(key: str):
+    """Load fixture data from test_vpc_pair_orchestrator.json."""
+    return load_fixture("test_vpc_pair_orchestrator")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "SITE1", config: list | None = None) -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    params = {"check_mode": False, "fabric_name": fabric_name}
+    if config is not None:
+        params["config"] = config
+    rest_send = RestSend(params)
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "SITE1", config: list | None = None) -> VpcPairOrchestrator:
+    """Construct a VpcPairOrchestrator with the file-based RestSend injected."""
+    return VpcPairOrchestrator(rest_send=_build_rest_send(gen_responses, fabric_name=fabric_name, config=config))
+
+
+def _model_default() -> VpcPairModel:
+    """Build a baseline VpcPairModel matching the lab SITE1 pair (S1_LE1 + S1_LE2)."""
+    return VpcPairModel(
+        fabric_name="SITE1",
+        switch_ip="192.168.12.151",
+        peer_switch_ip="192.168.12.155",
+        domain_id=1,
+    )
+
+
+# =============================================================================
+# Test: ClassVar / endpoint declarations
+# =============================================================================
+
+
+def test_vpc_pair_orch_00010() -> None:
+    """
+    # Summary
+
+    Verify model_class points to VpcPairModel.
+
+    ## Test
+
+    - model_class is VpcPairModel
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.model_class
+    """
+    assert VpcPairOrchestrator.model_class is VpcPairModel
+
+
+def test_vpc_pair_orch_00020() -> None:
+    """
+    # Summary
+
+    Verify endpoint class assignments map to the new vPC endpoints.
+
+    ## Test
+
+    - create/update/delete endpoint = EpManageFabricSwitchVpcPairPut
+    - query_one endpoint = EpManageFabricSwitchVpcPairGet
+    - query_all endpoint = EpManageFabricVpcPairsListGet
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator (instance field defaults)
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    assert orchestrator.create_endpoint is EpManageFabricSwitchVpcPairPut
+    assert orchestrator.update_endpoint is EpManageFabricSwitchVpcPairPut
+    assert orchestrator.delete_endpoint is EpManageFabricSwitchVpcPairPut
+    assert orchestrator.query_one_endpoint is EpManageFabricSwitchVpcPairGet
+    assert orchestrator.query_all_endpoint is EpManageFabricVpcPairsListGet
+
+
+def test_vpc_pair_orch_00030() -> None:
+    """
+    # Summary
+
+    Verify deploy_endpoint points to switchActions/deploy (NOT interfaceActions/deploy).
+
+    ## Test
+
+    - deploy_endpoint is EpManageFabricSwitchActionsDeployPost
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.deploy_endpoint
+    """
+    assert VpcPairOrchestrator.deploy_endpoint is EpManageFabricSwitchActionsDeployPost
+
+
+# =============================================================================
+# Test: query_one — 404 returns None, 200 returns model
+# =============================================================================
+
+
+def test_vpc_pair_orch_00100() -> None:
+    """
+    # Summary
+
+    Verify query_one returns None when the per-switch GET returns 404.
+
+    ## Test
+
+    - Switch list returns 2 switches (FabricContext IP -> serial)
+    - Per-switch GET vpcPair returns 404
+    - query_one returns None (404 mapped via not_found_ok)
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.query_one()
+    """
+
+    def responses():
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00100a_switches")
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00100b_get_404")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        result = orchestrator.query_one(_model_default())
+
+    assert result is None
+
+
+def test_vpc_pair_orch_00110() -> None:
+    """
+    # Summary
+
+    Verify query_one returns a populated VpcPairModel on 200.
+
+    ## Test
+
+    - Switch list returns 2 switches
+    - Per-switch GET vpcPair returns lab-shaped vpcPairDetails wrapper
+    - Result is a VpcPairModel populated from the wire shape (vpcPairDetails flattened)
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.query_one()
+    """
+
+    def responses():
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00110a_switches")
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00110b_get_200")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        result = orchestrator.query_one(_model_default())
+
+    assert isinstance(result, VpcPairModel)
+    assert result.switch_id == "9ASNKH8T9DJ"
+    assert result.peer_switch_id == "9SJKCSQND07"
+    assert result.use_virtual_peer_link is False
+    assert result.domain_id == 1
+    assert result.keep_alive_vrf == "management"
+
+
+# =============================================================================
+# Test: query_all — empty and populated
+# =============================================================================
+
+
+def test_vpc_pair_orch_00200() -> None:
+    """
+    # Summary
+
+    Verify query_all returns an empty list when the user's `config` is empty (no proposed peers to query).
+    The fabric-wide endpoint is intentionally not hit.
+
+    ## Test
+
+    - config is empty
+    - query_all returns []
+    - No API calls are made
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.query_all()
+    """
+
+    def responses():
+        yield from ()  # no responses expected
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses, config=[])
+
+    with does_not_raise():
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_vpc_pair_orch_00210() -> None:
+    """
+    # Summary
+
+    Verify query_all walks the proposed config items, performs per-switch GET vpcPair for each unique peer
+    pair, enriches the response with `fabric_name` / `switch_ip` / `peer_switch_ip`, and skips 404 entries.
+    The fabric-wide vpcPairs endpoint is NOT used because it lags in practice.
+
+    ## Test
+
+    - config has one proposed pair
+    - Switches list returns serials for IP resolution
+    - Per-switch GET returns a populated pair
+    - query_all returns one entry with wire shape + Ansible identifiers
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00110a_switches")
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00110b_get_200")
+
+    gen_responses = ResponseGenerator(responses())
+    config = [{"switch_ip": "192.168.12.151", "peer_switch_ip": "192.168.12.155", "domain_id": 1}]
+    orchestrator = _build_orchestrator(gen_responses, config=config)
+
+    with does_not_raise():
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["switchId"] == "9ASNKH8T9DJ"
+    assert result[0]["peerSwitchId"] == "9SJKCSQND07"
+    assert result[0]["fabric_name"] == "SITE1"
+    assert result[0]["switch_ip"] == "192.168.12.151"
+    assert result[0]["peer_switch_ip"] == "192.168.12.155"
+
+
+# =============================================================================
+# Test: create — PUT vpcPair + queue both serials for deploy
+# =============================================================================
+
+
+def test_vpc_pair_orch_00300() -> None:
+    """
+    # Summary
+
+    Verify create resolves both peer IPs to serials, performs the PUT vpcPair, and queues both serials for deploy.
+
+    ## Test
+
+    - Switch list returns 2 switches
+    - PUT vpcPair returns 204
+    - Both serials are queued in _pending_deploy_switch_ids
+    - Model.switch_id and Model.peer_switch_id are populated post-create
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.create()
+    - VpcPairOrchestrator._queue_deploy_switch()
+    """
+
+    def responses():
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00300a_switches")
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00300b_put_204")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    model_instance = _model_default()
+
+    with does_not_raise():
+        orchestrator.create(model_instance)
+
+    assert "9ASNKH8T9DJ" in orchestrator._pending_deploy_switch_ids
+    assert "9SJKCSQND07" in orchestrator._pending_deploy_switch_ids
+    assert model_instance.switch_id == "9ASNKH8T9DJ"
+    assert model_instance.peer_switch_id == "9SJKCSQND07"
+    assert model_instance.vpc_action == "pair"
+
+
+# =============================================================================
+# Test: delete — PUT vpcPair body vpcAction=unPair
+# =============================================================================
+
+
+def test_vpc_pair_orch_00500() -> None:
+    """
+    # Summary
+
+    Verify delete sends PUT vpcPair with body `{"vpcAction": "unPair"}` and queues both serials for deploy.
+
+    ## Test
+
+    - Switch list returns 2 switches
+    - PUT vpcPair returns 204
+    - vpc_action on the model is set to "unPair" before payload generation
+    - Both serials are queued for deploy
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.delete()
+    """
+
+    def responses():
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00500a_switches")
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00500b_put_unpair_204")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    model_instance = _model_default()
+
+    with does_not_raise():
+        orchestrator.delete(model_instance)
+
+    assert model_instance.vpc_action == "unPair"
+    assert "9ASNKH8T9DJ" in orchestrator._pending_deploy_switch_ids
+    assert "9SJKCSQND07" in orchestrator._pending_deploy_switch_ids
+
+
+# =============================================================================
+# Test: deploy_pending — 207 multi-status parsing
+# =============================================================================
+
+
+def test_vpc_pair_orch_00600() -> None:
+    """
+    # Summary
+
+    Verify deploy_pending posts to switchActions/deploy with both serials and clears the pending queue on all-success 207.
+
+    ## Test
+
+    - Both serials pre-queued
+    - 207 multi-status with both switches "success" (lowercase)
+    - deploy_pending succeeds
+    - Pending queue is cleared
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.deploy_pending()
+    """
+
+    def responses():
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00600a_deploy_207_all_success")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    orchestrator._pending_deploy_switch_ids = ["9ASNKH8T9DJ", "9SJKCSQND07"]
+
+    with does_not_raise():
+        orchestrator.deploy_pending()
+
+    assert orchestrator._pending_deploy_switch_ids == []
+
+
+def test_vpc_pair_orch_00610() -> None:
+    """
+    # Summary
+
+    Verify deploy_pending treats per-switch status case-insensitively. Lab observation: switchActions/deploy
+    returns lowercase 'success' but interfaceActions/remove returns 'Success' — orchestrator must accept both.
+
+    ## Test
+
+    - 207 multi-status with statuses "Success" (capital S) and "success" (lowercase) — both must pass
+    - deploy_pending succeeds without raising
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.deploy_pending()
+    """
+
+    def responses():
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00610a_deploy_207_mixed_case")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    orchestrator._pending_deploy_switch_ids = ["9ASNKH8T9DJ", "9SJKCSQND07"]
+
+    with does_not_raise():
+        orchestrator.deploy_pending()
+
+
+def test_vpc_pair_orch_00620() -> None:
+    """
+    # Summary
+
+    Verify deploy_pending raises RuntimeError when any per-switch status is not "success" (case-insensitive),
+    and surfaces the failure message in the exception text.
+
+    ## Test
+
+    - 207 multi-status with one "failed" status and a message
+    - deploy_pending raises RuntimeError
+    - Exception message contains the failed switch's message
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.deploy_pending()
+    """
+
+    def responses():
+        yield responses_vpc_pair_orch("test_vpc_pair_orch_00620a_deploy_207_one_failed")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    orchestrator._pending_deploy_switch_ids = ["9ASNKH8T9DJ", "9SJKCSQND07"]
+
+    with pytest.raises(RuntimeError, match=r"Switch unreachable"):
+        orchestrator.deploy_pending()
+
+
+def test_vpc_pair_orch_00630() -> None:
+    """
+    # Summary
+
+    Verify deploy_pending is a no-op when the pending queue is empty. No API call is made.
+
+    ## Test
+
+    - Empty pending queue
+    - deploy_pending returns None and queue stays empty
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator.deploy_pending()
+    """
+
+    def responses():
+        yield {}  # Should never be consumed
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        result = orchestrator.deploy_pending()
+
+    assert result is None
+    assert orchestrator._pending_deploy_switch_ids == []
+
+
+def test_vpc_pair_orch_00640() -> None:
+    """
+    # Summary
+
+    Verify _queue_deploy_switch deduplicates serial numbers (calling it twice with the same serial
+    keeps the queue at length 1).
+
+    ## Test
+
+    - Queue same serial twice
+    - Pending list contains exactly one entry
+
+    ## Classes and Methods
+
+    - VpcPairOrchestrator._queue_deploy_switch()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    orchestrator._queue_deploy_switch("9ASNKH8T9DJ")
+    orchestrator._queue_deploy_switch("9ASNKH8T9DJ")
+    assert orchestrator._pending_deploy_switch_ids == ["9ASNKH8T9DJ"]


### PR DESCRIPTION
## Related Issue(s)

<!-- none — to be filled in if applicable -->

Sivakami has an open PR [197 - VPC Pair 4.x Implementation](https://github.com/CiscoDevNet/ansible-nd/pull/197) for VPC pairing.  I needed this to implement VPC interface modules, but this has not been merged into develop, and it does not currently leverage Gaspard's framework.  Due to this, I asked Claude to write a VPC pair module that I could stack my VPC interface PRs (both will be created today) onto.  I want to acknowledge Sivakami's work and did ask Claude to ensure nd_vpc_pair is functionally equivalent to it (so the PR did serve as a baseline reference from a functionality perspective).  I'll  reach out to Sivakami to explain this situation and ask if this is OK with her.

## Proposed Changes

- Adds the `nd_vpc_pair` module, which manages vPC pair lifecycle (pair / unpair) between two switches in a fabric via the ND `PUT /api/v1/manage/fabrics/{fabric}/switches/{sn}/vpcPair` endpoint.
- Adds the shared `VpcBaseOrchestrator` (`plugins/module_utils/orchestrators/vpc_base.py`) that every `nd_interface_vpc_*` module will reuse for CRUD, peer-serial resolution, per-interface DELETE, and `query_all` dedupe.
- Adds endpoint models: `EpManageFabricSwitchVpcPairGet`, `EpManageFabricVpcPairsListGet`, `EpManageFabricSwitchActionsDeploy`, and `EpManageInterfacesDelete`.
- Adds the `VpcPairModel` Pydantic model with `vpcPairDetails` subtree and `identifier_strategy = "single"` on `switch_ip`.

Three ND 4.2.1 wire quirks are accommodated and tagged `TODO(4.2.1)`:

- `interfaceActions/remove` returns "Invalid Interface" for vPC entries; vPC delete uses the per-interface DELETE endpoint instead.
- ND echoes each vPC interface from BOTH peer switches in their per-switch `/interfaces` GET; the orchestrator dedupes by `interfaceName`, keeping the alphabetically-lower `switchId` as canonical.
- These are documented inline at each workaround site and audited by `/nd-workaround-audit`.

## Test Notes

- 69 new unit tests across model, orchestrator, and 3 endpoint files: \`python -m pytest tests/unit/module_utils/{models,orchestrators,endpoints}/ -q\` (926 total pass, no regressions).
- Integration target \`tests/integration/targets/nd_vpc_pair/\` with \`merged\` / \`replaced\` / \`deleted\` state coverage, exercised against ND 4.2.1 on the SITE1 lab (S1_LE1 / S1_LE2): \`ansible-test integration --docker nd_vpc_pair -vv\`.
- \`ansible-test sanity --docker default --python 3.11\` passes on the changed files.
- Wire shape verified live against ND 4.2.1: pair create returns 204, GET \`/vpcPair\` returns the per-peer record, \`vpcAction: unPair\` cleanly tears the pair down.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infa
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers