### PR TITLE
nd_interface_vpc_access

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -283,7 +283,7 @@ class EpManageInterfacesDelete(_EpManageInterfacesBase):
     """
     # Summary
 
-    Delete a specific interface configuration.
+    Delete a specific interface via the per-interface endpoint.
 
     - Path: `/api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/interfaces/{interface_name}`
     - Verb: DELETE
@@ -293,6 +293,10 @@ class EpManageInterfacesDelete(_EpManageInterfacesBase):
 
     To reset physical interfaces to their default state, see `EpManageInterfacesNormalize` and set the payload to an
     appropriate default config (for example `module_utils/models/interfaces/interface_default_config.py`).
+
+    Also used by vPC interface orchestrators because the `interfaceActions/remove` bulk endpoint returns
+    `Invalid Interface` for vPC entries on ND 4.2.1 (lab-verified). The per-interface DELETE returns 204
+    on success and a subsequent GET returns 404.
 
     ## Raises
 

--- a/plugins/module_utils/models/interfaces/enums.py
+++ b/plugins/module_utils/models/interfaces/enums.py
@@ -46,6 +46,16 @@ class TrunkPoHostPolicyTypeEnum(str, Enum):
     TRUNK_PO_HOST = "trunkPoHost"
 
 
+class AccessVpcHostPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for vPC access host interfaces (`int_vpc_access_host` template).
+    """
+
+    ACCESS_VPC_HOST = "accessVpcHost"
+
+
 class BpduFilterEnum(str, Enum):
     """
     # Summary

--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -1,0 +1,436 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+vPC access (accessVpcHost) interface Pydantic models for Nexus Dashboard.
+
+This module defines nested Pydantic models that mirror the ND Manage Interfaces API payload
+structure for vPC accessVpcHost interfaces (`int_vpc_access_host.template`). The playbook
+config uses the same nesting so that `to_payload()` and `from_response()` work via standard
+Pydantic serialization with no custom wrapping or flattening.
+
+A vPC access interface spans two switches in a vPC pair. The user supplies one peer's
+management IP as `switch_ip`; the orchestrator auto-resolves the peer serial via the
+`vpcPair` endpoint and injects it as `peerSwitchId` in the payload. Per-peer policy fields
+use the ND-native `peer1_*` / `peer2_*` naming where `peer1` corresponds to `switch_ip`
+(the switch in the URL path) and `peer2` corresponds to the auto-resolved peer.
+
+## Model Hierarchy
+
+- `AccessVpcHostInterfaceModel` (top-level, `NDBaseModel`)
+    - `switch_ip` (composite identifier; primary peer's management IP)
+    - `interface_name` (composite identifier; e.g. `vpc100`)
+    - `interface_type` (frozen: "vpc")
+    - `config_data` -> `AccessVpcHostConfigDataModel`
+        - `mode` (frozen: "access")
+        - `network_os` -> `AccessVpcHostNetworkOSModel`
+            - `network_os_type` (frozen: "nx-os")
+            - `policy` -> `AccessVpcHostPolicyModel`
+                - `policy_type` (frozen: "accessVpcHost")
+                - `peer_switch_id` (orchestrator-injected; not in argspec)
+                - per-peer fields: `peer1_*`, `peer2_*`
+                - shared fields: `admin_state`, `cdp`, `lacp_rate`, `mtu`, etc.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    field_validator,
+    model_serializer,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    AccessVpcHostPolicyTypeEnum,
+    BpduFilterEnum,
+    BpduGuardEnum,
+    DuplexModeEnum,
+    LacpRateEnum,
+    LinkTypeEnum,
+    MtuEnum,
+    PortChannelModeEnum,
+    SpeedEnum,
+    StormControlActionEnum,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+
+
+class AccessVpcHostPolicyModel(NDNestedModel):
+    """
+    # Summary
+
+    Policy fields for a vPC `accessVpcHost` interface. Maps directly to the `configData.networkOS.policy` object in the ND API.
+
+    Per-peer fields use the API-native `peer1*` / `peer2*` naming. `peer1` corresponds to the switch in the URL path
+    (the user-supplied `switch_ip`); `peer2` corresponds to the auto-resolved peer (the value of `peerSwitchId`).
+
+    `peer_switch_id` is set by the orchestrator from the vPC pair record. It is not exposed in the module argument spec.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Policy Discriminator ---
+
+    policy_type: AccessVpcHostPolicyTypeEnum = Field(
+        default=AccessVpcHostPolicyTypeEnum.ACCESS_VPC_HOST,
+        alias="policyType",
+        frozen=True,
+        description="Interface policy type (hardcoded for this module)",
+    )
+
+    # --- Orchestrator-Injected (Not In Argspec) ---
+
+    peer_switch_id: str | None = Field(
+        default=None,
+        alias="peerSwitchId",
+        description="Peer switch serial number, auto-resolved by the orchestrator from the vPC pair record",
+    )
+
+    # --- Shared (single-valued) access VLAN ---
+    # TODO(4.2.1) ND accessVpcHost wire echoes a single `accessVlan` even though the create schema requires
+    # per-peer `peer1AccessVlan` / `peer2AccessVlan`. See `expand_per_peer_fields` below for the split-on-write
+    # workaround.
+    access_vlan: int | None = Field(default=None, alias="accessVlan", ge=1, le=4094, description="VLAN for the access port on both peers")
+
+    # --- Per-Peer Fields (peer1 = switch_ip, peer2 = peer_switch_id) ---
+
+    peer1_member_ports: list[str] | None = Field(default=None, alias="peer1MemberPorts", description="Member interface names on Peer-1")
+    peer1_port_channel_configuration: str | None = Field(
+        default=None, alias="peer1PortChannelConfiguration", description="Additional CLI for Peer-1's port-channel"
+    )
+    peer1_port_channel_description: AsciiDescription = Field(
+        default=None, alias="peer1PortChannelDescription", max_length=254, description="Description for Peer-1's port-channel"
+    )
+    peer1_port_channel_id: int | None = Field(default=None, alias="peer1PortChannelId", ge=1, le=4096, description="Peer-1 vPC port-channel number")
+    peer2_member_ports: list[str] | None = Field(default=None, alias="peer2MemberPorts", description="Member interface names on Peer-2")
+    peer2_port_channel_configuration: str | None = Field(
+        default=None, alias="peer2PortChannelConfiguration", description="Additional CLI for Peer-2's port-channel"
+    )
+    peer2_port_channel_description: AsciiDescription = Field(
+        default=None, alias="peer2PortChannelDescription", max_length=254, description="Description for Peer-2's port-channel"
+    )
+    peer2_port_channel_id: int | None = Field(default=None, alias="peer2PortChannelId", ge=1, le=4096, description="Peer-2 vPC port-channel number")
+
+    # --- Shared Policy Fields ---
+
+    admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
+    bandwidth: int | None = Field(default=None, alias="bandwidth", ge=1, le=100000000, description="Configured bandwidth value for the interface")
+    bpdu_filter: BpduFilterEnum | None = Field(default=None, alias="bpduFilter", description="Configure spanning-tree BPDU filter")
+    bpdu_guard: BpduGuardEnum | None = Field(default=None, alias="bpduGuard", description="Enable spanning-tree BPDU guard")
+    cdp: bool | None = Field(default=None, alias="cdp", description="Enable CDP on the interface")
+    copy_description: bool | None = Field(
+        default=None,
+        alias="copyDescription",
+        description="Propagate the port-channel description to all member interfaces (per-peer)",
+    )
+    duplex_mode: DuplexModeEnum | None = Field(default=None, alias="duplexMode", description="Port duplex mode")
+    inherit_bandwidth: int | None = Field(
+        default=None,
+        alias="inheritBandwidth",
+        ge=1,
+        le=100000000,
+        description="Bandwidth value inherited by sub-interfaces",
+    )
+    lacp_port_priority: int | None = Field(default=None, alias="lacpPortPriority", ge=1, le=65535, description="LACP port priority (1-65535, default 32768)")
+    lacp_rate: LacpRateEnum | None = Field(default=None, alias="lacpRate", description="LACP rate (normal=30s, fast=1s)")
+    lacp_suspend: bool | None = Field(default=None, alias="lacpSuspend", description="Suspend port if LACP PDUs not received")
+    lacp_vpc_convergence: bool | None = Field(default=None, alias="lacpVpcConvergence", description="Enable LACP convergence for vPC port-channels")
+    link_type: LinkTypeEnum | None = Field(default=None, alias="linkType", description="Spanning-tree link type")
+    mirror_config: bool | None = Field(default=None, alias="mirrorConfig", description="Copy Peer-1 config to Peer-2")
+    mtu: MtuEnum | None = Field(default=None, alias="mtu", description="Interface MTU")
+    negotiate_auto: bool | None = Field(default=None, alias="negotiateAuto", description="Enable link auto-negotiation")
+    netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name")
+    netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name (N7K only)")
+    pfc: bool | None = Field(default=None, alias="pfc", description="Enable priority flow control")
+    port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode (on/active/passive)")
+    port_type_edge_trunk: bool | None = Field(default=None, alias="portTypeEdgeTrunk", description="Enable spanning-tree edge port (PortFast) behavior")
+    qos: bool | None = Field(default=None, alias="qos", description="Enable QoS configuration for this interface")
+    qos_policy: str | None = Field(default=None, alias="qosPolicy", description="Custom QoS policy name")
+    queuing_policy: str | None = Field(default=None, alias="queuingPolicy", description="Custom queuing policy name")
+    speed: SpeedEnum | None = Field(default=None, alias="speed", description="Interface speed")
+    storm_control: bool | None = Field(default=None, alias="stormControl", description="Enable traffic storm control")
+    storm_control_action: StormControlActionEnum | None = Field(
+        default=None, alias="stormControlAction", description="Storm control action on threshold violation"
+    )
+    storm_control_broadcast_level: float | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Broadcast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_broadcast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlBroadcastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Broadcast storm control level in packets per second",
+    )
+    storm_control_multicast_level: float | None = Field(
+        default=None,
+        alias="stormControlMulticastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Multicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_multicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlMulticastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Multicast storm control level in packets per second",
+    )
+    storm_control_unicast_level: float | None = Field(
+        default=None,
+        alias="stormControlUnicastLevel",
+        ge=0.0,
+        le=100.0,
+        description="Unicast storm control level in percentage (0.00-100.00)",
+    )
+    storm_control_unicast_level_pps: int | None = Field(
+        default=None,
+        alias="stormControlUnicastLevelPps",
+        ge=0,
+        le=200000000,
+        description="Unicast storm control level in packets per second",
+    )
+
+    # --- Validators ---
+
+    # --- Serializers ---
+
+    # TODO(4.2.1) accessVpcHost wire echoes a single `accessVlan` even though the create schema requires per-peer
+    # `peer1AccessVlan` / `peer2AccessVlan`. We expose a single `access_vlan` to users and split it back to the
+    # per-peer keys on the write side via this model_serializer so idempotency works against the actual wire shape.
+    @model_serializer(mode="wrap")
+    def expand_per_peer_fields(self, handler, info):
+        """
+        # Summary
+
+        Split single-value user-facing fields into the per-peer keys the ND write API expects, so they round-trip
+        correctly against ND's read response. Specifically, `accessVlan` is collapsed by ND on read but the create
+        schema accepts `peer1AccessVlan` / `peer2AccessVlan`. On payload serialization (context `mode == "payload"`),
+        we expand `accessVlan` to both per-peer keys. In all other modes (config / diff), the field is left as-is so
+        it matches the wire echo and keeps the diff symmetric.
+
+        ## Raises
+
+        None
+        """
+        data = handler(self)
+        context = getattr(info, "context", None) or {}
+        if context.get("mode") == "payload" and "accessVlan" in data:
+            vlan = data.pop("accessVlan")
+            data["peer1AccessVlan"] = vlan
+            data["peer2AccessVlan"] = vlan
+        return data
+
+    # --- Validators ---
+
+    @field_validator("peer1_member_ports", "peer2_member_ports", mode="before")
+    @classmethod
+    def normalize_member_ports(cls, value):
+        """
+        # Summary
+
+        Normalize each member interface name to ND API convention (e.g. `ethernet1/1` -> `Ethernet1/1`).
+
+        ## Raises
+
+        None
+        """
+        if value is None:
+            return value
+        if not isinstance(value, list):
+            return value
+        normalized = []
+        for name in value:
+            if isinstance(name, str) and name:
+                normalized.append(name[0].upper() + name[1:])
+            else:
+                normalized.append(name)
+        return normalized
+
+
+class AccessVpcHostNetworkOSModel(NDNestedModel):
+    """
+    # Summary
+
+    Network OS container for a vPC `accessVpcHost` interface. Maps to `configData.networkOS` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: AccessVpcHostPolicyModel | None = Field(default=None, alias="policy")
+
+
+class AccessVpcHostConfigDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Config data container for a vPC `accessVpcHost` interface. Maps to `configData` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    mode: Literal["access"] = Field(default="access", alias="mode", frozen=True)
+    network_os: AccessVpcHostNetworkOSModel = Field(alias="networkOS")
+
+
+class AccessVpcHostInterfaceModel(NDBaseModel):
+    """
+    # Summary
+
+    vPC `accessVpcHost` interface configuration for Nexus Dashboard.
+
+    Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
+    Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
+
+    The `interface_name` is the vPC's own name (e.g. `vpc100`), not a member interface. Member interfaces are listed
+    per-peer in `config_data.network_os.policy.peer1_member_ports` and `peer2_member_ports`.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+    # TODO(4.2.1) A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in
+    # the per-switch `/interfaces` GET (with identical `configData` and only `switchId` / `peerSwitchId` swapping).
+    # Using a composite (switch_ip, interface_name) identifier caused `_manage_override_deletions` to delete the
+    # peer-side duplicate. The identifier is therefore `interface_name` only; `switch_ip` is kept as a field for
+    # routing (URL-path resolution + peer-resolution) but is excluded from diff and dedup'd in `query_all`.
+
+    identifiers: ClassVar[list[str] | None] = ["interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
+    exclude_from_diff: ClassVar[set[str]] = {"switch_ip"}
+
+    # --- Fields ---
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["vpc"] = Field(default="vpc", alias="interfaceType", frozen=True)
+    config_data: AccessVpcHostConfigDataModel | None = Field(default=None, alias="configData")
+
+    @field_validator("interface_name", mode="before")
+    @classmethod
+    def normalize_interface_name(cls, value):
+        """
+        # Summary
+
+        Normalize the vPC interface name to lowercase to match ND API convention (e.g. `Vpc100` -> `vpc100`).
+
+        ## Raises
+
+        None
+        """
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_interface_vpc_access` module. Frozen scaffolding fields
+        (`interface_type`, `mode`, `network_os_type`, `policy_type`) are intentionally NOT exposed. `peer_switch_id`
+        is orchestrator-injected and NOT exposed.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    interface_name=dict(type="str", required=True),
+                    config_data=dict(
+                        type="dict",
+                        options=dict(
+                            network_os=dict(
+                                type="dict",
+                                options=dict(
+                                    policy=dict(
+                                        type="dict",
+                                        options=dict(
+                                            admin_state=dict(type="bool"),
+                                            bandwidth=dict(type="int"),
+                                            bpdu_filter=dict(type="str", choices=[e.value for e in BpduFilterEnum]),
+                                            bpdu_guard=dict(type="str", choices=[e.value for e in BpduGuardEnum]),
+                                            cdp=dict(type="bool"),
+                                            copy_description=dict(type="bool"),
+                                            duplex_mode=dict(type="str", choices=[e.value for e in DuplexModeEnum]),
+                                            inherit_bandwidth=dict(type="int"),
+                                            lacp_port_priority=dict(type="int"),
+                                            lacp_rate=dict(type="str", choices=[e.value for e in LacpRateEnum]),
+                                            lacp_suspend=dict(type="bool"),
+                                            lacp_vpc_convergence=dict(type="bool"),
+                                            link_type=dict(type="str", choices=[e.value for e in LinkTypeEnum]),
+                                            mirror_config=dict(type="bool"),
+                                            mtu=dict(type="str", choices=[e.value for e in MtuEnum]),
+                                            negotiate_auto=dict(type="bool"),
+                                            netflow=dict(type="bool"),
+                                            netflow_monitor=dict(type="str"),
+                                            netflow_sampler=dict(type="str"),
+                                            access_vlan=dict(type="int"),
+                                            peer1_member_ports=dict(type="list", elements="str"),
+                                            peer1_port_channel_configuration=dict(type="str"),
+                                            peer1_port_channel_description=dict(type="str"),
+                                            peer1_port_channel_id=dict(type="int"),
+                                            peer2_member_ports=dict(type="list", elements="str"),
+                                            peer2_port_channel_configuration=dict(type="str"),
+                                            peer2_port_channel_description=dict(type="str"),
+                                            peer2_port_channel_id=dict(type="int"),
+                                            pfc=dict(type="bool"),
+                                            port_channel_mode=dict(type="str", choices=[e.value for e in PortChannelModeEnum]),
+                                            port_type_edge_trunk=dict(type="bool"),
+                                            qos=dict(type="bool"),
+                                            qos_policy=dict(type="str"),
+                                            queuing_policy=dict(type="str"),
+                                            speed=dict(type="str", choices=[e.value for e in SpeedEnum]),
+                                            storm_control=dict(type="bool"),
+                                            storm_control_action=dict(type="str", choices=[e.value for e in StormControlActionEnum]),
+                                            storm_control_broadcast_level=dict(type="float"),
+                                            storm_control_broadcast_level_pps=dict(type="int"),
+                                            storm_control_multicast_level=dict(type="float"),
+                                            storm_control_multicast_level_pps=dict(type="int"),
+                                            storm_control_unicast_level=dict(type="float"),
+                                            storm_control_unicast_level_pps=dict(type="int"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -35,10 +35,12 @@ use the ND-native `peer1_*` / `peer2_*` naming where `peer1` corresponds to `swi
 
 from __future__ import annotations
 
+import re
 from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
+    SerializationInfo,
     field_validator,
     model_serializer,
 )
@@ -57,6 +59,14 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+
+# Splits an interface name into its leading alphabetic prefix and the rest (digits/separators).
+_INTERFACE_NAME_PREFIX_RE = re.compile(r"^([A-Za-z]+)(.*)$")
+
+# Member interfaces of a vPC are always physical ethernet ports, so the canonical wire prefix is always
+# "Ethernet". Any case-insensitive NX-OS abbreviation (e.g. "e", "eth", "ether") expands to the full form so
+# user input matches the wire key and idempotency holds.
+_CANONICAL_MEMBER_TYPE = "Ethernet"
 
 
 class AccessVpcHostPolicyModel(NDNestedModel):
@@ -93,9 +103,9 @@ class AccessVpcHostPolicyModel(NDNestedModel):
     )
 
     # --- Shared (single-valued) access VLAN ---
-    # TODO(4.2.1) ND accessVpcHost wire echoes a single `accessVlan` even though the create schema requires
-    # per-peer `peer1AccessVlan` / `peer2AccessVlan`. See `expand_per_peer_fields` below for the split-on-write
-    # workaround.
+    # TODO(4.2.1) vpc-interface-peer-vlan-collapse
+    # ND accessVpcHost wire echoes a single `accessVlan` even though the create schema requires per-peer
+    # `peer1AccessVlan` / `peer2AccessVlan`. See `serialize_policy` below for the split-on-write workaround.
     access_vlan: int | None = Field(default=None, alias="accessVlan", ge=1, le=4094, description="VLAN for the access port on both peers")
 
     # --- Per-Peer Fields (peer1 = switch_ip, peer2 = peer_switch_id) ---
@@ -202,34 +212,45 @@ class AccessVpcHostPolicyModel(NDNestedModel):
         description="Unicast storm control level in packets per second",
     )
 
-    # --- Validators ---
-
     # --- Serializers ---
 
-    # TODO(4.2.1) accessVpcHost wire echoes a single `accessVlan` even though the create schema requires per-peer
+    # TODO(4.2.1) vpc-interface-peer-vlan-collapse
+    # accessVpcHost wire echoes a single `accessVlan` even though the create schema requires per-peer
     # `peer1AccessVlan` / `peer2AccessVlan`. We expose a single `access_vlan` to users and split it back to the
     # per-peer keys on the write side via this model_serializer so idempotency works against the actual wire shape.
     @model_serializer(mode="wrap")
-    def expand_per_peer_fields(self, handler, info):
+    def serialize_policy(self, handler, info: SerializationInfo):
         """
         # Summary
 
-        Split single-value user-facing fields into the per-peer keys the ND write API expects, so they round-trip
-        correctly against ND's read response. Specifically, `accessVlan` is collapsed by ND on read but the create
-        schema accepts `peer1AccessVlan` / `peer2AccessVlan`. On payload serialization (context `mode == "payload"`),
-        we expand `accessVlan` to both per-peer keys. In all other modes (config / diff), the field is left as-is so
-        it matches the wire echo and keeps the diff symmetric.
+        Single wrap-mode model serializer for the policy block, applying two ND-specific adjustments keyed off the
+        serialization `mode` context:
+
+        - On payload serialization (`mode == "payload"`), split the single user-facing `accessVlan` into the per-peer
+          `peer1AccessVlan` / `peer2AccessVlan` keys the ND create/update schema requires. ND collapses the pair back
+          to a single `accessVlan` on read, so config / diff modes leave the field as-is and the diff stays symmetric.
+        - On config serialization (`mode == "config"`), drop the frozen, argspec-excluded `policy_type` so it does not
+          leak into `before` / `after` / `gathered` output. Payload and diff modes keep the wire value so the POST/PUT
+          body and the round-trip diff line up with what ND returns.
 
         ## Raises
 
-        None
+        ### AssertionError
+
+        - If the wrapped handler returns a non-`dict`. A model-level serializer always serializes to a `dict`, so this
+          is an invariant check that fails loudly rather than silently mis-serializing.
         """
         data = handler(self)
-        context = getattr(info, "context", None) or {}
-        if context.get("mode") == "payload" and "accessVlan" in data:
+        if not isinstance(data, dict):
+            raise AssertionError(f"Expected dict from model serialization, got {type(data).__name__}")
+        mode = (info.context or {}).get("mode", "payload")
+        if mode == "payload" and "accessVlan" in data:
             vlan = data.pop("accessVlan")
             data["peer1AccessVlan"] = vlan
             data["peer2AccessVlan"] = vlan
+        if mode == "config":
+            data.pop("policy_type", None)
+            data.pop("policyType", None)
         return data
 
     # --- Validators ---
@@ -240,23 +261,47 @@ class AccessVpcHostPolicyModel(NDNestedModel):
         """
         # Summary
 
-        Normalize each member interface name to ND API convention (e.g. `ethernet1/1` -> `Ethernet1/1`).
+        Normalize each per-peer member interface name to ND's canonical `Ethernet` form so any user-supplied casing or
+        NX-OS abbreviation round-trips against the wire form. Members are always physical ethernet ports. Examples:
+
+        - `ethernet1/1` -> `Ethernet1/1`
+        - `eth1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `e1/1` -> `Ethernet1/1` (abbreviation expanded)
+        - `Ethernet1/1` -> `Ethernet1/1` (idempotent)
+
+        An abbreviated prefix that is not expanded would never match ND's `Ethernet...` wire key, silently breaking
+        idempotency (the vPC re-deploys on every run). Only the leading alphabetic run is rewritten; digits and
+        separators are preserved verbatim.
 
         ## Raises
 
         None
         """
-        if value is None:
-            return value
         if not isinstance(value, list):
             return value
-        normalized = []
-        for name in value:
-            if isinstance(name, str) and name:
-                normalized.append(name[0].upper() + name[1:])
-            else:
-                normalized.append(name)
-        return normalized
+        return [cls._normalize_member_name(name) for name in value]
+
+    @staticmethod
+    def _normalize_member_name(name):
+        """
+        # Summary
+
+        Normalize a single member interface name to ND's canonical `Ethernet` form (see `normalize_member_ports`).
+        Non-string or empty values are returned unchanged.
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(name, str) or not name:
+            return name
+        match = _INTERFACE_NAME_PREFIX_RE.match(name)
+        if not match:
+            return name
+        prefix, rest = match.groups()
+        if _CANONICAL_MEMBER_TYPE.lower().startswith(prefix.lower()):
+            return _CANONICAL_MEMBER_TYPE + rest
+        return prefix[0].upper() + prefix[1:].lower() + rest
 
 
 class AccessVpcHostNetworkOSModel(NDNestedModel):
@@ -307,11 +352,12 @@ class AccessVpcHostInterfaceModel(NDBaseModel):
     """
 
     # --- Identifier Configuration ---
-    # TODO(4.2.1) A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in
-    # the per-switch `/interfaces` GET (with identical `configData` and only `switchId` / `peerSwitchId` swapping).
-    # Using a composite (switch_ip, interface_name) identifier caused `_manage_override_deletions` to delete the
-    # peer-side duplicate. The identifier is therefore `interface_name` only; `switch_ip` is kept as a field for
-    # routing (URL-path resolution + peer-resolution) but is excluded from diff and dedup'd in `query_all`.
+    # TODO(4.2.1) vpc-interface-dual-peer-duplicate
+    # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in the per-switch
+    # `/interfaces` GET (with identical `configData` and only `switchId` / `peerSwitchId` swapping). Using a composite
+    # (switch_ip, interface_name) identifier caused `_manage_override_deletions` to delete the peer-side duplicate. The
+    # identifier is therefore `interface_name` only; `switch_ip` is kept as a field for routing (URL-path resolution +
+    # peer-resolution) but is excluded from diff and dedup'd in `query_all`.
 
     identifiers: ClassVar[list[str] | None] = ["interface_name"]
     identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"

--- a/plugins/module_utils/orchestrators/vpc_access_interface.py
+++ b/plugins/module_utils/orchestrators/vpc_access_interface.py
@@ -1,0 +1,53 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+vPC accessVpcHost interface orchestrator for Nexus Dashboard.
+
+This module provides `AccessVpcHostInterfaceOrchestrator`, which manages CRUD operations for vPC
+`accessVpcHost` interfaces. It inherits all shared vPC logic from `VpcInterfaceBaseOrchestrator` and only
+defines the model class and managed policy types.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Type
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import AccessVpcHostPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+    AccessVpcHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import VpcInterfaceBaseOrchestrator
+
+
+class AccessVpcHostInterfaceOrchestrator(VpcInterfaceBaseOrchestrator):
+    """
+    # Summary
+
+    Orchestrator for vPC `accessVpcHost` interface CRUD operations on Nexus Dashboard.
+
+    Inherits all shared vPC logic from `VpcInterfaceBaseOrchestrator`. Defines `model_class` as
+    `AccessVpcHostInterfaceModel` and manages the `accessVpcHost` policy type.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via inherited methods. See `VpcInterfaceBaseOrchestrator` for full details.
+    """
+
+    model_class: ClassVar[Type[NDBaseModel]] = AccessVpcHostInterfaceModel
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator.
+
+        ## Raises
+
+        None
+        """
+        return {e.value for e in AccessVpcHostPolicyTypeEnum}

--- a/plugins/module_utils/orchestrators/vpc_access_interface.py
+++ b/plugins/module_utils/orchestrators/vpc_access_interface.py
@@ -12,7 +12,7 @@ defines the model class and managed policy types.
 
 from __future__ import annotations
 
-from typing import ClassVar, Type
+from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import AccessVpcHostPolicyTypeEnum
@@ -38,7 +38,7 @@ class AccessVpcHostInterfaceOrchestrator(VpcInterfaceBaseOrchestrator):
     - Via inherited methods. See `VpcInterfaceBaseOrchestrator` for full details.
     """
 
-    model_class: ClassVar[Type[NDBaseModel]] = AccessVpcHostInterfaceModel
+    model_class: ClassVar[type[NDBaseModel]] = AccessVpcHostInterfaceModel
 
     def _managed_policy_types(self) -> set[str]:
         """

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -362,6 +362,6 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
                     existing = interfaces_by_name.get(name)
                     if existing is None or switch_id < existing[0]:
                         interfaces_by_name[name] = (switch_id, iface)
-            return [entry for _, entry in interfaces_by_name.values()]
+            return [entry[1] for entry in interfaces_by_name.values()]
         except Exception as e:
             raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -45,6 +45,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import requires_bulk_support
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
@@ -63,9 +64,9 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
     Each create/update reads the `vpcPair` record for the primary switch to obtain the peer serial, which is
     then injected as `peerSwitchId` in the payload. Lookups are cached per orchestrator instance.
 
-    Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` queues vPC interfaces for
-    bulk removal via `interfaceActions/remove` and bulk deploy. Call `remove_pending` and `deploy_pending` after
-    all mutations are complete.
+    Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` issues an immediate
+    per-interface `DELETE /interfaces/{name}` (the bulk `interfaceActions/remove` endpoint rejects vPC interfaces;
+    see the `TODO(4.2.1)` below) and queues a deploy. Call `deploy_pending` after all mutations are complete.
 
     ## Raises
 
@@ -82,7 +83,8 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
     - Via `query_all` if the query API request fails.
     """
 
-    # TODO(4.2.1) The bulk `/api/v1/manage/fabrics/{fabric}/interfaceActions/remove` endpoint returns
+    # TODO(4.2.1) vpc-interface-bulk-delete-silent-fail
+    # The bulk `/api/v1/manage/fabrics/{fabric}/interfaceActions/remove` endpoint returns
     # `{"status":"Failed","message":"Invalid Interface"}` inside a 207 for vPC interfaces (lab-verified). The
     # per-interface `DELETE /interfaces/{name}` endpoint works (returns 204). We therefore disable bulk delete and
     # use the per-interface DELETE via `delete_endpoint`.
@@ -163,16 +165,22 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         """
         # Summary
 
-        Inject `peerSwitchId` into the nested `configData.networkOS.policy` block of an interface payload. The model
-        already nests `peer_switch_id` under `policy`, so this just sets the value if not already present.
+        Inject `peerSwitchId` into the nested `configData.networkOS.policy` block of an interface payload. Every vPC
+        interface requires a peer serial, so a payload without a `policy` block is structurally invalid and is rejected
+        here rather than silently sent to ND as a one-sided vPC.
 
         ## Raises
 
-        None
+        ### RuntimeError
+
+        - If the payload has no `configData.networkOS.policy` block to inject `peerSwitchId` into.
         """
-        policy = payload.get("configData", {}).get("networkOS", {}).get("policy")
-        if policy is not None:
-            policy["peerSwitchId"] = peer_serial
+        policy = (payload.get("configData") or {}).get("networkOS", {}).get("policy")
+        if policy is None:
+            raise RuntimeError(
+                f"vPC interface payload is missing the 'configData.networkOS.policy' block required to inject 'peerSwitchId'; received: {payload!r}"
+            )
+        policy["peerSwitchId"] = peer_serial
         return payload
 
     def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
@@ -257,6 +265,7 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
 
+    @requires_bulk_support("supports_bulk_create")
     def create_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
         """
         # Summary
@@ -315,18 +324,104 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
+    def _switches_to_query(self) -> dict[str, str]:
+        """
+        # Summary
+
+        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
+
+        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
+        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
+        config, so only those switches are returned. This keeps the interface-list request count proportional to
+        config size rather than fabric size (CLAUDE.md performance rule: no per-switch fan-out over the whole fabric).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Via `FabricContext.switch_map` if the switches API query fails.
+        """
+        switch_map = self.fabric_context.switch_map
+        if self.rest_send.params.get("state") == "overridden":
+            return switch_map
+        config_items = self.rest_send.params.get("config") or []
+        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
+        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
+
+    def _configured_switch_ip_by_interface_name(self) -> dict[str, str]:
+        """
+        # Summary
+
+        Map each config `interface_name` to the user-supplied `switch_ip`. A vPC interface spans two peers and ND
+        returns it on both; this lets `query_all` pick the peer whose IP the user actually configured so the existing
+        state's composite identifier `(switch_ip, interface_name)` matches the proposed identifier and the run stays
+        idempotent regardless of which peer the user names.
+
+        ## Raises
+
+        None
+        """
+        mapping: dict[str, str] = {}
+        for item in self.rest_send.params.get("config") or []:
+            name = item.get("interface_name")
+            switch_ip = item.get("switch_ip")
+            if name and switch_ip:
+                mapping[name] = switch_ip
+        return mapping
+
+    @staticmethod
+    def _policy_type(iface: dict) -> str | None:
+        """
+        # Summary
+
+        Return `configData.networkOS.policy.policyType` for an interface dict, tolerating a missing or null value at
+        any level of the nested chain (ND occasionally returns `configData: null`).
+
+        ## Raises
+
+        None
+        """
+        config_data = iface.get("configData") or {}
+        network_os = config_data.get("networkOS") or {}
+        policy = network_os.get("policy") or {}
+        return policy.get("policyType")
+
+    def _managed_vpc_interfaces(self, switch_ip: str, switch_id: str, managed_types: set[str]) -> list[dict]:
+        """
+        # Summary
+
+        Fetch one switch's interface list and return the vPC interfaces whose policy type this orchestrator manages,
+        each enriched with the `switchIp` of the switch it was read from. Tolerates a missing body (`not_found_ok`) and
+        a non-dict body (the `isinstance` guard) without raising.
+
+        ## Raises
+
+        ### Exception
+
+        - If the interface-list request fails (propagated to `query_all`'s wrapper).
+        """
+        api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
+        managed = [iface for iface in interfaces if iface.get("interfaceType") == "vpc" and self._policy_type(iface) in managed_types]
+        for iface in managed:
+            iface["switchIp"] = switch_ip
+        return managed
+
     def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
         """
         # Summary
 
-        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
-        vPC interfaces with policy types managed by this orchestrator (as defined by `_managed_policy_types()`).
+        Validate the fabric context and query interfaces, filtering for vPC interfaces with policy types managed by
+        this orchestrator (as defined by `_managed_policy_types()`).
+
+        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`, and
+        limited to switches named in the user config for all other states.
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
 
-        Each returned interface dict is enriched with a `switch_ip` field so that the model has routing context.
-        vPC interfaces are de-duplicated by `interfaceName` (ND returns each vPC twice — once per peer); the entry
-        with the alphabetically-lower `switchId` is kept as the canonical representative.
+        Each returned interface dict is enriched with a `switchIp` field so that the model can be constructed with the
+        composite identifier `(switch_ip, interface_name)`.
 
         ## Raises
 
@@ -339,29 +434,52 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         managed_types = self._managed_policy_types()
         try:
             self.validate_prerequisites()
-            # TODO(4.2.1) ND returns each vPC interface TWICE — once per peer switch — with identical configData.
-            # Dedupe by interfaceName, keeping the entry whose URL-path `switchId` is alphabetically lower so the
-            # chosen representative is stable across runs. Without this dedupe, `_manage_override_deletions` would
-            # see the peer-side copy as "not in proposed" and queue a spurious delete.
+            configured_ip_by_name = self._configured_switch_ip_by_interface_name()
+            # TODO(4.2.1) vpc-interface-dual-peer-duplicate
+            # ND returns each vPC interface TWICE — once per peer switch — with identical configData. Dedupe by
+            # interfaceName. When the interface is in the user config, keep the peer whose switchIp the user supplied so
+            # idempotency holds regardless of which peer they name; otherwise keep the alphabetically-lower switchId for
+            # a stable representative. Without this dedupe, `_manage_override_deletions` would see the peer-side copy as
+            # "not in proposed" and queue a spurious delete.
             interfaces_by_name: dict[str, tuple[str, dict]] = {}
-            for switch_ip, switch_id in self.fabric_context.switch_map.items():
-                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                if not result:
-                    continue
-                interfaces = result.get("interfaces", []) or []
-                vpc_interfaces = [iface for iface in interfaces if iface.get("interfaceType") == "vpc"]
-                managed = [
-                    iface for iface in vpc_interfaces if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
-                ]
-                for iface in managed:
-                    iface["switchIp"] = switch_ip
+            for switch_ip, switch_id in self._switches_to_query().items():
+                for iface in self._managed_vpc_interfaces(switch_ip, switch_id, managed_types):
                     name = iface.get("interfaceName")
                     if name is None:
                         continue
                     existing = interfaces_by_name.get(name)
-                    if existing is None or switch_id < existing[0]:
+                    if self._prefers_candidate(name, switch_id, switch_ip, existing, configured_ip_by_name):
                         interfaces_by_name[name] = (switch_id, iface)
             return [entry[1] for entry in interfaces_by_name.values()]
         except Exception as e:
             raise RuntimeError(f"Query all failed: {e}") from e
+
+    @staticmethod
+    def _prefers_candidate(
+        name: str,
+        switch_id: str,
+        switch_ip: str,
+        existing: tuple[str, dict] | None,
+        configured_ip_by_name: dict[str, str],
+    ) -> bool:
+        """
+        # Summary
+
+        Decide whether a newly-seen per-peer copy of a vPC interface should replace the one already kept for `name`.
+        Prefer the peer whose `switch_ip` the user configured (idempotency); when neither peer is the configured one
+        (or the interface is not in config, e.g. an `overridden` deletion candidate), prefer the alphabetically-lower
+        `switch_id` for a stable representative.
+
+        ## Raises
+
+        None
+        """
+        if existing is None:
+            return True
+        configured_ip = configured_ip_by_name.get(name)
+        if configured_ip is not None:
+            if switch_ip == configured_ip:
+                return True
+            if existing[1].get("switchIp") == configured_ip:
+                return False
+        return switch_id < existing[0]

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -1,0 +1,367 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# pyright: reportAttributeAccessIssue=false
+# ModelType is NDBaseModel which lacks interface-specific fields (switch_ip,
+# interface_name, config_data). Concrete subclasses always bind ModelType to a
+# model that provides these fields, so the accesses are safe at runtime.
+
+"""
+Base orchestrator for vPC interface modules on Nexus Dashboard.
+
+This module provides `VpcInterfaceBaseOrchestrator`, which implements shared CRUD operations for all vPC interface
+types (`accessVpcHost`, `trunkVpcHost`, etc.) via the ND Manage Interfaces API. Type-specific orchestrators
+inherit from this base and provide their own `model_class` and `_managed_policy_types()`.
+
+Inherits shared interface lifecycle operations (deploy queuing, fabric validation, switch resolution) from
+`NDBaseInterfaceOrchestrator` and adds vPC-specific functionality:
+
+- Peer-serial auto-resolution: each create/update reads the per-switch `vpcPair` endpoint to obtain the peer
+  serial, then injects it as `peerSwitchId` in the payload. Results are cached per orchestrator instance so
+  bulk operations make at most one lookup per primary switch.
+- Standard remove-based deletion (vPC interfaces are virtual and deletable).
+- Fabric-wide `query_all()` filtered by `interfaceType: "vpc"` and per-type policy filtering.
+
+A vPC interface spans two switches in a vPC pair; the user supplies one peer's management IP as `switch_ip`.
+If the supplied switch is not in a vPC pair the orchestrator raises a clear `RuntimeError` instructing the
+user to create the pair first via `nd_manage_vpc_pair`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switches_vpc_pair import (
+    EpVpcPairGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesDelete,
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+ModelType = NDBaseModel
+
+
+class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
+    """
+    # Summary
+
+    Base orchestrator for vPC interface CRUD operations on Nexus Dashboard.
+
+    Provides shared logic for all vPC interface types. Subclasses must set `model_class` and implement
+    `_managed_policy_types()` to define which policy types they manage.
+
+    Each create/update reads the `vpcPair` record for the primary switch to obtain the peer serial, which is
+    then injected as `peerSwitchId` in the payload. Lookups are cached per orchestrator instance.
+
+    Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` queues vPC interfaces for
+    bulk removal via `interfaceActions/remove` and bulk deploy. Call `remove_pending` and `deploy_pending` after
+    all mutations are complete.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
+    - Via `_resolve_peer_switch_id` if the switch is not in a vPC pair.
+    - Via `create` if the create API request fails.
+    - Via `update` if the update API request fails.
+    - Via `remove_pending` if the bulk remove API request fails.
+    - Via `deploy_pending` if the bulk deploy API request fails.
+    - Via `query_one` if the query API request fails.
+    - Via `query_all` if the query API request fails.
+    """
+
+    # TODO(4.2.1) The bulk `/api/v1/manage/fabrics/{fabric}/interfaceActions/remove` endpoint returns
+    # `{"status":"Failed","message":"Invalid Interface"}` inside a 207 for vPC interfaces (lab-verified). The
+    # per-interface `DELETE /interfaces/{name}` endpoint works (returns 204). We therefore disable bulk delete and
+    # use the per-interface DELETE via `delete_endpoint`.
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = False
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] | None = None
+
+    def model_post_init(self, __context) -> None:
+        """
+        # Summary
+
+        Initialize mutable private state. Extends `NDBaseInterfaceOrchestrator.model_post_init` with a
+        per-instance peer-serial cache so bulk operations make at most one `vpcPair` GET per primary switch.
+
+        ## Raises
+
+        None
+        """
+        super().model_post_init(__context)
+        self._peer_serial_cache: dict[str, str] = {}
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator. Subclasses must override this method
+        to return their specific policy types (e.g., `{"accessVpcHost"}` for the access orchestrator).
+
+        ## Raises
+
+        ### NotImplementedError
+
+        - Always, if not overridden by a subclass.
+        """
+        raise NotImplementedError("Subclasses must implement _managed_policy_types()")
+
+    def _resolve_peer_switch_id(self, switch_ip: str, primary_serial: str) -> str:
+        """
+        # Summary
+
+        Resolve the peer switch's serial number for the vPC pair containing `primary_serial`. Reads the per-switch
+        `vpcPair` endpoint. Caches the result per orchestrator instance so bulk operations issue at most one lookup
+        per primary switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the switch is not in a vPC pair (the `vpcPair` GET returns 404 / empty body).
+        - If the `vpcPair` GET returns success but omits `peerSwitchId`.
+        """
+        cached = self._peer_serial_cache.get(primary_serial)
+        if cached:
+            return cached
+        api_endpoint = EpVpcPairGet()
+        api_endpoint.fabric_name = self.fabric_name
+        api_endpoint.switch_id = primary_serial
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        if not result:
+            raise RuntimeError(
+                f"Switch {switch_ip} (serial {primary_serial}) is not in a vPC pair; "
+                f"create the pair via nd_manage_vpc_pair before configuring vPC interfaces."
+            )
+        peer_serial = result.get("peerSwitchId")
+        if not peer_serial:
+            raise RuntimeError(f"vPC pair record for switch {switch_ip} (serial {primary_serial}) is missing 'peerSwitchId'; " f"received: {result!r}")
+        self._peer_serial_cache[primary_serial] = peer_serial
+        return peer_serial
+
+    def _inject_peer_switch_id(self, payload: dict, peer_serial: str) -> dict:
+        """
+        # Summary
+
+        Inject `peerSwitchId` into the nested `configData.networkOS.policy` block of an interface payload. The model
+        already nests `peer_switch_id` under `policy`, so this just sets the value if not already present.
+
+        ## Raises
+
+        None
+        """
+        policy = payload.get("configData", {}).get("networkOS", {}).get("policy")
+        if policy is not None:
+            policy["peerSwitchId"] = peer_serial
+        return payload
+
+    def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create a vPC interface configuration. Resolves `switch_ip` to a primary serial, resolves the peer serial via
+        the vPC pair record, injects both into the payload, and POSTs the wrapped `interfaces` array. Queues a deploy
+        for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails.
+        - If the primary switch is not in a vPC pair.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+            api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            self._inject_peer_switch_id(payload, peer_serial)
+            request_body = {"interfaces": [payload]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update a vPC interface configuration. Resolves `switch_ip` to a primary serial, resolves the peer serial via
+        the vPC pair record, injects both into the payload, and PUTs the updated configuration. Queues a deploy for
+        later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails.
+        - If the primary switch is not in a vPC pair.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+            api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            self._inject_peer_switch_id(payload, peer_serial)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: ModelType, **kwargs) -> None:
+        """
+        # Summary
+
+        Delete a vPC interface immediately via the per-interface `DELETE /interfaces/{name}` endpoint, then queue
+        a deploy for later bulk execution via `deploy_pending`. The DELETE returns 204 on success; a subsequent GET
+        returns 404. The deploy pushes the removal to both peers and reverts member interfaces to their fabric
+        default configuration.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the DELETE API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.delete_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+        except Exception as e:
+            raise RuntimeError(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def create_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create multiple vPC interfaces in bulk. Groups by primary switch, resolves the peer serial once per group, and
+        sends one POST per primary switch with all vPC interfaces in the `interfaces` array. Queues deploys for all
+        created interfaces for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create API request fails.
+        - If any primary switch is not in a vPC pair.
+        """
+        try:
+            groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+            for model_instance in model_instances:
+                switch_id = self._resolve_switch_id(model_instance.switch_ip)
+                peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+                payload = model_instance.to_payload()
+                payload["switchId"] = switch_id
+                self._inject_peer_switch_id(payload, peer_serial)
+                groups[switch_id].append((model_instance.interface_name, payload))
+
+            results = []
+            for switch_id, items in groups.items():
+                # Guarded at runtime by @requires_bulk_support("supports_bulk_create")
+                api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
+                request_body = {"interfaces": [payload for interface_name, payload in items]}
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+                results.append(result)
+                for interface_name, payload in items:
+                    self._queue_deploy(interface_name, switch_id)
+            return results
+        except Exception as e:
+            raise RuntimeError(f"Bulk create failed: {e}") from e
+
+    def query_one(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Query a single vPC interface by name on a specific switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
+        vPC interfaces with policy types managed by this orchestrator (as defined by `_managed_policy_types()`).
+
+        Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
+
+        Each returned interface dict is enriched with a `switch_ip` field so that the model has routing context.
+        vPC interfaces are de-duplicated by `interfaceName` (ND returns each vPC twice — once per peer); the entry
+        with the alphabetically-lower `switchId` is kept as the canonical representative.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist on the target ND node.
+        - If the fabric is in deployment-freeze mode.
+        - If the query API request fails.
+        """
+        managed_types = self._managed_policy_types()
+        try:
+            self.validate_prerequisites()
+            # TODO(4.2.1) ND returns each vPC interface TWICE — once per peer switch — with identical configData.
+            # Dedupe by interfaceName, keeping the entry whose URL-path `switchId` is alphabetically lower so the
+            # chosen representative is stable across runs. Without this dedupe, `_manage_override_deletions` would
+            # see the peer-side copy as "not in proposed" and queue a spurious delete.
+            interfaces_by_name: dict[str, tuple[str, dict]] = {}
+            for switch_ip, switch_id in self.fabric_context.switch_map.items():
+                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                if not result:
+                    continue
+                interfaces = result.get("interfaces", []) or []
+                vpc_interfaces = [iface for iface in interfaces if iface.get("interfaceType") == "vpc"]
+                managed = [
+                    iface for iface in vpc_interfaces if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
+                ]
+                for iface in managed:
+                    iface["switchIp"] = switch_ip
+                    name = iface.get("interfaceName")
+                    if name is None:
+                        continue
+                    existing = interfaces_by_name.get(name)
+                    if existing is None or switch_id < existing[0]:
+                        interfaces_by_name[name] = (switch_id, iface)
+            return [entry for _, entry in interfaces_by_name.values()]
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -341,6 +341,50 @@ EXAMPLES = r"""
                 - Ethernet1/2
     state: merged
 
+- name: Replace the configuration of a specific vPC interface
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 20
+              peer1_port_channel_id: 100
+              peer1_member_ports:
+                - Ethernet1/3
+              peer2_port_channel_id: 100
+              peer2_member_ports:
+                - Ethernet1/3
+              port_channel_mode: active
+              peer1_port_channel_description: Reprovisioned Server-A on peer1
+              peer2_port_channel_description: Reprovisioned Server-A on peer2
+    state: replaced
+
+# state=overridden is fabric-wide: every vPC interface in the fabric that is managed by this module and is NOT
+# listed below is deleted. An empty config list deletes ALL such vPC interfaces in the fabric. Use with caution.
+- name: Enforce vPC interfaces fabric-wide, deleting all others managed by this module
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 10
+              peer1_port_channel_id: 100
+              peer1_member_ports:
+                - Ethernet1/1
+              peer2_port_channel_id: 100
+              peer2_member_ports:
+                - Ethernet1/1
+              port_channel_mode: active
+    state: overridden
+
 - name: Delete a vPC interface
   cisco.nd.nd_interface_vpc_access:
     fabric_name: my_fabric

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -264,15 +264,20 @@ options:
                     description:
                     - Unicast storm control level in packets per second (0-200000000).
                     type: int
-  deploy:
+  config_actions:
     description:
-    - Whether to deploy vPC interface changes after mutations are complete.
-    - When V(true), all queued vPC interface changes are deployed in a single bulk API call at the end of module
-      execution via the C(interfaceActions/deploy) API. Only the vPC interfaces modified by this task are deployed.
-    - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
-    - Setting O(deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
-    type: bool
-    default: true
+    - Controls deploy behavior after interface mutations are complete.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether to deploy vPC interface changes after mutations are complete.
+        - When V(true), all queued vPC interface changes are deployed in a single bulk API call at the end of module
+          execution via the C(interfaceActions/deploy) API. Only the vPC interfaces modified by this task are deployed.
+        - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        type: bool
+        default: true
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -357,7 +362,8 @@ EXAMPLES = r"""
               access_vlan: 10
               peer1_port_channel_id: 100
               peer2_port_channel_id: 100
-    deploy: false
+    config_actions:
+      deploy: false
     state: merged
 
 """
@@ -398,7 +404,12 @@ def main():
     argument_spec = nd_argument_spec()
     argument_spec.update(AccessVpcHostInterfaceModel.get_argument_spec())
     argument_spec.update(
-        deploy={"type": "bool", "default": True},
+        config_actions={
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
     )
 
     module = AnsibleModule(
@@ -418,13 +429,15 @@ def main():
         )
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
-        nd_state_machine.model_orchestrator.deploy = module.params["deploy"]
+        config_actions = module.params.get("config_actions") or {}
+        deploy = config_actions.get("deploy", True)
+        nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(
             "manage_state begin state=%s check_mode=%s deploy=%s",
             module.params.get("state"),
             module.check_mode,
-            module.params["deploy"],
+            deploy,
         )
         nd_state_machine.manage_state()
         module_log.debug("manage_state end")

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -412,7 +412,6 @@ EXAMPLES = r"""
     config_actions:
       deploy: false
     state: merged
-
 """
 
 RETURN = r"""

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -209,7 +209,7 @@ options:
                     description:
                     - Port-channel mode.
                     type: str
-                    choices: [ on, active, passive ]
+                    choices: [ 'on', active, passive ]
                   port_type_edge_trunk:
                     description:
                     - Enable spanning-tree edge port (PortFast) behavior.

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -287,8 +287,8 @@ options:
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       The resources on ND will be modified to exactly match the configuration.
       Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
-    - Use O(state=deleted) to remove the specified vPC interfaces via the C(interfaceActions/remove) API.
-      Member ethernet interfaces on both peers are reverted to their fabric default configuration.
+    - Use O(state=deleted) to remove the specified vPC interfaces via a per-interface C(DELETE) request to the
+      interfaces endpoint. Member ethernet interfaces on both peers are reverted to their fabric default configuration.
     type: str
     default: merged
     choices: [ merged, replaced, overridden, deleted ]
@@ -297,8 +297,11 @@ extends_documentation_fragment:
 - cisco.nd.check_mode
 notes:
 - This module is only supported on Nexus Dashboard.
-- This module manages NX-OS vPC accessVpcHost interfaces only (interface_type C(vpc), mode C(access), network_os_type C(nx-os), policy_type C(accessVpcHost)). These values are hardcoded by the module and are not user-configurable.
-- The primary switch supplied in O(config[].switch_ip) must already be in a vPC pair (managed by M(cisco.nd.nd_manage_vpc_pair)). The peer serial is auto-resolved from the pair record.
+- This module manages NX-OS vPC accessVpcHost interfaces only (interface_type C(vpc), mode C(access),
+  network_os_type C(nx-os), policy_type C(accessVpcHost)). These values are hardcoded by the module and are
+  not user-configurable.
+- The primary switch supplied in O(config[].switch_ip) must already be in a vPC pair (managed by
+  M(cisco.nd.nd_manage_vpc_pair)). The peer serial is auto-resolved from the pair record.
 - C(peer1) refers to the switch supplied in O(config[].switch_ip); C(peer2) refers to the auto-resolved peer.
 """
 
@@ -586,6 +589,14 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_interface_vpc_access
-version_added: "1.4.0"
+version_added: "2.0.0"
 short_description: Manage vPC accessVpcHost interfaces on Cisco Nexus Dashboard
 description:
 - Manage vPC accessVpcHost interfaces on Cisco Nexus Dashboard.

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -413,6 +413,96 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching interface configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc100
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          access_vlan: 10
+          peer1_port_channel_id: 100
+          peer1_member_ports:
+          - Ethernet1/1
+          peer2_port_channel_id: 100
+          peer2_member_ports:
+          - Ethernet1/1
+          port_channel_mode: active
+after:
+  description:
+  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc100
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          access_vlan: 20
+          peer1_port_channel_id: 100
+          peer1_member_ports:
+          - Ethernet1/1
+          peer2_port_channel_id: 100
+          peer2_member_ports:
+          - Ethernet1/1
+          port_channel_mode: active
+diff:
+  description: The per-interface difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc100
+    config_data:
+      network_os:
+        policy:
+          access_vlan: 20
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: vpc100
+    config_data:
+      network_os:
+        policy:
+          access_vlan: 20
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing vPC interface configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
 """
 
 # pylint: disable=wrong-import-position

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -1,0 +1,448 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Ansible module for managing vPC accessVpcHost interfaces on Cisco Nexus Dashboard."""
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_interface_vpc_access
+version_added: "1.4.0"
+short_description: Manage vPC accessVpcHost interfaces on Cisco Nexus Dashboard
+description:
+- Manage vPC accessVpcHost interfaces on Cisco Nexus Dashboard.
+- It supports creating, updating, and deleting accessVpcHost vPC configurations on switches within a fabric.
+- Each config item represents one vPC interface that spans the two switches in a vPC pair.
+- The user supplies one peer's management IP as O(config[].switch_ip); the module reads the vPC pair record to
+  auto-resolve the second peer's serial and injects it as C(peerSwitchId) in the payload.
+- Per-peer policy fields use the API-native C(peer1_*) / C(peer2_*) naming, where C(peer1) corresponds to the
+  switch supplied in O(config[].switch_ip) and C(peer2) corresponds to the auto-resolved peer.
+- The switch supplied in O(config[].switch_ip) must already be in a vPC pair (created via M(cisco.nd.nd_manage_vpc_pair))
+  before this module can manage interfaces on it.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target vPC pair.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of vPC accessVpcHost interfaces to configure.
+    - Each item specifies the primary switch, the vPC interface name, and its configuration.
+    - Multiple vPC pairs can be configured in a single task.
+    - The structure mirrors the ND Manage Interfaces API payload.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of one peer in the vPC pair (typically the primary).
+        - This is resolved to the switch serial number (switchId) internally; the peer's serial is auto-resolved
+          via the vPC pair record.
+        type: str
+        required: true
+      interface_name:
+        description:
+        - The vPC interface name (e.g. C(vpc100)).
+        type: str
+        required: true
+      config_data:
+        description:
+        - The configuration data for the vPC interface, following the ND API structure.
+        type: dict
+        suboptions:
+          network_os:
+            description:
+            - Network OS specific configuration.
+            type: dict
+            suboptions:
+              policy:
+                description:
+                - The policy configuration for the accessVpcHost vPC interface.
+                type: dict
+                suboptions:
+                  admin_state:
+                    description:
+                    - The administrative state of the vPC interface.
+                    type: bool
+                  bandwidth:
+                    description:
+                    - Configured bandwidth value for the interface.
+                    - Valid range is 1-100000000.
+                    type: int
+                  bpdu_filter:
+                    description:
+                    - BPDU filter setting for the vPC interface.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  bpdu_guard:
+                    description:
+                    - BPDU guard setting for the vPC interface.
+                    type: str
+                    choices: [ enable, disable, default ]
+                  cdp:
+                    description:
+                    - Whether Cisco Discovery Protocol is enabled on the vPC interface.
+                    type: bool
+                  copy_description:
+                    description:
+                    - Whether to propagate the per-peer port-channel description to all member interfaces.
+                    type: bool
+                  duplex_mode:
+                    description:
+                    - The duplex mode of the vPC interface.
+                    type: str
+                    choices: [ auto, full, half ]
+                  inherit_bandwidth:
+                    description:
+                    - Bandwidth value inherited by sub-interfaces.
+                    - Valid range is 1-100000000.
+                    type: int
+                  lacp_port_priority:
+                    description:
+                    - LACP port priority.
+                    - Valid range is 1-65535. Default 32768.
+                    type: int
+                  lacp_rate:
+                    description:
+                    - LACP rate (PDU transmit interval).
+                    - V(normal) = 30 seconds, V(fast) = 1 second.
+                    type: str
+                    choices: [ normal, fast ]
+                  lacp_suspend:
+                    description:
+                    - If disabled, LACP puts the port in individual state instead of suspending when LACP BPDUs are
+                      not received.
+                    type: bool
+                  lacp_vpc_convergence:
+                    description:
+                    - Enable LACP convergence for vPC port-channels.
+                    type: bool
+                  link_type:
+                    description:
+                    - Spanning-tree link type.
+                    type: str
+                    choices: [ auto, pointToPoint, shared ]
+                  mirror_config:
+                    description:
+                    - Copy Peer-1 configuration to Peer-2.
+                    type: bool
+                  mtu:
+                    description:
+                    - Interface MTU.
+                    type: str
+                    choices: [ default, jumbo ]
+                  negotiate_auto:
+                    description:
+                    - Enable link auto-negotiation.
+                    type: bool
+                  netflow:
+                    description:
+                    - Enable Netflow on the vPC interface.
+                    type: bool
+                  netflow_monitor:
+                    description:
+                    - Layer 2 Netflow monitor name.
+                    type: str
+                  netflow_sampler:
+                    description:
+                    - Netflow sampler name (N7K only).
+                    type: str
+                  access_vlan:
+                    description:
+                    - Access VLAN for the vPC. Applied identically on both peers.
+                    - ND collapses the OpenAPI per-peer C(peer1AccessVlan)/C(peer2AccessVlan) into a single
+                      C(accessVlan) value on the wire; this module splits the single value back to both per-peer
+                      keys when writing.
+                    - Valid range is 1-4094.
+                    type: int
+                  peer1_member_ports:
+                    description:
+                    - Member interface names on Peer-1 (e.g. C(Ethernet1/1)).
+                    type: list
+                    elements: str
+                  peer1_port_channel_configuration:
+                    description:
+                    - Additional CLI configuration commands for Peer-1's port-channel.
+                    type: str
+                  peer1_port_channel_description:
+                    description:
+                    - Description for Peer-1's port-channel.
+                    - Maximum 254 characters.
+                    type: str
+                  peer1_port_channel_id:
+                    description:
+                    - Peer-1 vPC port-channel number.
+                    - Valid range is 1-4096.
+                    type: int
+                  peer2_member_ports:
+                    description:
+                    - Member interface names on Peer-2 (e.g. C(Ethernet1/1)).
+                    type: list
+                    elements: str
+                  peer2_port_channel_configuration:
+                    description:
+                    - Additional CLI configuration commands for Peer-2's port-channel.
+                    type: str
+                  peer2_port_channel_description:
+                    description:
+                    - Description for Peer-2's port-channel.
+                    - Maximum 254 characters.
+                    type: str
+                  peer2_port_channel_id:
+                    description:
+                    - Peer-2 vPC port-channel number.
+                    - Valid range is 1-4096.
+                    type: int
+                  pfc:
+                    description:
+                    - Enable priority flow control.
+                    type: bool
+                  port_channel_mode:
+                    description:
+                    - Port-channel mode.
+                    type: str
+                    choices: [ on, active, passive ]
+                  port_type_edge_trunk:
+                    description:
+                    - Enable spanning-tree edge port (PortFast) behavior.
+                    type: bool
+                  qos:
+                    description:
+                    - Enable QoS configuration for the vPC interface.
+                    type: bool
+                  qos_policy:
+                    description:
+                    - Custom QoS policy name.
+                    type: str
+                  queuing_policy:
+                    description:
+                    - Custom queuing policy name.
+                    type: str
+                  speed:
+                    description:
+                    - Interface speed.
+                    type: str
+                    choices: [ auto, 10Mb, 100Mb, 1Gb, 2.5Gb, 5Gb, 10Gb, 25Gb, 40Gb, 50Gb, 100Gb, 200Gb, 400Gb, 800Gb ]
+                  storm_control:
+                    description:
+                    - Enable traffic storm control on the vPC interface.
+                    type: bool
+                  storm_control_action:
+                    description:
+                    - Storm control action on threshold violation.
+                    type: str
+                    choices: [ shutdown, trap, default ]
+                  storm_control_broadcast_level:
+                    description:
+                    - Broadcast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_broadcast_level_pps:
+                    description:
+                    - Broadcast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_multicast_level:
+                    description:
+                    - Multicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_multicast_level_pps:
+                    description:
+                    - Multicast storm control level in packets per second (0-200000000).
+                    type: int
+                  storm_control_unicast_level:
+                    description:
+                    - Unicast storm control level in percentage (0.00-100.00).
+                    type: float
+                  storm_control_unicast_level_pps:
+                    description:
+                    - Unicast storm control level in packets per second (0-200000000).
+                    type: int
+  deploy:
+    description:
+    - Whether to deploy vPC interface changes after mutations are complete.
+    - When V(true), all queued vPC interface changes are deployed in a single bulk API call at the end of module
+      execution via the C(interfaceActions/deploy) API. Only the vPC interfaces modified by this task are deployed.
+    - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+    - Setting O(deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+    type: bool
+    default: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the resources specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      The resources on ND will be modified to exactly match the configuration.
+      Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
+    - Use O(state=deleted) to remove the specified vPC interfaces via the C(interfaceActions/remove) API.
+      Member ethernet interfaces on both peers are reverted to their fabric default configuration.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This module manages NX-OS vPC accessVpcHost interfaces only (interface_type C(vpc), mode C(access), network_os_type C(nx-os), policy_type C(accessVpcHost)). These values are hardcoded by the module and are not user-configurable.
+- The primary switch supplied in O(config[].switch_ip) must already be in a vPC pair (managed by M(cisco.nd.nd_manage_vpc_pair)). The peer serial is auto-resolved from the pair record.
+- C(peer1) refers to the switch supplied in O(config[].switch_ip); C(peer2) refers to the auto-resolved peer.
+"""
+
+EXAMPLES = r"""
+- name: Create an accessVpcHost vPC with one member on each peer
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 10
+              peer1_port_channel_id: 100
+              peer1_member_ports:
+                - Ethernet1/1
+              peer2_port_channel_id: 100
+              peer2_member_ports:
+                - Ethernet1/1
+              port_channel_mode: active
+              lacp_rate: fast
+              peer1_port_channel_description: Server-A on peer1
+              peer2_port_channel_description: Server-A on peer2
+    state: merged
+  register: result
+
+- name: Update member ports on Peer-1 only
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              peer1_member_ports:
+                - Ethernet1/1
+                - Ethernet1/2
+    state: merged
+
+- name: Delete a vPC interface
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+    state: deleted
+
+- name: Stage vPC interface changes without deploying
+  cisco.nd.nd_interface_vpc_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: vpc100
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: 10
+              peer1_port_channel_id: 100
+              peer2_port_channel_id: 100
+    deploy: false
+    state: merged
+
+"""
+
+RETURN = r"""
+"""
+
+# pylint: disable=wrong-import-position
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+    AccessVpcHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_access_interface import (
+    AccessVpcHostInterfaceOrchestrator,
+)
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_interface_vpc_access` Ansible module. Initializes the
+    `NDStateMachine` with `AccessVpcHostInterfaceOrchestrator` and executes the requested state operation.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(AccessVpcHostInterfaceModel.get_argument_spec())
+    argument_spec.update(
+        deploy={"type": "bool", "default": True},
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_interface_vpc_access")
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=AccessVpcHostInterfaceOrchestrator,
+        )
+        if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
+            raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        nd_state_machine.model_orchestrator.deploy = module.params["deploy"]
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            module.params["deploy"],
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.remove_pending()
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/deleted.yaml
@@ -1,0 +1,41 @@
+---
+# Deleted state tests for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# After overridden.yaml, only vpc101 exists. Remove it explicitly and verify idempotency.
+
+- name: "DELETED: Remove vpc101 (check mode)"
+  cisco.nd.nd_interface_vpc_access: &delete_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip_peer1 }}"
+        interface_name: vpc101
+    state: deleted
+  check_mode: true
+  register: cm_deleted
+
+- name: "DELETED: Remove vpc101 (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *delete_vpc
+  register: nm_deleted
+
+- name: "DELETED: Verify delete produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted is changed
+      - nm_deleted is changed
+
+- name: "DELETED IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "DELETED IDEMPOTENT: Re-apply delete (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *delete_vpc
+  register: nm_deleted_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change after second delete"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
@@ -13,7 +13,7 @@
 # Lab pre-conditions (verified in reference_nd_lab.md):
 #   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.152) reachable
 #   - Ethernet1/5, Ethernet1/6, Ethernet1/7 free on both peers for vPC member testing
-#   - Peer-link cable: peer1 Ethernet1/2 <-> peer2 Ethernet1/2
+#   - vPC pair uses a virtual peer-link (no physical peer-link cable required); see vars/main.yaml
 #
 # Setup creates the vPC pair if missing; teardown unpairs it (which cascades and removes all
 # member vPC interfaces, so we don't need an explicit vPC-interface teardown).

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
@@ -1,0 +1,63 @@
+---
+# Test code for the nd_interface_vpc_access module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#
+#   ansible-test integration nd_interface_vpc_access
+#
+# Lab pre-conditions (verified in reference_nd_lab.md):
+#   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.155) reachable
+#   - Ethernet1/5, Ethernet1/6, Ethernet1/7 free on both peers for vPC member testing
+#   - Peer-link cable: peer1 Ethernet1/3 <-> peer2 Ethernet1/2
+#
+# Setup creates the vPC pair if missing; teardown unpairs it (which cascades and removes all
+# member vPC interfaces, so we don't need an explicit vPC-interface teardown).
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_interface_vpc_access state tests
+  block:
+    - name: Pre-test setup (create vPC pair, clean any prior vPC interfaces)
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run nd_interface_vpc_access merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run nd_interface_vpc_access replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run nd_interface_vpc_access overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run nd_interface_vpc_access deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  always:
+    - name: Teardown (unpair vPC, cascades to remove any remaining vPC interfaces)
+      cisco.nd.nd_manage_vpc_pair:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - peer1_switch_id: "{{ test_switch_ip_peer1 }}"
+            peer2_switch_id: "{{ test_switch_ip_peer2 }}"
+        state: deleted
+      ignore_errors: true
+  module_defaults:
+    cisco.nd.nd_interface_vpc_access:
+      timeout: 300
+    cisco.nd.nd_manage_vpc_pair:
+      timeout: 300
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
@@ -11,9 +11,9 @@
 #   ansible-test integration nd_interface_vpc_access
 #
 # Lab pre-conditions (verified in reference_nd_lab.md):
-#   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.155) reachable
+#   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.152) reachable
 #   - Ethernet1/5, Ethernet1/6, Ethernet1/7 free on both peers for vPC member testing
-#   - Peer-link cable: peer1 Ethernet1/3 <-> peer2 Ethernet1/2
+#   - Peer-link cable: peer1 Ethernet1/2 <-> peer2 Ethernet1/2
 #
 # Setup creates the vPC pair if missing; teardown unpairs it (which cascades and removes all
 # member vPC interfaces, so we don't need an explicit vPC-interface teardown).

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/merged.yaml
@@ -1,0 +1,48 @@
+---
+# Merged state tests for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- MERGED CREATE ---
+
+- name: "MERGED CREATE: Create vpc100 (check mode)"
+  cisco.nd.nd_interface_vpc_access: &merge_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_access_baseline }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create
+
+- name: "MERGED CREATE: Create vpc100 (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *merge_vpc
+  register: nm_merged_create
+
+- name: "MERGED CREATE: Verify creation produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create is changed
+      - nm_merged_create is changed
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Pause for switch convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "MERGED IDEMPOTENT: Re-apply vpc100 (check mode)"
+  cisco.nd.nd_interface_vpc_access: *merge_vpc
+  check_mode: true
+  register: cm_merged_idem
+
+- name: "MERGED IDEMPOTENT: Re-apply vpc100 (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *merge_vpc
+  register: nm_merged_idem
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem is not changed
+      - nm_merged_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/overridden.yaml
@@ -1,0 +1,41 @@
+---
+# Overridden state tests for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# After replaced.yaml, vpc100 exists. State overridden with a single new vpc (vpc101) should
+# remove vpc100 and create vpc101 fabric-wide.
+
+- name: "OVERRIDDEN: Single source of truth = vpc101 only (check mode)"
+  cisco.nd.nd_interface_vpc_access: &override_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_access_overridden }}"
+    state: overridden
+  check_mode: true
+  register: cm_overridden
+
+- name: "OVERRIDDEN: Single source of truth = vpc101 only (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *override_vpc
+  register: nm_overridden
+
+- name: "OVERRIDDEN: Verify override produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_overridden is changed
+      - nm_overridden is changed
+
+- name: "OVERRIDDEN IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *override_vpc
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change on re-apply"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/replaced.yaml
@@ -1,0 +1,41 @@
+---
+# Replaced state tests for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# vpc100 was created in merged.yaml. Replace its config (change VLAN, add a peer1 member)
+# and verify the change is reflected.
+
+- name: "REPLACED: Update vpc100 policy (check mode)"
+  cisco.nd.nd_interface_vpc_access: &replace_vpc
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_access_updated }}"
+    state: replaced
+  check_mode: true
+  register: cm_replaced
+
+- name: "REPLACED: Update vpc100 policy (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *replace_vpc
+  register: nm_replaced
+
+- name: "REPLACED: Verify replace produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced is changed
+      - nm_replaced is changed
+
+- name: "REPLACED IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "REPLACED IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *replace_vpc
+  register: nm_replaced_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on re-apply"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_idem is not changed

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/setup.yaml
@@ -1,0 +1,40 @@
+---
+# Pre-test setup for nd_interface_vpc_access
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Ensures:
+#   1. Any pre-existing vPC pair on the test peers is removed (clears any stale vPC interfaces).
+#   2. A fresh vPC pair is created so the access tests have a stable substrate.
+#   3. ND switch poller has time to discover the new pair before tests start.
+
+- name: "SETUP: Tear down any existing vPC pair on test peers"
+  cisco.nd.nd_manage_vpc_pair:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - peer1_switch_id: "{{ test_switch_ip_peer1 }}"
+        peer2_switch_id: "{{ test_switch_ip_peer2 }}"
+    state: deleted
+  ignore_errors: true
+  tags: always
+
+- name: "SETUP: Pause for unpair convergence"
+  ansible.builtin.pause:
+    seconds: 30
+  tags: always
+
+- name: "SETUP: Create vPC pair"
+  cisco.nd.nd_manage_vpc_pair:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_pair_setup }}"
+    state: merged
+  tags: always
+
+- name: "SETUP: Pause for pair-establishment convergence"
+  ansible.builtin.pause:
+    seconds: 30
+  tags: always

--- a/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
@@ -6,7 +6,7 @@
 
 test_fabric_name: "{{ nd_test_vpc_access_fabric_name | default(nd_test_fabric_name | default('SITE1')) }}"
 test_switch_ip_peer1: "{{ nd_test_vpc_peer1_ip | default('192.168.12.151') }}"
-test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.155') }}"
+test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.152') }}"
 
 # vPC pair substrate created by setup via M(cisco.nd.nd_manage_vpc_pair) (from PR #197 on develop).
 # The previous nd_vpc_pair module was closed (PR #278); the shared vPC interface infrastructure was
@@ -16,7 +16,7 @@ test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.155') }}"
 # peer-link (use_virtual_peer_link: false) because the Nexus 9000v testbed does not support virtual/
 # fabric peering. The peer-link members (switch_member_interfaces / peer_switch_member_interfaces) and
 # po ids live under nd_manage_vpc_pair's vpc_pair_details (VpcPairDetailsDefault) template. Values mirror
-# the known-good SITE1 physical pair (S1_LE1 Eth1/3 <-> S1_LE2 Eth1/2, mgmt-VRF keepalive, domain 1).
+# the known-good SITE1 physical pair (S1_LE1 Eth1/2 <-> S1_LE2 Eth1/2, mgmt-VRF keepalive, domain 1).
 # Keep-alive local IPs are set explicitly (nd_manage_vpc_pair does not auto-fill them from the mgmt IP).
 vpc_pair_setup:
   peer1_switch_id: "{{ test_switch_ip_peer1 }}"
@@ -31,7 +31,7 @@ vpc_pair_setup:
     switch_po_id: 1
     peer_switch_po_id: 1
     switch_member_interfaces:
-      - Ethernet1/3
+      - Ethernet1/2
     peer_switch_member_interfaces:
       - Ethernet1/2
 

--- a/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
@@ -1,0 +1,90 @@
+---
+# Variables for nd_interface_vpc_access integration tests.
+#
+# Override the defaults in your inventory or extra-vars to match a real ND 4.2 testbed.
+# The defaults below match the SITE1 lab documented in reference_nd_lab.md.
+
+test_fabric_name: "{{ nd_test_vpc_access_fabric_name | default(nd_test_fabric_name | default('SITE1')) }}"
+test_switch_ip_peer1: "{{ nd_test_vpc_peer1_ip | default('192.168.12.151') }}"
+test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.155') }}"
+
+# vPC pair substrate created by setup via M(cisco.nd.nd_manage_vpc_pair) (from PR #197 on develop).
+# The previous nd_vpc_pair module was closed (PR #278); the shared vPC interface infrastructure was
+# re-homed onto the nd_interface_vpc_base branch, and this substrate now uses nd_manage_vpc_pair.
+#
+# peer1_switch_id / peer2_switch_id accept management IPs (or serials). This config uses a PHYSICAL
+# peer-link (use_virtual_peer_link: false) because the Nexus 9000v testbed does not support virtual/
+# fabric peering. The peer-link members (switch_member_interfaces / peer_switch_member_interfaces) and
+# po ids live under nd_manage_vpc_pair's vpc_pair_details (VpcPairDetailsDefault) template. Values mirror
+# the known-good SITE1 physical pair (S1_LE1 Eth1/3 <-> S1_LE2 Eth1/2, mgmt-VRF keepalive, domain 1).
+# Keep-alive local IPs are set explicitly (nd_manage_vpc_pair does not auto-fill them from the mgmt IP).
+vpc_pair_setup:
+  peer1_switch_id: "{{ test_switch_ip_peer1 }}"
+  peer2_switch_id: "{{ test_switch_ip_peer2 }}"
+  use_virtual_peer_link: false
+  vpc_pair_details:
+    type: default
+    domain_id: 1
+    keep_alive_vrf: management
+    switch_keep_alive_local_ip: "{{ test_switch_ip_peer1 }}"
+    peer_switch_keep_alive_local_ip: "{{ test_switch_ip_peer2 }}"
+    switch_po_id: 1
+    peer_switch_po_id: 1
+    switch_member_interfaces:
+      - Ethernet1/3
+    peer_switch_member_interfaces:
+      - Ethernet1/2
+
+# Baseline vPC access interface used by merged + idempotency tests.
+vpc_access_baseline:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc100
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 10
+        peer1_port_channel_id: 100
+        peer1_member_ports:
+          - Ethernet1/5
+        peer2_port_channel_id: 100
+        peer2_member_ports:
+          - Ethernet1/5
+        port_channel_mode: active
+        lacp_rate: fast
+
+# Updated config for replaced tests (different access VLAN + add a member on peer1).
+vpc_access_updated:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc100
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 20
+        peer1_port_channel_id: 100
+        peer1_member_ports:
+          - Ethernet1/5
+          - Ethernet1/6
+        peer2_port_channel_id: 100
+        peer2_member_ports:
+          - Ethernet1/5
+        port_channel_mode: active
+        lacp_rate: fast
+
+# Second vPC for overridden test: define only this one, expect vpc100 to be removed.
+vpc_access_overridden:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: vpc101
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 30
+        peer1_port_channel_id: 101
+        peer1_member_ports:
+          - Ethernet1/7
+        peer2_port_channel_id: 101
+        peer2_member_ports:
+          - Ethernet1/7
+        port_channel_mode: active

--- a/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
@@ -12,28 +12,30 @@ test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.152') }}"
 # The previous nd_vpc_pair module was closed (PR #278); the shared vPC interface infrastructure was
 # re-homed onto the nd_interface_vpc_base branch, and this substrate now uses nd_manage_vpc_pair.
 #
-# peer1_switch_id / peer2_switch_id accept management IPs (or serials). This config uses a PHYSICAL
-# peer-link (use_virtual_peer_link: false) because the Nexus 9000v testbed does not support virtual/
-# fabric peering. The peer-link members (switch_member_interfaces / peer_switch_member_interfaces) and
-# po ids live under nd_manage_vpc_pair's vpc_pair_details (VpcPairDetailsDefault) template. Values mirror
-# the known-good SITE1 physical pair (S1_LE1 Eth1/2 <-> S1_LE2 Eth1/2, mgmt-VRF keepalive, domain 1).
-# Keep-alive local IPs are set explicitly (nd_manage_vpc_pair does not auto-fill them from the mgmt IP).
+# peer1_switch_id / peer2_switch_id accept management IPs (or serials).
+#
+# This substrate uses a VIRTUAL peer-link (use_virtual_peer_link: true). A PHYSICAL peer-link is the
+# real-world-preferred config, but it is currently broken at the ND controller layer: actions/configSave
+# fails to generate physical vPC peer-link config with HTTP 500 "Member port <Eth> is a member of
+# VPC_PAIR, remove ... first" (lab-verified on ND with NX-OS 10.6(2), reproducible via the raw API and
+# independent of nd_manage_vpc_pair). A virtual peer-link generates, deploys, and forms cleanly on the
+# same N9000v switches (both peers vpcConfigured, consistency OK). Virtual peer-link is sufficient here
+# because the vPC interface tests only need the pair to exist for peer-serial resolution.
+#
+# TODO(4.2.1) vpc-physical-peer-link-configsave-fails
+# Revert to a physical peer-link once ND fixes physical peer-link config generation, i.e. restore
+# use_virtual_peer_link: false plus switch_po_id / peer_switch_po_id / switch_member_interfaces /
+# peer_switch_member_interfaces (Ethernet1/2 on both peers) under vpc_pair_details.
 vpc_pair_setup:
   peer1_switch_id: "{{ test_switch_ip_peer1 }}"
   peer2_switch_id: "{{ test_switch_ip_peer2 }}"
-  use_virtual_peer_link: false
+  use_virtual_peer_link: true
   vpc_pair_details:
     type: default
     domain_id: 1
     keep_alive_vrf: management
     switch_keep_alive_local_ip: "{{ test_switch_ip_peer1 }}"
     peer_switch_keep_alive_local_ip: "{{ test_switch_ip_peer2 }}"
-    switch_po_id: 1
-    peer_switch_po_id: 1
-    switch_member_interfaces:
-      - Ethernet1/2
-    peer_switch_member_interfaces:
-      - Ethernet1/2
 
 # Baseline vPC access interface used by merged + idempotency tests.
 vpc_access_baseline:

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_access_interface_orchestrator.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_access_interface_orchestrator.json
@@ -1,0 +1,356 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for tests/unit/module_utils/orchestrators/test_vpc_access_interface.py",
+        "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
+        "The fixtures simulate ND responses for:",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/summary  (fabric_summary via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/deploymentFreeze (deploymentFreeze via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches (switch_map via FabricContext)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/vpcPair (peer-serial resolve)",
+        "  - GET /api/v1/manage/fabrics/{fabric_name}/switches/{sn}/interfaces (EpManageInterfacesListGet per switch)"
+    ],
+    "test_peer_resolve_happy_path_00500a": {
+        "TEST_NOTES": ["vpcPair GET on primary FDO11111AAA returns peer serial FDO22222BBB."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "peerSwitchId": "FDO22222BBB",
+            "vpcPairDetails": {
+                "domainId": 100,
+                "keepAliveVrf": "management"
+            }
+        }
+    },
+    "test_peer_resolve_not_paired_00510a": {
+        "TEST_NOTES": ["vpcPair GET returns 404 with structured error body (live lab shape)."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {
+            "code": 404,
+            "description": "",
+            "message": "No vPC Pair found for switch serial number: FDO11111AAA"
+        }
+    },
+    "test_peer_resolve_missing_field_00520a": {
+        "TEST_NOTES": ["vpcPair GET returns success but the response body omits peerSwitchId."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA"
+        }
+    },
+    "test_query_all_happy_path_00400a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_happy_path_00400_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_happy_path_00400b": {
+        "TEST_NOTES": ["Switch list: two switches forming a vPC pair."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDO22222BBB"
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400c": {
+        "TEST_NOTES": [
+            "Interfaces for FDO11111AAA: configured accessVpcHost vPC, trunkVpcHost vPC, ethernet trunkHost.",
+            "Expect: only accessVpcHost vPC is retained after filtering."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDO22222BBB",
+                                "peer1AccessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": ["Ethernet1/1"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "vpc101",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDO22222BBB"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400d": {
+        "TEST_NOTES": ["Interfaces for FDO22222BBB: one accessVpcHost vPC (the same vPC shows on both peers in the API)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc200",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDO11111AAA",
+                                "peer1AccessVlan": 20,
+                                "peer1PortChannelId": 200,
+                                "peer1MemberPorts": ["Ethernet1/3"]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_no_match_00410_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_no_match_00410b": {
+        "TEST_NOTES": ["Switch list: one switch."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_query_all_no_match_00410c": {
+        "TEST_NOTES": ["Switch interfaces: only ethernet and non-accessVpcHost interfaces."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "vpc999",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_dedup_00430a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_dedup_00430_freeze": {
+        "TEST_NOTES": ["Deployment freeze: disabled."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/deploymentFreeze",
+        "MESSAGE": "OK",
+        "DATA": {
+            "deploymentFreeze": false
+        }
+    },
+    "test_query_all_dedup_00430b": {
+        "TEST_NOTES": ["Switch list: two switches in a vPC pair."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_query_all_dedup_00430c": {
+        "TEST_NOTES": ["S1 interfaces: vpc100 returned (peerSwitchId=FDOBBBBBBBB)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDOBBBBBBBB",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": ["Ethernet1/1"],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": ["Ethernet1/1"]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_dedup_00430d": {
+        "TEST_NOTES": ["S2 interfaces: same vpc100 returned (peerSwitchId=FDOAAAAAAAA)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDOAAAAAAAA",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": ["Ethernet1/1"],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": ["Ethernet1/1"]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_fabric_not_found_00420a": {
+        "TEST_NOTES": ["Fabric summary 404 -> validate_prerequisites raises."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
@@ -1,0 +1,495 @@
+{
+    "TEST_NOTES": [
+        "Fixtures for tests/unit/module_utils/orchestrators/test_vpc_interface_base.py.",
+        "Exercises the shared VpcInterfaceBaseOrchestrator via the _StubVpcOrchestrator concrete subclass.",
+        "Switch A: fabricManagementIp 192.168.1.1 -> switchId FDO11111AAA (vPC peer FDO22222BBB).",
+        "Switch B: fabricManagementIp 192.168.1.2 -> switchId FDO22222BBB (vPC peer FDO11111AAA).",
+        "Response order per test matches the API call order in the code under test.",
+        "To refresh: capture the corresponding GET/POST/PUT/DELETE responses against a live ND 4.2 fabric with a vPC pair."
+    ],
+
+    "test_vpc_interface_base_00200a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id happy path: vpcPair GET returns the peer serial."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "peerSwitchId": "FDO22222BBB",
+            "vpcDomainId": 1
+        }
+    },
+
+    "test_vpc_interface_base_00210a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id caching: only one vpcPair GET is provided for two calls."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "peerSwitchId": "FDO22222BBB",
+            "vpcDomainId": 1
+        }
+    },
+
+    "test_vpc_interface_base_00220a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id missing pair: vpcPair GET returns 404 (switch not in a vPC pair)."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00230a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id missing peerSwitchId: vpcPair GET succeeds but omits peerSwitchId."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "vpcDomainId": 1
+        }
+    },
+
+    "test_vpc_interface_base_00400a": {
+        "TEST_NOTES": ["create happy path: switches list (one switch) for _resolve_switch_id."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00400b": {
+        "TEST_NOTES": ["create happy path: vpcPair GET for _resolve_peer_switch_id."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00400c": {
+        "TEST_NOTES": ["create happy path: POST /interfaces (200)."],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_vpc_interface_base_00410a": {
+        "TEST_NOTES": ["create failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00410b": {
+        "TEST_NOTES": ["create failure: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00410c": {
+        "TEST_NOTES": ["create failure: POST /interfaces returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00420a": {
+        "TEST_NOTES": ["create not-in-pair: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00420b": {
+        "TEST_NOTES": ["create not-in-pair: vpcPair GET returns 404."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00500a": {
+        "TEST_NOTES": ["update happy path: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00500b": {
+        "TEST_NOTES": ["update happy path: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00500c": {
+        "TEST_NOTES": ["update happy path: PUT /interfaces/{name} (200)."],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_vpc_interface_base_00510a": {
+        "TEST_NOTES": ["update failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00510b": {
+        "TEST_NOTES": ["update failure: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00510c": {
+        "TEST_NOTES": ["update failure: PUT returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00600a": {
+        "TEST_NOTES": ["delete happy path: switches list for _resolve_switch_id."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00600b": {
+        "TEST_NOTES": ["delete happy path: per-interface DELETE returns 204 (no body)."],
+        "RETURN_CODE": 204,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "No Content",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00610a": {
+        "TEST_NOTES": ["delete failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00610b": {
+        "TEST_NOTES": ["delete failure: per-interface DELETE returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00700a": {
+        "TEST_NOTES": ["create_bulk peer cache: switches list (one switch, fetched once and cached)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00700b": {
+        "TEST_NOTES": ["create_bulk peer cache: a single vpcPair GET serves both interfaces on the same primary switch."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00700c": {
+        "TEST_NOTES": ["create_bulk peer cache: one POST /interfaces carrying both vPC interfaces."],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_vpc_interface_base_00710a": {
+        "TEST_NOTES": ["create_bulk failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00710b": {
+        "TEST_NOTES": ["create_bulk failure: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00710c": {
+        "TEST_NOTES": ["create_bulk failure: per-switch POST returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00800a": {
+        "TEST_NOTES": ["query_one happy path: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00800b": {
+        "TEST_NOTES": ["query_one happy path: GET /interfaces/{name} returns the vPC interface."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaceName": "vpc501",
+            "interfaceType": "vpc",
+            "configData": {
+                "mode": "access",
+                "networkOS": {
+                    "networkOSType": "nx-os",
+                    "policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO22222BBB"}
+                }
+            }
+        }
+    },
+
+    "test_vpc_interface_base_00810a": {
+        "TEST_NOTES": ["query_one failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00810b": {
+        "TEST_NOTES": ["query_one failure: GET returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00900a": {
+        "TEST_NOTES": ["query_all dedupe: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00900b": {
+        "TEST_NOTES": ["query_all dedupe: switches list (two vPC peers)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00900c": {
+        "TEST_NOTES": [
+            "query_all dedupe: switch A (FDO11111AAA) interfaces.",
+            "Contains the managed accessVpcHost vpc501, an other-policy trunkVpcHost vpc502 (filtered out),",
+            "and a non-vPC ethernet (filtered out). vpc501 also appears on switch B (peer copy)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                },
+                {
+                    "interfaceName": "vpc502",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "trunkVpcHost", "allowedVlans": "1-10"}}}
+                },
+                {
+                    "interfaceName": "Ethernet1/5",
+                    "interfaceType": "ethernet",
+                    "configData": {"networkOS": {"policy": {"policyType": "trunkHost"}}}
+                }
+            ]
+        }
+    },
+    "test_vpc_interface_base_00900d": {
+        "TEST_NOTES": [
+            "query_all dedupe: switch B (FDO22222BBB) interfaces.",
+            "Returns the peer-side copy of vpc501 (same interfaceName) which must be deduped away,",
+            "keeping the alphabetically-lower switchId (FDO11111AAA) representative."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00910a": {
+        "TEST_NOTES": ["query_all no-name skip: fabric summary."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00910b": {
+        "TEST_NOTES": ["query_all no-name skip: switches list (one switch)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00910c": {
+        "TEST_NOTES": [
+            "query_all no-name skip: a managed accessVpcHost vPC interface with no interfaceName.",
+            "It passes the type + policy filters but must be skipped because it has no name to key on."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00930a": {
+        "TEST_NOTES": ["query_all fabric-not-found: summary returns 404; validate_prerequisites raises."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00940a": {
+        "TEST_NOTES": ["query_all switch-404: fabric summary."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00940b": {
+        "TEST_NOTES": ["query_all switch-404: switches list (one switch)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00940c": {
+        "TEST_NOTES": ["query_all switch-404: switch interfaces endpoint returns 404 (no body); switch is skipped."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
@@ -491,5 +491,147 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
         "MESSAGE": "Not Found",
         "DATA": {}
+    },
+
+    "test_vpc_interface_base_00920a": {
+        "TEST_NOTES": ["query_all config-scoped: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+
+    "test_vpc_interface_base_00920b": {
+        "TEST_NOTES": ["query_all config-scoped: switches list (two switches); only the config switch is queried."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00920c": {
+        "TEST_NOTES": ["query_all config-scoped: config switch (FDO11111AAA) interfaces; switch B is never fetched."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00950a": {
+        "TEST_NOTES": ["query_all peer-preference: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+
+    "test_vpc_interface_base_00950b": {
+        "TEST_NOTES": ["query_all peer-preference: switches list (two vPC peers)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00950c": {
+        "TEST_NOTES": ["query_all peer-preference: switch A (lower switchId) returns vpc501; deduped away in favor of the configured peer."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00950d": {
+        "TEST_NOTES": ["query_all peer-preference: switch B (higher switchId, the configured peer 192.168.1.2) returns vpc501; kept because the user configured it."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00960a": {
+        "TEST_NOTES": ["query_all malformed-body: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+
+    "test_vpc_interface_base_00960b": {
+        "TEST_NOTES": ["query_all malformed-body: switches list (two switches)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00960c": {
+        "TEST_NOTES": ["query_all malformed-body: switch A returns a vPC with configData:null; the null-safe policy-type accessor filters it out."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {"interfaceName": "vpc501", "interfaceType": "vpc", "configData": null}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00960d": {
+        "TEST_NOTES": ["query_all malformed-body: switch B returns a bare list as DATA (non-dict); the isinstance guard skips it without AttributeError."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": [{"interfaceName": "junk", "interfaceType": "vpc"}]
     }
 }

--- a/tests/unit/module_utils/models/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_access_interface.py
@@ -238,35 +238,42 @@ def test_vpc_access_interface_00120():
     [
         (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
         (["Ethernet1/1"], ["Ethernet1/1"]),
-        (["e1/1"], ["E1/1"]),
+        # NX-OS abbreviations expand to the canonical Ethernet form so they match the wire key (idempotency).
+        (["e1/1"], ["Ethernet1/1"]),
+        (["eth1/1", "et1/1"], ["Ethernet1/1", "Ethernet1/1"]),
+        # Any casing of the full prefix canonicalizes to "Ethernet".
+        (["ETHERNET1/2", "etHernet1/3"], ["Ethernet1/2", "Ethernet1/3"]),
         ([], []),
         (None, None),
-        (["ethernet1/1/1", "ETHERNET1/2"], ["Ethernet1/1/1", "ETHERNET1/2"]),
+        (["ethernet1/1/1"], ["Ethernet1/1/1"]),
     ],
     ids=[
-        "lowercase_to_capitalized",
-        "already_capitalized_passthrough",
-        "single_letter",
+        "lowercase_to_canonical",
+        "already_canonical_passthrough",
+        "single_letter_expanded",
+        "abbreviations_expanded",
+        "any_casing_canonicalized",
         "empty_list",
         "none_passthrough",
-        "mixed_breakout",
+        "breakout_preserved",
     ],
 )
 def test_vpc_access_interface_00180_peer1(value, expected):
     """
     # Summary
 
-    Verify `normalize_member_ports` capitalizes the first character of each peer1 member name.
+    Verify `normalize_member_ports` expands each peer1 member name to ND's canonical `Ethernet` form.
 
     ## Test
 
-    - Lowercase member names are capitalized
-    - Already-capitalized values pass through
-    - Empty list and None pass through
+    - Lowercase and abbreviated member names (`e1/1`, `eth1/1`, `et1/1`) expand to `Ethernet...`
+    - Any casing of the full prefix canonicalizes to `Ethernet`
+    - Already-canonical values pass through; empty list and None pass through; breakout suffixes are preserved
 
     ## Classes and Methods
 
     - AccessVpcHostPolicyModel.normalize_member_ports()
+    - AccessVpcHostPolicyModel._normalize_member_name()
     """
     with does_not_raise():
         instance = AccessVpcHostPolicyModel(peer1_member_ports=value)
@@ -278,9 +285,10 @@ def test_vpc_access_interface_00180_peer1(value, expected):
     [
         (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
         (["Ethernet1/1"], ["Ethernet1/1"]),
+        (["eth1/1"], ["Ethernet1/1"]),
         (None, None),
     ],
-    ids=["lowercase_to_capitalized", "already_capitalized_passthrough", "none_passthrough"],
+    ids=["lowercase_to_canonical", "already_canonical_passthrough", "abbreviation_expanded", "none_passthrough"],
 )
 def test_vpc_access_interface_00185_peer2(value, expected):
     """
@@ -295,6 +303,7 @@ def test_vpc_access_interface_00185_peer2(value, expected):
     ## Classes and Methods
 
     - AccessVpcHostPolicyModel.normalize_member_ports()
+    - AccessVpcHostPolicyModel._normalize_member_name()
     """
     with does_not_raise():
         instance = AccessVpcHostPolicyModel(peer2_member_ports=value)
@@ -496,7 +505,7 @@ def test_vpc_access_interface_00420_to_payload():
     ## Classes and Methods
 
     - AccessVpcHostInterfaceModel.to_payload()
-    - AccessVpcHostPolicyModel.expand_per_peer_fields()
+    - AccessVpcHostPolicyModel.serialize_policy()
     """
     instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
     payload = instance.to_payload()
@@ -530,7 +539,7 @@ def test_vpc_access_interface_00425_to_config_keeps_single_vlan():
     ## Classes and Methods
 
     - AccessVpcHostInterfaceModel.to_config()
-    - AccessVpcHostPolicyModel.expand_per_peer_fields()
+    - AccessVpcHostPolicyModel.serialize_policy()
     """
     instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
     config = instance.to_config()
@@ -538,6 +547,32 @@ def test_vpc_access_interface_00425_to_config_keeps_single_vlan():
     assert policy["access_vlan"] == 10
     assert "peer1_access_vlan" not in policy
     assert "peer2_access_vlan" not in policy
+
+
+def test_vpc_access_interface_00427_to_config_strips_policy_type():
+    """
+    # Summary
+
+    Verify `to_config()` omits the frozen, argspec-excluded `policy_type` so it does not leak into
+    `before` / `after` / `gathered` output, while `to_payload()` still emits the wire `policyType`.
+
+    ## Test
+
+    - to_config() output does NOT contain `policy_type` or `policyType`
+    - to_payload() output DOES contain `policyType` (the wire key ND expects)
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.to_config()
+    - AccessVpcHostInterfaceModel.to_payload()
+    - AccessVpcHostPolicyModel.serialize_policy()
+    """
+    instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    config_policy = instance.to_config()["config_data"]["network_os"]["policy"]
+    assert "policy_type" not in config_policy
+    assert "policyType" not in config_policy
+    payload_policy = instance.to_payload()["configData"]["networkOS"]["policy"]
+    assert payload_policy["policyType"] == "accessVpcHost"
 
 
 # =============================================================================

--- a/tests/unit/module_utils/models/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_access_interface.py
@@ -1,0 +1,623 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for vpc_access_interface.py
+
+Tests the vPC accessVpcHost Interface Pydantic model classes.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+    AccessVpcHostConfigDataModel,
+    AccessVpcHostInterfaceModel,
+    AccessVpcHostNetworkOSModel,
+    AccessVpcHostPolicyModel,
+)
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test data constants
+# =============================================================================
+
+SAMPLE_API_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "vpc100",
+    "interfaceType": "vpc",
+    "configData": {
+        "mode": "access",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "policyType": "accessVpcHost",
+                "peerSwitchId": "FDOPEER0001",
+                "adminState": True,
+                "accessVlan": 10,
+                "peer1PortChannelId": 100,
+                "peer1MemberPorts": ["Ethernet1/1"],
+                "peer2PortChannelId": 100,
+                "peer2MemberPorts": ["Ethernet1/2"],
+                "portChannelMode": "active",
+                "lacpRate": "fast",
+                "mtu": "jumbo",
+            },
+        },
+    },
+}
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "vpc100",
+    "config_data": {
+        "network_os": {
+            "policy": {
+                "admin_state": True,
+                "access_vlan": 10,
+                "peer1_port_channel_id": 100,
+                "peer1_member_ports": ["Ethernet1/1"],
+                "peer2_port_channel_id": 100,
+                "peer2_member_ports": ["Ethernet1/2"],
+                "port_channel_mode": "active",
+                "lacp_rate": "fast",
+                "mtu": "jumbo",
+            },
+        },
+    },
+}
+
+
+# =============================================================================
+# Test: AccessVpcHostPolicyModel — initialization
+# =============================================================================
+
+
+def test_vpc_access_interface_00100():
+    """
+    # Summary
+
+    Verify every policy field defaults to None except the frozen policy_type.
+
+    ## Test
+
+    - Instantiate with no arguments
+    - Every per-peer and shared field is None
+    - policy_type defaults to "accessVpcHost"
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel()
+    assert instance.policy_type == "accessVpcHost"
+    assert instance.peer_switch_id is None
+    # Shared access VLAN
+    assert instance.access_vlan is None
+    # Per-peer
+    assert instance.peer1_member_ports is None
+    assert instance.peer1_port_channel_configuration is None
+    assert instance.peer1_port_channel_description is None
+    assert instance.peer1_port_channel_id is None
+    assert instance.peer2_member_ports is None
+    assert instance.peer2_port_channel_configuration is None
+    assert instance.peer2_port_channel_description is None
+    assert instance.peer2_port_channel_id is None
+    # Shared
+    assert instance.admin_state is None
+    assert instance.bandwidth is None
+    assert instance.bpdu_filter is None
+    assert instance.bpdu_guard is None
+    assert instance.cdp is None
+    assert instance.copy_description is None
+    assert instance.duplex_mode is None
+    assert instance.inherit_bandwidth is None
+    assert instance.lacp_port_priority is None
+    assert instance.lacp_rate is None
+    assert instance.lacp_suspend is None
+    assert instance.lacp_vpc_convergence is None
+    assert instance.link_type is None
+    assert instance.mirror_config is None
+    assert instance.mtu is None
+    assert instance.negotiate_auto is None
+    assert instance.netflow is None
+    assert instance.netflow_monitor is None
+    assert instance.netflow_sampler is None
+    assert instance.pfc is None
+    assert instance.port_channel_mode is None
+    assert instance.port_type_edge_trunk is None
+    assert instance.qos is None
+    assert instance.qos_policy is None
+    assert instance.queuing_policy is None
+    assert instance.speed is None
+    assert instance.storm_control is None
+    assert instance.storm_control_action is None
+
+
+def test_vpc_access_interface_00110():
+    """
+    # Summary
+
+    Verify construction with snake_case field names.
+
+    ## Test
+
+    - Construct with Python field names
+    - Values accessible via Python attributes
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel(
+            admin_state=True,
+            access_vlan=10,
+            peer1_port_channel_id=100,
+            peer1_member_ports=["Ethernet1/1"],
+            peer2_port_channel_id=100,
+            peer2_member_ports=["Ethernet1/2"],
+            port_channel_mode="active",
+            lacp_rate="fast",
+        )
+    assert instance.admin_state is True
+    assert instance.access_vlan == 10
+    assert instance.peer1_port_channel_id == 100
+    assert instance.peer1_member_ports == ["Ethernet1/1"]
+    assert instance.peer2_port_channel_id == 100
+    assert instance.peer2_member_ports == ["Ethernet1/2"]
+    assert instance.port_channel_mode == "active"
+    assert instance.lacp_rate == "fast"
+    assert instance.policy_type == "accessVpcHost"
+
+
+def test_vpc_access_interface_00120():
+    """
+    # Summary
+
+    Verify construction with camelCase aliases.
+
+    ## Test
+
+    - Construct with API alias names
+    - Values accessible by Python names
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel(
+            adminState=True,
+            accessVlan=20,
+            peer1PortChannelId=200,
+            peer1MemberPorts=["Ethernet1/5"],
+            peer2PortChannelId=200,
+            peer2MemberPorts=["Ethernet1/6"],
+            portChannelMode="passive",
+            policyType="accessVpcHost",
+            peerSwitchId="FDOPEER0001",
+        )
+    assert instance.admin_state is True
+    assert instance.access_vlan == 20
+    assert instance.peer1_port_channel_id == 200
+    assert instance.peer1_member_ports == ["Ethernet1/5"]
+    assert instance.peer2_port_channel_id == 200
+    assert instance.peer2_member_ports == ["Ethernet1/6"]
+    assert instance.port_channel_mode == "passive"
+    assert instance.policy_type == "accessVpcHost"
+    assert instance.peer_switch_id == "FDOPEER0001"
+
+
+# =============================================================================
+# Test: AccessVpcHostPolicyModel — validators
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
+        (["Ethernet1/1"], ["Ethernet1/1"]),
+        (["e1/1"], ["E1/1"]),
+        ([], []),
+        (None, None),
+        (["ethernet1/1/1", "ETHERNET1/2"], ["Ethernet1/1/1", "ETHERNET1/2"]),
+    ],
+    ids=[
+        "lowercase_to_capitalized",
+        "already_capitalized_passthrough",
+        "single_letter",
+        "empty_list",
+        "none_passthrough",
+        "mixed_breakout",
+    ],
+)
+def test_vpc_access_interface_00180_peer1(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_member_ports` capitalizes the first character of each peer1 member name.
+
+    ## Test
+
+    - Lowercase member names are capitalized
+    - Already-capitalized values pass through
+    - Empty list and None pass through
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.normalize_member_ports()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel(peer1_member_ports=value)
+    assert instance.peer1_member_ports == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (["ethernet1/1", "ethernet1/2"], ["Ethernet1/1", "Ethernet1/2"]),
+        (["Ethernet1/1"], ["Ethernet1/1"]),
+        (None, None),
+    ],
+    ids=["lowercase_to_capitalized", "already_capitalized_passthrough", "none_passthrough"],
+)
+def test_vpc_access_interface_00185_peer2(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_member_ports` also applies to peer2_member_ports.
+
+    ## Test
+
+    - Same normalization rules as peer1
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel.normalize_member_ports()
+    """
+    with does_not_raise():
+        instance = AccessVpcHostPolicyModel(peer2_member_ports=value)
+    assert instance.peer2_member_ports == expected
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("access_vlan", 0),
+        ("access_vlan", 4095),
+        ("peer1_port_channel_id", 0),
+        ("peer1_port_channel_id", 4097),
+        ("peer2_port_channel_id", 0),
+        ("peer2_port_channel_id", 4097),
+    ],
+    ids=[
+        "vlan_below_min",
+        "vlan_above_max",
+        "peer1_pc_id_below_min",
+        "peer1_pc_id_above_max",
+        "peer2_pc_id_below_min",
+        "peer2_pc_id_above_max",
+    ],
+)
+def test_vpc_access_interface_00200_range(field, value):
+    """
+    # Summary
+
+    Verify VLAN (1-4094) and port-channel-id (1-4096) range validation.
+
+    ## Test
+
+    - Values outside the valid range raise ValidationError
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel (Pydantic Field constraints)
+    """
+    with pytest.raises(ValidationError):
+        AccessVpcHostPolicyModel(**{field: value})
+
+
+def test_vpc_access_interface_00210_policy_type_frozen():
+    """
+    # Summary
+
+    Verify `policy_type` cannot be reassigned to a different value (frozen=True).
+
+    ## Test
+
+    - Construct with default policy_type
+    - Attempt to assign a different value raises ValidationError
+
+    ## Classes and Methods
+
+    - AccessVpcHostPolicyModel (frozen Field)
+    """
+    instance = AccessVpcHostPolicyModel()
+    with pytest.raises(ValidationError):
+        instance.policy_type = "trunkVpcHost"
+
+
+# =============================================================================
+# Test: AccessVpcHostInterfaceModel — identifier behavior
+# =============================================================================
+
+
+def test_vpc_access_interface_00300_identifier():
+    """
+    # Summary
+
+    Verify the identifier is `interface_name` only (single strategy). A vPC interface is one fabric-level resource;
+    ND echoes it from both peers but it must collapse to one identity for diff/override-deletion correctness.
+
+    ## Test
+
+    - Identifier is `["interface_name"]`
+    - Identifier strategy is `"single"`
+    - get_identifier_value returns the interface name string
+    - `switch_ip` is excluded from the diff dict (routing-only field)
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.get_identifier_value()
+    - AccessVpcHostInterfaceModel.to_diff_dict()
+    """
+    instance = AccessVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc100")
+    assert instance.identifiers == ["interface_name"]
+    assert instance.identifier_strategy == "single"
+    assert instance.get_identifier_value() == "vpc100"
+    # switch_ip is for routing only; it must not appear in the diff dict so two peers' echoes diff-equal.
+    assert "switchIp" not in instance.to_diff_dict()
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("Vpc100", "vpc100"),
+        ("VPC100", "vpc100"),
+        ("vpc100", "vpc100"),
+        ("vPC100", "vpc100"),
+    ],
+    ids=["title_case", "upper_case", "lower_case_passthrough", "mixed_case"],
+)
+def test_vpc_access_interface_00310_normalize_name(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` lowercases interface names.
+
+    ## Test
+
+    - Various casings are normalized to lowercase
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.normalize_interface_name()
+    """
+    instance = AccessVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name=value)
+    assert instance.interface_name == expected
+
+
+# =============================================================================
+# Test: AccessVpcHostInterfaceModel — round-trip
+# =============================================================================
+
+
+def test_vpc_access_interface_00400_round_trip_from_api():
+    """
+    # Summary
+
+    Verify the model accepts the camelCase API response shape and exposes values via Python attributes.
+
+    ## Test
+
+    - Construct from SAMPLE_API_RESPONSE
+    - Nested values accessible
+    - peerSwitchId reads through
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.__init__()
+    """
+    instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    assert instance.switch_ip == "192.168.1.1"
+    assert instance.interface_name == "vpc100"
+    assert instance.interface_type == "vpc"
+    policy = instance.config_data.network_os.policy
+    assert policy.policy_type == "accessVpcHost"
+    assert policy.peer_switch_id == "FDOPEER0001"
+    assert policy.access_vlan == 10
+    assert policy.peer1_member_ports == ["Ethernet1/1"]
+    assert policy.peer2_member_ports == ["Ethernet1/2"]
+    assert policy.admin_state is True
+
+
+def test_vpc_access_interface_00410_round_trip_from_ansible():
+    """
+    # Summary
+
+    Verify the model accepts the snake_case Ansible config shape.
+
+    ## Test
+
+    - Construct from SAMPLE_ANSIBLE_CONFIG
+    - Nested values accessible
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.__init__()
+    """
+    instance = AccessVpcHostInterfaceModel(**copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
+    assert instance.switch_ip == "192.168.1.1"
+    policy = instance.config_data.network_os.policy
+    assert policy.peer1_port_channel_id == 100
+    assert policy.peer2_port_channel_id == 100
+    assert policy.access_vlan == 10
+    assert policy.policy_type == "accessVpcHost"
+
+
+def test_vpc_access_interface_00420_to_payload():
+    """
+    # Summary
+
+    Verify `to_payload()` serializes the model back to camelCase, drops the `switch_ip` identifier, and splits the
+    user-facing single `access_vlan` into the per-peer write keys (`peer1AccessVlan` + `peer2AccessVlan`) that ND's
+    create schema requires.
+
+    ## Test
+
+    - to_payload() returns wire-shaped dict
+    - switchIp is excluded (Ansible-facing only)
+    - interfaceType is present
+    - Nested policy aliases are camelCase
+    - accessVlan is absent from the payload (split into per-peer keys)
+    - peer1AccessVlan and peer2AccessVlan are both present with the same value
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.to_payload()
+    - AccessVpcHostPolicyModel.expand_per_peer_fields()
+    """
+    instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+    assert "switchIp" not in payload
+    assert payload["interfaceName"] == "vpc100"
+    assert payload["interfaceType"] == "vpc"
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert policy["policyType"] == "accessVpcHost"
+    assert policy["peer1MemberPorts"] == ["Ethernet1/1"]
+    assert policy["peer2MemberPorts"] == ["Ethernet1/2"]
+    assert policy["peer1PortChannelId"] == 100
+    assert policy["peer2PortChannelId"] == 100
+    # access_vlan split to both per-peer keys; the single-valued accessVlan key is removed on payload.
+    assert "accessVlan" not in policy
+    assert policy["peer1AccessVlan"] == 10
+    assert policy["peer2AccessVlan"] == 10
+
+
+def test_vpc_access_interface_00425_to_config_keeps_single_vlan():
+    """
+    # Summary
+
+    Verify `to_config()` keeps `access_vlan` as a single field (does NOT expand to per-peer). The expansion only
+    happens for payload mode; config / diff modes use the wire-echo (single) shape so idempotency works.
+
+    ## Test
+
+    - to_config() returns the snake_case field `access_vlan`
+    - `peer1_access_vlan` and `peer2_access_vlan` are NOT in the config
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.to_config()
+    - AccessVpcHostPolicyModel.expand_per_peer_fields()
+    """
+    instance = AccessVpcHostInterfaceModel(**SAMPLE_API_RESPONSE)
+    config = instance.to_config()
+    policy = config["config_data"]["network_os"]["policy"]
+    assert policy["access_vlan"] == 10
+    assert "peer1_access_vlan" not in policy
+    assert "peer2_access_vlan" not in policy
+
+
+# =============================================================================
+# Test: Argument spec exposure
+# =============================================================================
+
+
+def test_vpc_access_interface_00500_argument_spec_shape():
+    """
+    # Summary
+
+    Verify the argument spec exposes the right shape: fabric_name, config list, state choices.
+
+    ## Test
+
+    - top-level keys: fabric_name, config, state
+    - state choices contain merged/replaced/overridden/deleted
+    - config has nested policy options including peer1_/peer2_ fields
+    - Frozen scaffolding (interface_type, mode, network_os_type, policy_type) is NOT exposed
+    - peer_switch_id (orchestrator-injected) is NOT exposed
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceModel.get_argument_spec()
+    """
+    spec = AccessVpcHostInterfaceModel.get_argument_spec()
+    assert set(spec) == {"fabric_name", "config", "state"}
+    assert spec["fabric_name"]["required"] is True
+    assert set(spec["state"]["choices"]) == {"merged", "replaced", "overridden", "deleted"}
+
+    config_options = spec["config"]["options"]
+    assert "switch_ip" in config_options
+    assert "interface_name" in config_options
+    assert "config_data" in config_options
+
+    policy_options = config_options["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    # Shared access VLAN (collapsed by ND on read; single field on the user side)
+    assert "access_vlan" in policy_options
+    # Per-peer presence
+    assert "peer1_port_channel_id" in policy_options
+    assert "peer1_member_ports" in policy_options
+    assert "peer2_port_channel_id" in policy_options
+    assert "peer2_member_ports" in policy_options
+    # Shared field samples
+    assert "admin_state" in policy_options
+    assert "lacp_rate" in policy_options
+    assert "port_channel_mode" in policy_options
+    # Frozen/injected exclusions
+    assert "interface_type" not in config_options
+    assert "policy_type" not in policy_options
+    assert "mode" not in policy_options
+    assert "network_os_type" not in policy_options
+    assert "peer_switch_id" not in policy_options
+    # Per-peer access VLANs are explicitly NOT exposed (ND collapses to single accessVlan on read).
+    assert "peer1_access_vlan" not in policy_options
+    assert "peer2_access_vlan" not in policy_options
+
+
+# =============================================================================
+# Test: Nested-model sanity (Config / NetworkOS)
+# =============================================================================
+
+
+def test_vpc_access_interface_00600_nested_defaults():
+    """
+    # Summary
+
+    Verify ConfigData and NetworkOS containers default their frozen discriminators.
+
+    ## Test
+
+    - AccessVpcHostConfigDataModel.mode defaults to "access"
+    - AccessVpcHostNetworkOSModel.network_os_type defaults to "nx-os"
+
+    ## Classes and Methods
+
+    - AccessVpcHostConfigDataModel
+    - AccessVpcHostNetworkOSModel
+    """
+    network_os = AccessVpcHostNetworkOSModel(policy=AccessVpcHostPolicyModel())
+    config = AccessVpcHostConfigDataModel(network_os=network_os)
+    assert config.mode == "access"
+    assert config.network_os.network_os_type == "nx-os"

--- a/tests/unit/module_utils/orchestrators/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_access_interface.py
@@ -51,8 +51,18 @@ def responses_vpc_access(key: str):
     return load_fixture("test_vpc_access_interface_orchestrator")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
-    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list | None = None,
+) -> RestSend:
+    """
+    Build a RestSend wired to the file-based Sender and the real ResponseHandler.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    """
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
@@ -62,7 +72,13 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -70,9 +86,14 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     return rest_send
 
 
-def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> AccessVpcHostInterfaceOrchestrator:
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list | None = None,
+) -> AccessVpcHostInterfaceOrchestrator:
     """Construct an orchestrator with the file-based RestSend injected."""
-    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
     return AccessVpcHostInterfaceOrchestrator(rest_send=rest_send)
 
 
@@ -352,6 +373,9 @@ def test_vpc_access_orchestrator_00400_query_all_happy() -> None:
     Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=="vpc"
     and policyType=="accessVpcHost", and injects `switchIp` onto each kept interface.
 
+    `state=overridden` keeps `query_all` fabric-wide so every switch is scanned (config-scoped states only
+    visit switches named in the user config — see `_switches_to_query`).
+
     ## Test
 
     - Fabric summary (validate_prerequisites) returns 200
@@ -376,7 +400,7 @@ def test_vpc_access_orchestrator_00400_query_all_happy() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        orchestrator = _build_orchestrator(gen_responses)
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
         result = orchestrator.query_all()
 
     assert isinstance(result, list)
@@ -399,6 +423,8 @@ def test_vpc_access_orchestrator_00410_query_all_no_match() -> None:
 
     Verify `query_all` returns an empty list when no switch reports any accessVpcHost vPC.
 
+    `state=overridden` keeps `query_all` fabric-wide so the switch is scanned and the policy-type filter is exercised.
+
     ## Test
 
     - Switch returns only non-vPC and non-accessVpcHost vPC interfaces
@@ -418,7 +444,7 @@ def test_vpc_access_orchestrator_00410_query_all_no_match() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        orchestrator = _build_orchestrator(gen_responses)
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
         result = orchestrator.query_all()
 
     assert result == []
@@ -431,6 +457,8 @@ def test_vpc_access_orchestrator_00430_query_all_dedup() -> None:
     Verify `query_all` dedupes vPC interfaces that appear on both peers. ND returns each vPC interface twice
     (once per peer GET) with identical configData; without dedupe, `_manage_override_deletions` would treat the
     peer-side copy as "not in proposed" and queue a spurious delete.
+
+    `state=overridden` keeps `query_all` fabric-wide so both peers are scanned and the per-peer dedup is exercised.
 
     ## Test
 
@@ -453,7 +481,7 @@ def test_vpc_access_orchestrator_00430_query_all_dedup() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        orchestrator = _build_orchestrator(gen_responses)
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
         result = orchestrator.query_all()
 
     assert isinstance(result, list)

--- a/tests/unit/module_utils/orchestrators/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_access_interface.py
@@ -1,0 +1,491 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for vpc_access_interface orchestrator.
+
+Verifies that `AccessVpcHostInterfaceOrchestrator` correctly:
+- declares the right `model_class` and `_managed_policy_types`
+- inherits bulk-support flags from `VpcInterfaceBaseOrchestrator`
+- resolves the peer switch's serial via the vPC pair GET endpoint
+- raises a clear `RuntimeError` when the primary switch is not in a vPC pair
+- caches peer-serial lookups per orchestrator instance
+- filters fabric-wide interface results to `interfaceType: "vpc"` plus the managed
+  policy types (so non-vPC interfaces and other-flavor vPCs are excluded)
+- propagates `RuntimeError` from the inherited `validate_prerequisites` path
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as the
+`sender` dependency injected into a real `RestSend`. Responses are read from
+`tests/unit/module_utils/fixtures/fixture_data/test_vpc_access_interface_orchestrator.json`.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+    AccessVpcHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_access_interface import (
+    AccessVpcHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_vpc_access(key: str):
+    """Load fixture data for the orchestrator's test_vpc_access_interface_orchestrator.json file."""
+    return load_fixture("test_vpc_access_interface_orchestrator")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> AccessVpcHostInterfaceOrchestrator:
+    """Construct an orchestrator with the file-based RestSend injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    return AccessVpcHostInterfaceOrchestrator(rest_send=rest_send)
+
+
+# =============================================================================
+# Test: ClassVar / model_class
+# =============================================================================
+
+
+def test_vpc_access_orchestrator_00010() -> None:
+    """
+    # Summary
+
+    Verify `model_class` points to `AccessVpcHostInterfaceModel`.
+
+    ## Test
+
+    - model_class is AccessVpcHostInterfaceModel
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator.model_class
+    """
+    assert AccessVpcHostInterfaceOrchestrator.model_class is AccessVpcHostInterfaceModel
+
+
+def test_vpc_access_orchestrator_00020() -> None:
+    """
+    # Summary
+
+    Verify bulk-support flags inherited from `VpcInterfaceBaseOrchestrator`. Bulk-create is enabled (POST /interfaces accepts
+    an array); bulk-delete is disabled because ND 4.2.1's `interfaceActions/remove` returns `Invalid Interface` for
+    vPC entries — we use per-interface `DELETE` instead via the state machine's individual delete path.
+
+    ## Test
+
+    - supports_bulk_create is True
+    - supports_bulk_delete is False
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator
+    """
+    assert AccessVpcHostInterfaceOrchestrator.supports_bulk_create is True
+    assert AccessVpcHostInterfaceOrchestrator.supports_bulk_delete is False
+
+
+# =============================================================================
+# Test: _managed_policy_types
+# =============================================================================
+
+
+def test_vpc_access_orchestrator_00100() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns the single `"accessVpcHost"` API value.
+
+    ## Test
+
+    - Returned set contains exactly "accessVpcHost"
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    assert orchestrator._managed_policy_types() == {"accessVpcHost"}
+
+
+def test_vpc_access_orchestrator_00110() -> None:
+    """
+    # Summary
+
+    Verify `_managed_policy_types` returns a set.
+
+    ## Test
+
+    - Return type is set
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    result = orchestrator._managed_policy_types()
+    assert isinstance(result, set)
+    assert "accessVpcHost" in result
+
+
+# =============================================================================
+# Test: _resolve_peer_switch_id
+# =============================================================================
+
+
+def test_vpc_access_orchestrator_00500_peer_resolve_happy() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` returns the peer serial when the primary is in a vPC pair.
+
+    ## Test
+
+    - GET /vpcPair returns peerSwitchId
+    - Helper returns that value
+    - Result is cached on the orchestrator
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_peer_resolve_happy_path_00500a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        peer = orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+    assert peer == "FDO22222BBB"
+    assert orchestrator._peer_serial_cache == {"FDO11111AAA": "FDO22222BBB"}
+
+
+def test_vpc_access_orchestrator_00505_peer_resolve_cached() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` returns the cached value without issuing a second GET.
+
+    ## Test
+
+    - First call fetches and caches
+    - Second call returns the cached value (no additional response is yielded)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_peer_resolve_happy_path_00500a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    first = orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+    second = orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+    assert first == second == "FDO22222BBB"
+
+
+def test_vpc_access_orchestrator_00510_peer_resolve_not_paired() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises a clear RuntimeError when the primary switch is not in a vPC pair.
+
+    ## Test
+
+    - GET /vpcPair returns 404 (live-lab structured error body)
+    - Helper raises RuntimeError mentioning the switch_ip and pointing the user at nd_manage_vpc_pair
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_peer_resolve_not_paired_00510a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with pytest.raises(RuntimeError, match=r"192\.168\.1\.1.*not in a vPC pair.*nd_manage_vpc_pair"):
+        orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+
+def test_vpc_access_orchestrator_00520_peer_resolve_missing_field() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises RuntimeError when the vPC pair record is missing `peerSwitchId`.
+
+    ## Test
+
+    - GET /vpcPair returns 200 but body omits peerSwitchId
+    - Helper raises RuntimeError mentioning the missing field
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_peer_resolve_missing_field_00520a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with pytest.raises(RuntimeError, match=r"missing 'peerSwitchId'"):
+        orchestrator._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+
+# =============================================================================
+# Test: query_all — happy path with filtering
+# =============================================================================
+
+
+def test_vpc_access_orchestrator_00600_delete_uses_per_interface_endpoint() -> None:
+    """
+    # Summary
+
+    Verify `delete()` calls the per-interface `DELETE /interfaces/{name}` endpoint (not the bulk
+    `interfaceActions/remove` which silently fails for vPC on ND 4.2.1) and queues a deploy for the same
+    `(interface_name, switch_id)` pair.
+
+    ## Test
+
+    - Switch-map fixture resolves switch_ip -> switch_id
+    - DELETE call returns 204 (no body)
+    - delete() does not raise
+    - Deploy queue contains exactly one entry: (vpc100, FDOAAAAAAAA)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.delete()
+    """
+    method_name = "test_delete_per_interface_00600"
+
+    def responses():
+        yield {
+            "RETURN_CODE": 200,
+            "METHOD": "GET",
+            "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+            "MESSAGE": "OK",
+            "DATA": {"switches": [{"fabricManagementIp": "192.168.1.1", "switchId": "FDOAAAAAAAA"}]},
+        }
+        yield {
+            "RETURN_CODE": 204,
+            "METHOD": "DELETE",
+            "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces/vpc100",
+            "MESSAGE": "No Content",
+            "DATA": {},
+        }
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+        AccessVpcHostInterfaceModel,
+    )
+
+    model = AccessVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc100")
+    with does_not_raise():
+        orchestrator.delete(model)
+
+    assert orchestrator._pending_deploys == [("vpc100", "FDOAAAAAAAA")]
+    # Bulk-remove queue stays untouched because we use per-interface DELETE.
+    assert orchestrator._pending_removes == []
+    # Sanity reference
+    assert method_name.endswith("00600")
+
+
+def test_vpc_access_orchestrator_00400_query_all_happy() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=="vpc"
+    and policyType=="accessVpcHost", and injects `switchIp` onto each kept interface.
+
+    ## Test
+
+    - Fabric summary (validate_prerequisites) returns 200
+    - Switches list returns two switches
+    - Switch 1 returns: configured accessVpcHost vpc, trunkVpcHost vpc, ethernet trunkHost
+    - Switch 2 returns: one configured accessVpcHost vpc
+    - Result contains exactly the two accessVpcHost vPC interfaces
+    - Each has switchIp injected with the fabricManagementIp
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator._managed_policy_types()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_query_all_happy_path_00400a")
+        yield responses_vpc_access("test_query_all_happy_path_00400b")
+        yield responses_vpc_access("test_query_all_happy_path_00400c")
+        yield responses_vpc_access("test_query_all_happy_path_00400d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    by_name = {iface["interfaceName"]: iface for iface in result}
+    assert set(by_name) == {"vpc100", "vpc200"}
+
+    assert by_name["vpc100"]["switchIp"] == "192.168.1.1"
+    assert by_name["vpc200"]["switchIp"] == "192.168.1.2"
+
+    # Filtered out: trunkVpcHost (vpc101) and ethernet trunkHost (Ethernet1/1)
+    assert "vpc101" not in by_name
+    assert "Ethernet1/1" not in by_name
+
+
+def test_vpc_access_orchestrator_00410_query_all_no_match() -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty list when no switch reports any accessVpcHost vPC.
+
+    ## Test
+
+    - Switch returns only non-vPC and non-accessVpcHost vPC interfaces
+    - Result is an empty list
+
+    ## Classes and Methods
+
+    - AccessVpcHostInterfaceOrchestrator._managed_policy_types()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_query_all_no_match_00410a")
+        yield responses_vpc_access("test_query_all_no_match_00410b")
+        yield responses_vpc_access("test_query_all_no_match_00410c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_vpc_access_orchestrator_00430_query_all_dedup() -> None:
+    """
+    # Summary
+
+    Verify `query_all` dedupes vPC interfaces that appear on both peers. ND returns each vPC interface twice
+    (once per peer GET) with identical configData; without dedupe, `_manage_override_deletions` would treat the
+    peer-side copy as "not in proposed" and queue a spurious delete.
+
+    ## Test
+
+    - Two switches in the fabric, both return the same `vpc100` configuration
+    - Result contains exactly ONE entry for `vpc100`
+    - Canonical representative is the entry with the alphabetically-lower `switchId`
+      (FDOAAAAAAAA = 192.168.1.1 is kept; FDOBBBBBBBB = 192.168.1.2 is dropped)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all() dedupe logic
+    """
+
+    def responses():
+        yield responses_vpc_access("test_query_all_dedup_00430a")
+        yield responses_vpc_access("test_query_all_dedup_00430b")
+        yield responses_vpc_access("test_query_all_dedup_00430c")
+        yield responses_vpc_access("test_query_all_dedup_00430d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc100"
+    # Canonical representative is the lower-switchId one
+    assert result[0]["switchIp"] == "192.168.1.1"
+    assert result[0]["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDOBBBBBBBB"
+
+
+def test_vpc_access_orchestrator_00420_query_all_fabric_not_found() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - query_all raises RuntimeError with "Query all failed"
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - FabricContext.validate_for_mutation()
+    """
+
+    def responses():
+        yield responses_vpc_access("test_query_all_fabric_not_found_00420a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        orchestrator.query_all()

--- a/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
@@ -119,8 +119,17 @@ def responses_vpc_base(key: str):
     return load_fixture("test_vpc_interface_base")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
-    """Build a `RestSend` wired to the file-based `Sender` and the real `ResponseHandler`."""
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> RestSend:
+    """Build a `RestSend` wired to the file-based `Sender` and the real `ResponseHandler`.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) and its config-preference dedup can be exercised.
+    """
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
@@ -130,7 +139,13 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -138,9 +153,14 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     return rest_send
 
 
-def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> _StubVpcOrchestrator:
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> _StubVpcOrchestrator:
     """Construct a `_StubVpcOrchestrator` with the file-based `RestSend` injected."""
-    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
     return _StubVpcOrchestrator(rest_send=rest_send)
 
 
@@ -418,12 +438,14 @@ def test_vpc_interface_base_00310() -> None:
     """
     # Summary
 
-    Verify `_inject_peer_switch_id` is a safe no-op when there is no nested policy to inject into.
+    Verify `_inject_peer_switch_id` raises `RuntimeError` when there is no nested `policy` block to inject into. A
+    vPC interface always needs a peer serial, so a policy-less payload is structurally invalid and must fail fast
+    rather than be silently sent to ND as a one-sided vPC.
 
     ## Test
 
-    - Payload with no `policy` key is returned unchanged (no `peerSwitchId` added, no KeyError)
-    - Payload with no `configData` key is returned unchanged
+    - Payload with no `policy` key raises `RuntimeError` matching `missing the 'configData.networkOS.policy' block`
+    - Payload with no `configData` key raises the same `RuntimeError`
 
     ## Classes and Methods
 
@@ -436,11 +458,15 @@ def test_vpc_interface_base_00310() -> None:
     gen_responses = ResponseGenerator(responses())
     instance = _build_orchestrator(gen_responses)
 
+    match = r"missing the 'configData\.networkOS\.policy' block"
+
     no_policy: dict = {"configData": {"networkOS": {}}}
-    assert instance._inject_peer_switch_id(no_policy, "FDO22222BBB") == {"configData": {"networkOS": {}}}
+    with pytest.raises(RuntimeError, match=match):
+        instance._inject_peer_switch_id(no_policy, "FDO22222BBB")
 
     no_config: dict = {"interfaceName": "vpc501"}
-    assert instance._inject_peer_switch_id(no_config, "FDO22222BBB") == {"interfaceName": "vpc501"}
+    with pytest.raises(RuntimeError, match=match):
+        instance._inject_peer_switch_id(no_config, "FDO22222BBB")
 
 
 # =============================================================================
@@ -903,6 +929,8 @@ def test_vpc_interface_base_00900() -> None:
     - The kept entry carries `switchIp` of the lower-`switchId` peer (192.168.1.1 / FDO11111AAA)
     - Request count is exactly 4: summary + switches-list + one interface GET per switch (locks the scan cost)
 
+    `state=overridden` keeps `query_all` fabric-wide so both peers are scanned and the per-peer dedup is exercised.
+
     ## Classes and Methods
 
     - VpcInterfaceBaseOrchestrator.query_all()
@@ -919,7 +947,7 @@ def test_vpc_interface_base_00900() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        instance = _build_orchestrator(gen_responses)
+        instance = _build_orchestrator(gen_responses, state="overridden")
         result = instance.query_all()
 
     assert isinstance(result, list)
@@ -948,6 +976,8 @@ def test_vpc_interface_base_00910() -> None:
     - The single switch returns one managed `accessVpcHost` vPC interface with no `interfaceName`
     - `query_all` returns `[]` (the nameless entry is skipped, not raised on)
 
+    `state=overridden` keeps `query_all` fabric-wide so the switch is scanned.
+
     ## Classes and Methods
 
     - VpcInterfaceBaseOrchestrator.query_all()
@@ -962,7 +992,7 @@ def test_vpc_interface_base_00910() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        instance = _build_orchestrator(gen_responses)
+        instance = _build_orchestrator(gen_responses, state="overridden")
         result = instance.query_all()
 
     assert result == []
@@ -1008,6 +1038,8 @@ def test_vpc_interface_base_00940() -> None:
     - The switch's interfaces endpoint returns 404 (no body)
     - `query_all` returns `[]`
 
+    `state=overridden` keeps `query_all` fabric-wide so the 404 switch is still visited and skipped.
+
     ## Classes and Methods
 
     - VpcInterfaceBaseOrchestrator.query_all()
@@ -1022,7 +1054,123 @@ def test_vpc_interface_base_00940() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        instance = _build_orchestrator(gen_responses)
+        instance = _build_orchestrator(gen_responses, state="overridden")
+        result = instance.query_all()
+
+    assert result == []
+
+
+def test_vpc_interface_base_00920() -> None:
+    """
+    # Summary
+
+    Verify `query_all` scopes its per-switch interface-list fan-out to switches named in the user config when
+    `state` is not `overridden`, rather than querying every switch in the fabric (CLAUDE.md performance rule).
+
+    ## Test
+
+    - Fabric has two switches (192.168.1.1, 192.168.1.2), but config names only 192.168.1.1
+    - state is `merged` (non-overridden), so `_switches_to_query` returns only the config switch
+    - Only the config switch's interfaces are fetched; the second switch is never queried (the response generator
+      yields exactly three responses — summary, switch list, switch-1 interfaces — and would raise if a second
+      per-switch GET were issued)
+    - Result contains only the `accessVpcHost` vPC on the config switch, stamped with the config `switchIp`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._switches_to_query()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "vpc501"}]
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="merged", config=config)
+        result = instance.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc501"
+    assert result[0]["switchIp"] == "192.168.1.1"
+
+
+def test_vpc_interface_base_00950() -> None:
+    """
+    # Summary
+
+    Verify the per-peer dedup keeps the peer whose `switchIp` the user actually configured, so idempotency holds
+    even when the user names the HIGHER-`switchId` peer. A vPC is returned on both peers; without this preference
+    the dedup would canonicalize to the lower-`switchId` peer (192.168.1.1) and the existing-state identifier would
+    never match a config naming 192.168.1.2, churning a spurious delete + recreate under `overridden`.
+
+    ## Test
+
+    - `state=overridden` so both peers are scanned (192.168.1.1 / FDO11111AAA and 192.168.1.2 / FDO22222BBB)
+    - Config names vpc501 on the higher-`switchId` peer 192.168.1.2
+    - The deduped entry carries `switchIp` 192.168.1.2 (the configured peer), not the lower-`switchId` default
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._prefers_candidate()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.2", "interface_name": "vpc501"}]
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden", config=config)
+        result = instance.query_all()
+
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc501"
+    assert result[0]["switchIp"] == "192.168.1.2"
+
+
+def test_vpc_interface_base_00960() -> None:
+    """
+    # Summary
+
+    Verify `query_all` tolerates malformed per-switch bodies without aborting the whole run: a `configData: null`
+    interface is filtered out via the null-safe policy-type accessor, and a non-dict interfaces body is skipped via
+    the `isinstance(result, dict)` guard. Neither raises `AttributeError`.
+
+    ## Test
+
+    - `state=overridden` so both switches are scanned
+    - Switch A returns a vPC interface with `configData: null` (policy type resolves to None → filtered out)
+    - Switch B returns a bare list as its DATA body (non-dict → skipped by the isinstance guard)
+    - `query_all` returns `[]` rather than raising
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._policy_type()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden")
         result = instance.query_all()
 
     assert result == []

--- a/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
@@ -1,0 +1,1028 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for `VpcInterfaceBaseOrchestrator`.
+
+`VpcInterfaceBaseOrchestrator` is an abstract base shared by every vPC interface module (access, trunk-host, ...).
+The concrete per-type orchestrators and models live on the branches stacked above this one, so these tests exercise
+the base directly through `_StubVpcOrchestrator` / `_StubVpcInterfaceModel` -- minimal concrete subclasses that
+bind `model_class` and `_managed_policy_types` without coupling to any per-feature module.
+
+Coverage (per PR #334 review):
+- `_resolve_peer_switch_id`: success, per-instance caching, missing-pair, and missing-`peerSwitchId`.
+- `_inject_peer_switch_id`: injection into `configData.networkOS.policy`, and no-op when no policy is present.
+- `create` / `update`: `switchId` + `peerSwitchId` injection, endpoint path/verb, deploy queuing, error wrapping.
+- `delete`: per-interface DELETE path construction, deploy queuing (no bulk remove), error wrapping.
+- `create_bulk`: per-switch grouping with a single peer lookup per primary switch (cache).
+- `query_one`: per-interface GET path construction and error wrapping.
+- `query_all`: fabric validation, `interfaceType`/`policyType` filtering, `switchIp` enrichment, per-peer dedup,
+  and an explicit request-count lock (2 + one GET per switch) for the fabric-wide scan flagged in review.
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` injected into a real `RestSend`.
+Responses are read from `tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json`.
+"""
+
+# pylint: disable=disallowed-name
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-few-public-methods
+# pylint: disable=too-many-lines
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+from __future__ import annotations
+
+import inspect
+from typing import ClassVar, Literal, Type
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesDelete,
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import VpcInterfaceBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+# =============================================================================
+# Stub model + orchestrator: minimal concrete subclasses of the abstract base
+# =============================================================================
+
+
+class _StubVpcPolicyModel(NDNestedModel):
+    """Minimal vPC policy block mapping to `configData.networkOS.policy`."""
+
+    policy_type: Literal["accessVpcHost"] = Field(default="accessVpcHost", alias="policyType", frozen=True)
+    access_vlan: int | None = Field(default=None, alias="accessVlan")
+    peer_switch_id: str | None = Field(default=None, alias="peerSwitchId")
+
+
+class _StubVpcNetworkOSModel(NDNestedModel):
+    """Minimal networkOS container mapping to `configData.networkOS`."""
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: _StubVpcPolicyModel | None = Field(default=None, alias="policy")
+
+
+class _StubVpcConfigDataModel(NDNestedModel):
+    """Minimal config-data container mapping to `configData`."""
+
+    mode: Literal["access"] = Field(default="access", alias="mode", frozen=True)
+    network_os: _StubVpcNetworkOSModel = Field(default_factory=_StubVpcNetworkOSModel, alias="networkOS")
+
+
+class _StubVpcInterfaceModel(NDBaseModel):
+    """Minimal vPC interface model: composite identifier, nested config mirroring the ND wire shape."""
+
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["vpc"] = Field(default="vpc", alias="interfaceType", frozen=True)
+    config_data: _StubVpcConfigDataModel | None = Field(default=None, alias="configData")
+
+
+class _StubVpcOrchestrator(VpcInterfaceBaseOrchestrator):
+    """Concrete subclass binding `model_class` and the managed policy type for the abstract base."""
+
+    model_class: ClassVar[Type[NDBaseModel]] = _StubVpcInterfaceModel
+
+    def _managed_policy_types(self) -> set[str]:
+        return {"accessVpcHost"}
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def responses_vpc_base(key: str):
+    """Load fixture data for the test_vpc_interface_base.json file."""
+    return load_fixture("test_vpc_interface_base")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+    """Build a `RestSend` wired to the file-based `Sender` and the real `ResponseHandler`."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> _StubVpcOrchestrator:
+    """Construct a `_StubVpcOrchestrator` with the file-based `RestSend` injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    return _StubVpcOrchestrator(rest_send=rest_send)
+
+
+def _build_model(
+    switch_ip: str = "192.168.1.1",
+    interface_name: str = "vpc501",
+    include_config: bool = True,
+) -> _StubVpcInterfaceModel:
+    """Build a minimal `_StubVpcInterfaceModel` instance for CRUD tests."""
+    kwargs: dict = {"switch_ip": switch_ip, "interface_name": interface_name}
+    if include_config:
+        kwargs["config_data"] = _StubVpcConfigDataModel(
+            network_os=_StubVpcNetworkOSModel(policy=_StubVpcPolicyModel(access_vlan=100)),
+        )
+    return _StubVpcInterfaceModel(**kwargs)
+
+
+# =============================================================================
+# Test: ClassVars / endpoint wiring
+# =============================================================================
+
+
+def test_vpc_interface_base_00010() -> None:
+    """
+    # Summary
+
+    Verify the bulk-support flags: vPC supports bulk create but NOT bulk delete (the `interfaceActions/remove`
+    endpoint returns `Invalid Interface` for vPC entries on ND 4.2.1, so delete goes per-interface).
+
+    ## Test
+
+    - `supports_bulk_create` is True
+    - `supports_bulk_delete` is False
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator
+    """
+    assert VpcInterfaceBaseOrchestrator.supports_bulk_create is True
+    assert VpcInterfaceBaseOrchestrator.supports_bulk_delete is False
+
+
+def test_vpc_interface_base_00020() -> None:
+    """
+    # Summary
+
+    Verify the per-verb endpoint classes are wired to the ND Manage Interfaces endpoints, including the
+    per-interface DELETE endpoint added by this PR.
+
+    The `*_endpoint` attributes are Pydantic instance fields (they hold the endpoint *type*), so they are read
+    off an instance, not the class.
+
+    ## Test
+
+    - create/update/query_one/query_all endpoints point at the expected `EpManageInterfaces*` classes
+    - `delete_endpoint` is the per-interface `EpManageInterfacesDelete`
+    - `delete_bulk_endpoint` is None (bulk delete disabled)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    assert instance.create_endpoint is EpManageInterfacesPost
+    assert instance.update_endpoint is EpManageInterfacesPut
+    assert instance.delete_endpoint is EpManageInterfacesDelete
+    assert instance.query_one_endpoint is EpManageInterfacesGet
+    assert instance.query_all_endpoint is EpManageInterfacesListGet
+    assert instance.delete_bulk_endpoint is None
+
+
+# =============================================================================
+# Test: _managed_policy_types
+# =============================================================================
+
+
+def test_vpc_interface_base_00100() -> None:
+    """
+    # Summary
+
+    Verify the abstract base raises `NotImplementedError` for `_managed_policy_types` and the concrete stub overrides it.
+
+    ## Test
+
+    - Calling `VpcInterfaceBaseOrchestrator._managed_policy_types` (unbound) raises `NotImplementedError`
+    - `_StubVpcOrchestrator._managed_policy_types()` returns `{"accessVpcHost"}`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with pytest.raises(NotImplementedError, match=r"Subclasses must implement _managed_policy_types"):
+        VpcInterfaceBaseOrchestrator._managed_policy_types(orchestrator)
+
+    assert orchestrator._managed_policy_types() == {"accessVpcHost"}
+
+
+# =============================================================================
+# Test: _resolve_peer_switch_id
+# =============================================================================
+
+
+def test_vpc_interface_base_00200() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` reads the per-switch `vpcPair` endpoint and returns the peer serial.
+
+    ## Test
+
+    - vpcPair GET returns `peerSwitchId: FDO22222BBB`
+    - `_resolve_peer_switch_id` returns `"FDO22222BBB"` and caches it under the primary serial
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        peer = instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert peer == "FDO22222BBB"
+    assert instance._peer_serial_cache == {"FDO11111AAA": "FDO22222BBB"}
+
+
+def test_vpc_interface_base_00210() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` caches per primary serial: a second call for the same switch does NOT
+    issue another `vpcPair` GET (only one response is provided).
+
+    ## Test
+
+    - First call consumes the single vpcPair response and returns the peer
+    - Second call returns the cached peer without consuming another response (generator would be exhausted)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        first = instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+        second = instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert first == "FDO22222BBB"
+    assert second == "FDO22222BBB"
+
+
+def test_vpc_interface_base_00220() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises `RuntimeError` when the switch is not in a vPC pair (vpcPair GET 404).
+
+    ## Test
+
+    - vpcPair GET returns 404 (empty body via `not_found_ok`)
+    - `RuntimeError` mentions the switch IP, the serial, and points the user at `nd_manage_vpc_pair`
+    - Nothing is cached
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    match = r"Switch 192\.168\.1\.1 \(serial FDO11111AAA\) is not in a vPC pair.*nd_manage_vpc_pair"
+    with pytest.raises(RuntimeError, match=match):
+        instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert instance._peer_serial_cache == {}
+
+
+def test_vpc_interface_base_00230() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises `RuntimeError` when the vpcPair record omits `peerSwitchId`.
+
+    ## Test
+
+    - vpcPair GET returns 200 but the body has no `peerSwitchId`
+    - `RuntimeError` matches `missing 'peerSwitchId'`
+    - Nothing is cached
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    match = r"missing 'peerSwitchId'"
+    with pytest.raises(RuntimeError, match=match):
+        instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert instance._peer_serial_cache == {}
+
+
+# =============================================================================
+# Test: _inject_peer_switch_id
+# =============================================================================
+
+
+def test_vpc_interface_base_00300() -> None:
+    """
+    # Summary
+
+    Verify `_inject_peer_switch_id` sets `peerSwitchId` inside `configData.networkOS.policy`.
+
+    ## Test
+
+    - Payload with a nested policy gets `peerSwitchId` injected
+    - The same dict object is returned (in-place mutation)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._inject_peer_switch_id()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    payload = {"configData": {"networkOS": {"policy": {"policyType": "accessVpcHost"}}}}
+    result = instance._inject_peer_switch_id(payload, "FDO22222BBB")
+
+    assert result is payload
+    assert payload["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+
+
+def test_vpc_interface_base_00310() -> None:
+    """
+    # Summary
+
+    Verify `_inject_peer_switch_id` is a safe no-op when there is no nested policy to inject into.
+
+    ## Test
+
+    - Payload with no `policy` key is returned unchanged (no `peerSwitchId` added, no KeyError)
+    - Payload with no `configData` key is returned unchanged
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._inject_peer_switch_id()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    no_policy: dict = {"configData": {"networkOS": {}}}
+    assert instance._inject_peer_switch_id(no_policy, "FDO22222BBB") == {"configData": {"networkOS": {}}}
+
+    no_config: dict = {"interfaceName": "vpc501"}
+    assert instance._inject_peer_switch_id(no_config, "FDO22222BBB") == {"interfaceName": "vpc501"}
+
+
+# =============================================================================
+# Test: create
+# =============================================================================
+
+
+def test_vpc_interface_base_00400() -> None:
+    """
+    # Summary
+
+    Verify `create` resolves the switch and peer serials, injects `switchId` and `peerSwitchId`, wraps the payload
+    in `{"interfaces": [...]}`, POSTs to the per-switch interfaces URL, and queues a deploy.
+
+    ## Test
+
+    - POST hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces`
+    - Request body is `{"interfaces": [ {...} ]}` with one element
+    - The element carries `interfaceType: vpc`, `switchId: FDO11111AAA`, no `switchIp`
+    - `configData.networkOS.policy.peerSwitchId` is the resolved peer serial
+    - `_pending_deploys` contains the single `(interface_name, switch_id)` pair
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    - VpcInterfaceBaseOrchestrator._inject_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with does_not_raise():
+        instance.create(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert len(body["interfaces"]) == 1
+    payload_item = body["interfaces"][0]
+    assert payload_item["interfaceName"] == "vpc501"
+    assert payload_item["interfaceType"] == "vpc"
+    assert payload_item["switchId"] == "FDO11111AAA"
+    assert "switchIp" not in payload_item
+    assert payload_item["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+    assert instance._pending_deploys == [("vpc501", "FDO11111AAA")]
+
+
+def test_vpc_interface_base_00410() -> None:
+    """
+    # Summary
+
+    Verify `create` wraps a `_request` failure in `RuntimeError` and queues no deploy.
+
+    ## Test
+
+    - switches-list and vpcPair succeed; POST returns 500
+    - `RuntimeError` matches `Create failed for`
+    - `_pending_deploys` stays empty
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with pytest.raises(RuntimeError, match=r"Create failed for"):
+        instance.create(model)
+
+    assert instance._pending_deploys == []
+
+
+def test_vpc_interface_base_00420() -> None:
+    """
+    # Summary
+
+    Verify `create` surfaces the not-in-a-vPC-pair error (wrapped as `Create failed`) when the primary switch
+    has no vpcPair record.
+
+    ## Test
+
+    - switches-list succeeds; vpcPair GET returns 404
+    - `RuntimeError` matches `Create failed for .*is not in a vPC pair`
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with pytest.raises(RuntimeError, match=r"Create failed for .*is not in a vPC pair"):
+        instance.create(model)
+
+    assert instance._pending_deploys == []
+
+
+# =============================================================================
+# Test: update
+# =============================================================================
+
+
+def test_vpc_interface_base_00500() -> None:
+    """
+    # Summary
+
+    Verify `update` issues a PUT to the per-interface URL, injects `switchId` + `peerSwitchId`, and queues a deploy.
+
+    ## Test
+
+    - PUT hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501`
+    - Body carries `switchId`, no `switchIp`, and the injected `peerSwitchId`
+    - `_pending_deploys` contains the `(vpc501, FDO11111AAA)` pair
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501"
+    assert rest_send.verb == HttpVerbEnum.PUT.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert body["interfaceName"] == "vpc501"
+    assert body["switchId"] == "FDO11111AAA"
+    assert "switchIp" not in body
+    assert body["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+    assert instance._pending_deploys == [("vpc501", "FDO11111AAA")]
+
+
+def test_vpc_interface_base_00510() -> None:
+    """
+    # Summary
+
+    Verify `update` wraps a `_request` failure in `RuntimeError` and queues no deploy.
+
+    ## Test
+
+    - switches-list and vpcPair succeed; PUT returns 500
+    - `RuntimeError` matches `Update failed for`
+    - `_pending_deploys` stays empty
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with pytest.raises(RuntimeError, match=r"Update failed for"):
+        instance.update(model)
+
+    assert instance._pending_deploys == []
+
+
+# =============================================================================
+# Test: delete (per-interface DELETE)
+# =============================================================================
+
+
+def test_vpc_interface_base_00600() -> None:
+    """
+    # Summary
+
+    Verify `delete` issues a per-interface DELETE (not a bulk remove) and queues a deploy.
+
+    ## Test
+
+    - DELETE hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501`
+    - The DELETE returns 204
+    - `_pending_deploys` contains `(vpc501, FDO11111AAA)`; `_pending_removes` stays empty (bulk remove unused)
+    - `delete` returns None
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.delete()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with does_not_raise():
+        result = instance.delete(model)
+
+    assert result is None
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501"
+    assert rest_send.verb == HttpVerbEnum.DELETE.value
+    assert instance._pending_deploys == [("vpc501", "FDO11111AAA")]
+    assert instance._pending_removes == []
+
+
+def test_vpc_interface_base_00610() -> None:
+    """
+    # Summary
+
+    Verify `delete` wraps a DELETE failure in `RuntimeError` and queues no deploy.
+
+    ## Test
+
+    - switches-list succeeds; per-interface DELETE returns 500
+    - `RuntimeError` matches `Delete failed for`
+    - Both queues stay empty
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.delete()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with pytest.raises(RuntimeError, match=r"Delete failed for"):
+        instance.delete(model)
+
+    assert instance._pending_deploys == []
+    assert instance._pending_removes == []
+
+
+# =============================================================================
+# Test: create_bulk (peer lookup cached per primary switch)
+# =============================================================================
+
+
+def test_vpc_interface_base_00700() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` groups interfaces by primary switch and resolves the peer serial only ONCE per primary
+    switch (cache), issuing a single POST carrying both interfaces.
+
+    ## Test
+
+    - Two vPC interfaces on the same primary switch (192.168.1.1)
+    - Only one switches-list, one vpcPair GET, and one POST are consumed (cache prevents a second peer lookup)
+    - Both interfaces carry the injected `peerSwitchId`
+    - Both `(interface_name, switch_id)` pairs are queued for deploy
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create_bulk()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    models = [
+        _build_model(interface_name="vpc501"),
+        _build_model(interface_name="vpc502"),
+    ]
+
+    with does_not_raise():
+        instance.create_bulk(models)
+
+    # A single vpcPair lookup served both interfaces on the same primary switch.
+    assert instance._peer_serial_cache == {"FDO11111AAA": "FDO22222BBB"}
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert len(body["interfaces"]) == 2
+    for item in body["interfaces"]:
+        assert item["switchId"] == "FDO11111AAA"
+        assert item["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+    assert sorted(instance._pending_deploys) == sorted([("vpc501", "FDO11111AAA"), ("vpc502", "FDO11111AAA")])
+
+
+def test_vpc_interface_base_00710() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` wraps a per-switch `_request` failure in `RuntimeError` matching `Bulk create failed`.
+
+    ## Test
+
+    - switches-list and vpcPair succeed; the per-switch POST returns 500
+    - `RuntimeError` matches `Bulk create failed`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    models = [_build_model(interface_name="vpc501")]
+
+    with pytest.raises(RuntimeError, match=r"Bulk create failed"):
+        instance.create_bulk(models)
+
+
+# =============================================================================
+# Test: query_one
+# =============================================================================
+
+
+def test_vpc_interface_base_00800() -> None:
+    """
+    # Summary
+
+    Verify `query_one` issues a GET against the per-interface URL and returns the DATA dict.
+
+    ## Test
+
+    - GET hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501`
+    - Returned dict carries the vPC interface (`interfaceType: vpc`, `policyType: accessVpcHost`)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with does_not_raise():
+        result = instance.query_one(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501"
+    assert rest_send.verb == HttpVerbEnum.GET.value
+    assert result["interfaceName"] == "vpc501"
+    assert result["interfaceType"] == "vpc"
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "accessVpcHost"
+
+
+def test_vpc_interface_base_00810() -> None:
+    """
+    # Summary
+
+    Verify `query_one` wraps a `_request` failure in `RuntimeError` mentioning the identifier.
+
+    ## Test
+
+    - switches-list succeeds; GET returns 500
+    - `RuntimeError` matches `Query failed for`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with pytest.raises(RuntimeError, match=r"Query failed for"):
+        instance.query_one(model)
+
+
+# =============================================================================
+# Test: query_all (fabric-wide scan, filtering, dedup, request count)
+# =============================================================================
+
+
+def test_vpc_interface_base_00900() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, scans every switch, filters to vPC interfaces with managed policy
+    types, injects `switchIp`, de-duplicates the per-peer copies, and -- per PR #334 review -- issues exactly
+    one request per switch plus the fabric summary and switches-list (no N+1 beyond the documented per-switch scan).
+
+    ## Test
+
+    - Switch A returns: managed `accessVpcHost` vpc501, other-policy `trunkVpcHost` vpc502, non-vPC ethernet
+    - Switch B returns: the peer-side copy of vpc501
+    - Result contains exactly vpc501 (vpc502 and the ethernet are filtered out; the peer copy is deduped)
+    - The kept entry carries `switchIp` of the lower-`switchId` peer (192.168.1.1 / FDO11111AAA)
+    - Request count is exactly 4: summary + switches-list + one interface GET per switch (locks the scan cost)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._managed_policy_types()
+    """
+    method_name = inspect.stack()[0][3]
+    calls: list[str] = []
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            calls.append(suffix)
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses)
+        result = instance.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    iface = result[0]
+    assert iface["interfaceName"] == "vpc501"
+    assert iface["switchIp"] == "192.168.1.1"
+
+    by_name = {entry["interfaceName"] for entry in result}
+    assert "vpc502" not in by_name  # other-policy vPC filtered out
+    assert "Ethernet1/5" not in by_name  # non-vPC filtered out
+
+    # Request-count lock: 1 summary (validate) + 1 switches-list + 1 GET per switch (2 switches) = 4.
+    # This pins the fabric-wide scan cost flagged in review so a regression to N+1 fails the test.
+    assert len(calls) == 4
+
+
+def test_vpc_interface_base_00910() -> None:
+    """
+    # Summary
+
+    Verify `query_all` skips a managed vPC interface that has no `interfaceName` (it cannot be keyed for dedup).
+
+    ## Test
+
+    - The single switch returns one managed `accessVpcHost` vPC interface with no `interfaceName`
+    - `query_all` returns `[]` (the nameless entry is skipped, not raised on)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses)
+        result = instance.query_all()
+
+    assert result == []
+
+
+def test_vpc_interface_base_00930() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` (wrapping the validation failure) when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - `query_all` raises `RuntimeError` matching `Query all failed.*missing_fabric`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        instance.query_all()
+
+
+def test_vpc_interface_base_00940() -> None:
+    """
+    # Summary
+
+    Verify `query_all` skips a switch whose interfaces endpoint returns no body (the `not_found_ok` branch) and
+    yields an empty list when no managed vPC interfaces are found.
+
+    ## Test
+
+    - Fabric summary and switches-list succeed (one switch)
+    - The switch's interfaces endpoint returns 404 (no body)
+    - `query_all` returns `[]`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses)
+        result = instance.query_all()
+
+    assert result == []


### PR DESCRIPTION
## Related Issue(s)

Stacked on #334 (`nd_interface_vpc_base`), which carries the shared vPC-interface infrastructure that previously lived on the now-closed #278 (`nd_vpc_pair`). #278 was closed in favor of #197 (`nd_manage_vpc_pair`); the shared interface base was re-homed onto #334 so this module can reach `develop` independently.

- CiscoDevNet/ansible-nd#322

### Deferred follow-ups (tracked)

Code-review findings (`/code-review high`) deferred from this PR, each tracked as a GitHub issue:

- #355 — vPC `peer1`/`peer2` member-port orientation may not track the user-supplied `switch_ip` (needs ND lab verification; shared with #280).
- #356 — vPC name-only identifier breaks when two pairs reuse the same vPC id in one fabric (shared with #280).
- #350 — `config_data` is optional on create, so a policy-less config item yields a late `RuntimeError` rather than a clear validation error (matches the sibling interface models).
- #348 — Lift duplicated interface-orchestrator CRUD + policy-type serializer into shared bases (this module's `normalize_member_ports` / `serialize_policy` are sibling-parity copies).
- #349 — `query_all` fans out one GET per switch; no fabric-wide interface-list endpoint.
- #354 — vPC interface delete queues a deploy even when the per-interface DELETE was a 404 no-op (inherited from `VpcInterfaceBaseOrchestrator`).

## Proposed Changes

- Adds the `nd_interface_vpc_access` module, which manages vPC `accessVpcHost` interfaces (template `int_vpc_access_host`) on Cisco Nexus Dashboard.
- Adds `AccessVpcHostPolicyTypeEnum` to `plugins/module_utils/models/interfaces/enums.py` so the model can frozen-pin its `policy_type`.
- Inherits all CRUD, peer-serial resolution, per-interface DELETE, and `query_all` dedupe from `VpcInterfaceBaseOrchestrator` (introduced in the stack-parent PR #334 `nd_interface_vpc_base`). Peer-serial resolution uses develop's `EpVpcPairGet` endpoint.

Access-specific design (lab-verified on ND 4.2.1):

- Single user-facing `access_vlan` field fans out to `peer1AccessVlan` / `peer2AccessVlan` at payload-serialization time via a `@model_serializer`. ND collapses both per-peer keys back to a single `accessVlan` in the GET response, so the round-trip matches the wire echo without further normalization. Tagged `TODO(4.2.1)`.
- Per-peer `peer1/peer2` `member_ports` / `port_channel_id` / `port_channel_description` / `port_channel_configuration` are exposed (the OpenAPI schema preserves these on read).
- `identifier_strategy = "single"` on `interface_name`; `switch_ip` is routing-only and excluded from diff/payload because ND echoes the same vPC record from BOTH peers' `/interfaces` GETs.

## Test Notes

- Unit tests across model + orchestrator + fixture JSON: `python -m pytest tests/unit/module_utils/models/test_vpc_access_interface.py tests/unit/module_utils/orchestrators/test_vpc_access_interface.py -q`. Full repo suite stays green (no regressions).
- Integration target `tests/integration/targets/nd_interface_vpc_access/` with `merged` / `replaced` / `overridden` / `deleted` state coverage, exercised against ND 4.2.1 on the SITE1 lab (S1_LE1 / S1_LE2): `ansible-test integration --docker nd_interface_vpc_access -vv`.
- The vPC pair substrate is created via `nd_manage_vpc_pair` using a **virtual** peer-link. Physical peer-link is currently broken at the ND controller (`configSave` 500 "Member port … is a member of VPC_PAIR"); see bug-vault `vpc-physical-peer-link-configsave-fails`. A `TODO(4.2.1)` marker in the test vars tracks reverting to physical once ND fixes it.
- `ansible-test sanity --docker default --python 3.11` passes on the changed files.
- Wire round-trip verified live: writing `peer1AccessVlan` + `peer2AccessVlan` returns 207 success; GET echoes a single `accessVlan` matching what the model exposes.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
