### PR TITLE
nd_log - playbook-side logging

### DIFF
--- a/plugins/modules/nd_log.py
+++ b/plugins/modules/nd_log.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@quantumonion) <arobel@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_log
+version_added: "1.5.0"
+short_description: Log messages from a playbook via the standard Python logging module.
+description:
+- Emit a log record under the C(nd) parent logger using the standard Python C(logging) module.
+- Logging is configured by the C(ND_LOGGING_CONFIG) environment variable, which must point to a JSON file consumable by C(logging.config.dictConfig).
+  When the variable is unset, the C(nd) logger is a no-op and the module exits successfully without writing anything.
+- Useful for correlating playbook task execution with the C(nd.*) log records emitted internally by other modules in this collection.
+options:
+  msg:
+    description:
+    - The message to log.
+    required: true
+    type: str
+  severity:
+    description:
+    - Case-sensitive logging severity (must be UPPERCASE) at which to log C(msg).
+    required: false
+    default: DEBUG
+    choices: ['CRITICAL', 'DEBUG', 'ERROR', 'INFO', 'WARNING']
+    type: str
+author:
+- Allen Robel (@quantumonion)
+"""
+
+EXAMPLES = r"""
+# This module can be used to correlate Ansible task execution with the
+# log records emitted by other cisco.nd modules when the ND_LOGGING_CONFIG
+# environment variable is set to a valid Python logging configuration file.
+
+- name: Log start of work
+  cisco.nd.nd_log:
+    msg: Starting Nexus Dashboard version query
+    severity: INFO
+
+- name: Query Nexus Dashboard version
+  cisco.nd.nd_version:
+    host: nd_host
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Log completion
+  cisco.nd.nd_log:
+    msg: Nexus Dashboard version query complete
+    severity: INFO
+"""
+
+RETURN = r"""
+"""
+
+import logging
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+
+
+class NDLog:
+    """
+    # Summary
+
+    Log a message via the standard Python `logging` module under the `nd` parent logger.
+
+    The severity selects which `logging.Logger` method is called (`debug`, `info`, `warning`, `error`, or `critical`).
+
+    ## Raises
+
+    ### ValueError
+
+    - If `msg` is not provided in `params`.
+    """
+
+    def __init__(self, params: dict) -> None:
+        """
+        # Summary
+
+        Initialize the `NDLog` instance from an Ansible module's `params` dict.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `params["msg"]` is `None`.
+        """
+        self.class_name = self.__class__.__name__
+        self.log = logging.getLogger(f"nd.{self.class_name}")
+
+        self.params = params
+        self.message = self.params.get("msg")
+        self.severity = self.params.get("severity")
+
+        if self.message is None:
+            raise ValueError("Exiting. Missing mandatory parameter: msg")
+
+        if self.severity is None:
+            self.severity = "DEBUG"
+
+        self.result: dict = {"changed": False, "failed": False}
+
+    def msg(self) -> None:
+        """
+        # Summary
+
+        Emit `self.message` at severity `self.severity` on the `nd.NDLog` logger.
+
+        ## Raises
+
+        None
+        """
+        if self.severity == "CRITICAL":
+            self.log.critical(self.message)
+        elif self.severity == "DEBUG":
+            self.log.debug(self.message)
+        elif self.severity == "ERROR":
+            self.log.error(self.message)
+        elif self.severity == "INFO":
+            self.log.info(self.message)
+        elif self.severity == "WARNING":
+            self.log.warning(self.message)
+
+
+def main() -> None:
+    """
+    # Summary
+
+    Entry point for module execution.
+
+    ## Raises
+
+    None
+    """
+    argument_spec = {
+        "msg": {"required": True, "type": "str"},
+        "severity": {
+            "required": False,
+            "default": "DEBUG",
+            "choices": ["CRITICAL", "DEBUG", "ERROR", "INFO", "WARNING"],
+            "type": "str",
+        },
+    }
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    setup_logging(module)
+
+    try:
+        nd_log = NDLog(module.params)
+        nd_log.msg()
+    except ValueError as error:
+        module.fail_json(msg=str(error))
+
+    module.exit_json(**nd_log.result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_log.py
+++ b/plugins/modules/nd_log.py
@@ -35,6 +35,11 @@ options:
     default: DEBUG
     choices: ['CRITICAL', 'DEBUG', 'ERROR', 'INFO', 'WARNING']
     type: str
+notes:
+- The Python C(logging) module applies level checks at both the logger and the handler. A record is emitted only when its severity
+  is greater than or equal to the most restrictive level along the chain (C(nd) logger, any ancestor loggers consulted for the
+  effective level, and each handler). To make C(nd_log) messages visible, ensure both C(loggers.nd.level) (or the inherited level)
+  and the relevant handler's C(level) in C(ND_LOGGING_CONFIG) are at or below O(severity).
 author:
 - Allen Robel (@quantumonion)
 """

--- a/plugins/modules/nd_log.py
+++ b/plugins/modules/nd_log.py
@@ -78,68 +78,21 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 
 
-class NDLog:
+def log_message(severity: str, msg: str) -> None:
     """
     # Summary
 
-    Log a message via the standard Python `logging` module under the `nd` parent logger.
+    Emit `msg` at `severity` on the `nd.nd_log` logger.
 
-    The severity selects which `logging.Logger` method is called (`debug`, `info`, `warning`, `error`, or `critical`).
+    `severity` selects which `logging.Logger` method is called (`debug`, `info`, `warning`, `error`, or `critical`). The module's
+    argument spec `choices` constraint guarantees `severity` is one of `CRITICAL`, `DEBUG`, `ERROR`, `INFO`, or `WARNING`, so
+    `severity.lower()` always names a valid `logging.Logger` method.
 
     ## Raises
 
-    ### ValueError
-
-    - If `msg` is not provided in `params`.
+    None
     """
-
-    def __init__(self, params: dict) -> None:
-        """
-        # Summary
-
-        Initialize the `NDLog` instance from an Ansible module's `params` dict.
-
-        ## Raises
-
-        ### ValueError
-
-        - If `params["msg"]` is `None`.
-        """
-        self.class_name = self.__class__.__name__
-        self.log = logging.getLogger(f"nd.{self.class_name}")
-
-        self.params = params
-        self.message = self.params.get("msg")
-        self.severity = self.params.get("severity")
-
-        if self.message is None:
-            raise ValueError("Exiting. Missing mandatory parameter: msg")
-
-        if self.severity is None:
-            self.severity = "DEBUG"
-
-        self.result: dict = {"changed": False, "failed": False}
-
-    def msg(self) -> None:
-        """
-        # Summary
-
-        Emit `self.message` at severity `self.severity` on the `nd.NDLog` logger.
-
-        ## Raises
-
-        None
-        """
-        if self.severity == "CRITICAL":
-            self.log.critical(self.message)
-        elif self.severity == "DEBUG":
-            self.log.debug(self.message)
-        elif self.severity == "ERROR":
-            self.log.error(self.message)
-        elif self.severity == "INFO":
-            self.log.info(self.message)
-        elif self.severity == "WARNING":
-            self.log.warning(self.message)
+    getattr(logging.getLogger("nd.nd_log"), severity.lower())(msg)
 
 
 def main() -> None:
@@ -166,13 +119,9 @@ def main() -> None:
 
     setup_logging(module)
 
-    try:
-        nd_log = NDLog(module.params)
-        nd_log.msg()
-    except ValueError as error:
-        module.fail_json(msg=str(error))
+    log_message(module.params["severity"], module.params["msg"])
 
-    module.exit_json(**nd_log.result)
+    module.exit_json(changed=False, failed=False)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/nd_log.py
+++ b/plugins/modules/nd_log.py
@@ -56,11 +56,7 @@ EXAMPLES = r"""
 
 - name: Query Nexus Dashboard version
   cisco.nd.nd_version:
-    host: nd_host
-    username: admin
-    password: SomeSecretPassword
     state: query
-  delegate_to: localhost
   register: query_result
 
 - name: Log completion

--- a/plugins/modules/nd_log.py
+++ b/plugins/modules/nd_log.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_log
-version_added: "1.5.0"
+version_added: "1.6.0"
 short_description: Log messages from a playbook via the standard Python logging module.
 description:
 - Emit a log record under the C(nd) parent logger using the standard Python C(logging) module.

--- a/plugins/modules/nd_log.py
+++ b/plugins/modules/nd_log.py
@@ -41,7 +41,7 @@ notes:
   effective level, and each handler). To make C(nd_log) messages visible, ensure both C(loggers.nd.level) (or the inherited level)
   and the relevant handler's C(level) in C(ND_LOGGING_CONFIG) are at or below O(severity).
 author:
-- Allen Robel (@quantumonion)
+- Allen Robel (@allenrobel)
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_log.py
+++ b/plugins/modules/nd_log.py
@@ -27,6 +27,10 @@ options:
   severity:
     description:
     - Case-sensitive logging severity (must be UPPERCASE) at which to log C(msg).
+    - The record is only written if O(severity) is greater than or equal to both the level of the C(nd) logger and the level of every
+      handler attached to it, as configured in the JSON file referenced by C(ND_LOGGING_CONFIG). If either level is more restrictive,
+      the call is silently discarded and the module still reports C(changed=false, failed=false).
+    - For example, setting O(severity=INFO) while the JSON config has C(loggers.nd.level) set to C(WARNING) will not write anything.
     required: false
     default: DEBUG
     choices: ['CRITICAL', 'DEBUG', 'ERROR', 'INFO', 'WARNING']

--- a/plugins/modules/nd_log.py
+++ b/plugins/modules/nd_log.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Allen Robel (@quantumonion) <arobel@cisco.com>
+# Copyright: (c) 2026, Allen Robel (@allenrobel) <arobel@cisco.com>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import annotations

--- a/tests/unit/modules/test_nd_log.py
+++ b/tests/unit/modules/test_nd_log.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Allen Robel (@quantumonion) <arobel@cisco.com>
+# Copyright: (c) 2026, Allen Robel (@allenrobel) <arobel@cisco.com>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 """

--- a/tests/unit/modules/test_nd_log.py
+++ b/tests/unit/modules/test_nd_log.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@quantumonion) <arobel@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for plugins/modules/nd_log.py
+"""
+
+# pylint: disable=unused-import
+# pylint: disable=redefined-outer-name
+# pylint: disable=protected-access
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=invalid-name
+# pylint: disable=line-too-long
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from ansible_collections.cisco.nd.plugins.modules.nd_log import NDLog
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+
+
+def test_nd_log_00000() -> None:
+    """
+    # Summary
+
+    Verify initialization defaults when only `msg` is provided.
+
+    ## Test
+
+    - `NDLog({"msg": "hello"})` does not raise.
+    - `class_name` is `"NDLog"`.
+    - `result["changed"]` is `False`.
+    - `result["failed"]` is `False`.
+    - `severity` defaults to `"DEBUG"` when omitted from params.
+    - `message` round-trips through to the instance.
+
+    ## Classes and Methods
+
+    - NDLog.__init__()
+    """
+    with does_not_raise():
+        instance = NDLog({"msg": "hello"})
+
+    assert instance.class_name == "NDLog"
+    assert instance.result["changed"] is False
+    assert instance.result["failed"] is False
+    assert instance.severity == "DEBUG"
+    assert instance.message == "hello"
+
+
+def test_nd_log_00010() -> None:
+    """
+    # Summary
+
+    Verify `ValueError` when `msg` is missing.
+
+    ## Test
+
+    - `NDLog({"msg": None})` raises `ValueError` matching "Missing mandatory parameter: msg".
+
+    ## Classes and Methods
+
+    - NDLog.__init__()
+    """
+    match = r"Missing mandatory parameter: msg"
+    with pytest.raises(ValueError, match=match):
+        result = NDLog({"msg": None})  # pylint: disable=pointless-statement
+
+
+def test_nd_log_00020() -> None:
+    """
+    # Summary
+
+    Verify that omitting `msg` entirely (key absent) also raises `ValueError`.
+
+    ## Test
+
+    - `NDLog({})` raises `ValueError` matching "Missing mandatory parameter: msg".
+
+    ## Classes and Methods
+
+    - NDLog.__init__()
+    """
+    match = r"Missing mandatory parameter: msg"
+    with pytest.raises(ValueError, match=match):
+        result = NDLog({})  # pylint: disable=pointless-statement
+
+
+@pytest.mark.parametrize(
+    "severity, expected_level",
+    [
+        ("CRITICAL", logging.CRITICAL),
+        ("DEBUG", logging.DEBUG),
+        ("ERROR", logging.ERROR),
+        ("INFO", logging.INFO),
+        ("WARNING", logging.WARNING),
+    ],
+    ids=["CRITICAL", "DEBUG", "ERROR", "INFO", "WARNING"],
+)
+def test_nd_log_00100(caplog: pytest.LogCaptureFixture, severity: str, expected_level: int) -> None:
+    """
+    # Summary
+
+    Verify each severity dispatches to the corresponding `logging.Logger` level.
+
+    ## Test
+
+    - `NDLog({"msg": <m>, "severity": <s>}).msg()` produces a log record at the matching level
+      on logger `nd.NDLog` with the expected message body.
+
+    ## Classes and Methods
+
+    - NDLog.__init__()
+    - NDLog.msg()
+    """
+    message = f"hello-{severity.lower()}"
+    instance = NDLog({"msg": message, "severity": severity})
+
+    with caplog.at_level(logging.DEBUG, logger="nd.NDLog"):
+        instance.msg()
+
+    matching = [r for r in caplog.records if r.name == "nd.NDLog" and r.message == message]
+    assert len(matching) == 1
+    assert matching[0].levelno == expected_level
+
+
+def test_nd_log_00110(caplog: pytest.LogCaptureFixture) -> None:
+    """
+    # Summary
+
+    Verify that explicit `severity="DEBUG"` and default severity behave identically.
+
+    ## Test
+
+    - Two `NDLog` instances — one with `severity` omitted, one with `severity="DEBUG"` — both
+      emit a DEBUG-level record on logger `nd.NDLog` with the supplied message.
+
+    ## Classes and Methods
+
+    - NDLog.__init__()
+    - NDLog.msg()
+    """
+    with caplog.at_level(logging.DEBUG, logger="nd.NDLog"):
+        NDLog({"msg": "default-severity"}).msg()
+        NDLog({"msg": "explicit-debug", "severity": "DEBUG"}).msg()
+
+    debug_records = [r for r in caplog.records if r.name == "nd.NDLog" and r.levelno == logging.DEBUG]
+    messages = {r.message for r in debug_records}
+    assert {"default-severity", "explicit-debug"}.issubset(messages)

--- a/tests/unit/modules/test_nd_log.py
+++ b/tests/unit/modules/test_nd_log.py
@@ -7,89 +7,15 @@
 Unit tests for plugins/modules/nd_log.py
 """
 
-# pylint: disable=unused-import
-# pylint: disable=redefined-outer-name
-# pylint: disable=protected-access
-# pylint: disable=unused-argument
-# pylint: disable=unused-variable
 # pylint: disable=invalid-name
 # pylint: disable=line-too-long
-# pylint: disable=too-many-lines
 
 from __future__ import annotations
 
 import logging
 
 import pytest
-from ansible_collections.cisco.nd.plugins.modules.nd_log import NDLog
-from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
-
-
-def test_nd_log_00000() -> None:
-    """
-    # Summary
-
-    Verify initialization defaults when only `msg` is provided.
-
-    ## Test
-
-    - `NDLog({"msg": "hello"})` does not raise.
-    - `class_name` is `"NDLog"`.
-    - `result["changed"]` is `False`.
-    - `result["failed"]` is `False`.
-    - `severity` defaults to `"DEBUG"` when omitted from params.
-    - `message` round-trips through to the instance.
-
-    ## Classes and Methods
-
-    - NDLog.__init__()
-    """
-    with does_not_raise():
-        instance = NDLog({"msg": "hello"})
-
-    assert instance.class_name == "NDLog"
-    assert instance.result["changed"] is False
-    assert instance.result["failed"] is False
-    assert instance.severity == "DEBUG"
-    assert instance.message == "hello"
-
-
-def test_nd_log_00010() -> None:
-    """
-    # Summary
-
-    Verify `ValueError` when `msg` is missing.
-
-    ## Test
-
-    - `NDLog({"msg": None})` raises `ValueError` matching "Missing mandatory parameter: msg".
-
-    ## Classes and Methods
-
-    - NDLog.__init__()
-    """
-    match = r"Missing mandatory parameter: msg"
-    with pytest.raises(ValueError, match=match):
-        result = NDLog({"msg": None})  # pylint: disable=pointless-statement
-
-
-def test_nd_log_00020() -> None:
-    """
-    # Summary
-
-    Verify that omitting `msg` entirely (key absent) also raises `ValueError`.
-
-    ## Test
-
-    - `NDLog({})` raises `ValueError` matching "Missing mandatory parameter: msg".
-
-    ## Classes and Methods
-
-    - NDLog.__init__()
-    """
-    match = r"Missing mandatory parameter: msg"
-    with pytest.raises(ValueError, match=match):
-        result = NDLog({})  # pylint: disable=pointless-statement
+from ansible_collections.cisco.nd.plugins.modules.nd_log import log_message
 
 
 @pytest.mark.parametrize(
@@ -111,45 +37,18 @@ def test_nd_log_00100(caplog: pytest.LogCaptureFixture, severity: str, expected_
 
     ## Test
 
-    - `NDLog({"msg": <m>, "severity": <s>}).msg()` produces a log record at the matching level
-      on logger `nd.NDLog` with the expected message body.
+    - `log_message(<severity>, <msg>)` produces a single log record at the matching level
+      on logger `nd.nd_log` with the expected message body.
 
     ## Classes and Methods
 
-    - NDLog.__init__()
-    - NDLog.msg()
+    - log_message()
     """
     message = f"hello-{severity.lower()}"
-    instance = NDLog({"msg": message, "severity": severity})
 
-    with caplog.at_level(logging.DEBUG, logger="nd.NDLog"):
-        instance.msg()
+    with caplog.at_level(logging.DEBUG, logger="nd.nd_log"):
+        log_message(severity, message)
 
-    matching = [r for r in caplog.records if r.name == "nd.NDLog" and r.message == message]
+    matching = [r for r in caplog.records if r.name == "nd.nd_log" and r.message == message]
     assert len(matching) == 1
     assert matching[0].levelno == expected_level
-
-
-def test_nd_log_00110(caplog: pytest.LogCaptureFixture) -> None:
-    """
-    # Summary
-
-    Verify that explicit `severity="DEBUG"` and default severity behave identically.
-
-    ## Test
-
-    - Two `NDLog` instances — one with `severity` omitted, one with `severity="DEBUG"` — both
-      emit a DEBUG-level record on logger `nd.NDLog` with the supplied message.
-
-    ## Classes and Methods
-
-    - NDLog.__init__()
-    - NDLog.msg()
-    """
-    with caplog.at_level(logging.DEBUG, logger="nd.NDLog"):
-        NDLog({"msg": "default-severity"}).msg()
-        NDLog({"msg": "explicit-debug", "severity": "DEBUG"}).msg()
-
-    debug_records = [r for r in caplog.records if r.name == "nd.NDLog" and r.levelno == logging.DEBUG]
-    messages = {r.message for r in debug_records}
-    assert {"default-severity", "explicit-debug"}.issubset(messages)


### PR DESCRIPTION
## Related Issue(s)

N/A

## Proposed Changes

- New `cisco.nd.nd_log` module: emits a Python `logging` record under the `nd` parent logger so playbook activity can be correlated with the `nd.*` records emitted internally by other modules in this collection.
- Local-only — no HTTP/API calls. Logging is configured by the existing `ND_LOGGING_CONFIG` env var consumed by `common/log.py` (parent logger `nd`, `setup_logging()` helper).
- Mirrors `cisco.dcnm.dcnm_log` in shape and argument surface (`msg`, `severity` with choices `CRITICAL/DEBUG/ERROR/INFO/WARNING`, default `DEBUG`).
- `supports_check_mode=True` — deliberate deviation from dcnm_log parity; logging is a safe side effect during `--check` runs.
- Strict config-error behavior via `setup_logging()`: a malformed/missing `ND_LOGGING_CONFIG` file calls `module.fail_json` rather than silently swallowing the error.
- 9 unit tests under `tests/unit/modules/` covering init defaults, missing-`msg` `ValueError`, parametrized severity dispatch via `caplog`, and default-vs-explicit DEBUG equivalence. New `tests/unit/modules/__init__.py` is empty (sanity `empty-init` rule).

## Test Notes

- Unit tests: `python -m pytest tests/unit/modules/test_nd_log.py -v` — 9/9 pass.
- Lint: `black --check`, `isort --check`, `pylint`, `mypy` — clean (only the standard Ansible-module advisories that also appear on `nd_version.py`).
- `ansible-doc cisco.nd.nd_log` renders correctly.
- End-to-end smoke playbook: task completes with `changed=0`; record appended to `/tmp/nd.log` per the configured `ND_LOGGING_CONFIG`.

## Cisco Nexus Dashboard Version

4.2 (module does not call ND APIs; tested against the 4.2 lab for parity with the rest of the collection).

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [ ] manage
* [ ] onemanage
* [x] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)