### PR TITLE
nd_maintenance_mode

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics_switch_actions.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics_switch_actions.py
@@ -16,6 +16,7 @@ in the ND Manage API.
 from __future__ import annotations
 
 from typing import Literal, Optional
+from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
@@ -141,7 +142,7 @@ class EpManageFabricsSwitchActionsChangeSystemModePost(FabricNameMixin, NDEndpoi
         """
         if self.fabric_name is None:
             raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
-        base_path = BasePath.path("fabrics", self.fabric_name, "switchActions", "changeSystemMode")
+        base_path = BasePath.path("fabrics", quote(self.fabric_name, safe=""), "switchActions", "changeSystemMode")
         query_string = self.endpoint_params.to_query_string()
         if query_string:
             return f"{base_path}?{query_string}"

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics_switch_actions.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics_switch_actions.py
@@ -1,0 +1,161 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+ND Manage Fabric switchActions endpoint models.
+
+This module contains endpoint definitions for fabric-scoped switch action operations
+in the ND Manage API.
+
+## Endpoints
+
+- `EpManageFabricsSwitchActionsChangeSystemModePost` - Change the system mode of one or more switches
+  (POST /api/v1/manage/fabrics/{fabric_name}/switchActions/changeSystemMode)
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+class ChangeSystemModeEndpointParams(EndpointQueryParams):
+    """
+    # Summary
+
+    Query parameters for the changeSystemMode switchAction endpoint.
+
+    ## Parameters
+
+    - `deploy`: If `True`, the new system mode is deployed to the switches. Default `False` updates ND intent only.
+    - `blocking`: When `deploy` is `True`, block until the deploy operation completes or the server-configured timeout expires.
+    - `ticket_id`: Optional Change Control ticket ID associated with the mode change. Serialized as `ticketId`.
+    - `cluster_name`: Target cluster name in a multi-cluster deployment. Serialized as `clusterName`.
+
+    ## Raises
+
+    None
+    """
+
+    deploy: Optional[bool] = Field(
+        default=None,
+        description="If true, the new system mode is deployed to the switches",
+    )
+
+    blocking: Optional[bool] = Field(
+        default=None,
+        description="When deploy is true, block until the deploy completes or the server timeout expires",
+    )
+
+    ticket_id: Optional[str] = Field(
+        default=None,
+        alias="ticketId",
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-zA-Z][a-zA-Z0-9_-]+$",
+        description="Change Control ticket ID associated with the mode change",
+    )
+
+    cluster_name: Optional[str] = Field(
+        default=None,
+        alias="clusterName",
+        min_length=1,
+        description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
+    )
+
+
+class EpManageFabricsSwitchActionsChangeSystemModePost(FabricNameMixin, NDEndpointBaseModel):
+    """
+    # Summary
+
+    Change the system mode of one or more switches in a fabric.
+
+    ## Description
+
+    Sets the system mode (`normal` or `maintenance`) for one or more switches in the named fabric. The request body must
+    include a single `mode` value plus a non-empty `switchIds` array of switch serial numbers. The response is HTTP 207
+    multi-status with a per-switch `items` array; see the ND API documentation for details.
+
+    ## Path
+
+    - `/api/v1/manage/fabrics/{fabric_name}/switchActions/changeSystemMode`
+    - `/api/v1/manage/fabrics/{fabric_name}/switchActions/changeSystemMode?deploy=true&blocking=true`
+
+    ## Verb
+
+    - POST
+
+    ## Request Body (application/json)
+
+    - `mode` (str, required): One of `"normal"` or `"maintenance"`.
+    - `switchIds` (list[str], required, minItems=1): Switch serial numbers (the `switchId` field returned by switch GET endpoints).
+
+    ## Raises
+
+    ### ValueError
+
+    - If `fabric_name` is not set when accessing `path`.
+
+    ## Usage
+
+    ```python
+    ep = EpManageFabricsSwitchActionsChangeSystemModePost()
+    ep.fabric_name = "SITE1"
+    ep.endpoint_params.deploy = True
+    ep.endpoint_params.blocking = True
+    rest_send.path = ep.path
+    rest_send.verb = ep.verb
+    rest_send.payload = {"mode": "maintenance", "switchIds": ["9UOJ3E8A6O9", "9ASNKH8T9DJ"]}
+    ```
+    """
+
+    class_name: Literal["EpManageFabricsSwitchActionsChangeSystemModePost"] = Field(
+        default="EpManageFabricsSwitchActionsChangeSystemModePost",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    endpoint_params: ChangeSystemModeEndpointParams = Field(
+        default_factory=ChangeSystemModeEndpointParams,
+        description="Endpoint-specific query parameters",
+    )
+
+    @property
+    def path(self) -> str:
+        """
+        # Summary
+
+        Build the changeSystemMode endpoint path with optional query string.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `fabric_name` is not set before accessing `path`.
+        """
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        base_path = BasePath.path("fabrics", self.fabric_name, "switchActions", "changeSystemMode")
+        query_string = self.endpoint_params.to_query_string()
+        if query_string:
+            return f"{base_path}?{query_string}"
+        return base_path
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """
+        # Summary
+
+        Return `HttpVerbEnum.POST`.
+
+        ## Raises
+
+        None
+        """
+        return HttpVerbEnum.POST

--- a/plugins/module_utils/endpoints/v1/manage/manage_switches.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_switches.py
@@ -144,6 +144,11 @@ class EpManageSwitchesListGet(_EpManageSwitchesBase):
         return HttpVerbEnum.GET
 
 
+# TODO: Remove EpManageSwitchesGet once the in-flight stacked branches have merged into develop.
+# It is currently unused here -- nd_maintenance_mode resolves per-switch intendedSystemMode from the
+# bulk EpManageSwitchesListGet snapshot, not from a per-switch GET. It is retained for now because
+# sibling branches in the current stack may still reference the per-switch endpoint; revisit after
+# the stack lands and delete it if no caller has appeared.
 class EpManageSwitchesGet(FabricNameMixin, NDEndpointBaseModel):
     """
     # Summary

--- a/plugins/module_utils/endpoints/v1/manage/manage_switches.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_switches.py
@@ -11,13 +11,15 @@ in the ND Manage API.
 
 - `EpManageSwitchesListGet` - List switches in a fabric with optional Lucene filtering
   (GET /api/v1/manage/fabrics/{fabric_name}/switches)
+- `EpManageSwitchesGet` - Get the details of a specific switch in a fabric
+  (GET /api/v1/manage/fabrics/{fabric_name}/switches/{switch_id})
 - `EpManageSwitchActionsDeploy` - Deploy all pending switch configuration
   (POST /api/v1/manage/fabrics/{fabric_name}/switchActions/deploy)
 """
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Optional
 from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
@@ -127,6 +129,93 @@ class EpManageSwitchesListGet(_EpManageSwitchesBase):
     """
 
     class_name: Literal["EpManageSwitchesListGet"] = Field(default="EpManageSwitchesListGet", frozen=True, description="Class name for backward compatibility")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """
+        # Summary
+
+        Return `HttpVerbEnum.GET`.
+
+        ## Raises
+
+        None
+        """
+        return HttpVerbEnum.GET
+
+
+class EpManageSwitchesGet(FabricNameMixin, NDEndpointBaseModel):
+    """
+    # Summary
+
+    Get the details of a specific switch in a fabric.
+
+    ## Description
+
+    Endpoint to retrieve a specific switch's details from a fabric. The fabric name and switch ID (NX-OS serial number or
+    ACI node ID) are both required. The response contains switch metadata; the `systemMode` / `intendedSystemMode` /
+    `discoveredSystemMode` fields used by `nd_maintenance_mode` are nested under `additionalData` on the live wire.
+
+    ## Path
+
+    - `/api/v1/manage/fabrics/{fabric_name}/switches/{switch_id}`
+
+    ## Verb
+
+    - GET
+
+    ## Raises
+
+    ### ValueError
+
+    - If `fabric_name` or `switch_id` is not set when accessing `path`.
+
+    ## Usage
+
+    ```python
+    ep = EpManageSwitchesGet()
+    ep.fabric_name = "SITE1"
+    ep.switch_id = "9UOJ3E8A6O9"
+    rest_send.path = ep.path
+    rest_send.verb = ep.verb
+    # Path: /api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9
+    ```
+    """
+
+    class_name: Literal["EpManageSwitchesGet"] = Field(default="EpManageSwitchesGet", frozen=True, description="Class name for backward compatibility")
+
+    switch_id: Optional[str] = Field(default=None, description="Switch identifier (NX-OS serial number or ACI node ID)")
+
+    def set_identifiers(self, identifier: IdentifierKey = None):
+        """
+        # Summary
+
+        Set `switch_id` from `identifier`. `fabric_name` must be set separately.
+
+        ## Raises
+
+        None
+        """
+        self.switch_id = identifier
+
+    @property
+    def path(self) -> str:
+        """
+        # Summary
+
+        Build the per-switch GET endpoint path.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `fabric_name` or `switch_id` is not set before accessing `path`.
+        """
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        if self.switch_id is None:
+            raise ValueError(f"{type(self).__name__}.path: switch_id must be set before accessing path.")
+        return BasePath.path("fabrics", self.fabric_name, "switches", self.switch_id)
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_switches.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_switches.py
@@ -215,7 +215,7 @@ class EpManageSwitchesGet(FabricNameMixin, NDEndpointBaseModel):
             raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
         if self.switch_id is None:
             raise ValueError(f"{type(self).__name__}.path: switch_id must be set before accessing path.")
-        return BasePath.path("fabrics", self.fabric_name, "switches", self.switch_id)
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "switches", quote(self.switch_id, safe=""))
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/models/maintenance_mode/maintenance_mode.py
+++ b/plugins/module_utils/models/maintenance_mode/maintenance_mode.py
@@ -26,8 +26,8 @@ class MaintenanceModeSwitchModel(NDNestedModel):
     # Summary
 
     Single switch entry in `config.switches`. The user supplies `switch_ip`; the orchestrator resolves
-    it to the switch serial number (`switchId`) via `FabricContext.get_switch_id()` before building the
-    `switchIds` array in the POST body.
+    it to the switch serial number (`switchId`) from the bulk `EpManageSwitchesListGet` snapshot cached
+    by `query_all()` before building the `switchIds` array in the POST body.
 
     ## Raises
 

--- a/plugins/module_utils/models/maintenance_mode/maintenance_mode.py
+++ b/plugins/module_utils/models/maintenance_mode/maintenance_mode.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Set
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field, model_validator
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 
@@ -88,6 +88,33 @@ class MaintenanceModeModel(NDBaseModel):
 
     # Snapshot-only: map of switch_ip -> current intendedSystemMode. Populated by query_all().
     switch_modes: Optional[Dict[str, str]] = Field(default=None, exclude=True)
+
+    # --- Validators ---
+
+    @model_validator(mode="after")
+    def _require_switches_when_mode_set(self) -> "MaintenanceModeModel":
+        """
+        # Summary
+
+        Reject `switches: []` when a target `mode` is requested. The Ansible argspec marks `switches`
+        as `required=True`, but `required=True` only enforces key presence — not non-empty content.
+        Without this check, a user submitting `switches: []` would silently produce a no-op against
+        the `changeSystemMode` action endpoint (which itself requires `switchIds` with `minItems=1`)
+        and the module would report `changed=False` instead of telling the user the request was
+        malformed.
+
+        Snapshots built by `query_all` (and other `mode=None` callers) are exempt; the gate is
+        keyed on `mode` so only proposed-config instances are checked.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `mode` is set and `switches` is empty.
+        """
+        if self.mode is not None and not self.switches:
+            raise ValueError("config.switches must contain at least one switch when 'mode' is set.")
+        return self
 
     # --- Custom Diff (per-switch mode comparison) ---
 

--- a/plugins/module_utils/models/maintenance_mode/maintenance_mode.py
+++ b/plugins/module_utils/models/maintenance_mode/maintenance_mode.py
@@ -1,0 +1,154 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Pydantic feature models for the `nd_maintenance_mode` module.
+
+The endpoint backing this module is a switch *action* (not a CRUD resource):
+`POST /api/v1/manage/fabrics/{fabric_name}/switchActions/changeSystemMode`. A single
+invocation sets one `mode` for a list of `switchIds`. The Ansible-facing `config` is a
+dict (not a list) and is wrapped into a 1-item list by the module's `main()` so it can
+flow through the standard `NDStateMachine` driver as a singleton.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Set
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+
+
+class MaintenanceModeSwitchModel(NDNestedModel):
+    """
+    # Summary
+
+    Single switch entry in `config.switches`. The user supplies `switch_ip`; the orchestrator resolves
+    it to the switch serial number (`switchId`) via `FabricContext.get_switch_id()` before building the
+    `switchIds` array in the POST body.
+
+    ## Raises
+
+    None
+    """
+
+    switch_ip: str = Field(alias="switchIp", description="Switch management IP")
+
+
+class MaintenanceModeModel(NDBaseModel):
+    """
+    # Summary
+
+    Singleton model for a `changeSystemMode` operation. One model instance describes one POST: a
+    target `mode`, optional deploy / blocking / ticket_id query params, and the set of switches
+    to which the mode applies.
+
+    The model is used in two flavors:
+
+    - **Proposed** — built from the user's Ansible `config` dict via `from_config`. Populates `mode`,
+      `deploy`, `blocking`, `ticket_id`, `switches`. `switch_modes` is `None`.
+    - **Snapshot** — built from the orchestrator's `query_all()` response via `from_response`. Populates
+      `switches` (same set the user asked about) and `switch_modes` (per-IP current `intendedSystemMode`
+      read from the live wire). `mode` is left unset on the snapshot.
+
+    The custom `get_diff` compares the proposed `mode` against each switch's snapshot
+    `intendedSystemMode` and returns `True` (no diff) only when every requested switch already has
+    intent matching the desired mode.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[Optional[List[str]]] = []
+    identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "singleton"
+
+    # --- Serialization Configuration ---
+
+    # The wire POST body is just `{"mode": ..., "switchIds": [...]}`. Everything else is either a
+    # query param (deploy/blocking/ticket_id) or client-side metadata (switches, switch_modes).
+    # `switchIds` itself is injected by the orchestrator after resolving switch_ip -> switchId.
+    payload_exclude_fields: ClassVar[Set[str]] = {"deploy", "blocking", "ticket_id", "switches", "switch_modes"}
+
+    # Query params do not influence whether a state change is needed.
+    exclude_from_diff: ClassVar[Set[str]] = {"deploy", "blocking", "ticket_id", "switch_modes"}
+
+    # --- Fields ---
+
+    # Optional so a snapshot built from query_all can omit it; argspec enforces required for users.
+    mode: Optional[Literal["maintenance", "normal"]] = Field(default=None, alias="mode")
+    deploy: bool = Field(default=False, alias="deploy")
+    blocking: bool = Field(default=False, alias="blocking")
+    ticket_id: Optional[str] = Field(default=None, alias="ticketId")
+    switches: List[MaintenanceModeSwitchModel] = Field(default_factory=list, alias="switches")
+
+    # Snapshot-only: map of switch_ip -> current intendedSystemMode. Populated by query_all().
+    switch_modes: Optional[Dict[str, str]] = Field(default=None, exclude=True)
+
+    # --- Custom Diff (per-switch mode comparison) ---
+
+    def get_diff(self, other: "NDBaseModel", exclude_unset: bool = False) -> bool:
+        """
+        # Summary
+
+        Return `True` ("no_diff") iff every switch in the proposed config already has its current
+        `intendedSystemMode` (from the snapshot) equal to the proposed `mode`.
+
+        `self` is the snapshot (existing); `other` is the proposed config. Default `NDBaseModel.get_diff`
+        does a generic subset check that does not understand the per-switch mode comparison we need.
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(other, MaintenanceModeModel):
+            return False
+        if other.mode is None or not other.switches:
+            return True
+        snapshot_modes = self.switch_modes or {}
+        for switch in other.switches:
+            if snapshot_modes.get(switch.switch_ip) != other.mode:
+                return False
+        return True
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> Dict[str, Any]:
+        """
+        # Summary
+
+        Return the Ansible argspec for the `config` and `state` parameters. `config` is a dict
+        (matching the underlying ND API body shape); `state` is restricted to `merged`. A future
+        `gathered` state will be added when Gaspard's framework support lands.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="dict",
+                required=True,
+                options=dict(
+                    mode=dict(type="str", required=True, choices=["maintenance", "normal"]),
+                    deploy=dict(type="bool", default=False),
+                    blocking=dict(type="bool", default=False),
+                    ticket_id=dict(type="str"),
+                    switches=dict(
+                        type="list",
+                        elements="dict",
+                        required=True,
+                        options=dict(
+                            switch_ip=dict(type="str", required=True),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(type="str", default="merged", choices=["merged"]),
+        )

--- a/plugins/module_utils/orchestrators/maintenance_mode.py
+++ b/plugins/module_utils/orchestrators/maintenance_mode.py
@@ -13,12 +13,14 @@ CRUD-shaped driver:
 
 - The Ansible-facing `config` is a dict, wrapped into a 1-item list by `nd_maintenance_mode.main()`
   so the state machine sees a singleton collection.
-- `query_all()` fans out per-switch GETs to read the current `intendedSystemMode` and returns a
-  single snapshot dict that becomes `output.before`. It also hard-fails the entire operation if any
-  requested switch is currently in `migration` mode (a stuck/failed deployment state that the user
-  must clear in the ND UI before the module can operate).
-- `update()` is the real action method: resolves IPs to serials, filters to only the switches whose
-  current intent differs from the desired mode, sets query params from the model, and POSTs.
+- `query_all()` issues **one** bulk GET of the fabric's switches and reads each row's
+  `additionalData.intendedSystemMode`/`discoveredSystemMode`. It builds a snapshot dict that
+  becomes `output.before` and caches both the per-IP mode map and the per-IP switchId map on the
+  orchestrator instance. It hard-fails if any requested switch is currently in `migration` mode
+  (a stuck/failed deployment state that the user must clear in the ND UI before the module can
+  operate).
+- `update()` reads the cached maps to filter to switches whose intent differs from the desired
+  mode, sets query params from the model, and POSTs. It does not re-query.
 - `create()` aliases `update()`. `delete()` is not supported (state `deleted` is not advertised).
 
 Uses `FabricContext` for fabric existence / freeze / locality pre-checks and switch IP-to-serial
@@ -33,7 +35,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDE
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switch_actions import (
     EpManageFabricsSwitchActionsChangeSystemModePost,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_switches import EpManageSwitchesGet
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_switches import EpManageSwitchesListGet
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.maintenance_mode.maintenance_mode import MaintenanceModeModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
@@ -52,21 +54,25 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
 
     Orchestrator for the `changeSystemMode` switch action.
 
-    Builds a snapshot of per-switch `intendedSystemMode` in `query_all()` (which `NDStateMachine`
-    calls during init), then `update()` POSTs the desired mode for only the switches whose current
-    intent differs from the request. The 207 response body is inspected per-item; any `status:
-    failed` entry triggers a `RuntimeError` with an aggregate message naming the failing switches
-    by IP.
+    Builds a snapshot of per-switch `intendedSystemMode` in `query_all()` via a single bulk GET
+    of the fabric's switches (which `NDStateMachine` calls during init), then `update()` POSTs the
+    desired mode for only the switches whose current intent differs from the request, reusing the
+    IP→switchId map captured by `query_all()`. The 207 response body is inspected per-item; any
+    `status: failed` entry triggers a `RuntimeError` with an aggregate message naming the failing
+    switches by IP.
 
-    Inherits from `NDBaseInterfaceOrchestrator` for `FabricContext` plumbing, switch IP resolution,
-    and pre-flight validation. The deploy/remove queuing methods on that base are unused here.
+    Inherits from `NDBaseInterfaceOrchestrator` for `FabricContext` plumbing and pre-flight
+    validation. The deploy/remove queuing methods on that base are unused here. The IP→switchId
+    resolution provided by `FabricContext.get_switch_id` is intentionally bypassed: this
+    orchestrator parses the same bulk switches GET it issues for mode reads, so calling
+    `FabricContext` would trigger a second list GET.
 
     ## Raises
 
     ### RuntimeError
 
     - Via `validate_prerequisites` if the fabric does not exist, is not local, or is in deployment-freeze mode.
-    - Via `_resolve_switch_id` if a user-supplied `switch_ip` is not found in the fabric.
+    - Via `query_all` if a user-supplied `switch_ip` is not found in the fabric.
     - Via `query_all` if any switch is currently in `migration` mode.
     - Via `update` if the POST changeSystemMode request fails or the 207 body contains per-switch failures.
 
@@ -82,13 +88,17 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
     create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsSwitchActionsChangeSystemModePost
     update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsSwitchActionsChangeSystemModePost
     delete_endpoint: type[NDEndpointBaseModel] = NDEndpointBaseModel  # unused; delete() raises NotImplementedError
-    query_one_endpoint: type[NDEndpointBaseModel] = EpManageSwitchesGet  # unused; query_one() delegates to query_all()
-    query_all_endpoint: type[NDEndpointBaseModel] = EpManageSwitchesGet  # used per-switch in query_all() fan-out
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageSwitchesListGet  # unused; query_one() delegates to query_all()
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageSwitchesListGet  # bulk fabric switches GET
 
     # Snapshot of switch_ip -> intendedSystemMode captured by query_all() and reused by update().
     # NDStateMachine invokes query_all() during init and the same orchestrator instance is reused for
     # update(), so caching here avoids a second per-switch GET fan-out per module run.
     _snapshot_modes: dict[str, str] | None = None
+    # Companion cache of switch_ip -> switchId for the user-supplied switches, parsed from the same
+    # bulk list-GET, so update() does not need to fall back to FabricContext (which would issue a
+    # second list GET).
+    _snapshot_switch_ids: dict[str, str] | None = None
 
     # ------------------------------------------------------------------ #
     # CRUD method overrides (action-shaped semantics)
@@ -98,9 +108,15 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
         """
         # Summary
 
-        Build a snapshot of the user's requested switches by fanning out per-switch GETs and reading
-        `additionalData.intendedSystemMode`. If any switch is currently in `migration` mode, hard-fail
-        with a remediation message before returning. This runs unconditionally during `NDStateMachine`
+        Build a snapshot of the user's requested switches with **one** bulk GET of the fabric's
+        switches (`/api/v1/manage/fabrics/{fabric_name}/switches`). Each row's `additionalData`
+        carries `intendedSystemMode` and `discoveredSystemMode`, so a single round-trip replaces
+        the per-switch GET fan-out and avoids touching `FabricContext.get_switch_id` (which would
+        issue its own list GET).
+
+        If any user-supplied `switch_ip` is not present in the fabric, hard-fail with a
+        FabricContext-style message. If any user switch is in `migration` mode, hard-fail with
+        the remediation message before returning. This runs unconditionally during `NDStateMachine`
         init, so the migration check fires even in `check_mode`.
 
         Returns a 1-element list (the singleton snapshot) so `NDConfigCollection.from_api_response`
@@ -110,10 +126,10 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
 
         ### RuntimeError
 
-        - If any switch is currently in `migration` mode.
         - If the fabric pre-flight check fails.
-        - If a `switch_ip` is not found in the fabric.
-        - If a per-switch GET fails.
+        - If any user `switch_ip` is not found in the fabric.
+        - If any user switch is currently in `migration` mode.
+        - If the bulk switches GET fails.
         """
         try:
             self.validate_prerequisites()
@@ -121,29 +137,33 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
             if not user_switches:
                 # Empty config (e.g. during argspec failure cases) — return an empty snapshot.
                 self._snapshot_modes = {}
+                self._snapshot_switch_ids = {}
                 return [{"switches": [], "switch_modes": {}}]
 
-            switch_modes: dict[str, str] = {}
-            migration_ips: list[str] = []
+            wanted_ips = [entry["switch_ip"] for entry in user_switches if entry.get("switch_ip")]
+            wanted_ip_set = set(wanted_ips)
 
-            for entry in user_switches:
-                switch_ip = entry.get("switch_ip")
-                if not switch_ip:
-                    continue
-                intended, discovered = self._fetch_switch_modes(switch_ip)
-                if discovered == "migration":
-                    migration_ips.append(switch_ip)
-                if intended is not None:
-                    switch_modes[switch_ip] = intended
+            list_endpoint = EpManageSwitchesListGet()
+            list_endpoint.fabric_name = self.fabric_name
+            response = self._request(path=list_endpoint.path, verb=list_endpoint.verb)
+            rows = response.get("switches") if isinstance(response, dict) else None
+
+            switch_ids, switch_modes, migration_ips = self._parse_switch_rows(rows or [], wanted_ip_set)
+
+            missing = [ip for ip in wanted_ips if ip not in switch_ids]
+            if missing:
+                # Match the FabricContext error shape so existing tests/messages stay consistent.
+                raise RuntimeError(f"No switch found with fabricManagementIp '{missing[0]}' in fabric '{self.fabric_name}'.")
 
             if migration_ips:
                 raise RuntimeError(_MIGRATION_REMEDIATION.format(ips=migration_ips))
 
-            # Cache for update() so we don't re-issue the per-switch GET fan-out.
+            # Cache for update() so we don't re-issue the bulk GET (or fall back to FabricContext).
             self._snapshot_modes = switch_modes
+            self._snapshot_switch_ids = switch_ids
 
             snapshot = {
-                "switches": [{"switch_ip": entry.get("switch_ip")} for entry in user_switches if entry.get("switch_ip")],
+                "switches": [{"switch_ip": ip} for ip in wanted_ips],
                 "switch_modes": switch_modes,
             }
             return [snapshot]
@@ -207,6 +227,7 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
                 # Defensive: caller skipped query_all (e.g. direct orchestrator use outside NDStateMachine).
                 self.query_all()
             snapshot_modes = self._snapshot_modes or {}
+            snapshot_switch_ids = self._snapshot_switch_ids or {}
 
             target_ips: list[str] = []
             target_switch_ids: list[str] = []
@@ -214,7 +235,9 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
                 if snapshot_modes.get(switch.switch_ip) == model_instance.mode:
                     continue
                 target_ips.append(switch.switch_ip)
-                target_switch_ids.append(self._resolve_switch_id(switch.switch_ip))
+                # Read from the cached map (built by query_all); never fall back to FabricContext,
+                # which would issue a second list GET on its first switch_map access.
+                target_switch_ids.append(snapshot_switch_ids[switch.switch_ip])
 
             if not target_switch_ids:
                 # Every requested switch already has matching intent — nothing to do.
@@ -255,32 +278,40 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
     # Helpers
     # ------------------------------------------------------------------ #
 
-    def _fetch_switch_modes(self, switch_ip: str) -> tuple[str | None, str | None]:
+    @staticmethod
+    def _parse_switch_rows(rows: list[Any], wanted_ip_set: set[str]) -> tuple[dict[str, str], dict[str, str], list[str]]:
         """
         # Summary
 
-        GET a single switch and return its `(intendedSystemMode, discoveredSystemMode)` pair from
-        `additionalData`. Returns `(None, None)` if the response is malformed.
+        Walk one bulk `/switches` response, keep only rows whose `fabricManagementIp` is in
+        `wanted_ip_set`, and return `(switch_ids, switch_modes, migration_ips)`:
+
+        - `switch_ids`: IP → switchId for every wanted row that carries both.
+        - `switch_modes`: IP → `additionalData.intendedSystemMode` (when present and non-null).
+        - `migration_ips`: wanted IPs whose `additionalData.discoveredSystemMode` is `"migration"`.
 
         ## Raises
 
-        ### RuntimeError
-
-        - Via `_resolve_switch_id` if the IP is not in the fabric.
-        - Via `_request` if the GET fails.
+        None
         """
-        switch_id = self._resolve_switch_id(switch_ip)
-        api_endpoint = EpManageSwitchesGet()
-        api_endpoint.fabric_name = self.fabric_name
-        api_endpoint.switch_id = switch_id
-        response = self._request(path=api_endpoint.path, verb=api_endpoint.verb)
-        if not isinstance(response, dict):
-            return None, None
-        # Read `intendedSystemMode` for idempotency rather than the aggregator `systemMode`, because
-        # `systemMode` returns "inconsistent" when intent != discovered (e.g. after a no-deploy POST).
-        # Comparing against the aggregator would re-POST on every playbook run that left intent != discovered.
-        additional = response.get("additionalData") or {}
-        return additional.get("intendedSystemMode"), additional.get("discoveredSystemMode")
+        switch_ids: dict[str, str] = {}
+        switch_modes: dict[str, str] = {}
+        migration_ips: list[str] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            ip = row.get("fabricManagementIp")
+            switch_id = row.get("switchId")
+            if not ip or not switch_id or ip not in wanted_ip_set:
+                continue
+            switch_ids[ip] = switch_id
+            additional = row.get("additionalData") or {}
+            intended = additional.get("intendedSystemMode")
+            if additional.get("discoveredSystemMode") == "migration":
+                migration_ips.append(ip)
+            if intended is not None:
+                switch_modes[ip] = intended
+        return switch_ids, switch_modes, migration_ips
 
     def _user_switches(self) -> list[dict[str, Any]]:
         """

--- a/plugins/module_utils/orchestrators/maintenance_mode.py
+++ b/plugins/module_utils/orchestrators/maintenance_mode.py
@@ -85,6 +85,11 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
     query_one_endpoint: type[NDEndpointBaseModel] = EpManageSwitchesGet  # unused; query_one() delegates to query_all()
     query_all_endpoint: type[NDEndpointBaseModel] = EpManageSwitchesGet  # used per-switch in query_all() fan-out
 
+    # Snapshot of switch_ip -> intendedSystemMode captured by query_all() and reused by update().
+    # NDStateMachine invokes query_all() during init and the same orchestrator instance is reused for
+    # update(), so caching here avoids a second per-switch GET fan-out per module run.
+    _snapshot_modes: dict[str, str] | None = None
+
     # ------------------------------------------------------------------ #
     # CRUD method overrides (action-shaped semantics)
     # ------------------------------------------------------------------ #
@@ -115,6 +120,7 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
             user_switches = self._user_switches()
             if not user_switches:
                 # Empty config (e.g. during argspec failure cases) — return an empty snapshot.
+                self._snapshot_modes = {}
                 return [{"switches": [], "switch_modes": {}}]
 
             switch_modes: dict[str, str] = {}
@@ -132,6 +138,9 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
 
             if migration_ips:
                 raise RuntimeError(_MIGRATION_REMEDIATION.format(ips=migration_ips))
+
+            # Cache for update() so we don't re-issue the per-switch GET fan-out.
+            self._snapshot_modes = switch_modes
 
             snapshot = {
                 "switches": [{"switch_ip": entry.get("switch_ip")} for entry in user_switches if entry.get("switch_ip")],
@@ -175,10 +184,13 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
 
         Apply the requested system mode to the switches that currently differ.
 
-        Resolves `switch_ip` to `switchId` for every entry, reads the snapshot from `query_all` to
-        determine which switches actually need to change, sets the endpoint query params from the
-        model, and POSTs. The 207 response body is parsed; any `status: failed` items raise a
-        `RuntimeError` with switch IPs included.
+        Reads the snapshot cached by `query_all()` (populated during `NDStateMachine` init) to decide
+        which switches need to change, resolves `switch_ip` to `switchId` for those, sets the endpoint
+        query params from the model, and POSTs. The 207 response body is parsed; any `status: failed`
+        items raise a `RuntimeError` with switch IPs included.
+
+        If the cache is empty (defensive path for callers that invoke `update()` without going through
+        `query_all()` first), `query_all()` is called once to populate it.
 
         ## Raises
 
@@ -188,15 +200,13 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
         - If the 207 response body contains one or more per-switch failures.
         """
         try:
-            self.validate_prerequisites()
             if model_instance.mode is None or not model_instance.switches:
                 return {}
 
-            # Re-read the live snapshot so we only POST switches whose intent actually needs to change.
-            snapshot_response = self.query_all()
-            snapshot_modes: dict[str, str] = {}
-            if snapshot_response and isinstance(snapshot_response, list):
-                snapshot_modes = (snapshot_response[0] or {}).get("switch_modes", {}) or {}
+            if self._snapshot_modes is None:
+                # Defensive: caller skipped query_all (e.g. direct orchestrator use outside NDStateMachine).
+                self.query_all()
+            snapshot_modes = self._snapshot_modes or {}
 
             target_ips: list[str] = []
             target_switch_ids: list[str] = []

--- a/plugins/module_utils/orchestrators/maintenance_mode.py
+++ b/plugins/module_utils/orchestrators/maintenance_mode.py
@@ -1,0 +1,327 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Maintenance mode orchestrator for Nexus Dashboard.
+
+Wraps `POST /api/v1/manage/fabrics/{fabric_name}/switchActions/changeSystemMode` — a switch *action*
+endpoint that sets the system mode (`normal` or `maintenance`) for a batch of switches in one call.
+
+The endpoint is action-shaped (not CRUD), so the orchestrator adapts it to fit `NDStateMachine`'s
+CRUD-shaped driver:
+
+- The Ansible-facing `config` is a dict, wrapped into a 1-item list by `nd_maintenance_mode.main()`
+  so the state machine sees a singleton collection.
+- `query_all()` fans out per-switch GETs to read the current `intendedSystemMode` and returns a
+  single snapshot dict that becomes `output.before`. It also hard-fails the entire operation if any
+  requested switch is currently in `migration` mode (a stuck/failed deployment state that the user
+  must clear in the ND UI before the module can operate).
+- `update()` is the real action method: resolves IPs to serials, filters to only the switches whose
+  current intent differs from the desired mode, sets query params from the model, and POSTs.
+- `create()` aliases `update()`. `delete()` is not supported (state `deleted` is not advertised).
+
+Uses `FabricContext` for fabric existence / freeze / locality pre-checks and switch IP-to-serial
+resolution.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switch_actions import (
+    EpManageFabricsSwitchActionsChangeSystemModePost,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_switches import EpManageSwitchesGet
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.maintenance_mode.maintenance_mode import MaintenanceModeModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+_MIGRATION_REMEDIATION = (
+    "Switch(es) are in 'migration' mode: {ips}. Please remediate any deployment errors in "
+    "Nexus Dashboard and run 'Recalculate and Deploy' before attempting to change modes to normal "
+    "or maintenance."
+)
+
+
+class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeModel]):
+    """
+    # Summary
+
+    Orchestrator for the `changeSystemMode` switch action.
+
+    Builds a snapshot of per-switch `intendedSystemMode` in `query_all()` (which `NDStateMachine`
+    calls during init), then `update()` POSTs the desired mode for only the switches whose current
+    intent differs from the request. The 207 response body is inspected per-item; any `status:
+    failed` entry triggers a `RuntimeError` with an aggregate message naming the failing switches
+    by IP.
+
+    Inherits from `NDBaseInterfaceOrchestrator` for `FabricContext` plumbing, switch IP resolution,
+    and pre-flight validation. The deploy/remove queuing methods on that base are unused here.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate_prerequisites` if the fabric does not exist, is not local, or is in deployment-freeze mode.
+    - Via `_resolve_switch_id` if a user-supplied `switch_ip` is not found in the fabric.
+    - Via `query_all` if any switch is currently in `migration` mode.
+    - Via `update` if the POST changeSystemMode request fails or the 207 body contains per-switch failures.
+
+    ### NotImplementedError
+
+    - Via `delete` — state `deleted` is not supported for switch maintenance mode.
+    """
+
+    model_class: ClassVar[type[NDBaseModel]] = MaintenanceModeModel
+    supports_bulk_create: ClassVar[bool] = False
+    supports_bulk_delete: ClassVar[bool] = False
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsSwitchActionsChangeSystemModePost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsSwitchActionsChangeSystemModePost
+    delete_endpoint: type[NDEndpointBaseModel] = NDEndpointBaseModel  # unused; delete() raises NotImplementedError
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageSwitchesGet  # unused; query_one() delegates to query_all()
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageSwitchesGet  # used per-switch in query_all() fan-out
+
+    # ------------------------------------------------------------------ #
+    # CRUD method overrides (action-shaped semantics)
+    # ------------------------------------------------------------------ #
+
+    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Build a snapshot of the user's requested switches by fanning out per-switch GETs and reading
+        `additionalData.intendedSystemMode`. If any switch is currently in `migration` mode, hard-fail
+        with a remediation message before returning. This runs unconditionally during `NDStateMachine`
+        init, so the migration check fires even in `check_mode`.
+
+        Returns a 1-element list (the singleton snapshot) so `NDConfigCollection.from_api_response`
+        builds exactly one `MaintenanceModeModel`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any switch is currently in `migration` mode.
+        - If the fabric pre-flight check fails.
+        - If a `switch_ip` is not found in the fabric.
+        - If a per-switch GET fails.
+        """
+        try:
+            self.validate_prerequisites()
+            user_switches = self._user_switches()
+            if not user_switches:
+                # Empty config (e.g. during argspec failure cases) — return an empty snapshot.
+                return [{"switches": [], "switch_modes": {}}]
+
+            switch_modes: dict[str, str] = {}
+            migration_ips: list[str] = []
+
+            for entry in user_switches:
+                switch_ip = entry.get("switch_ip")
+                if not switch_ip:
+                    continue
+                intended, discovered = self._fetch_switch_modes(switch_ip)
+                if discovered == "migration":
+                    migration_ips.append(switch_ip)
+                if intended is not None:
+                    switch_modes[switch_ip] = intended
+
+            if migration_ips:
+                raise RuntimeError(_MIGRATION_REMEDIATION.format(ips=migration_ips))
+
+            snapshot = {
+                "switches": [{"switch_ip": entry.get("switch_ip")} for entry in user_switches if entry.get("switch_ip")],
+                "switch_modes": switch_modes,
+            }
+            return [snapshot]
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"query_all failed: {e}") from e
+
+    def query_one(self, model_instance: MaintenanceModeModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Delegate to `query_all`. `nd_maintenance_mode` is a singleton operation; there is no
+        meaningful "query one" distinct from "query all" for this module.
+
+        ## Raises
+
+        - Whatever `query_all` raises.
+        """
+        return self.query_all(model_instance=model_instance, **kwargs)
+
+    def create(self, model_instance: MaintenanceModeModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Alias to `update`. `NDStateMachine` only routes to `create` when the existing collection is
+        empty, which cannot happen for this singleton (the snapshot is always non-empty).
+
+        ## Raises
+
+        - Whatever `update` raises.
+        """
+        return self.update(model_instance, **kwargs)
+
+    def update(self, model_instance: MaintenanceModeModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Apply the requested system mode to the switches that currently differ.
+
+        Resolves `switch_ip` to `switchId` for every entry, reads the snapshot from `query_all` to
+        determine which switches actually need to change, sets the endpoint query params from the
+        model, and POSTs. The 207 response body is parsed; any `status: failed` items raise a
+        `RuntimeError` with switch IPs included.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the POST request fails outright.
+        - If the 207 response body contains one or more per-switch failures.
+        """
+        try:
+            self.validate_prerequisites()
+            if model_instance.mode is None or not model_instance.switches:
+                return {}
+
+            # Re-read the live snapshot so we only POST switches whose intent actually needs to change.
+            snapshot_response = self.query_all()
+            snapshot_modes: dict[str, str] = {}
+            if snapshot_response and isinstance(snapshot_response, list):
+                snapshot_modes = (snapshot_response[0] or {}).get("switch_modes", {}) or {}
+
+            target_ips: list[str] = []
+            target_switch_ids: list[str] = []
+            for switch in model_instance.switches:
+                if snapshot_modes.get(switch.switch_ip) == model_instance.mode:
+                    continue
+                target_ips.append(switch.switch_ip)
+                target_switch_ids.append(self._resolve_switch_id(switch.switch_ip))
+
+            if not target_switch_ids:
+                # Every requested switch already has matching intent — nothing to do.
+                return {}
+
+            api_endpoint = EpManageFabricsSwitchActionsChangeSystemModePost()
+            api_endpoint.fabric_name = self.fabric_name
+            api_endpoint.endpoint_params.deploy = model_instance.deploy
+            api_endpoint.endpoint_params.blocking = model_instance.blocking
+            api_endpoint.endpoint_params.ticket_id = model_instance.ticket_id
+
+            payload = {"mode": model_instance.mode, "switchIds": target_switch_ids}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+
+            self._raise_on_207_failures(result, target_ips, target_switch_ids)
+            return result
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"changeSystemMode failed: {e}") from e
+
+    def delete(self, model_instance: MaintenanceModeModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Not supported. Maintenance mode is a binary switch attribute, not a managed resource. Users
+        who want to take a switch out of maintenance set `mode: normal` under `state: merged`.
+
+        ## Raises
+
+        ### NotImplementedError
+
+        - Always.
+        """
+        raise NotImplementedError("state 'deleted' is not supported by nd_maintenance_mode. Use 'state: merged' with 'mode: normal' to restore a switch.")
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+
+    def _fetch_switch_modes(self, switch_ip: str) -> tuple[str | None, str | None]:
+        """
+        # Summary
+
+        GET a single switch and return its `(intendedSystemMode, discoveredSystemMode)` pair from
+        `additionalData`. Returns `(None, None)` if the response is malformed.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Via `_resolve_switch_id` if the IP is not in the fabric.
+        - Via `_request` if the GET fails.
+        """
+        switch_id = self._resolve_switch_id(switch_ip)
+        api_endpoint = EpManageSwitchesGet()
+        api_endpoint.fabric_name = self.fabric_name
+        api_endpoint.switch_id = switch_id
+        response = self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        if not isinstance(response, dict):
+            return None, None
+        # TODO(4.2.1) systemMode fields are nested under `additionalData` in the GET switch response,
+        # not at the top level as the OpenAPI schema documents. We read `intendedSystemMode` (what ND
+        # has committed) for idempotency rather than the aggregator `systemMode`, which returns the
+        # string "inconsistent" between an intent change and a deploy.
+        additional = response.get("additionalData") or {}
+        return additional.get("intendedSystemMode"), additional.get("discoveredSystemMode")
+
+    def _user_switches(self) -> list[dict[str, Any]]:
+        """
+        # Summary
+
+        Return the list of `{switch_ip: ...}` dicts the user supplied in `config.switches`, after the
+        `main()` wrap that puts the original `config` dict inside a 1-item list.
+
+        ## Raises
+
+        None
+        """
+        config_list = self.rest_send.params.get("config") or []
+        if not isinstance(config_list, list) or not config_list:
+            return []
+        first = config_list[0]
+        if not isinstance(first, dict):
+            return []
+        switches = first.get("switches") or []
+        return [s for s in switches if isinstance(s, dict)]
+
+    def _raise_on_207_failures(self, result: Any, target_ips: list[str], target_switch_ids: list[str]) -> None:
+        """
+        # Summary
+
+        Inspect the 207 multi-status response body. If any item has `status` other than `success`,
+        raise `RuntimeError` with the failing switches translated back to their IPs.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the response body contains one or more per-switch failures.
+        """
+        if not isinstance(result, dict):
+            return
+        items = result.get("items")
+        if not isinstance(items, list) or not items:
+            return
+        ip_by_id = dict(zip(target_switch_ids, target_ips))
+        failures: list[str] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            status = (item.get("status") or "").lower()
+            if status == "success":
+                continue
+            switch_id = item.get("switchId") or "?"
+            ip = ip_by_id.get(switch_id, switch_id)
+            message = item.get("message") or "unknown error"
+            failures.append(f"{ip}: {message}")
+        if failures:
+            raise RuntimeError(f"changeSystemMode reported per-switch failures: {'; '.join(failures)}")

--- a/plugins/module_utils/orchestrators/maintenance_mode.py
+++ b/plugins/module_utils/orchestrators/maintenance_mode.py
@@ -152,9 +152,14 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
             list_endpoint = EpManageSwitchesListGet()
             list_endpoint.fabric_name = self.fabric_name
             response = self._request(path=list_endpoint.path, verb=list_endpoint.verb)
-            rows = response.get("switches") if isinstance(response, dict) else None
+            rows = response.get("switches") if isinstance(response, dict) else []
+            # `_parse_switch_rows` is typed `list[Any]`; guard the container shape at the boundary so
+            # a malformed `switches` value (string, dict, scalar) does not iterate character-by-
+            # character or TypeError inside the helper.
+            if not isinstance(rows, list):
+                rows = []
 
-            switch_ids, switch_modes, migration_ips = self._parse_switch_rows(rows or [], wanted_ip_set)
+            switch_ids, switch_modes, migration_ips = self._parse_switch_rows(rows, wanted_ip_set)
 
             missing = [ip for ip in wanted_ips if ip not in switch_ids]
             if missing:

--- a/plugins/module_utils/orchestrators/maintenance_mode.py
+++ b/plugins/module_utils/orchestrators/maintenance_mode.py
@@ -47,6 +47,12 @@ _MIGRATION_REMEDIATION = (
     "or maintenance."
 )
 
+# Explicit denylist of 207 per-item status values that count as a failure. Anything else --
+# `success`, missing, empty, or future progress/info tokens like `pending` or `warning` -- is
+# tolerated. ND's switchAction APIs occasionally include informational rows; treating "not
+# success" as failure would surface those as spurious errors.
+_FAILURE_STATUSES = frozenset({"failed", "failure", "error"})
+
 
 class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeModel]):
     """
@@ -362,7 +368,7 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
             if not isinstance(item, dict):
                 continue
             status = (item.get("status") or "").lower()
-            if status == "success":
+            if status not in _FAILURE_STATUSES:
                 continue
             switch_id = item.get("switchId") or "?"
             ip = ip_by_id.get(switch_id, switch_id)

--- a/plugins/module_utils/orchestrators/maintenance_mode.py
+++ b/plugins/module_utils/orchestrators/maintenance_mode.py
@@ -245,8 +245,13 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
 
             api_endpoint = EpManageFabricsSwitchActionsChangeSystemModePost()
             api_endpoint.fabric_name = self.fabric_name
-            api_endpoint.endpoint_params.deploy = model_instance.deploy
-            api_endpoint.endpoint_params.blocking = model_instance.blocking
+            # Only push truthy deploy/blocking onto the endpoint params: the model defaults are
+            # False, and the endpoint serializes via `exclude_none=True` (not `exclude_defaults`),
+            # so assigning False would emit `?deploy=false&blocking=false` on every request.
+            if model_instance.deploy:
+                api_endpoint.endpoint_params.deploy = True
+            if model_instance.blocking:
+                api_endpoint.endpoint_params.blocking = True
             api_endpoint.endpoint_params.ticket_id = model_instance.ticket_id
 
             payload = {"mode": model_instance.mode, "switchIds": target_switch_ids}

--- a/plugins/module_utils/orchestrators/maintenance_mode.py
+++ b/plugins/module_utils/orchestrators/maintenance_mode.py
@@ -266,10 +266,9 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
         response = self._request(path=api_endpoint.path, verb=api_endpoint.verb)
         if not isinstance(response, dict):
             return None, None
-        # TODO(4.2.1) systemMode fields are nested under `additionalData` in the GET switch response,
-        # not at the top level as the OpenAPI schema documents. We read `intendedSystemMode` (what ND
-        # has committed) for idempotency rather than the aggregator `systemMode`, which returns the
-        # string "inconsistent" between an intent change and a deploy.
+        # Read `intendedSystemMode` for idempotency rather than the aggregator `systemMode`, because
+        # `systemMode` returns "inconsistent" when intent != discovered (e.g. after a no-deploy POST).
+        # Comparing against the aggregator would re-POST on every playbook run that left intent != discovered.
         additional = response.get("additionalData") or {}
         return additional.get("intendedSystemMode"), additional.get("discoveredSystemMode")
 

--- a/plugins/modules/nd_maintenance_mode.py
+++ b/plugins/modules/nd_maintenance_mode.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_maintenance_mode
-version_added: "1.4.0"
+version_added: "2.0.0"
 short_description: Manage the system mode (normal or maintenance) of switches in a fabric on Cisco Nexus Dashboard
 description:
 - Manage the system mode of one or more switches in a fabric on Cisco Nexus Dashboard.

--- a/plugins/modules/nd_maintenance_mode.py
+++ b/plugins/modules/nd_maintenance_mode.py
@@ -17,8 +17,8 @@ description:
 - Manage the system mode of one or more switches in a fabric on Cisco Nexus Dashboard.
 - Wraps the C(POST /api/v1/manage/fabrics/{fabric_name}/switchActions/changeSystemMode) endpoint, which sets a single
   C(mode) (C(normal) or C(maintenance)) for a batch of switches in one request.
-- For idempotency the module reads each switch's current C(intendedSystemMode) from C(GET /api/v1/manage/fabrics/{fabric_name}/switches/{switch_id})
-  and only POSTs the subset of switches whose intent differs from the requested mode.
+- For idempotency the module reads every switch's current C(intendedSystemMode) from a single bulk
+  C(GET /api/v1/manage/fabrics/{fabric_name}/switches) and only POSTs the subset of switches whose intent differs from the requested mode.
 - If any requested switch is currently in C(migration) mode, the module fails before any change is made and asks the
   operator to clear the migration state via the ND UI's "Recalculate and Deploy" workflow.
 - This module currently supports O(state=merged) only. A future O(state=gathered) will report current per-switch system

--- a/plugins/modules/nd_maintenance_mode.py
+++ b/plugins/modules/nd_maintenance_mode.py
@@ -94,6 +94,11 @@ notes:
   re-POSTs on every playbook run.
 - A request that includes any unknown C(switch_ip) is rejected wholesale by ND (no partial application). The module
   validates all C(switch_ip) values against the fabric inventory client-side before issuing the POST.
+- When O(config.deploy=true) and O(config.blocking=true), ND holds the HTTP response open for the duration of the deploy
+  (often several minutes per switch). Ansible's C(persistent_command_timeout) defaults to 30 seconds and will reap the
+  C(ansible-connection) socket mid-request, surfacing as a confusing C(ConnectionError ... socket path ... does not exist).
+  Raise C(ansible_command_timeout) in your inventory C([nd:vars]) section (e.g. V(3600)) AND set a generous module-level
+  C(timeout) via C(module_defaults). The Examples section below shows the recommended play-level pattern.
 """
 
 EXAMPLES = r"""
@@ -110,7 +115,7 @@ EXAMPLES = r"""
         - switch_ip: 192.168.12.151
         - switch_ip: 192.168.12.155
 
-- name: Take a switch out of maintenance mode (intent only — caller deploys later)
+- name: Take a switch out of maintenance mode (intent only -- caller deploys later)
   cisco.nd.nd_maintenance_mode:
     fabric_name: SITE1
     state: merged
@@ -119,6 +124,27 @@ EXAMPLES = r"""
       deploy: false
       switches:
         - switch_ip: 192.168.12.151
+
+# Recommended pattern for blocking deploys: bump the per-task timeout via module_defaults at the
+# play level, and set `ansible_command_timeout=3600` in your inventory's [nd:vars] section so the
+# persistent connection survives the wait.
+- name: Maintenance mode with extended timeout for a blocking deploy
+  hosts: nd
+  module_defaults:
+    cisco.nd.nd_maintenance_mode:
+      timeout: 1800
+  tasks:
+    - name: Place switches into maintenance mode and block until ND finishes deploying
+      cisco.nd.nd_maintenance_mode:
+        fabric_name: SITE1
+        state: merged
+        config:
+          mode: maintenance
+          deploy: true
+          blocking: true
+          switches:
+            - switch_ip: 192.168.12.151
+            - switch_ip: 192.168.12.155
 """
 
 RETURN = r"""

--- a/plugins/modules/nd_maintenance_mode.py
+++ b/plugins/modules/nd_maintenance_mode.py
@@ -1,0 +1,210 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Ansible module for managing switch maintenance mode on Cisco Nexus Dashboard."""
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_maintenance_mode
+version_added: "1.4.0"
+short_description: Manage the system mode (normal or maintenance) of switches in a fabric on Cisco Nexus Dashboard
+description:
+- Manage the system mode of one or more switches in a fabric on Cisco Nexus Dashboard.
+- Wraps the C(POST /api/v1/manage/fabrics/{fabric_name}/switchActions/changeSystemMode) endpoint, which sets a single
+  C(mode) (C(normal) or C(maintenance)) for a batch of switches in one request.
+- For idempotency the module reads each switch's current C(intendedSystemMode) from C(GET /api/v1/manage/fabrics/{fabric_name}/switches/{switch_id})
+  and only POSTs the subset of switches whose intent differs from the requested mode.
+- If any requested switch is currently in C(migration) mode, the module fails before any change is made and asks the
+  operator to clear the migration state via the ND UI's "Recalculate and Deploy" workflow.
+- This module currently supports O(state=merged) only. A future O(state=gathered) will report current per-switch system
+  mode as runnable playbook configuration once the underlying framework support lands.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target switches.
+    type: str
+    required: true
+  config:
+    description:
+    - The system mode change to apply.
+    - The structure mirrors the ND C(changeSystemMode) API body plus its query parameters.
+    type: dict
+    required: true
+    suboptions:
+      mode:
+        description:
+        - The desired system mode for every switch in O(config.switches).
+        type: str
+        required: true
+        choices: [ maintenance, normal ]
+      deploy:
+        description:
+        - When V(true), the new system mode is deployed to the switches.
+        - When V(false) (default), the new mode is recorded in ND's intent only. A subsequent deploy is required.
+        type: bool
+        default: false
+      blocking:
+        description:
+        - When V(true) and O(config.deploy=true), the API blocks until the deploy operation completes or the
+          server-configured timeout expires (see the ND server setting "Maintenance mode deploy wait time in minutes").
+        - Has no effect when O(config.deploy=false).
+        type: bool
+        default: false
+      ticket_id:
+        description:
+        - Optional Change Control ticket ID associated with the mode change.
+        - Must start with a letter and contain only letters, digits, underscores, or hyphens (max 64 characters).
+        type: str
+      switches:
+        description:
+        - The switches on which to apply the requested mode.
+        - All switches must be members of O(fabric_name); the module pre-resolves each O(config.switches.switch_ip)
+          to its switch serial number via the fabric inventory before posting.
+        type: list
+        elements: dict
+        required: true
+        suboptions:
+          switch_ip:
+            description:
+            - The management IP address of the switch.
+            - Resolved internally to the switch serial number used in the ND C(switchIds) array.
+            type: str
+            required: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to apply the requested mode to the switches that currently differ.
+    type: str
+    default: merged
+    choices: [ merged ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- The module reads C(additionalData.intendedSystemMode) per switch for idempotency. The wire's C(additionalData.systemMode)
+  aggregator returns C(inconsistent) between an intent change and a deploy, so comparing against it would cause spurious
+  re-POSTs on every playbook run.
+- A request that includes any unknown C(switch_ip) is rejected wholesale by ND (no partial application). The module
+  validates all C(switch_ip) values against the fabric inventory client-side before issuing the POST.
+"""
+
+EXAMPLES = r"""
+- name: Place two switches into maintenance mode and deploy
+  cisco.nd.nd_maintenance_mode:
+    fabric_name: SITE1
+    state: merged
+    config:
+      mode: maintenance
+      deploy: true
+      blocking: true
+      ticket_id: CHG12345
+      switches:
+        - switch_ip: 192.168.12.151
+        - switch_ip: 192.168.12.155
+
+- name: Take a switch out of maintenance mode (intent only — caller deploys later)
+  cisco.nd.nd_maintenance_mode:
+    fabric_name: SITE1
+    state: merged
+    config:
+      mode: normal
+      deploy: false
+      switches:
+        - switch_ip: 192.168.12.151
+"""
+
+RETURN = r"""
+"""
+# pylint: disable=wrong-import-position
+
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.maintenance_mode.maintenance_mode import MaintenanceModeModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.maintenance_mode import MaintenanceModeOrchestrator
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_maintenance_mode` Ansible module.
+
+    The ND `changeSystemMode` endpoint is action-shaped — one request mutates a batch of switches with a single mode.
+    The Ansible-facing `config` is a dict (not a list) to mirror the API body shape. `NDStateMachine`, however, drives a
+    *list* of model instances. To bridge the two, this function wraps `module.params["config"]` into a one-item list
+    immediately after argspec validation. The orchestrator's `query_all` and `update` see the original dict via
+    `rest_send.params["config"][0]`.
+
+    Only `state: merged` is supported. The collection has retired `state: query`; once `state: gathered` lands in
+    `NDStateMachine`, this module will gain it with no other surface changes — `query_all` already produces a per-switch
+    snapshot.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(MaintenanceModeModel.get_argument_spec())
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_maintenance_mode")
+
+    # Wrap the dict-shaped `config` into a 1-item list so NDStateMachine's
+    # collection iterator can treat it as a singleton.
+    config = module.params.get("config")
+    if isinstance(config, dict):
+        module.params["config"] = [config]
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=MaintenanceModeOrchestrator,
+        )
+
+        module_log.debug("manage_state begin state=%s check_mode=%s", module.params.get("state"), module.check_mode)
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/nd_maintenance_mode/tasks/main.yaml
+++ b/tests/integration/targets/nd_maintenance_mode/tasks/main.yaml
@@ -1,0 +1,53 @@
+---
+# Test code for the nd_maintenance_mode module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#
+#   ansible-test integration nd_maintenance_mode
+#
+# --- Optional test variables ---
+#
+# Set the variables below in the [nd:vars] section of tests/integration/inventory.networking
+# to override the defaults in vars/main.yaml:
+#
+#   nd_test_maintenance_mode_fabric_name=SITE1
+#   nd_test_maintenance_mode_switch_ip_a=192.168.12.131
+#   nd_test_maintenance_mode_switch_ip_b=192.168.12.141
+#
+# The module's POST endpoint requires write authentication. If the inventory's
+# ansible_httpapi_login_domain is read-only on the target ND (e.g. radius), set
+# `-e ansible_httpapi_login_domain=local` on the ansible-test invocation, or
+# override in the [nd:vars] section.
+#
+# nd_logging_config (str, default: "") — see nd_interface_loopback for details.
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_maintenance_mode tests
+  block:
+    - name: Pre-test setup (capture initial modes, restore to normal)
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run nd_maintenance_mode merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+  always:
+    - name: Teardown (restore initial modes)
+      ansible.builtin.include_tasks: teardown.yaml
+  module_defaults:
+    cisco.nd.nd_maintenance_mode:
+      timeout: 300
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_maintenance_mode/tasks/merged.yaml
+++ b/tests/integration/targets/nd_maintenance_mode/tasks/merged.yaml
@@ -1,0 +1,243 @@
+---
+# Merged state tests for nd_maintenance_mode
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Convention: each scenario defines a YAML anchor on the first task and reuses
+# it via *alias for the normal-mode and idempotent re-runs. This is the YAML
+# anchor pattern requested by the reviewers (see feedback_integration_test_anchors).
+
+# ---------------------------------------------------------------------------
+# MERGED: single switch to maintenance, then idempotent, then restore, then idempotent
+# ---------------------------------------------------------------------------
+
+- name: "MERGED: Switch A to maintenance (check mode)"
+  cisco.nd.nd_maintenance_mode: &maint_a
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      mode: maintenance
+      switches:
+        - switch_ip: "{{ test_switch_ip_a }}"
+    state: merged
+  check_mode: true
+  register: cm_maint_a
+
+- name: "MERGED: Switch A to maintenance (normal mode)"
+  cisco.nd.nd_maintenance_mode: *maint_a
+  register: nm_maint_a
+
+- name: "MERGED: Verify Switch A maintenance applied"
+  ansible.builtin.assert:
+    that:
+      - cm_maint_a is changed
+      - nm_maint_a is changed
+
+- name: "MERGED IDEMP: Re-apply Switch A maintenance (check mode)"
+  cisco.nd.nd_maintenance_mode: *maint_a
+  check_mode: true
+  register: cm_idemp_maint_a
+
+- name: "MERGED IDEMP: Re-apply Switch A maintenance (normal mode)"
+  cisco.nd.nd_maintenance_mode: *maint_a
+  register: nm_idemp_maint_a
+
+- name: "MERGED IDEMP: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_idemp_maint_a is not changed
+      - nm_idemp_maint_a is not changed
+
+- name: "MERGED: Restore Switch A to normal (check mode)"
+  cisco.nd.nd_maintenance_mode: &normal_a
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      mode: normal
+      switches:
+        - switch_ip: "{{ test_switch_ip_a }}"
+    state: merged
+  check_mode: true
+  register: cm_normal_a
+
+- name: "MERGED: Restore Switch A to normal (normal mode)"
+  cisco.nd.nd_maintenance_mode: *normal_a
+  register: nm_normal_a
+
+- name: "MERGED: Verify Switch A normal applied"
+  ansible.builtin.assert:
+    that:
+      - cm_normal_a is changed
+      - nm_normal_a is changed
+
+- name: "MERGED IDEMP: Re-apply Switch A normal (normal mode)"
+  cisco.nd.nd_maintenance_mode: *normal_a
+  register: nm_idemp_normal_a
+
+- name: "MERGED IDEMP: Verify no change for Switch A normal idempotent run"
+  ansible.builtin.assert:
+    that:
+      - nm_idemp_normal_a is not changed
+
+# ---------------------------------------------------------------------------
+# MERGED: multi-switch to maintenance with deploy + ticket_id
+# ---------------------------------------------------------------------------
+
+- name: "MERGED MULTI: Both switches to maintenance with ticket_id (check mode)"
+  cisco.nd.nd_maintenance_mode: &maint_ab
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      mode: maintenance
+      ticket_id: "CHG-NDMAINT-1"
+      switches:
+        - switch_ip: "{{ test_switch_ip_a }}"
+        - switch_ip: "{{ test_switch_ip_b }}"
+    state: merged
+  check_mode: true
+  register: cm_maint_ab
+
+- name: "MERGED MULTI: Both switches to maintenance (normal mode)"
+  cisco.nd.nd_maintenance_mode: *maint_ab
+  register: nm_maint_ab
+
+- name: "MERGED MULTI: Verify both moved to maintenance"
+  ansible.builtin.assert:
+    that:
+      - cm_maint_ab is changed
+      - nm_maint_ab is changed
+
+- name: "MERGED MULTI IDEMP: Re-apply (normal mode)"
+  cisco.nd.nd_maintenance_mode: *maint_ab
+  register: nm_idemp_maint_ab
+
+- name: "MERGED MULTI IDEMP: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_idemp_maint_ab is not changed
+
+- name: "MERGED MULTI: Restore both to normal (normal mode)"
+  cisco.nd.nd_maintenance_mode: &normal_ab
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      mode: normal
+      switches:
+        - switch_ip: "{{ test_switch_ip_a }}"
+        - switch_ip: "{{ test_switch_ip_b }}"
+    state: merged
+  register: nm_normal_ab
+
+- name: "MERGED MULTI: Verify both restored to normal"
+  ansible.builtin.assert:
+    that:
+      - nm_normal_ab is changed
+
+- name: "MERGED MULTI IDEMP: Re-apply normal (normal mode)"
+  cisco.nd.nd_maintenance_mode: *normal_ab
+  register: nm_idemp_normal_ab
+
+- name: "MERGED MULTI IDEMP: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_idemp_normal_ab is not changed
+
+# ---------------------------------------------------------------------------
+# MERGED: partial mismatch — A in maintenance, B in normal, request A=maintenance + B=maintenance
+# Only B should be touched, but the task as a whole still reports changed.
+# ---------------------------------------------------------------------------
+
+- name: "MERGED PARTIAL: Put A in maintenance first"
+  cisco.nd.nd_maintenance_mode: *maint_a
+  register: nm_partial_setup_a
+  failed_when: nm_partial_setup_a is not changed
+
+- name: "MERGED PARTIAL: Request both in maintenance (only B differs)"
+  cisco.nd.nd_maintenance_mode: *maint_ab
+  register: nm_partial_both
+
+- name: "MERGED PARTIAL: Verify changed=True (B was added)"
+  ansible.builtin.assert:
+    that:
+      - nm_partial_both is changed
+
+- name: "MERGED PARTIAL: Re-apply — now both are in maintenance, no change"
+  cisco.nd.nd_maintenance_mode: *maint_ab
+  register: nm_partial_both_idemp
+
+- name: "MERGED PARTIAL: Verify idempotent"
+  ansible.builtin.assert:
+    that:
+      - nm_partial_both_idemp is not changed
+
+# ---------------------------------------------------------------------------
+# NEGATIVE: unknown switch_ip — must fail with a clear message before any POST
+# ---------------------------------------------------------------------------
+
+- name: "NEGATIVE: Unknown switch_ip"
+  cisco.nd.nd_maintenance_mode:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      mode: maintenance
+      switches:
+        - switch_ip: "{{ bogus_switch_ip }}"
+    state: merged
+  register: nm_bad_ip
+  ignore_errors: true
+
+- name: "NEGATIVE: Verify bad switch_ip surfaced as a module failure"
+  ansible.builtin.assert:
+    that:
+      - nm_bad_ip is failed
+      - nm_bad_ip.msg is search("No switch found with fabricManagementIp")
+      - bogus_switch_ip in nm_bad_ip.msg
+
+# ---------------------------------------------------------------------------
+# NEGATIVE: unknown fabric_name — must fail at FabricContext pre-flight
+# ---------------------------------------------------------------------------
+
+- name: "NEGATIVE: Unknown fabric_name"
+  cisco.nd.nd_maintenance_mode:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: NOSUCHFABRIC
+    config:
+      mode: maintenance
+      switches:
+        - switch_ip: "{{ test_switch_ip_a }}"
+    state: merged
+  register: nm_bad_fabric
+  ignore_errors: true
+
+- name: "NEGATIVE: Verify bad fabric surfaced as a module failure"
+  ansible.builtin.assert:
+    that:
+      - nm_bad_fabric is failed
+      - nm_bad_fabric.msg is search("Fabric 'NOSUCHFABRIC' not found")
+
+# ---------------------------------------------------------------------------
+# CHECK_MODE: confirm a would-be change is reported but no mutation happens
+# ---------------------------------------------------------------------------
+
+- name: "CHECK_MODE: Reset A to normal so the next task would change it"
+  cisco.nd.nd_maintenance_mode: *normal_a
+
+- name: "CHECK_MODE: Request A to maintenance in check_mode"
+  cisco.nd.nd_maintenance_mode: *maint_a
+  check_mode: true
+  register: cm_check_only
+
+- name: "CHECK_MODE: Verify changed=True but no actual mutation"
+  ansible.builtin.assert:
+    that:
+      - cm_check_only is changed
+
+- name: "CHECK_MODE: Re-apply without check_mode — should still change (proves the previous task was a dry-run)"
+  cisco.nd.nd_maintenance_mode: *maint_a
+  register: nm_check_followup
+
+- name: "CHECK_MODE: Verify the followup actually changed (otherwise check_mode mutated the lab)"
+  ansible.builtin.assert:
+    that:
+      - nm_check_followup is changed

--- a/tests/integration/targets/nd_maintenance_mode/tasks/setup.yaml
+++ b/tests/integration/targets/nd_maintenance_mode/tasks/setup.yaml
@@ -1,0 +1,24 @@
+---
+# Pre-test setup for nd_maintenance_mode
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Called from main.yaml before the merged-state tests. Restores both test
+# switches to mode 'normal' so the merged tests have a known baseline. The
+# teardown task does the same, so the lab returns to mode normal whether the
+# tests pass or fail.
+#
+# NOTE: this clobbers any operator-set maintenance mode on the test switches.
+
+- name: "SETUP: Force both test switches to mode normal"
+  cisco.nd.nd_maintenance_mode:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      mode: normal
+      switches:
+        - switch_ip: "{{ test_switch_ip_a }}"
+        - switch_ip: "{{ test_switch_ip_b }}"
+    state: merged
+  tags: always

--- a/tests/integration/targets/nd_maintenance_mode/tasks/teardown.yaml
+++ b/tests/integration/targets/nd_maintenance_mode/tasks/teardown.yaml
@@ -1,0 +1,21 @@
+---
+# Teardown for nd_maintenance_mode
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Called from main.yaml after the merged-state tests (in the block's `always`
+# section, so it runs even when an earlier task fails). Restores both test
+# switches to mode 'normal'.
+
+- name: "TEARDOWN: Restore both test switches to mode normal"
+  cisco.nd.nd_maintenance_mode:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      mode: normal
+      switches:
+        - switch_ip: "{{ test_switch_ip_a }}"
+        - switch_ip: "{{ test_switch_ip_b }}"
+    state: merged
+  tags: always

--- a/tests/integration/targets/nd_maintenance_mode/vars/main.yaml
+++ b/tests/integration/targets/nd_maintenance_mode/vars/main.yaml
@@ -1,0 +1,11 @@
+---
+# Variables for nd_maintenance_mode integration tests.
+#
+# Override these in your inventory or with -e to match a real ND 4.2 testbed.
+
+test_fabric_name: "{{ nd_test_maintenance_mode_fabric_name | default('SITE1') }}"
+test_switch_ip_a: "{{ nd_test_maintenance_mode_switch_ip_a | default('192.168.12.131') }}"
+test_switch_ip_b: "{{ nd_test_maintenance_mode_switch_ip_b | default('192.168.12.141') }}"
+
+# An IP that is intentionally NOT in the fabric, used for negative tests.
+bogus_switch_ip: 10.99.99.99

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_switch_actions.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_switch_actions.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for endpoints under
+`plugins/module_utils/endpoints/v1/manage/manage_fabrics_switch_actions.py`.
+"""
+
+# pylint: disable=disallowed-name,protected-access,redefined-outer-name
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switch_actions import (
+    ChangeSystemModeEndpointParams,
+    EpManageFabricsSwitchActionsChangeSystemModePost,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+def test_change_system_mode_endpoint_00010() -> None:
+    """
+    # Summary
+
+    Verify path defaults: with only fabric_name set, no query string is appended.
+
+    ## Classes and Methods
+
+    - EpManageFabricsSwitchActionsChangeSystemModePost.path
+    - EpManageFabricsSwitchActionsChangeSystemModePost.verb
+    """
+    ep = EpManageFabricsSwitchActionsChangeSystemModePost()
+    ep.fabric_name = "SITE1"
+    assert ep.path == "/api/v1/manage/fabrics/SITE1/switchActions/changeSystemMode"
+    assert ep.verb == HttpVerbEnum.POST
+
+
+def test_change_system_mode_endpoint_00020() -> None:
+    """
+    # Summary
+
+    Verify all query params serialize correctly with camelCase aliases.
+
+    ## Classes and Methods
+
+    - ChangeSystemModeEndpointParams.to_query_string
+    """
+    ep = EpManageFabricsSwitchActionsChangeSystemModePost()
+    ep.fabric_name = "SITE1"
+    ep.endpoint_params.deploy = True
+    ep.endpoint_params.blocking = True
+    ep.endpoint_params.ticket_id = "CHG-INT-1"
+    ep.endpoint_params.cluster_name = "cluster_a"
+
+    assert "deploy=true" in ep.path
+    assert "blocking=true" in ep.path
+    assert "ticketId=CHG-INT-1" in ep.path
+    assert "clusterName=cluster_a" in ep.path
+
+
+def test_change_system_mode_endpoint_00030() -> None:
+    """
+    # Summary
+
+    Verify that the path raises ValueError when fabric_name is unset.
+
+    ## Classes and Methods
+
+    - EpManageFabricsSwitchActionsChangeSystemModePost.path
+    """
+    ep = EpManageFabricsSwitchActionsChangeSystemModePost()
+    match = r"fabric_name must be set"
+    with pytest.raises(ValueError, match=match):
+        result = ep.path  # pylint: disable=unused-variable
+
+
+def test_change_system_mode_endpoint_00040() -> None:
+    """
+    # Summary
+
+    Verify class_name field is frozen.
+
+    ## Classes and Methods
+
+    - EpManageFabricsSwitchActionsChangeSystemModePost.class_name
+    """
+    ep = EpManageFabricsSwitchActionsChangeSystemModePost()
+    assert ep.class_name == "EpManageFabricsSwitchActionsChangeSystemModePost"
+
+
+@pytest.mark.parametrize(
+    "deploy,blocking,expected",
+    [
+        (True, False, "deploy=true"),
+        (False, True, "blocking=true"),
+        (False, False, ""),
+    ],
+    ids=["deploy-only", "blocking-only", "neither"],
+)
+def test_change_system_mode_endpoint_00050(deploy: bool, blocking: bool, expected: str) -> None:
+    """
+    # Summary
+
+    Verify selective query-param emission.
+
+    ## Classes and Methods
+
+    - ChangeSystemModeEndpointParams.to_query_string
+    """
+    params = ChangeSystemModeEndpointParams()
+    if deploy:
+        params.deploy = True
+    if blocking:
+        params.blocking = True
+    qs = params.to_query_string()
+    if expected:
+        assert expected in qs
+    else:
+        assert qs == ""
+
+
+def test_change_system_mode_endpoint_00060() -> None:
+    """
+    # Summary
+
+    Verify ticket_id accepts valid identifiers and round-trips into the path query string.
+
+    ## Classes and Methods
+
+    - ChangeSystemModeEndpointParams.ticket_id
+    """
+    ep = EpManageFabricsSwitchActionsChangeSystemModePost()
+    ep.fabric_name = "SITE1"
+    ep.endpoint_params.ticket_id = "CHG-INT_42"
+    assert "ticketId=CHG-INT_42" in ep.path

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_switch_actions.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_switch_actions.py
@@ -139,3 +139,21 @@ def test_change_system_mode_endpoint_00060() -> None:
     ep.fabric_name = "SITE1"
     ep.endpoint_params.ticket_id = "CHG-INT_42"
     assert "ticketId=CHG-INT_42" in ep.path
+
+
+def test_change_system_mode_endpoint_00070() -> None:
+    """
+    # Summary
+
+    Verify `fabric_name` is URL-encoded in the path so reserved characters do not break the route.
+
+    ## Classes and Methods
+
+    - EpManageFabricsSwitchActionsChangeSystemModePost.path
+    """
+    ep = EpManageFabricsSwitchActionsChangeSystemModePost()
+    ep.fabric_name = "SITE A/B"
+    # Space encodes to %20, slash to %2F.
+    assert "/fabrics/SITE%20A%2FB/switchActions/changeSystemMode" in ep.path
+    assert " " not in ep.path
+    assert "SITE A/B" not in ep.path

--- a/tests/unit/module_utils/fixtures/fixture_data/test_maintenance_mode.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_maintenance_mode.json
@@ -105,6 +105,27 @@
         }
     },
 
+    "test_maintenance_mode_00140a": {
+        "TEST_NOTES": ["query_all malformed /switches: fabric summary"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
+    },
+    "test_maintenance_mode_00140b": {
+        "TEST_NOTES": [
+            "query_all malformed: `switches` is a non-iterable scalar (int) — without the orchestrator's list-type",
+            "guard, `_parse_switch_rows` would TypeError on `for row in 0`. With the guard, the value collapses to",
+            "[] and the user gets the standard 'No switch found' message instead."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": 0}
+    },
+
     "test_maintenance_mode_00200a": {
         "TEST_NOTES": ["update changes one switch: fabric summary (validate_prerequisites)"],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/fixtures/fixture_data/test_maintenance_mode.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_maintenance_mode.json
@@ -3,8 +3,10 @@
         "Fixture data for test_maintenance_mode.py (orchestrator tests).",
         "Keys follow the test_<module>_<NNNNN><a|b|c|...> convention from CLAUDE.md.",
         "Suffix order matches the order RestSend.commit() will consume responses within each test.",
-        "Each query_all() call sequence is: GET fabric summary, GET switches list, then per-switch GETs.",
-        "Each update() call sequence after query_all is: per-switch GETs (re-fan-out), POST changeSystemMode.",
+        "Each query_all() call sequence is: GET fabric summary, then ONE bulk GET of /switches whose",
+        "rows carry additionalData.intendedSystemMode and discoveredSystemMode per switch. The bulk",
+        "GET shape is captured verbatim from ND 4.2.1 lab against fabric SITE1 on 2026-05-28.",
+        "Each update() call after query_all() adds: POST changeSystemMode (the snapshot is cached).",
         "Switch A: ip=192.168.12.131, switchId=9UOJ3E8A6O9 (S1_BG1).",
         "Switch B: ip=192.168.12.151, switchId=9ASNKH8T9DJ (S1_LE1)."
     ],
@@ -22,83 +24,6 @@
             "fabricStatus": "default"
         }
     },
-    "switches_list_two": {
-        "TEST_NOTES": ["Reusable switches-list response: two switches in SITE1"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switches": [
-                {"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"},
-                {"fabricManagementIp": "192.168.12.151", "switchId": "9ASNKH8T9DJ"}
-            ]
-        }
-    },
-    "switch_a_normal": {
-        "TEST_NOTES": ["Switch A GET: intendedSystemMode=normal"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9UOJ3E8A6O9",
-            "fabricManagementIp": "192.168.12.131",
-            "additionalData": {
-                "systemMode": "normal",
-                "intendedSystemMode": "normal",
-                "discoveredSystemMode": "normal"
-            }
-        }
-    },
-    "switch_a_maintenance": {
-        "TEST_NOTES": ["Switch A GET: intendedSystemMode=maintenance"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9UOJ3E8A6O9",
-            "fabricManagementIp": "192.168.12.131",
-            "additionalData": {
-                "systemMode": "maintenance",
-                "intendedSystemMode": "maintenance",
-                "discoveredSystemMode": "maintenance"
-            }
-        }
-    },
-    "switch_a_migration": {
-        "TEST_NOTES": ["Switch A GET: discoveredSystemMode=migration"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9UOJ3E8A6O9",
-            "fabricManagementIp": "192.168.12.131",
-            "additionalData": {
-                "systemMode": "inconsistent",
-                "intendedSystemMode": "maintenance",
-                "discoveredSystemMode": "migration"
-            }
-        }
-    },
-    "switch_b_normal": {
-        "TEST_NOTES": ["Switch B GET: intendedSystemMode=normal"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9ASNKH8T9DJ",
-            "fabricManagementIp": "192.168.12.151",
-            "additionalData": {
-                "systemMode": "normal",
-                "intendedSystemMode": "normal",
-                "discoveredSystemMode": "normal"
-            }
-        }
-    },
 
     "test_maintenance_mode_00100a": {
         "TEST_NOTES": ["query_all happy path: fabric summary"],
@@ -109,38 +34,24 @@
         "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
     },
     "test_maintenance_mode_00100b": {
-        "TEST_NOTES": ["query_all happy path: switches list"],
+        "TEST_NOTES": ["query_all happy path: bulk /switches with additionalData per row"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
         "MESSAGE": "OK",
         "DATA": {
             "switches": [
-                {"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"},
-                {"fabricManagementIp": "192.168.12.151", "switchId": "9ASNKH8T9DJ"}
+                {
+                    "fabricManagementIp": "192.168.12.131",
+                    "switchId": "9UOJ3E8A6O9",
+                    "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
+                },
+                {
+                    "fabricManagementIp": "192.168.12.151",
+                    "switchId": "9ASNKH8T9DJ",
+                    "additionalData": {"intendedSystemMode": "maintenance", "discoveredSystemMode": "maintenance"}
+                }
             ]
-        }
-    },
-    "test_maintenance_mode_00100c": {
-        "TEST_NOTES": ["query_all happy path: switch A GET (normal)"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9UOJ3E8A6O9",
-            "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
-        }
-    },
-    "test_maintenance_mode_00100d": {
-        "TEST_NOTES": ["query_all happy path: switch B GET (maintenance)"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9ASNKH8T9DJ",
-            "additionalData": {"intendedSystemMode": "maintenance", "discoveredSystemMode": "maintenance"}
         }
     },
 
@@ -153,24 +64,19 @@
         "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
     },
     "test_maintenance_mode_00110b": {
-        "TEST_NOTES": ["query_all migration: switches list"],
+        "TEST_NOTES": ["query_all migration: bulk /switches with switch A in migration"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
         "MESSAGE": "OK",
         "DATA": {
-            "switches": [{"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"}]
-        }
-    },
-    "test_maintenance_mode_00110c": {
-        "TEST_NOTES": ["query_all migration: switch A GET (in migration)"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9UOJ3E8A6O9",
-            "additionalData": {"intendedSystemMode": "maintenance", "discoveredSystemMode": "migration"}
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.12.131",
+                    "switchId": "9UOJ3E8A6O9",
+                    "additionalData": {"intendedSystemMode": "maintenance", "discoveredSystemMode": "migration"}
+                }
+            ]
         }
     },
 
@@ -183,13 +89,19 @@
         "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
     },
     "test_maintenance_mode_00120b": {
-        "TEST_NOTES": ["query_all unknown switch_ip: switches list contains a different IP"],
+        "TEST_NOTES": ["query_all unknown switch_ip: bulk /switches contains a different IP"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
         "MESSAGE": "OK",
         "DATA": {
-            "switches": [{"fabricManagementIp": "192.168.12.999", "switchId": "OTHER"}]
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.12.999",
+                    "switchId": "OTHER",
+                    "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
+                }
+            ]
         }
     },
 
@@ -202,27 +114,22 @@
         "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
     },
     "test_maintenance_mode_00200b": {
-        "TEST_NOTES": ["update: switches list (cached by FabricContext after this call)"],
+        "TEST_NOTES": ["update: bulk /switches (switch A currently normal)"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
         "MESSAGE": "OK",
         "DATA": {
-            "switches": [{"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"}]
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.12.131",
+                    "switchId": "9UOJ3E8A6O9",
+                    "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
+                }
+            ]
         }
     },
     "test_maintenance_mode_00200c": {
-        "TEST_NOTES": ["update: switch A GET (currently normal)"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9UOJ3E8A6O9",
-            "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
-        }
-    },
-    "test_maintenance_mode_00200d": {
         "TEST_NOTES": ["update: POST changeSystemMode response (207 success)"],
         "RETURN_CODE": 207,
         "METHOD": "POST",
@@ -244,24 +151,19 @@
         "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
     },
     "test_maintenance_mode_00210b": {
-        "TEST_NOTES": ["update no-op: switches list"],
+        "TEST_NOTES": ["update no-op: bulk /switches (switch A already in maintenance)"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
         "MESSAGE": "OK",
         "DATA": {
-            "switches": [{"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"}]
-        }
-    },
-    "test_maintenance_mode_00210c": {
-        "TEST_NOTES": ["update no-op: switch A already in maintenance"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9UOJ3E8A6O9",
-            "additionalData": {"intendedSystemMode": "maintenance", "discoveredSystemMode": "maintenance"}
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.12.131",
+                    "switchId": "9UOJ3E8A6O9",
+                    "additionalData": {"intendedSystemMode": "maintenance", "discoveredSystemMode": "maintenance"}
+                }
+            ]
         }
     },
 
@@ -274,27 +176,22 @@
         "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
     },
     "test_maintenance_mode_00220b": {
-        "TEST_NOTES": ["update 207 failure: switches list"],
+        "TEST_NOTES": ["update 207 failure: bulk /switches (switch A normal)"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
         "MESSAGE": "OK",
         "DATA": {
-            "switches": [{"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"}]
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.12.131",
+                    "switchId": "9UOJ3E8A6O9",
+                    "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
+                }
+            ]
         }
     },
     "test_maintenance_mode_00220c": {
-        "TEST_NOTES": ["update 207 failure: switch A GET (normal)"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
-        "MESSAGE": "OK",
-        "DATA": {
-            "switchId": "9UOJ3E8A6O9",
-            "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
-        }
-    },
-    "test_maintenance_mode_00220d": {
         "TEST_NOTES": ["update 207 failure: POST returns one failed item"],
         "RETURN_CODE": 207,
         "METHOD": "POST",

--- a/tests/unit/module_utils/fixtures/fixture_data/test_maintenance_mode.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_maintenance_mode.json
@@ -1,0 +1,309 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for test_maintenance_mode.py (orchestrator tests).",
+        "Keys follow the test_<module>_<NNNNN><a|b|c|...> convention from CLAUDE.md.",
+        "Suffix order matches the order RestSend.commit() will consume responses within each test.",
+        "Each query_all() call sequence is: GET fabric summary, GET switches list, then per-switch GETs.",
+        "Each update() call sequence after query_all is: per-switch GETs (re-fan-out), POST changeSystemMode.",
+        "Switch A: ip=192.168.12.131, switchId=9UOJ3E8A6O9 (S1_BG1).",
+        "Switch B: ip=192.168.12.151, switchId=9ASNKH8T9DJ (S1_LE1)."
+    ],
+
+    "summary_ok": {
+        "TEST_NOTES": ["Reusable fabric-summary response: fabric exists, local, not frozen"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "SITE1",
+            "ownerCluster": "nd-4-2-1-10",
+            "local": true,
+            "fabricStatus": "default"
+        }
+    },
+    "switches_list_two": {
+        "TEST_NOTES": ["Reusable switches-list response: two switches in SITE1"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"},
+                {"fabricManagementIp": "192.168.12.151", "switchId": "9ASNKH8T9DJ"}
+            ]
+        }
+    },
+    "switch_a_normal": {
+        "TEST_NOTES": ["Switch A GET: intendedSystemMode=normal"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9UOJ3E8A6O9",
+            "fabricManagementIp": "192.168.12.131",
+            "additionalData": {
+                "systemMode": "normal",
+                "intendedSystemMode": "normal",
+                "discoveredSystemMode": "normal"
+            }
+        }
+    },
+    "switch_a_maintenance": {
+        "TEST_NOTES": ["Switch A GET: intendedSystemMode=maintenance"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9UOJ3E8A6O9",
+            "fabricManagementIp": "192.168.12.131",
+            "additionalData": {
+                "systemMode": "maintenance",
+                "intendedSystemMode": "maintenance",
+                "discoveredSystemMode": "maintenance"
+            }
+        }
+    },
+    "switch_a_migration": {
+        "TEST_NOTES": ["Switch A GET: discoveredSystemMode=migration"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9UOJ3E8A6O9",
+            "fabricManagementIp": "192.168.12.131",
+            "additionalData": {
+                "systemMode": "inconsistent",
+                "intendedSystemMode": "maintenance",
+                "discoveredSystemMode": "migration"
+            }
+        }
+    },
+    "switch_b_normal": {
+        "TEST_NOTES": ["Switch B GET: intendedSystemMode=normal"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9ASNKH8T9DJ",
+            "fabricManagementIp": "192.168.12.151",
+            "additionalData": {
+                "systemMode": "normal",
+                "intendedSystemMode": "normal",
+                "discoveredSystemMode": "normal"
+            }
+        }
+    },
+
+    "test_maintenance_mode_00100a": {
+        "TEST_NOTES": ["query_all happy path: fabric summary"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
+    },
+    "test_maintenance_mode_00100b": {
+        "TEST_NOTES": ["query_all happy path: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"},
+                {"fabricManagementIp": "192.168.12.151", "switchId": "9ASNKH8T9DJ"}
+            ]
+        }
+    },
+    "test_maintenance_mode_00100c": {
+        "TEST_NOTES": ["query_all happy path: switch A GET (normal)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9UOJ3E8A6O9",
+            "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
+        }
+    },
+    "test_maintenance_mode_00100d": {
+        "TEST_NOTES": ["query_all happy path: switch B GET (maintenance)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9ASNKH8T9DJ",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9ASNKH8T9DJ",
+            "additionalData": {"intendedSystemMode": "maintenance", "discoveredSystemMode": "maintenance"}
+        }
+    },
+
+    "test_maintenance_mode_00110a": {
+        "TEST_NOTES": ["query_all migration: fabric summary"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
+    },
+    "test_maintenance_mode_00110b": {
+        "TEST_NOTES": ["query_all migration: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [{"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"}]
+        }
+    },
+    "test_maintenance_mode_00110c": {
+        "TEST_NOTES": ["query_all migration: switch A GET (in migration)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9UOJ3E8A6O9",
+            "additionalData": {"intendedSystemMode": "maintenance", "discoveredSystemMode": "migration"}
+        }
+    },
+
+    "test_maintenance_mode_00120a": {
+        "TEST_NOTES": ["query_all unknown switch_ip: fabric summary"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
+    },
+    "test_maintenance_mode_00120b": {
+        "TEST_NOTES": ["query_all unknown switch_ip: switches list contains a different IP"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [{"fabricManagementIp": "192.168.12.999", "switchId": "OTHER"}]
+        }
+    },
+
+    "test_maintenance_mode_00200a": {
+        "TEST_NOTES": ["update changes one switch: fabric summary (validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
+    },
+    "test_maintenance_mode_00200b": {
+        "TEST_NOTES": ["update: switches list (cached by FabricContext after this call)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [{"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"}]
+        }
+    },
+    "test_maintenance_mode_00200c": {
+        "TEST_NOTES": ["update: switch A GET (currently normal)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9UOJ3E8A6O9",
+            "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
+        }
+    },
+    "test_maintenance_mode_00200d": {
+        "TEST_NOTES": ["update: POST changeSystemMode response (207 success)"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switchActions/changeSystemMode",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "items": [
+                {"status": "success", "message": "switch 9UOJ3E8A6O9 success to set mode to maintenance", "switchId": "9UOJ3E8A6O9"}
+            ]
+        }
+    },
+
+    "test_maintenance_mode_00210a": {
+        "TEST_NOTES": ["update no-op (snapshot matches desired): fabric summary"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
+    },
+    "test_maintenance_mode_00210b": {
+        "TEST_NOTES": ["update no-op: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [{"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"}]
+        }
+    },
+    "test_maintenance_mode_00210c": {
+        "TEST_NOTES": ["update no-op: switch A already in maintenance"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9UOJ3E8A6O9",
+            "additionalData": {"intendedSystemMode": "maintenance", "discoveredSystemMode": "maintenance"}
+        }
+    },
+
+    "test_maintenance_mode_00220a": {
+        "TEST_NOTES": ["update 207 failure: fabric summary"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "SITE1", "local": true, "fabricStatus": "default"}
+    },
+    "test_maintenance_mode_00220b": {
+        "TEST_NOTES": ["update 207 failure: switches list"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [{"fabricManagementIp": "192.168.12.131", "switchId": "9UOJ3E8A6O9"}]
+        }
+    },
+    "test_maintenance_mode_00220c": {
+        "TEST_NOTES": ["update 207 failure: switch A GET (normal)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switches/9UOJ3E8A6O9",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "9UOJ3E8A6O9",
+            "additionalData": {"intendedSystemMode": "normal", "discoveredSystemMode": "normal"}
+        }
+    },
+    "test_maintenance_mode_00220d": {
+        "TEST_NOTES": ["update 207 failure: POST returns one failed item"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/switchActions/changeSystemMode",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "items": [
+                {"status": "failed", "message": "deploy aborted", "switchId": "9UOJ3E8A6O9"}
+            ]
+        }
+    }
+}

--- a/tests/unit/module_utils/models/test_maintenance_mode_model.py
+++ b/tests/unit/module_utils/models/test_maintenance_mode_model.py
@@ -47,7 +47,8 @@ def test_maintenance_mode_model_00010() -> None:
     assert MaintenanceModeModel.identifier_strategy == "singleton"
     assert MaintenanceModeModel.identifiers == []
 
-    instance = MaintenanceModeModel(mode="maintenance")
+    # mode left unset so the `mode set + switches=[]` validator does not fire here.
+    instance = MaintenanceModeModel()
     assert instance.get_identifier_value() is None
 
 
@@ -281,6 +282,44 @@ def test_maintenance_mode_model_00090() -> None:
     assert switches["elements"] == "dict"
     assert switches["required"] is True
     assert switches["options"]["switch_ip"] == {"type": "str", "required": True}
+
+
+# =============================================================================
+# Test: empty-switches rejection
+# =============================================================================
+
+
+def test_maintenance_mode_model_00100() -> None:
+    """
+    # Summary
+
+    Verify the model rejects an empty `switches` list when `mode` is set. The Ansible argspec only
+    enforces key presence; without this validator a `switches: []` config would silently no-op
+    against an action endpoint that requires a non-empty `switchIds` array.
+
+    ## Classes and Methods
+
+    - MaintenanceModeModel._require_switches_when_mode_set
+    """
+    with pytest.raises(ValueError, match=r"config\.switches must contain at least one switch when 'mode' is set"):
+        MaintenanceModeModel.from_config({"mode": "maintenance", "switches": []})
+
+
+def test_maintenance_mode_model_00110() -> None:
+    """
+    # Summary
+
+    Verify the empty-switches validator is gated on `mode` so query_all snapshots (which leave `mode`
+    unset and may legitimately carry an empty switches list, e.g. when config is missing) still build.
+
+    ## Classes and Methods
+
+    - MaintenanceModeModel._require_switches_when_mode_set
+    """
+    with does_not_raise():
+        snapshot = MaintenanceModeModel.from_response({"switches": [], "switch_modes": {}})
+    assert snapshot.mode is None
+    assert snapshot.switches == []
 
 
 def test_maintenance_mode_switch_model_00010() -> None:

--- a/tests/unit/module_utils/models/test_maintenance_mode_model.py
+++ b/tests/unit/module_utils/models/test_maintenance_mode_model.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for `MaintenanceModeModel` and `MaintenanceModeSwitchModel`.
+"""
+
+# pylint: disable=disallowed-name,protected-access,redefined-outer-name
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.maintenance_mode.maintenance_mode import (
+    MaintenanceModeModel,
+    MaintenanceModeSwitchModel,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+
+# =============================================================================
+# Test: initialization / identifier behavior
+# =============================================================================
+
+
+def test_maintenance_mode_model_00010() -> None:
+    """
+    # Summary
+
+    Verify identifier strategy is singleton.
+
+    ## Test
+
+    - `identifier_strategy` is `"singleton"`
+    - `identifiers` is the empty list
+    - `get_identifier_value()` returns None
+
+    ## Classes and Methods
+
+    - MaintenanceModeModel.identifier_strategy
+    - MaintenanceModeModel.get_identifier_value
+    """
+    assert MaintenanceModeModel.identifier_strategy == "singleton"
+    assert MaintenanceModeModel.identifiers == []
+
+    instance = MaintenanceModeModel(mode="maintenance")
+    assert instance.get_identifier_value() is None
+
+
+def test_maintenance_mode_model_00020() -> None:
+    """
+    # Summary
+
+    Verify defaults for optional fields.
+
+    ## Classes and Methods
+
+    - MaintenanceModeModel.__init__
+    """
+    instance = MaintenanceModeModel()
+    assert instance.mode is None
+    assert instance.deploy is False
+    assert instance.blocking is False
+    assert instance.ticket_id is None
+    assert instance.switches == []
+    assert instance.switch_modes is None
+
+
+# =============================================================================
+# Test: from_config / from_response factories
+# =============================================================================
+
+
+def test_maintenance_mode_model_00030() -> None:
+    """
+    # Summary
+
+    Verify `from_config` accepts Ansible-style keys and populates nested switch models.
+
+    ## Classes and Methods
+
+    - NDBaseModel.from_config
+    """
+    instance = MaintenanceModeModel.from_config(
+        {
+            "mode": "maintenance",
+            "deploy": True,
+            "blocking": True,
+            "ticket_id": "CHG-1",
+            "switches": [{"switch_ip": "192.168.12.131"}, {"switch_ip": "192.168.12.151"}],
+        }
+    )
+    assert instance.mode == "maintenance"
+    assert instance.deploy is True
+    assert instance.blocking is True
+    assert instance.ticket_id == "CHG-1"
+    assert len(instance.switches) == 2
+    assert all(isinstance(s, MaintenanceModeSwitchModel) for s in instance.switches)
+    assert [s.switch_ip for s in instance.switches] == ["192.168.12.131", "192.168.12.151"]
+    assert instance.switch_modes is None
+
+
+def test_maintenance_mode_model_00040() -> None:
+    """
+    # Summary
+
+    Verify `from_response` accepts a snapshot dict with switch_modes.
+
+    ## Classes and Methods
+
+    - NDBaseModel.from_response
+    """
+    snapshot = MaintenanceModeModel.from_response(
+        {
+            "switches": [{"switch_ip": "192.168.12.131"}],
+            "switch_modes": {"192.168.12.131": "normal"},
+        }
+    )
+    assert snapshot.mode is None
+    assert snapshot.switch_modes == {"192.168.12.131": "normal"}
+
+
+# =============================================================================
+# Test: to_payload (wire shape)
+# =============================================================================
+
+
+def test_maintenance_mode_model_00050() -> None:
+    """
+    # Summary
+
+    Verify `to_payload` returns only `mode` — everything else is either a query param or client-side
+    metadata (orchestrator injects `switchIds` separately).
+
+    ## Classes and Methods
+
+    - MaintenanceModeModel.to_payload
+    """
+    instance = MaintenanceModeModel.from_config(
+        {
+            "mode": "maintenance",
+            "deploy": True,
+            "blocking": True,
+            "ticket_id": "CHG-1",
+            "switches": [{"switch_ip": "192.168.12.131"}],
+        }
+    )
+    payload = instance.to_payload()
+    assert payload == {"mode": "maintenance"}
+
+
+# =============================================================================
+# Test: get_diff (per-switch mode comparison)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "snapshot_modes,desired_mode,switches,expected",
+    [
+        ({"192.168.12.131": "normal"}, "normal", ["192.168.12.131"], True),
+        ({"192.168.12.131": "normal"}, "maintenance", ["192.168.12.131"], False),
+        (
+            {"192.168.12.131": "maintenance", "192.168.12.151": "maintenance"},
+            "maintenance",
+            ["192.168.12.131", "192.168.12.151"],
+            True,
+        ),
+        (
+            {"192.168.12.131": "maintenance", "192.168.12.151": "normal"},
+            "maintenance",
+            ["192.168.12.131", "192.168.12.151"],
+            False,
+        ),
+        ({"192.168.12.131": "inconsistent"}, "maintenance", ["192.168.12.131"], False),
+        ({}, "maintenance", ["192.168.12.131"], False),
+    ],
+    ids=[
+        "match-normal-single",
+        "diff-want-maint-have-normal",
+        "match-maint-two-switches",
+        "mixed-state",
+        "snapshot-inconsistent",
+        "snapshot-empty",
+    ],
+)
+def test_maintenance_mode_model_00060(snapshot_modes: dict, desired_mode: str, switches: list, expected: bool) -> None:
+    """
+    # Summary
+
+    Verify `get_diff` returns True (no_diff) iff every requested switch already has the desired mode.
+
+    ## Classes and Methods
+
+    - MaintenanceModeModel.get_diff
+    """
+    snapshot = MaintenanceModeModel.from_response(
+        {
+            "switches": [{"switch_ip": ip} for ip in switches],
+            "switch_modes": snapshot_modes,
+        }
+    )
+    proposed = MaintenanceModeModel.from_config(
+        {
+            "mode": desired_mode,
+            "switches": [{"switch_ip": ip} for ip in switches],
+        }
+    )
+    assert snapshot.get_diff(proposed) is expected
+
+
+def test_maintenance_mode_model_00070() -> None:
+    """
+    # Summary
+
+    Verify `get_diff` returns True when proposed has no mode set (defensive — should never happen via
+    argspec, but the diff should not POST in that pathological case).
+
+    ## Classes and Methods
+
+    - MaintenanceModeModel.get_diff
+    """
+    snapshot = MaintenanceModeModel.from_response(
+        {
+            "switches": [{"switch_ip": "192.168.12.131"}],
+            "switch_modes": {"192.168.12.131": "normal"},
+        }
+    )
+    proposed = MaintenanceModeModel()  # mode=None, switches=[]
+    assert snapshot.get_diff(proposed) is True
+
+
+def test_maintenance_mode_model_00080() -> None:
+    """
+    # Summary
+
+    Verify `get_diff` returns False when compared against a different type.
+
+    ## Classes and Methods
+
+    - MaintenanceModeModel.get_diff
+    """
+    snapshot = MaintenanceModeModel.from_response({"switches": [], "switch_modes": {}})
+    assert snapshot.get_diff("not a model") is False  # type: ignore[arg-type]
+
+
+# =============================================================================
+# Test: argument spec
+# =============================================================================
+
+
+def test_maintenance_mode_model_00090() -> None:
+    """
+    # Summary
+
+    Verify argspec shape matches the documented module surface.
+
+    ## Classes and Methods
+
+    - MaintenanceModeModel.get_argument_spec
+    """
+    spec = MaintenanceModeModel.get_argument_spec()
+    assert spec["fabric_name"] == {"type": "str", "required": True}
+    assert spec["state"] == {"type": "str", "default": "merged", "choices": ["merged"]}
+
+    config = spec["config"]
+    assert config["type"] == "dict"
+    assert config["required"] is True
+
+    opts = config["options"]
+    assert opts["mode"] == {"type": "str", "required": True, "choices": ["maintenance", "normal"]}
+    assert opts["deploy"] == {"type": "bool", "default": False}
+    assert opts["blocking"] == {"type": "bool", "default": False}
+    assert opts["ticket_id"] == {"type": "str"}
+
+    switches = opts["switches"]
+    assert switches["type"] == "list"
+    assert switches["elements"] == "dict"
+    assert switches["required"] is True
+    assert switches["options"]["switch_ip"] == {"type": "str", "required": True}
+
+
+def test_maintenance_mode_switch_model_00010() -> None:
+    """
+    # Summary
+
+    Verify `MaintenanceModeSwitchModel` parses both the Ansible field name and the API alias.
+
+    ## Classes and Methods
+
+    - MaintenanceModeSwitchModel.__init__
+    """
+    with does_not_raise():
+        from_field = MaintenanceModeSwitchModel(switch_ip="192.168.12.131")
+        from_alias = MaintenanceModeSwitchModel.model_validate({"switchIp": "192.168.12.131"})
+    assert from_field.switch_ip == "192.168.12.131"
+    assert from_alias.switch_ip == "192.168.12.131"

--- a/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
+++ b/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
@@ -587,7 +587,9 @@ def test_maintenance_mode_00310() -> None:
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
     instance = MaintenanceModeOrchestrator(rest_send=rest_send)
-    model = MaintenanceModeModel(mode="normal")
+    # switches is required when mode is set (see MaintenanceModeModel validator); the value here is
+    # arbitrary — this test only exercises the unconditional NotImplementedError from delete().
+    model = MaintenanceModeModel(mode="normal", switches=[{"switch_ip": "192.168.12.131"}])
 
     match = r"state 'deleted' is not supported"
     with pytest.raises(NotImplementedError, match=match):

--- a/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
+++ b/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
@@ -1,0 +1,592 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for `MaintenanceModeOrchestrator`.
+
+Verifies that the orchestrator drives `RestSend` correctly for the changeSystemMode switch action:
+per-switch GET fan-out and snapshot construction in `query_all`, migration hard-fail, idempotency
+filtering in `update`, and per-switch 207-failure parsing.
+
+Scope: methods defined in `maintenance_mode.py` only. Inherited `FabricContext` plumbing is
+exercised through `query_all` but tested in detail by `test_fabric_context.py`.
+"""
+
+# pylint: disable=disallowed-name,protected-access,redefined-outer-name,too-many-lines
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+import inspect
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.maintenance_mode.maintenance_mode import MaintenanceModeModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.maintenance_mode import MaintenanceModeOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_maintenance_mode(key: str):
+    """Load fixture data for test_maintenance_mode tests."""
+    return load_fixture("test_maintenance_mode")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, config: list | None = None) -> RestSend:
+    """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    params = {"check_mode": False, "fabric_name": "SITE1", "config": config or []}
+    rest_send = RestSend(params)
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+# =============================================================================
+# Test: initialization
+# =============================================================================
+
+
+def test_maintenance_mode_00010() -> None:
+    """
+    # Summary
+
+    Verify `MaintenanceModeOrchestrator` instantiates and exposes expected ClassVars.
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.__init__
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    assert instance.model_class is MaintenanceModeModel
+    assert instance.supports_bulk_create is False
+    assert instance.supports_bulk_delete is False
+    assert instance.fabric_name == "SITE1"
+
+
+# =============================================================================
+# Test: _user_switches helper
+# =============================================================================
+
+
+def test_maintenance_mode_00020() -> None:
+    """
+    # Summary
+
+    `_user_switches` returns the switches list from the wrapped config dict.
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator._user_switches
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    assert instance._user_switches() == [{"switch_ip": "192.168.12.131"}]
+
+
+def test_maintenance_mode_00030() -> None:
+    """
+    # Summary
+
+    `_user_switches` returns [] when config is empty or malformed.
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator._user_switches
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, config=[])
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    assert instance._user_switches() == []
+
+
+# =============================================================================
+# Test: query_all
+# =============================================================================
+
+
+def test_maintenance_mode_00100() -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns a singleton snapshot with per-switch `intendedSystemMode`.
+
+    ## Test
+
+    - 2 switches in config
+    - Fabric summary, switches list, then per-switch GETs are consumed in order
+    - Snapshot contains both IPs with their current `intendedSystemMode`
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.query_all
+    - MaintenanceModeOrchestrator._fetch_switch_modes
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")  # fabric summary
+        yield responses_maintenance_mode(f"{method_name}b")  # switches list
+        yield responses_maintenance_mode(f"{method_name}c")  # switch A
+        yield responses_maintenance_mode(f"{method_name}d")  # switch B
+
+    gen_responses = ResponseGenerator(responses())
+    config = [
+        {
+            "mode": "maintenance",
+            "switches": [
+                {"switch_ip": "192.168.12.131"},
+                {"switch_ip": "192.168.12.151"},
+            ],
+        }
+    ]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    snapshot = result[0]
+    assert snapshot["switch_modes"] == {
+        "192.168.12.131": "normal",
+        "192.168.12.151": "maintenance",
+    }
+    assert {s["switch_ip"] for s in snapshot["switches"]} == {"192.168.12.131", "192.168.12.151"}
+
+
+def test_maintenance_mode_00110() -> None:
+    """
+    # Summary
+
+    Verify `query_all` hard-fails with the remediation message when any switch is in migration mode.
+
+    ## Test
+
+    - 1 switch in config
+    - Switch's discoveredSystemMode is `migration`
+    - `RuntimeError` raised; message contains exact remediation text and the switch IP
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.query_all
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")  # summary
+        yield responses_maintenance_mode(f"{method_name}b")  # switches list
+        yield responses_maintenance_mode(f"{method_name}c")  # switch in migration
+
+    gen_responses = ResponseGenerator(responses())
+    config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    match = r"Switch\(es\) are in 'migration' mode:.*192\.168\.12\.131.*Recalculate and Deploy"
+    with pytest.raises(RuntimeError, match=match):
+        instance.query_all()
+
+
+def test_maintenance_mode_00120() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises when a user-supplied switch_ip is not found in the fabric.
+
+    ## Test
+
+    - 1 switch in config with IP not in the switches list
+    - `RuntimeError` raised (wrapped from `_resolve_switch_id`)
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.query_all
+    - NDBaseInterfaceOrchestrator._resolve_switch_id
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")  # summary
+        yield responses_maintenance_mode(f"{method_name}b")  # switches list with different IP
+
+    gen_responses = ResponseGenerator(responses())
+    config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    match = r"No switch found with fabricManagementIp '192\.168\.12\.131'"
+    with pytest.raises(RuntimeError, match=match):
+        instance.query_all()
+
+
+def test_maintenance_mode_00130() -> None:
+    """
+    # Summary
+
+    Verify `query_all` returns an empty snapshot when config has no switches (defensive path; argspec
+    normally prevents this).
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.query_all
+    """
+
+    def responses():
+        yield responses_maintenance_mode("summary_ok")  # only summary is consumed
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, config=[])
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    assert result == [{"switches": [], "switch_modes": {}}]
+
+
+# =============================================================================
+# Test: update
+# =============================================================================
+
+
+def test_maintenance_mode_00200() -> None:
+    """
+    # Summary
+
+    Verify `update` resolves IPs, filters to switches needing change, sets query params, and POSTs.
+
+    ## Test
+
+    - 1 switch in config with desired mode=maintenance, currently normal
+    - POST issued to /switchActions/changeSystemMode with switchIds=[serial]
+    - Query params deploy/blocking/ticketId appended
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.update
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")  # summary
+        yield responses_maintenance_mode(f"{method_name}b")  # switches list
+        yield responses_maintenance_mode(f"{method_name}c")  # switch A (normal)
+        yield responses_maintenance_mode(f"{method_name}d")  # POST 207 success
+
+    gen_responses = ResponseGenerator(responses())
+    config = [
+        {
+            "mode": "maintenance",
+            "deploy": True,
+            "blocking": True,
+            "ticket_id": "CHG-1",
+            "switches": [{"switch_ip": "192.168.12.131"}],
+        }
+    ]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    model = MaintenanceModeModel.from_config(config[0])
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert "switchActions/changeSystemMode" in rest_send.path
+    assert "deploy=true" in rest_send.path
+    assert "blocking=true" in rest_send.path
+    assert "ticketId=CHG-1" in rest_send.path
+
+    body = rest_send.committed_payload
+    assert body == {"mode": "maintenance", "switchIds": ["9UOJ3E8A6O9"]}
+
+
+def test_maintenance_mode_00210() -> None:
+    """
+    # Summary
+
+    Verify `update` short-circuits (no POST) when every switch already has the desired intent.
+
+    ## Test
+
+    - Snapshot says switch is already in maintenance, model requests maintenance
+    - No POST is issued; only the snapshot GETs are consumed
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.update
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")  # summary
+        yield responses_maintenance_mode(f"{method_name}b")  # switches list
+        yield responses_maintenance_mode(f"{method_name}c")  # switch A already maintenance
+
+    gen_responses = ResponseGenerator(responses())
+    config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    model = MaintenanceModeModel.from_config(config[0])
+
+    with does_not_raise():
+        result = instance.update(model)
+
+    assert result == {}
+    # If a POST had been issued we'd see verb=POST; instead the last call was the GET on switch A.
+    assert rest_send.verb == HttpVerbEnum.GET.value
+
+
+def test_maintenance_mode_00220() -> None:
+    """
+    # Summary
+
+    Verify `update` raises with switch IPs when the 207 body contains per-switch failures.
+
+    ## Test
+
+    - POST returns 207 with one item status=failed
+    - `RuntimeError` raised; message names the offending switch IP (resolved from switchId)
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.update
+    - MaintenanceModeOrchestrator._raise_on_207_failures
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")  # summary
+        yield responses_maintenance_mode(f"{method_name}b")  # switches list
+        yield responses_maintenance_mode(f"{method_name}c")  # switch A (normal)
+        yield responses_maintenance_mode(f"{method_name}d")  # POST 207 with failure
+
+    gen_responses = ResponseGenerator(responses())
+    config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    model = MaintenanceModeModel.from_config(config[0])
+
+    match = r"changeSystemMode reported per-switch failures:.*192\.168\.12\.131.*deploy aborted"
+    with pytest.raises(RuntimeError, match=match):
+        instance.update(model)
+
+
+def test_maintenance_mode_00230() -> None:
+    """
+    # Summary
+
+    `update` returns early when the model has no mode or no switches (defensive — argspec normally
+    rejects both).
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.update
+    """
+
+    def responses():
+        # Only the fabric-summary call from validate_prerequisites is consumed before the early-return.
+        yield responses_maintenance_mode("summary_ok")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, config=[{"mode": None, "switches": []}])
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    model = MaintenanceModeModel()  # mode=None, switches=[]
+
+    with does_not_raise():
+        result = instance.update(model)
+
+    assert result == {}
+
+
+# =============================================================================
+# Test: create / delete / query_one delegation
+# =============================================================================
+
+
+def test_maintenance_mode_00300() -> None:
+    """
+    # Summary
+
+    `create` delegates to `update`.
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.create
+    """
+    method_name = "test_maintenance_mode_00200"  # reuse 00200's response sequence (create == update)
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")
+        yield responses_maintenance_mode(f"{method_name}b")
+        yield responses_maintenance_mode(f"{method_name}c")
+        yield responses_maintenance_mode(f"{method_name}d")
+
+    gen_responses = ResponseGenerator(responses())
+    config = [
+        {
+            "mode": "maintenance",
+            "deploy": True,
+            "blocking": True,
+            "ticket_id": "CHG-1",
+            "switches": [{"switch_ip": "192.168.12.131"}],
+        }
+    ]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+    model = MaintenanceModeModel.from_config(config[0])
+
+    with does_not_raise():
+        instance.create(model)
+
+    assert rest_send.verb == HttpVerbEnum.POST.value
+
+
+def test_maintenance_mode_00310() -> None:
+    """
+    # Summary
+
+    `delete` always raises `NotImplementedError`.
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.delete
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+    model = MaintenanceModeModel(mode="normal")
+
+    match = r"state 'deleted' is not supported"
+    with pytest.raises(NotImplementedError, match=match):
+        instance.delete(model)
+
+
+def test_maintenance_mode_00320() -> None:
+    """
+    # Summary
+
+    `query_one` delegates to `query_all`.
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.query_one
+    """
+    method_name = "test_maintenance_mode_00100"  # reuse the query_all happy-path fixtures
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")
+        yield responses_maintenance_mode(f"{method_name}b")
+        yield responses_maintenance_mode(f"{method_name}c")
+        yield responses_maintenance_mode(f"{method_name}d")
+
+    gen_responses = ResponseGenerator(responses())
+    config = [
+        {
+            "mode": "maintenance",
+            "switches": [{"switch_ip": "192.168.12.131"}, {"switch_ip": "192.168.12.151"}],
+        }
+    ]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+    model = MaintenanceModeModel.from_config(config[0])
+
+    with does_not_raise():
+        result = instance.query_one(model)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+
+
+# =============================================================================
+# Test: 207 parser helper (direct)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "body,should_raise",
+    [
+        ({"items": [{"status": "success", "switchId": "X"}]}, False),
+        ({"items": []}, False),
+        ({"items": [{"status": "SUCCESS", "switchId": "X"}]}, False),  # case-insensitive
+        ({"unrelated": "no items key"}, False),
+        ("not a dict", False),
+        (None, False),
+    ],
+    ids=["all-success", "empty-items", "case-insensitive", "missing-items-key", "non-dict", "none"],
+)
+def test_maintenance_mode_00400(body, should_raise: bool) -> None:
+    """
+    # Summary
+
+    Verify `_raise_on_207_failures` is permissive about malformed/successful bodies and only raises on
+    real per-switch failures.
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator._raise_on_207_failures
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    if should_raise:
+        with pytest.raises(RuntimeError):
+            instance._raise_on_207_failures(body, ["1.1.1.1"], ["X"])
+    else:
+        with does_not_raise():
+            instance._raise_on_207_failures(body, ["1.1.1.1"], ["X"])

--- a/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
+++ b/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
@@ -155,21 +155,18 @@ def test_maintenance_mode_00100() -> None:
     ## Test
 
     - 2 switches in config
-    - Fabric summary, switches list, then per-switch GETs are consumed in order
+    - Fabric summary and one bulk /switches GET are consumed in order
     - Snapshot contains both IPs with their current `intendedSystemMode`
 
     ## Classes and Methods
 
     - MaintenanceModeOrchestrator.query_all
-    - MaintenanceModeOrchestrator._fetch_switch_modes
     """
     method_name = inspect.stack()[0][3]
 
     def responses():
         yield responses_maintenance_mode(f"{method_name}a")  # fabric summary
-        yield responses_maintenance_mode(f"{method_name}b")  # switches list
-        yield responses_maintenance_mode(f"{method_name}c")  # switch A
-        yield responses_maintenance_mode(f"{method_name}d")  # switch B
+        yield responses_maintenance_mode(f"{method_name}b")  # bulk switches GET
 
     gen_responses = ResponseGenerator(responses())
     config = [
@@ -217,8 +214,7 @@ def test_maintenance_mode_00110() -> None:
 
     def responses():
         yield responses_maintenance_mode(f"{method_name}a")  # summary
-        yield responses_maintenance_mode(f"{method_name}b")  # switches list
-        yield responses_maintenance_mode(f"{method_name}c")  # switch in migration
+        yield responses_maintenance_mode(f"{method_name}b")  # bulk switches GET (switch in migration)
 
     gen_responses = ResponseGenerator(responses())
     config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
@@ -239,18 +235,17 @@ def test_maintenance_mode_00120() -> None:
     ## Test
 
     - 1 switch in config with IP not in the switches list
-    - `RuntimeError` raised (wrapped from `_resolve_switch_id`)
+    - `RuntimeError` raised with FabricContext-style message
 
     ## Classes and Methods
 
     - MaintenanceModeOrchestrator.query_all
-    - NDBaseInterfaceOrchestrator._resolve_switch_id
     """
     method_name = inspect.stack()[0][3]
 
     def responses():
         yield responses_maintenance_mode(f"{method_name}a")  # summary
-        yield responses_maintenance_mode(f"{method_name}b")  # switches list with different IP
+        yield responses_maintenance_mode(f"{method_name}b")  # bulk switches GET with different IP
 
     gen_responses = ResponseGenerator(responses())
     config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
@@ -312,9 +307,8 @@ def test_maintenance_mode_00200() -> None:
 
     def responses():
         yield responses_maintenance_mode(f"{method_name}a")  # summary
-        yield responses_maintenance_mode(f"{method_name}b")  # switches list
-        yield responses_maintenance_mode(f"{method_name}c")  # switch A (normal)
-        yield responses_maintenance_mode(f"{method_name}d")  # POST 207 success
+        yield responses_maintenance_mode(f"{method_name}b")  # bulk switches GET (switch A normal)
+        yield responses_maintenance_mode(f"{method_name}c")  # POST 207 success
 
     gen_responses = ResponseGenerator(responses())
     config = [
@@ -363,8 +357,7 @@ def test_maintenance_mode_00210() -> None:
 
     def responses():
         yield responses_maintenance_mode(f"{method_name}a")  # summary
-        yield responses_maintenance_mode(f"{method_name}b")  # switches list
-        yield responses_maintenance_mode(f"{method_name}c")  # switch A already maintenance
+        yield responses_maintenance_mode(f"{method_name}b")  # bulk switches GET (switch A already maintenance)
 
     gen_responses = ResponseGenerator(responses())
     config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
@@ -377,7 +370,7 @@ def test_maintenance_mode_00210() -> None:
         result = instance.update(model)
 
     assert result == {}
-    # If a POST had been issued we'd see verb=POST; instead the last call was the GET on switch A.
+    # If a POST had been issued we'd see verb=POST; instead the last call was the bulk switches GET.
     assert rest_send.verb == HttpVerbEnum.GET.value
 
 
@@ -401,9 +394,8 @@ def test_maintenance_mode_00220() -> None:
 
     def responses():
         yield responses_maintenance_mode(f"{method_name}a")  # summary
-        yield responses_maintenance_mode(f"{method_name}b")  # switches list
-        yield responses_maintenance_mode(f"{method_name}c")  # switch A (normal)
-        yield responses_maintenance_mode(f"{method_name}d")  # POST 207 with failure
+        yield responses_maintenance_mode(f"{method_name}b")  # bulk switches GET (switch A normal)
+        yield responses_maintenance_mode(f"{method_name}c")  # POST 207 with failure
 
     gen_responses = ResponseGenerator(responses())
     config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
@@ -455,7 +447,7 @@ def test_maintenance_mode_00240() -> None:
 
     ## Test
 
-    - Call `query_all` first (consumes summary, switches list, switch A GET).
+    - Call `query_all` first (consumes summary and the bulk /switches GET).
     - Call `update`. Fixture generator yields only the POST next; if `update` re-queried, the
       generator would underflow and raise.
 
@@ -464,14 +456,13 @@ def test_maintenance_mode_00240() -> None:
     - MaintenanceModeOrchestrator.query_all
     - MaintenanceModeOrchestrator.update
     """
-    # Reuse 00200's response sequence: summary, switches list, switch A normal, POST.
+    # Reuse 00200's response sequence: summary, bulk /switches GET, POST.
     method_name = "test_maintenance_mode_00200"
 
     def responses():
         yield responses_maintenance_mode(f"{method_name}a")  # summary
-        yield responses_maintenance_mode(f"{method_name}b")  # switches list
-        yield responses_maintenance_mode(f"{method_name}c")  # switch A (normal)
-        yield responses_maintenance_mode(f"{method_name}d")  # POST 207 success
+        yield responses_maintenance_mode(f"{method_name}b")  # bulk switches GET (switch A normal)
+        yield responses_maintenance_mode(f"{method_name}c")  # POST 207 success
 
     gen_responses = ResponseGenerator(responses())
     config = [
@@ -517,7 +508,6 @@ def test_maintenance_mode_00300() -> None:
         yield responses_maintenance_mode(f"{method_name}a")
         yield responses_maintenance_mode(f"{method_name}b")
         yield responses_maintenance_mode(f"{method_name}c")
-        yield responses_maintenance_mode(f"{method_name}d")
 
     gen_responses = ResponseGenerator(responses())
     config = [
@@ -578,8 +568,6 @@ def test_maintenance_mode_00320() -> None:
     def responses():
         yield responses_maintenance_mode(f"{method_name}a")
         yield responses_maintenance_mode(f"{method_name}b")
-        yield responses_maintenance_mode(f"{method_name}c")
-        yield responses_maintenance_mode(f"{method_name}d")
 
     gen_responses = ResponseGenerator(responses())
     config = [

--- a/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
+++ b/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
@@ -638,19 +638,42 @@ def test_maintenance_mode_00320() -> None:
     [
         ({"items": [{"status": "success", "switchId": "X"}]}, False),
         ({"items": []}, False),
-        ({"items": [{"status": "SUCCESS", "switchId": "X"}]}, False),  # case-insensitive
+        ({"items": [{"status": "SUCCESS", "switchId": "X"}]}, False),  # case-insensitive success
         ({"unrelated": "no items key"}, False),
         ("not a dict", False),
         (None, False),
+        # Denylist semantics: only explicit failure tokens raise; everything else is tolerated.
+        ({"items": [{"switchId": "X"}]}, False),  # missing status
+        ({"items": [{"status": "", "switchId": "X"}]}, False),  # empty status
+        ({"items": [{"status": "pending", "switchId": "X"}]}, False),  # progress
+        ({"items": [{"status": "warning", "switchId": "X", "message": "noop"}]}, False),  # informational
+        ({"items": [{"status": "failed", "switchId": "X", "message": "boom"}]}, True),
+        ({"items": [{"status": "FAILURE", "switchId": "X", "message": "boom"}]}, True),  # case-insensitive
+        ({"items": [{"status": "error", "switchId": "X", "message": "boom"}]}, True),
     ],
-    ids=["all-success", "empty-items", "case-insensitive", "missing-items-key", "non-dict", "none"],
+    ids=[
+        "all-success",
+        "empty-items",
+        "case-insensitive",
+        "missing-items-key",
+        "non-dict",
+        "none",
+        "missing-status",
+        "empty-status",
+        "pending-progress",
+        "warning-info",
+        "failed-raises",
+        "failure-case-insensitive",
+        "error-raises",
+    ],
 )
 def test_maintenance_mode_00400(body, should_raise: bool) -> None:
     """
     # Summary
 
-    Verify `_raise_on_207_failures` is permissive about malformed/successful bodies and only raises on
-    real per-switch failures.
+    Verify `_raise_on_207_failures` raises ONLY on explicit failure tokens
+    (`failed` / `failure` / `error`, case-insensitive) and tolerates anything else --
+    success, missing/empty status, progress/info tokens like `pending` / `warning`.
 
     ## Classes and Methods
 

--- a/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
+++ b/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
@@ -445,6 +445,57 @@ def test_maintenance_mode_00230() -> None:
     assert result == {}
 
 
+def test_maintenance_mode_00240() -> None:
+    """
+    # Summary
+
+    Verify that `update` reuses the snapshot cached by `query_all` and does NOT re-issue per-switch
+    GETs when called after `query_all`. Together they should consume exactly one snapshot pass
+    (summary + switches list + per-switch GET) and one POST.
+
+    ## Test
+
+    - Call `query_all` first (consumes summary, switches list, switch A GET).
+    - Call `update`. Fixture generator yields only the POST next; if `update` re-queried, the
+      generator would underflow and raise.
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.query_all
+    - MaintenanceModeOrchestrator.update
+    """
+    # Reuse 00200's response sequence: summary, switches list, switch A normal, POST.
+    method_name = "test_maintenance_mode_00200"
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")  # summary
+        yield responses_maintenance_mode(f"{method_name}b")  # switches list
+        yield responses_maintenance_mode(f"{method_name}c")  # switch A (normal)
+        yield responses_maintenance_mode(f"{method_name}d")  # POST 207 success
+
+    gen_responses = ResponseGenerator(responses())
+    config = [
+        {
+            "mode": "maintenance",
+            "deploy": True,
+            "blocking": True,
+            "ticket_id": "CHG-1",
+            "switches": [{"switch_ip": "192.168.12.131"}],
+        }
+    ]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+    model = MaintenanceModeModel.from_config(config[0])
+
+    with does_not_raise():
+        instance.query_all()
+        instance.update(model)
+
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert "switchActions/changeSystemMode" in rest_send.path
+    assert rest_send.committed_payload == {"mode": "maintenance", "switchIds": ["9UOJ3E8A6O9"]}
+
+
 # =============================================================================
 # Test: create / delete / query_one delegation
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
+++ b/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
@@ -487,6 +487,47 @@ def test_maintenance_mode_00240() -> None:
     assert rest_send.committed_payload == {"mode": "maintenance", "switchIds": ["9UOJ3E8A6O9"]}
 
 
+def test_maintenance_mode_00250() -> None:
+    """
+    # Summary
+
+    Verify `update` does NOT emit `deploy=false` / `blocking=false` on the URL when the user did
+    not opt into them. The model defaults both fields to `False`; the endpoint's `to_query_string`
+    excludes None but not False, so an unconditional push would put `?deploy=false&blocking=false`
+    on every request.
+
+    ## Test
+
+    - Config with mode only (no deploy, no blocking, no ticket_id)
+    - POST URL must not contain any query string at all
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.update
+    """
+    # Reuse 00200's response sequence: summary, bulk switches GET, POST.
+    method_name = "test_maintenance_mode_00200"
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")  # summary
+        yield responses_maintenance_mode(f"{method_name}b")  # bulk switches GET (switch A normal)
+        yield responses_maintenance_mode(f"{method_name}c")  # POST 207 success
+
+    gen_responses = ResponseGenerator(responses())
+    config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+    model = MaintenanceModeModel.from_config(config[0])
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert "deploy" not in rest_send.path
+    assert "blocking" not in rest_send.path
+    assert "?" not in rest_send.path
+
+
 # =============================================================================
 # Test: create / delete / query_one delegation
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
+++ b/tests/unit/module_utils/orchestrators/test_maintenance_mode.py
@@ -282,6 +282,35 @@ def test_maintenance_mode_00130() -> None:
     assert result == [{"switches": [], "switch_modes": {}}]
 
 
+def test_maintenance_mode_00140() -> None:
+    """
+    # Summary
+
+    Verify the orchestrator's list-type guard on the bulk `/switches` response. If ND returns
+    `switches` as a non-list (here: an int), `_parse_switch_rows` must not be invoked over a
+    non-iterable. The guard collapses the bad value to `[]`, so the user gets the standard
+    "No switch found" error rather than a `TypeError` blowing up the module.
+
+    ## Classes and Methods
+
+    - MaintenanceModeOrchestrator.query_all
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_maintenance_mode(f"{method_name}a")  # fabric summary
+        yield responses_maintenance_mode(f"{method_name}b")  # bulk /switches with malformed shape
+
+    gen_responses = ResponseGenerator(responses())
+    config = [{"mode": "maintenance", "switches": [{"switch_ip": "192.168.12.131"}]}]
+    rest_send = _build_rest_send(gen_responses, config=config)
+    instance = MaintenanceModeOrchestrator(rest_send=rest_send)
+
+    match = r"No switch found with fabricManagementIp '192\.168\.12\.131'"
+    with pytest.raises(RuntimeError, match=match):
+        instance.query_all()
+
+
 # =============================================================================
 # Test: update
 # =============================================================================


### PR DESCRIPTION
## Related Issue(s)
<!--- None tracked yet for this work. -->

## Proposed Changes

Add `cisco.nd.nd_maintenance_mode`, a new Ansible module that sets the system mode (`normal` or `maintenance`) of switches in a fabric via `POST /api/v1/manage/fabrics/{fabric_name}/switchActions/changeSystemMode`.

The endpoint is action-shaped — one POST mutates a batch of switches with a single mode. The module adapts that to `NDStateMachine`'s CRUD-shaped driver via an `identifier_strategy="singleton"` model and a `config`-dict-to-list wrap in `main()`. Idempotency reads `additionalData.intendedSystemMode` per switch (from one bulk `GET /fabrics/{f}/switches`) and only POSTs switches whose intent differs from the request. Any switch currently in `migration` mode triggers a hard-fail with a remediation message asking the operator to run 'Recalculate and Deploy' in the ND UI before retrying. The 207 response body is inspected per-item; entries whose `status` is `failed`, `failure`, or `error` (case-insensitive) surface as a `RuntimeError` naming the offending switches by IP. Other tokens (`success`, missing, empty, `pending`, `warning`) are tolerated.

State support is `merged` only for now. The collection-wide `query` state is retired; `gathered` will be added once the underlying `NDStateMachine`/`NDOutput` framework support lands (the orchestrator's `query_all` already produces the per-switch snapshot it will need).

Two `TODO(4.2.1)` workaround markers flag observed ND wire/schema divergences:

- `GET /fabrics/{f}/switches/{sid}` nests `systemMode` under `additionalData`, not at the top level the OpenAPI schema documents.
- The aggregator `additionalData.systemMode` returns `"inconsistent"` (a value not in the OpenAPI enum) between an intent change and a deploy, so idempotency must compare against `intendedSystemMode`, not `systemMode`.

New / modified files:

- `plugins/modules/nd_maintenance_mode.py` — module entry point (DOCUMENTATION / EXAMPLES / argspec / `main()`). DOCUMENTATION includes a notes paragraph and a play-level `module_defaults` example covering the `ansible_command_timeout` / `persistent_command_timeout` interaction with blocking deploys.
- `plugins/module_utils/orchestrators/maintenance_mode.py` — `MaintenanceModeOrchestrator` inheriting `NDBaseInterfaceOrchestrator` for `FabricContext` plumbing. `query_all()` issues one bulk `EpManageSwitchesListGet` and caches both the IP→intendedSystemMode map and the IP→switchId map on the instance; `update()` reuses both, so each module run does one fabric-summary GET, one switches GET, and (when changes are needed) one POST.
- `plugins/module_utils/models/maintenance_mode/{__init__.py, maintenance_mode.py}` — singleton model + per-switch `get_diff`.
- `plugins/module_utils/endpoints/v1/manage/manage_fabrics_switch_actions.py` — new endpoint module for `changeSystemMode`. Path is URL-encoded; query string omits `deploy` and `blocking` when the user did not opt into them.
- `plugins/module_utils/endpoints/v1/manage/manage_switches.py` — added `EpManageSwitchesGet` (generic per-switch GET, retained as collection infrastructure though `nd_maintenance_mode` itself reads via the bulk `EpManageSwitchesListGet`). URL encoding on both new paths hardened to match the existing `EpManageSwitchActionsDeploy` convention.
- Unit tests: endpoint (9), model (15), orchestrator (29 collected). Total suite: 554/554 pass.
- Integration target `nd_maintenance_mode` with YAML-anchored single-switch, multi-switch, partial-mismatch, negative, and `check_mode` scenarios.

## Test Notes

- **Unit tests**: `source env && python -m pytest tests/unit/module_utils/` — 554/554 pass, zero regressions. Coverage: orchestrator 93%, model 97%, endpoint 97%.
- **Lint**: `black`, `isort`, `pylint`, `mypy` all clean against `pyproject.toml`. `pylint` 9.97/10 on tests, 9.78/10 on production. `yamllint` clean on integration target.
- **Integration**: Verified live on ND 4.2.1.10 @ 192.168.7.7 / SITE1 against switches S1_BG1 (192.168.12.131) and S1_SP1 (192.168.12.141). Full target green; lab state verified back to `intendedSystemMode=normal` for all test switches after the run. Re-verified green after the follow-up commits below.
- **Smoke test**: Eight standalone scenarios (baseline, set maintenance, idempotent, restore, idempotent, negative `switch_ip`, negative fabric, check_mode) all green prior to writing the integration target.
- The `radius` auth domain on this lab is effectively read-only on SITE1/SITE2; live tests use `-e ansible_httpapi_login_domain=local`. Documented in the integration target's `main.yaml`.

## Refinements since PR opened

Six follow-up commits land behavior/perf refinements on top of the initial implementation:

1. `e65143d` — Cache the `query_all()` snapshot on the orchestrator and skip the redundant re-query in `update()`. Avoids a second per-run snapshot pass when `NDStateMachine` already populated one during init.
2. `d9d09fa` — Replace the per-switch GET fan-out in `query_all()` with one bulk `EpManageSwitchesListGet` call (verified on ND 4.2.1 lab: the list response carries `additionalData.intendedSystemMode` and `discoveredSystemMode` per row). Per-run controller round-trips drop from `2 + N` to `2 + 1`; on a 32-switch fabric that is 64 GETs eliminated per task.
3. `3dde916` — URL-encode `fabric_name` (and `switch_id`) in `EpManageSwitchesGet.path` and `EpManageFabricsSwitchActionsChangeSystemModePost.path`. Matches the existing `quote(safe="")` convention used by sibling endpoints; protects against future fabric names containing reserved URL characters.
4. `8374b4b` — Only push truthy `deploy` / `blocking` onto the endpoint's query params. Previously the bool defaults (False) were assigned unconditionally and serialized as `?deploy=false&blocking=false` on every request. Functionally harmless on ND today but inconsistent with the endpoint's own `to_query_string` design.
5. `f77bd42` — 207 parser uses an explicit failure denylist (`failed` / `failure` / `error`, case-insensitive) rather than treating anything not `success` as a failure. ND's switchAction APIs occasionally return rows with missing status or progress tokens like `pending`/`warning`; the old code would surface those as spurious task failures.
6. `0efba32` — Document the `blocking=true` deploy interaction with `persistent_command_timeout`. New notes paragraph and a play-level `module_defaults` example showing the recommended `timeout: 1800` + inventory `ansible_command_timeout` pattern.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
