### PR TITLE
[ND 4.2+] Add module for Routing Policies Prefix Lists (NDA-27)

### DIFF
--- a/plugins/module_utils/endpoints/mixins.py
+++ b/plugins/module_utils/endpoints/mixins.py
@@ -119,6 +119,7 @@ class UpdateGroupNameMixin(BaseModel):
 
     update_group_name: str | None = Field(default=None, min_length=1, description="Update group name")
 
+
 class PrefixListNameMixin(BaseModel):
     """Mixin for endpoints that require prefix_list_name parameter."""
 

--- a/plugins/module_utils/endpoints/mixins.py
+++ b/plugins/module_utils/endpoints/mixins.py
@@ -119,6 +119,11 @@ class UpdateGroupNameMixin(BaseModel):
 
     update_group_name: str | None = Field(default=None, min_length=1, description="Update group name")
 
+class PrefixListNameMixin(BaseModel):
+    """Mixin for endpoints that require prefix_list_name parameter."""
+
+    prefix_list_name: Optional[str] = Field(default=None, min_length=1, max_length=115, description="Prefix list name")
+
 
 class RouteMapNameMixin(BaseModel):
     """Mixin for endpoints that require route_map_name parameter."""

--- a/plugins/module_utils/endpoints/mixins.py
+++ b/plugins/module_utils/endpoints/mixins.py
@@ -123,7 +123,7 @@ class UpdateGroupNameMixin(BaseModel):
 class PrefixListNameMixin(BaseModel):
     """Mixin for endpoints that require prefix_list_name parameter."""
 
-    prefix_list_name: Optional[str] = Field(default=None, min_length=1, max_length=115, description="Prefix list name")
+    prefix_list_name: str | None = Field(default=None, min_length=1, max_length=115, description="Prefix list name")
 
 
 class RouteMapNameMixin(BaseModel):

--- a/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
@@ -130,11 +130,14 @@ class _EpManagePrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpointB
 
     def set_identifiers(self, identifier: IdentifierKey = None) -> None:
         """
-        Accept either a plain name or a composite tuple ``(ip_version, name)``
-        and assign the prefix list name.
+        Accept either a plain name, ``(ip_version, name)``, or
+        ``(ip_version, tenant_name, name)`` and assign the API prefix list name.
         """
         if isinstance(identifier, tuple):
-            self.prefix_list_name = identifier[1]
+            if len(identifier) >= 3 and identifier[1]:
+                self.prefix_list_name = f"{identifier[1]}~{identifier[2]}"
+            else:
+                self.prefix_list_name = identifier[-1]
         else:
             self.prefix_list_name = identifier
 

--- a/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 __metaclass__ = type
 
-from typing import ClassVar, Literal, Optional, Tuple, Union
+from typing import ClassVar, Literal, Optional
 
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
@@ -179,7 +179,9 @@ class EpManageIpv4PrefixListsListGet(_EpManageIpv4PrefixListsBase):
 
     _require_prefix_list_name: ClassVar[bool] = False
 
-    class_name: Literal["EpManageIpv4PrefixListsListGet"] = Field(default="EpManageIpv4PrefixListsListGet", description="Class name for backward compatibility")
+    class_name: Literal["EpManageIpv4PrefixListsListGet"] = Field(
+        default="EpManageIpv4PrefixListsListGet", description="Class name for backward compatibility"
+    )
     endpoint_params: PrefixListsListEndpointParams = Field(default_factory=PrefixListsListEndpointParams)
 
     @property
@@ -244,7 +246,9 @@ class EpManageIpv4PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
     Request body: ``{"ipv4PrefixListNames": ["name1", ...]}``.
     """
 
-    class_name: Literal["EpManageIpv4PrefixListsBulkDelete"] = Field(default="EpManageIpv4PrefixListsBulkDelete", description="Class name for backward compatibility")
+    class_name: Literal["EpManageIpv4PrefixListsBulkDelete"] = Field(
+        default="EpManageIpv4PrefixListsBulkDelete", description="Class name for backward compatibility"
+    )
 
     @property
     def path(self) -> str:
@@ -324,7 +328,9 @@ class EpManageIpv6PrefixListsListGet(_EpManageIpv6PrefixListsBase):
 
     _require_prefix_list_name: ClassVar[bool] = False
 
-    class_name: Literal["EpManageIpv6PrefixListsListGet"] = Field(default="EpManageIpv6PrefixListsListGet", description="Class name for backward compatibility")
+    class_name: Literal["EpManageIpv6PrefixListsListGet"] = Field(
+        default="EpManageIpv6PrefixListsListGet", description="Class name for backward compatibility"
+    )
     endpoint_params: PrefixListsListEndpointParams = Field(default_factory=PrefixListsListEndpointParams)
 
     @property
@@ -389,7 +395,9 @@ class EpManageIpv6PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
     Request body: ``{"ipv6PrefixListNames": ["name1", ...]}``.
     """
 
-    class_name: Literal["EpManageIpv6PrefixListsBulkDelete"] = Field(default="EpManageIpv6PrefixListsBulkDelete", description="Class name for backward compatibility")
+    class_name: Literal["EpManageIpv6PrefixListsBulkDelete"] = Field(
+        default="EpManageIpv6PrefixListsBulkDelete", description="Class name for backward compatibility"
+    )
 
     @property
     def path(self) -> str:

--- a/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
@@ -255,12 +255,15 @@ class _EpManagePrefixListsBulkDeleteBase(FabricNameMixin, NDEndpointBaseModel):
 
     # Address-family action segment, set by the per-family subclasses below.
     _action_segment: ClassVar[str] = ""
+    endpoint_params: PrefixListsEndpointParams = Field(default_factory=PrefixListsEndpointParams)
 
     @property
     def path(self) -> str:
         if self.fabric_name is None:
             raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
-        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), self._action_segment, "remove")
+        base = BasePath.path("fabrics", quote(self.fabric_name, safe=""), self._action_segment, "remove")
+        qs = self.endpoint_params.to_query_string()
+        return f"{base}?{qs}" if qs else base
 
 
 class EpManageIpv4PrefixListsBulkDelete(_EpManagePrefixListsBulkDeleteBase):

--- a/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
@@ -1,0 +1,402 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+ND Manage Prefix Lists endpoint models (IPv4 and IPv6).
+
+This module contains endpoint definitions for prefix-list operations
+in the ND Manage API, covering both IPv4 and IPv6 prefix lists.
+
+## IPv4 Endpoints
+
+- `EpManageIpv4PrefixListsGet` - Get a specific IPv4 prefix list by name
+  (GET /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists/{ipv4PrefixListName})
+- `EpManageIpv4PrefixListsListGet` - List all IPv4 prefix lists for a fabric
+  (GET /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists)
+- `EpManageIpv4PrefixListsPost` - Bulk-create IPv4 prefix lists
+  (POST /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists)
+- `EpManageIpv4PrefixListsPut` - Update a specific IPv4 prefix list
+  (PUT /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists/{ipv4PrefixListName})
+- `EpManageIpv4PrefixListsDelete` - Delete a specific IPv4 prefix list
+  (DELETE /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists/{ipv4PrefixListName})
+- `EpManageIpv4PrefixListsBulkDelete` - Bulk-delete IPv4 prefix lists
+  (POST /api/v1/manage/fabrics/{fabricName}/ipv4PrefixListActions/remove)
+
+## IPv6 Endpoints
+
+- `EpManageIpv6PrefixListsGet` - Get a specific IPv6 prefix list by name
+  (GET /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists/{ipv6PrefixListName})
+- `EpManageIpv6PrefixListsListGet` - List all IPv6 prefix lists for a fabric
+  (GET /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists)
+- `EpManageIpv6PrefixListsPost` - Bulk-create IPv6 prefix lists
+  (POST /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists)
+- `EpManageIpv6PrefixListsPut` - Update a specific IPv6 prefix list
+  (PUT /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists/{ipv6PrefixListName})
+- `EpManageIpv6PrefixListsDelete` - Delete a specific IPv6 prefix list
+  (DELETE /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists/{ipv6PrefixListName})
+- `EpManageIpv6PrefixListsBulkDelete` - Bulk-delete IPv6 prefix lists
+  (POST /api/v1/manage/fabrics/{fabricName}/ipv6PrefixListActions/remove)
+"""
+
+from __future__ import annotations
+
+__metaclass__ = type
+
+from typing import ClassVar, Literal, Optional, Tuple, Union
+
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin, PrefixListNameMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
+
+
+class PrefixListsEndpointParams(EndpointQueryParams):
+    """
+    Query parameters shared by single-item prefix list endpoints.
+
+    - cluster_name: Name of the target Nexus Dashboard cluster (multi-cluster deployments)
+    """
+
+    cluster_name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
+    )
+
+
+class PrefixListsListEndpointParams(EndpointQueryParams):
+    """
+    Query parameters for prefix list collection (list) endpoints.
+
+    - cluster_name: multi-cluster target cluster name
+    - filter: Lucene-format filter string
+    - max: maximum number of records
+    - offset: records to skip for pagination
+    - sort: sort field with optional ``:desc`` suffix
+    """
+
+    cluster_name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
+    )
+
+    filter: Optional[str] = Field(
+        default=None,
+        description="Lucene format filter - Filter the response based on this filter field",
+    )
+
+    max: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Number of records to return",
+    )
+
+    offset: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Number of records to skip for pagination",
+    )
+
+    sort: Optional[str] = Field(
+        default=None,
+        description="Sort the records by the declared fields in either ascending (default) or descending (:desc) order",
+    )
+
+
+# ---------------------------------------------------------------------------
+# IPv4 base class
+# ---------------------------------------------------------------------------
+
+
+class _EpManageIpv4PrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpointBaseModel):
+    """
+    Base class for IPv4 prefix list endpoints.
+
+    Path: ``/api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists[/{name}]``
+
+    Subclasses set ``_require_prefix_list_name = False`` for collection-level
+    operations (list, bulk-create).
+    """
+
+    _require_prefix_list_name: ClassVar[bool] = True
+
+    endpoint_params: EndpointQueryParams = Field(default_factory=EndpointQueryParams, description="Endpoint-specific query parameters")
+
+    def set_identifiers(self, identifier: IdentifierKey = None) -> None:
+        """
+        Accept either a plain name or a composite tuple ``("ipv4", name)``
+        and assign the prefix list name.
+        """
+        if isinstance(identifier, tuple):
+            self.prefix_list_name = identifier[1]
+        else:
+            self.prefix_list_name = identifier
+
+    @property
+    def path(self) -> str:
+        if self._require_prefix_list_name and self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        if self._require_prefix_list_name and self.prefix_list_name is None:
+            raise ValueError(f"{type(self).__name__}.path: prefix_list_name must be set before accessing path.")
+        segments = ["fabrics"]
+        if self.fabric_name is not None:
+            segments.append(self.fabric_name)
+        segments.append("ipv4PrefixLists")
+        if self.prefix_list_name is not None:
+            segments.append(self.prefix_list_name)
+        base = BasePath.path(*segments)
+        qs = self.endpoint_params.to_query_string()
+        return f"{base}?{qs}" if qs else base
+
+
+class EpManageIpv4PrefixListsGet(_EpManageIpv4PrefixListsBase):
+    """
+    GET /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists/{ipv4PrefixListName}
+
+    Retrieve a specific IPv4 prefix list by name.
+    """
+
+    class_name: Literal["EpManageIpv4PrefixListsGet"] = Field(default="EpManageIpv4PrefixListsGet", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsEndpointParams = Field(default_factory=PrefixListsEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.GET
+
+
+class EpManageIpv4PrefixListsListGet(_EpManageIpv4PrefixListsBase):
+    """
+    GET /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists
+
+    List all IPv4 prefix lists for a fabric.
+    """
+
+    _require_prefix_list_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageIpv4PrefixListsListGet"] = Field(default="EpManageIpv4PrefixListsListGet", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsListEndpointParams = Field(default_factory=PrefixListsListEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.GET
+
+
+class EpManageIpv4PrefixListsPost(_EpManageIpv4PrefixListsBase):
+    """
+    POST /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists
+
+    Bulk-create IPv4 prefix lists.
+    Request body: ``{"ipv4PrefixLists": [...]}``.
+    """
+
+    _require_prefix_list_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageIpv4PrefixListsPost"] = Field(default="EpManageIpv4PrefixListsPost", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsEndpointParams = Field(default_factory=PrefixListsEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.POST
+
+
+class EpManageIpv4PrefixListsPut(_EpManageIpv4PrefixListsBase):
+    """
+    PUT /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists/{ipv4PrefixListName}
+
+    Update a specific IPv4 prefix list.
+    Request body: ``ipv4PrefixListItem`` schema.
+    """
+
+    class_name: Literal["EpManageIpv4PrefixListsPut"] = Field(default="EpManageIpv4PrefixListsPut", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsEndpointParams = Field(default_factory=PrefixListsEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.PUT
+
+
+class EpManageIpv4PrefixListsDelete(_EpManageIpv4PrefixListsBase):
+    """
+    DELETE /api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists/{ipv4PrefixListName}
+
+    Delete a specific IPv4 prefix list.
+    """
+
+    class_name: Literal["EpManageIpv4PrefixListsDelete"] = Field(default="EpManageIpv4PrefixListsDelete", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsEndpointParams = Field(default_factory=PrefixListsEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.DELETE
+
+
+class EpManageIpv4PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
+    """
+    POST /api/v1/manage/fabrics/{fabricName}/ipv4PrefixListActions/remove
+
+    Bulk-delete IPv4 prefix lists.
+    Request body: ``{"ipv4PrefixListNames": ["name1", ...]}``.
+    """
+
+    class_name: Literal["EpManageIpv4PrefixListsBulkDelete"] = Field(default="EpManageIpv4PrefixListsBulkDelete", description="Class name for backward compatibility")
+
+    @property
+    def path(self) -> str:
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        return BasePath.path("fabrics", self.fabric_name, "ipv4PrefixListActions", "remove")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.POST
+
+
+# ---------------------------------------------------------------------------
+# IPv6 base class
+# ---------------------------------------------------------------------------
+
+
+class _EpManageIpv6PrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpointBaseModel):
+    """
+    Base class for IPv6 prefix list endpoints.
+
+    Path: ``/api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists[/{name}]``
+    """
+
+    _require_prefix_list_name: ClassVar[bool] = True
+
+    endpoint_params: EndpointQueryParams = Field(default_factory=EndpointQueryParams, description="Endpoint-specific query parameters")
+
+    def set_identifiers(self, identifier: IdentifierKey = None) -> None:
+        """
+        Accept either a plain name or a composite tuple ``("ipv6", name)``
+        and assign the prefix list name.
+        """
+        if isinstance(identifier, tuple):
+            self.prefix_list_name = identifier[1]
+        else:
+            self.prefix_list_name = identifier
+
+    @property
+    def path(self) -> str:
+        if self._require_prefix_list_name and self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        if self._require_prefix_list_name and self.prefix_list_name is None:
+            raise ValueError(f"{type(self).__name__}.path: prefix_list_name must be set before accessing path.")
+        segments = ["fabrics"]
+        if self.fabric_name is not None:
+            segments.append(self.fabric_name)
+        segments.append("ipv6PrefixLists")
+        if self.prefix_list_name is not None:
+            segments.append(self.prefix_list_name)
+        base = BasePath.path(*segments)
+        qs = self.endpoint_params.to_query_string()
+        return f"{base}?{qs}" if qs else base
+
+
+class EpManageIpv6PrefixListsGet(_EpManageIpv6PrefixListsBase):
+    """
+    GET /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists/{ipv6PrefixListName}
+
+    Retrieve a specific IPv6 prefix list by name.
+    """
+
+    class_name: Literal["EpManageIpv6PrefixListsGet"] = Field(default="EpManageIpv6PrefixListsGet", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsEndpointParams = Field(default_factory=PrefixListsEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.GET
+
+
+class EpManageIpv6PrefixListsListGet(_EpManageIpv6PrefixListsBase):
+    """
+    GET /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists
+
+    List all IPv6 prefix lists for a fabric.
+    """
+
+    _require_prefix_list_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageIpv6PrefixListsListGet"] = Field(default="EpManageIpv6PrefixListsListGet", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsListEndpointParams = Field(default_factory=PrefixListsListEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.GET
+
+
+class EpManageIpv6PrefixListsPost(_EpManageIpv6PrefixListsBase):
+    """
+    POST /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists
+
+    Bulk-create IPv6 prefix lists.
+    Request body: ``{"ipv6PrefixLists": [...]}``.
+    """
+
+    _require_prefix_list_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageIpv6PrefixListsPost"] = Field(default="EpManageIpv6PrefixListsPost", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsEndpointParams = Field(default_factory=PrefixListsEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.POST
+
+
+class EpManageIpv6PrefixListsPut(_EpManageIpv6PrefixListsBase):
+    """
+    PUT /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists/{ipv6PrefixListName}
+
+    Update a specific IPv6 prefix list.
+    Request body: ``ipv6PrefixListItem`` schema.
+    """
+
+    class_name: Literal["EpManageIpv6PrefixListsPut"] = Field(default="EpManageIpv6PrefixListsPut", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsEndpointParams = Field(default_factory=PrefixListsEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.PUT
+
+
+class EpManageIpv6PrefixListsDelete(_EpManageIpv6PrefixListsBase):
+    """
+    DELETE /api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists/{ipv6PrefixListName}
+
+    Delete a specific IPv6 prefix list.
+    """
+
+    class_name: Literal["EpManageIpv6PrefixListsDelete"] = Field(default="EpManageIpv6PrefixListsDelete", description="Class name for backward compatibility")
+    endpoint_params: PrefixListsEndpointParams = Field(default_factory=PrefixListsEndpointParams)
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.DELETE
+
+
+class EpManageIpv6PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
+    """
+    POST /api/v1/manage/fabrics/{fabricName}/ipv6PrefixListActions/remove
+
+    Bulk-delete IPv6 prefix lists.
+    Request body: ``{"ipv6PrefixListNames": ["name1", ...]}``.
+    """
+
+    class_name: Literal["EpManageIpv6PrefixListsBulkDelete"] = Field(default="EpManageIpv6PrefixListsBulkDelete", description="Class name for backward compatibility")
+
+    @property
+    def path(self) -> str:
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        return BasePath.path("fabrics", self.fabric_name, "ipv6PrefixListActions", "remove")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        return HttpVerbEnum.POST

--- a/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 __metaclass__ = type
 
 from typing import ClassVar, Literal, Optional
+from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
@@ -109,11 +110,7 @@ class PrefixListsListEndpointParams(EndpointQueryParams):
     )
 
 
-# ---------------------------------------------------------------------------
 # IPv4 base class
-# ---------------------------------------------------------------------------
-
-
 class _EpManageIpv4PrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpointBaseModel):
     """
     Base class for IPv4 prefix list endpoints.
@@ -140,16 +137,16 @@ class _EpManageIpv4PrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpo
 
     @property
     def path(self) -> str:
-        if self._require_prefix_list_name and self.fabric_name is None:
+        if self.fabric_name is None:
             raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
         if self._require_prefix_list_name and self.prefix_list_name is None:
             raise ValueError(f"{type(self).__name__}.path: prefix_list_name must be set before accessing path.")
         segments = ["fabrics"]
         if self.fabric_name is not None:
-            segments.append(self.fabric_name)
+            segments.append(quote(self.fabric_name, safe=""))
         segments.append("ipv4PrefixLists")
         if self.prefix_list_name is not None:
-            segments.append(self.prefix_list_name)
+            segments.append(quote(self.prefix_list_name, safe=""))
         base = BasePath.path(*segments)
         qs = self.endpoint_params.to_query_string()
         return f"{base}?{qs}" if qs else base
@@ -254,18 +251,14 @@ class EpManageIpv4PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
     def path(self) -> str:
         if self.fabric_name is None:
             raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
-        return BasePath.path("fabrics", self.fabric_name, "ipv4PrefixListActions", "remove")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "ipv4PrefixListActions", "remove")
 
     @property
     def verb(self) -> HttpVerbEnum:
         return HttpVerbEnum.POST
 
 
-# ---------------------------------------------------------------------------
 # IPv6 base class
-# ---------------------------------------------------------------------------
-
-
 class _EpManageIpv6PrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpointBaseModel):
     """
     Base class for IPv6 prefix list endpoints.
@@ -289,16 +282,16 @@ class _EpManageIpv6PrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpo
 
     @property
     def path(self) -> str:
-        if self._require_prefix_list_name and self.fabric_name is None:
+        if self.fabric_name is None:
             raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
         if self._require_prefix_list_name and self.prefix_list_name is None:
             raise ValueError(f"{type(self).__name__}.path: prefix_list_name must be set before accessing path.")
         segments = ["fabrics"]
         if self.fabric_name is not None:
-            segments.append(self.fabric_name)
+            segments.append(quote(self.fabric_name, safe=""))
         segments.append("ipv6PrefixLists")
         if self.prefix_list_name is not None:
-            segments.append(self.prefix_list_name)
+            segments.append(quote(self.prefix_list_name, safe=""))
         base = BasePath.path(*segments)
         qs = self.endpoint_params.to_query_string()
         return f"{base}?{qs}" if qs else base
@@ -403,7 +396,7 @@ class EpManageIpv6PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
     def path(self) -> str:
         if self.fabric_name is None:
             raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
-        return BasePath.path("fabrics", self.fabric_name, "ipv6PrefixListActions", "remove")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "ipv6PrefixListActions", "remove")
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
@@ -42,8 +42,6 @@ in the ND Manage API, covering both IPv4 and IPv6 prefix lists.
 
 from __future__ import annotations
 
-__metaclass__ = type
-
 from typing import ClassVar, Literal, Optional
 from urllib.parse import quote
 

--- a/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
@@ -49,7 +49,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin, PrefixListNameMixin
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import CompositeQueryParams, EndpointQueryParams, LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
@@ -73,38 +73,12 @@ class PrefixListsListEndpointParams(EndpointQueryParams):
     Query parameters for prefix list collection (list) endpoints.
 
     - cluster_name: multi-cluster target cluster name
-    - filter: Lucene-format filter string
-    - max: maximum number of records
-    - offset: records to skip for pagination
-    - sort: sort field with optional ``:desc`` suffix
     """
 
     cluster_name: str | None = Field(
         default=None,
         min_length=1,
         description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
-    )
-
-    filter: str | None = Field(
-        default=None,
-        description="Lucene format filter - Filter the response based on this filter field",
-    )
-
-    max: int | None = Field(
-        default=None,
-        ge=1,
-        description="Number of records to return",
-    )
-
-    offset: int | None = Field(
-        default=None,
-        ge=0,
-        description="Number of records to skip for pagination",
-    )
-
-    sort: str | None = Field(
-        default=None,
-        description="Sort the records by the declared fields in either ascending (default) or descending (:desc) order",
     )
 
 
@@ -151,7 +125,11 @@ class _EpManagePrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpointB
         if self.prefix_list_name is not None:
             segments.append(quote(self.prefix_list_name, safe=""))
         base = BasePath.path(*segments)
-        qs = self.endpoint_params.to_query_string()
+        query_params = CompositeQueryParams().add(self.endpoint_params)
+        lucene_params = getattr(self, "lucene_params", None)
+        if lucene_params is not None:
+            query_params.add(lucene_params)
+        qs = query_params.to_query_string()
         return f"{base}?{qs}" if qs else base
 
 
@@ -189,6 +167,7 @@ class EpManageIpv4PrefixListsListGet(_EpManageIpv4PrefixListsBase):
         default="EpManageIpv4PrefixListsListGet", description="Class name for backward compatibility"
     )
     endpoint_params: PrefixListsListEndpointParams = Field(default_factory=PrefixListsListEndpointParams)
+    lucene_params: LuceneQueryParams = Field(default_factory=LuceneQueryParams, description="Lucene query parameters")
 
     @property
     def verb(self) -> HttpVerbEnum:
@@ -322,6 +301,7 @@ class EpManageIpv6PrefixListsListGet(_EpManageIpv6PrefixListsBase):
         default="EpManageIpv6PrefixListsListGet", description="Class name for backward compatibility"
     )
     endpoint_params: PrefixListsListEndpointParams = Field(default_factory=PrefixListsListEndpointParams)
+    lucene_params: LuceneQueryParams = Field(default_factory=LuceneQueryParams, description="Lucene query parameters")
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
@@ -42,7 +42,7 @@ in the ND Manage API, covering both IPv4 and IPv6 prefix lists.
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal, Optional
+from typing import ClassVar, Literal
 from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
@@ -61,7 +61,7 @@ class PrefixListsEndpointParams(EndpointQueryParams):
     - cluster_name: Name of the target Nexus Dashboard cluster (multi-cluster deployments)
     """
 
-    cluster_name: Optional[str] = Field(
+    cluster_name: str | None = Field(
         default=None,
         min_length=1,
         description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
@@ -79,30 +79,30 @@ class PrefixListsListEndpointParams(EndpointQueryParams):
     - sort: sort field with optional ``:desc`` suffix
     """
 
-    cluster_name: Optional[str] = Field(
+    cluster_name: str | None = Field(
         default=None,
         min_length=1,
         description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
     )
 
-    filter: Optional[str] = Field(
+    filter: str | None = Field(
         default=None,
         description="Lucene format filter - Filter the response based on this filter field",
     )
 
-    max: Optional[int] = Field(
+    max: int | None = Field(
         default=None,
         ge=1,
         description="Number of records to return",
     )
 
-    offset: Optional[int] = Field(
+    offset: int | None = Field(
         default=None,
         ge=0,
         description="Number of records to skip for pagination",
     )
 
-    sort: Optional[str] = Field(
+    sort: str | None = Field(
         default=None,
         description="Sort the records by the declared fields in either ascending (default) or descending (:desc) order",
     )

--- a/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_prefix_lists.py
@@ -110,24 +110,29 @@ class PrefixListsListEndpointParams(EndpointQueryParams):
     )
 
 
-# IPv4 base class
-class _EpManageIpv4PrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpointBaseModel):
+# Shared base for IPv4/IPv6 prefix list item + collection endpoints
+class _EpManagePrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpointBaseModel):
     """
-    Base class for IPv4 prefix list endpoints.
+    Shared base for IPv4 and IPv6 prefix list endpoints.
 
-    Path: ``/api/v1/manage/fabrics/{fabricName}/ipv4PrefixLists[/{name}]``
+    Path: ``/api/v1/manage/fabrics/{fabricName}/<collection>[/{name}]`` where
+    ``<collection>`` is set per address family by ``_collection_segment``
+    (``ipv4PrefixLists`` / ``ipv6PrefixLists``).
 
     Subclasses set ``_require_prefix_list_name = False`` for collection-level
-    operations (list, bulk-create).
+    operations (list, bulk-create). ``verb`` is intentionally left abstract so this
+    base (and the thin per-family bases) stay abstract and require no ``class_name``.
     """
 
+    # Address-family collection segment, set by the per-family bases below.
+    _collection_segment: ClassVar[str] = ""
     _require_prefix_list_name: ClassVar[bool] = True
 
     endpoint_params: EndpointQueryParams = Field(default_factory=EndpointQueryParams, description="Endpoint-specific query parameters")
 
     def set_identifiers(self, identifier: IdentifierKey = None) -> None:
         """
-        Accept either a plain name or a composite tuple ``("ipv4", name)``
+        Accept either a plain name or a composite tuple ``(ip_version, name)``
         and assign the prefix list name.
         """
         if isinstance(identifier, tuple):
@@ -141,15 +146,18 @@ class _EpManageIpv4PrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpo
             raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
         if self._require_prefix_list_name and self.prefix_list_name is None:
             raise ValueError(f"{type(self).__name__}.path: prefix_list_name must be set before accessing path.")
-        segments = ["fabrics"]
-        if self.fabric_name is not None:
-            segments.append(quote(self.fabric_name, safe=""))
-        segments.append("ipv4PrefixLists")
+        segments = ["fabrics", quote(self.fabric_name, safe=""), self._collection_segment]
         if self.prefix_list_name is not None:
             segments.append(quote(self.prefix_list_name, safe=""))
         base = BasePath.path(*segments)
         qs = self.endpoint_params.to_query_string()
         return f"{base}?{qs}" if qs else base
+
+
+class _EpManageIpv4PrefixListsBase(_EpManagePrefixListsBase):
+    """IPv4 prefix list base -- path segment ``ipv4PrefixLists``."""
+
+    _collection_segment: ClassVar[str] = "ipv4PrefixLists"
 
 
 class EpManageIpv4PrefixListsGet(_EpManageIpv4PrefixListsBase):
@@ -235,7 +243,29 @@ class EpManageIpv4PrefixListsDelete(_EpManageIpv4PrefixListsBase):
         return HttpVerbEnum.DELETE
 
 
-class EpManageIpv4PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
+class _EpManagePrefixListsBulkDeleteBase(FabricNameMixin, NDEndpointBaseModel):
+    """
+    Shared base for IPv4/IPv6 prefix list bulk-delete action endpoints.
+
+    Path: ``/api/v1/manage/fabrics/{fabricName}/<action>/remove`` where ``<action>``
+    is set per address family by ``_action_segment`` (``ipv4PrefixListActions`` /
+    ``ipv6PrefixListActions``). ``verb`` is intentionally left abstract so this base
+    stays abstract and requires no ``class_name``.
+
+    Request body: ``{"<family>PrefixListNames": ["name1", ...]}``.
+    """
+
+    # Address-family action segment, set by the per-family subclasses below.
+    _action_segment: ClassVar[str] = ""
+
+    @property
+    def path(self) -> str:
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), self._action_segment, "remove")
+
+
+class EpManageIpv4PrefixListsBulkDelete(_EpManagePrefixListsBulkDeleteBase):
     """
     POST /api/v1/manage/fabrics/{fabricName}/ipv4PrefixListActions/remove
 
@@ -243,58 +273,21 @@ class EpManageIpv4PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
     Request body: ``{"ipv4PrefixListNames": ["name1", ...]}``.
     """
 
+    _action_segment: ClassVar[str] = "ipv4PrefixListActions"
+
     class_name: Literal["EpManageIpv4PrefixListsBulkDelete"] = Field(
         default="EpManageIpv4PrefixListsBulkDelete", description="Class name for backward compatibility"
     )
-
-    @property
-    def path(self) -> str:
-        if self.fabric_name is None:
-            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
-        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "ipv4PrefixListActions", "remove")
 
     @property
     def verb(self) -> HttpVerbEnum:
         return HttpVerbEnum.POST
 
 
-# IPv6 base class
-class _EpManageIpv6PrefixListsBase(PrefixListNameMixin, FabricNameMixin, NDEndpointBaseModel):
-    """
-    Base class for IPv6 prefix list endpoints.
+class _EpManageIpv6PrefixListsBase(_EpManagePrefixListsBase):
+    """IPv6 prefix list base -- path segment ``ipv6PrefixLists``."""
 
-    Path: ``/api/v1/manage/fabrics/{fabricName}/ipv6PrefixLists[/{name}]``
-    """
-
-    _require_prefix_list_name: ClassVar[bool] = True
-
-    endpoint_params: EndpointQueryParams = Field(default_factory=EndpointQueryParams, description="Endpoint-specific query parameters")
-
-    def set_identifiers(self, identifier: IdentifierKey = None) -> None:
-        """
-        Accept either a plain name or a composite tuple ``("ipv6", name)``
-        and assign the prefix list name.
-        """
-        if isinstance(identifier, tuple):
-            self.prefix_list_name = identifier[1]
-        else:
-            self.prefix_list_name = identifier
-
-    @property
-    def path(self) -> str:
-        if self.fabric_name is None:
-            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
-        if self._require_prefix_list_name and self.prefix_list_name is None:
-            raise ValueError(f"{type(self).__name__}.path: prefix_list_name must be set before accessing path.")
-        segments = ["fabrics"]
-        if self.fabric_name is not None:
-            segments.append(quote(self.fabric_name, safe=""))
-        segments.append("ipv6PrefixLists")
-        if self.prefix_list_name is not None:
-            segments.append(quote(self.prefix_list_name, safe=""))
-        base = BasePath.path(*segments)
-        qs = self.endpoint_params.to_query_string()
-        return f"{base}?{qs}" if qs else base
+    _collection_segment: ClassVar[str] = "ipv6PrefixLists"
 
 
 class EpManageIpv6PrefixListsGet(_EpManageIpv6PrefixListsBase):
@@ -380,7 +373,7 @@ class EpManageIpv6PrefixListsDelete(_EpManageIpv6PrefixListsBase):
         return HttpVerbEnum.DELETE
 
 
-class EpManageIpv6PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
+class EpManageIpv6PrefixListsBulkDelete(_EpManagePrefixListsBulkDeleteBase):
     """
     POST /api/v1/manage/fabrics/{fabricName}/ipv6PrefixListActions/remove
 
@@ -388,15 +381,11 @@ class EpManageIpv6PrefixListsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
     Request body: ``{"ipv6PrefixListNames": ["name1", ...]}``.
     """
 
+    _action_segment: ClassVar[str] = "ipv6PrefixListActions"
+
     class_name: Literal["EpManageIpv6PrefixListsBulkDelete"] = Field(
         default="EpManageIpv6PrefixListsBulkDelete", description="Class name for backward compatibility"
     )
-
-    @property
-    def path(self) -> str:
-        if self.fabric_name is None:
-            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
-        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "ipv6PrefixListActions", "remove")
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/models/manage_prefix_list/__init__.py
+++ b/plugins/module_utils/models/manage_prefix_list/__init__.py
@@ -1,0 +1,3 @@
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/module_utils/models/manage_prefix_list/__init__.py
+++ b/plugins/module_utils/models/manage_prefix_list/__init__.py
@@ -1,3 +1,0 @@
-# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
-
-# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/module_utils/models/manage_prefix_list/enums.py
+++ b/plugins/module_utils/models/manage_prefix_list/enums.py
@@ -7,7 +7,7 @@
 Enumerations for Prefix List management.
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from enum import Enum
 

--- a/plugins/module_utils/models/manage_prefix_list/enums.py
+++ b/plugins/module_utils/models/manage_prefix_list/enums.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+Enumerations for Prefix List management.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from enum import Enum
+
+
+class PrefixListActionEnum(str, Enum):
+    """Permit/deny action for a prefix list entry."""
+
+    PERMIT = "permit"
+    DENY = "deny"
+
+
+class IpVersionEnum(str, Enum):
+    """IP version discriminator for a prefix list."""
+
+    IPV4 = "ipv4"
+    IPV6 = "ipv6"

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -25,11 +25,11 @@ distinguished solely by the ``ip_version`` field (values: ``"ipv4"`` /
   - Injected by the orchestrator during ``query_all`` (not present in API
     responses).
   - Excluded from API payloads via ``payload_exclude_fields``.
-  - Used as part of the composite identifier ``(ip_version, name)`` so that
-    an IPv4 "PL-1" and an IPv6 "PL-1" coexist in the same collection.
+  - Used as part of the composite identifier ``(ip_version, tenant_name, name)`` so that
+    IPv4, IPv6, and tenant-scoped prefix lists with the same bare name coexist in the same collection.
 
-Entry-level validation checks that ``prefix`` and ``mask`` (when supplied)
-match the declared ``ip_version`` of the containing prefix list.
+Entry-level validation normalizes ``prefix`` and ``mask`` spellings and checks that
+they match the declared ``ip_version`` of the containing prefix list.
 
 ## Usage
 
@@ -126,8 +126,28 @@ class PrefixListEntryModel(NDNestedModel):
     mask: Optional[str] = Field(
         default=None,
         alias="mask",
-        description="Network mask in dotted-decimal (IPv4) or full IPv6 format.",
+        description="Explicit match mask in dotted-decimal IPv4 or IPv6 address format.",
     )
+
+    @field_validator("prefix")
+    @classmethod
+    def normalize_prefix(cls, value: str) -> str:
+        """Normalize CIDR notation so equivalent IPv6 spellings do not cause false diffs."""
+        try:
+            return str(ipaddress.ip_network(value, strict=False))
+        except ValueError:
+            raise ValueError(f"prefix '{value}' is not a valid IP network in CIDR notation.")
+
+    @field_validator("mask")
+    @classmethod
+    def normalize_mask(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize explicit match masks so equivalent IPv6 spellings do not cause false diffs."""
+        if value is None:
+            return None
+        try:
+            return str(ipaddress.ip_address(value))
+        except ValueError:
+            raise ValueError(f"mask '{value}' is not a valid IP address.")
 
 
 class PrefixListModel(NDBaseModel):
@@ -136,9 +156,9 @@ class PrefixListModel(NDBaseModel):
 
     ## Identifier
 
-    ``composite`` strategy using ``(ip_version, name)``, which allows an
-    IPv4 prefix list and an IPv6 prefix list with the same name to coexist
-    in the same ``NDConfigCollection``.
+    ``composite`` strategy using ``(ip_version, tenant_name, name)``, which allows
+    IPv4 and IPv6 prefix lists and tenant-scoped prefix lists with the same bare
+    name to coexist in the same ``NDConfigCollection``.
 
     ## Serialization Notes
 
@@ -151,7 +171,7 @@ class PrefixListModel(NDBaseModel):
 
     # --- Identifier Configuration ---
 
-    identifiers: ClassVar[Optional[List[str]]] = ["ip_version", "name"]
+    identifiers: ClassVar[Optional[List[str]]] = ["ip_version", "tenant_name", "name"]
     identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "composite"
 
     # --- Serialization Configuration ---
@@ -200,7 +220,32 @@ class PrefixListModel(NDBaseModel):
         description="List of prefix list entries.",
     )
 
+    @property
+    def api_name(self) -> str:
+        """Return the name format required by item and bulk-delete endpoints."""
+        if self.tenant_name:
+            return f"{self.tenant_name}~{self.name}"
+        return self.name
+
     # --- Field Validators ---
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_tenant_scoped_name(cls, data: Any) -> Any:
+        """
+        Normalize API-returned tenant-scoped names from ``tenant~name`` to the
+        Ansible-facing bare ``name`` plus ``tenant_name`` field.
+        """
+        if not isinstance(data, dict):
+            return data
+        tenant_name = data.get("tenantName", data.get("tenant_name"))
+        name = data.get("name")
+        if isinstance(tenant_name, str) and isinstance(name, str):
+            prefix = f"{tenant_name}~"
+            if name.startswith(prefix):
+                data = dict(data)
+                data["name"] = name[len(prefix) :]
+        return data
 
     @field_validator("name")
     @classmethod
@@ -285,6 +330,20 @@ class PrefixListModel(NDBaseModel):
         return self
 
     # --- Argument Spec ---
+
+    def get_identifier_value(self) -> tuple[str, str | None, str]:
+        """Return the tenant-aware composite identifier."""
+        return (str(self.ip_version), self.tenant_name, self.name)
+
+    @classmethod
+    def validate_config_for_state(cls, config: List[Dict[str, Any]], state: str) -> None:
+        """Validate state-dependent requirements that cannot be expressed in a static Ansible argspec."""
+        if state not in {"merged", "replaced", "overridden"}:
+            return
+        for index, item in enumerate(config or []):
+            entries = item.get("entries") if isinstance(item, dict) else None
+            if not entries:
+                raise ValueError(f"config[{index}].entries is required and must contain at least one entry when state is '{state}'.")
 
     @classmethod
     def get_argument_spec(cls) -> Dict[str, Any]:

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -359,6 +359,21 @@ class PrefixListModel(NDBaseModel):
         """Return the tenant-aware composite identifier."""
         return (str(self.ip_version), self.tenant_name, self.name)
 
+    def get_diff(self, other: NDBaseModel, exclude_unset: bool = False) -> bool:
+        """
+        Compare prefix-list config, treating omitted description as empty in replace-style states.
+
+        ``NDStateMachine`` calls this with ``exclude_unset=True`` for ``merged``,
+        where omitted fields must be left untouched. For ``replaced`` and
+        ``overridden`` it passes ``exclude_unset=False``; in that path an omitted
+        description means the desired value is empty/absent, so a stale controller
+        description must trigger an update.
+        """
+        if not exclude_unset and isinstance(other, PrefixListModel):
+            if other.description is None and self.description not in (None, ""):
+                return False
+        return super().get_diff(other, exclude_unset=exclude_unset)
+
     @classmethod
     def validate_config_for_state(cls, config: List[Dict[str, Any]], state: str) -> None:
         """Validate state-dependent requirements that cannot be expressed in a static Ansible argspec."""

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -71,6 +71,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list
 # Allowed characters for prefix list / tenant names (from OpenAPI pattern)
 _NAME_RE = re.compile(r"^[a-zA-Z0-9~_-]+$")
 _TENANT_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_DEFAULT_TENANT_NAME_MAX_LENGTH = 63
+_QUALIFIED_NAME_MAX_LENGTH = 115
 
 
 class PrefixListEntryModel(NDNestedModel):
@@ -265,6 +267,27 @@ class PrefixListModel(NDBaseModel):
         return value
 
     # --- Model Validators (cross-field) ---
+
+    @model_validator(mode="after")
+    def validate_name_length_for_tenant_scope(self) -> "PrefixListModel":
+        """
+        Enforce the API's default-tenant and tenant-qualified prefix-list name lengths.
+
+        The OpenAPI schema caps the path/body ``prefixListName`` at 115 characters
+        but documents a stricter 63-character limit for names in the default tenant.
+        Tenant-scoped item paths use the qualified ``tenantName~name`` form, so the
+        combined value must also fit the 115-character endpoint field.
+        """
+        if self.tenant_name is None and len(self.name) > _DEFAULT_TENANT_NAME_MAX_LENGTH:
+            raise ValueError(
+                f"name must be {_DEFAULT_TENANT_NAME_MAX_LENGTH} characters or fewer when tenant_name is omitted; got {len(self.name)}."
+            )
+        if self.tenant_name is not None and len(self.api_name) > _QUALIFIED_NAME_MAX_LENGTH:
+            raise ValueError(
+                f"combined tenant-qualified prefix list name '{self.api_name}' must be {_QUALIFIED_NAME_MAX_LENGTH} characters or fewer; "
+                f"got {len(self.api_name)} from tenant_name length {len(self.tenant_name)} and name length {len(self.name)}."
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_entries_for_ip_version(self) -> "PrefixListModel":

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -64,6 +64,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.enums import (
     IpVersionEnum,
     PrefixListActionEnum,
@@ -175,7 +176,7 @@ class PrefixListModel(NDBaseModel):
         description="Name of the prefix list (pattern: ^[a-zA-Z0-9~_-]+$).",
     )
 
-    description: Optional[str] = Field(
+    description: AsciiDescription = Field(
         default=None,
         alias="description",
         max_length=90,
@@ -195,7 +196,8 @@ class PrefixListModel(NDBaseModel):
         description="Name of the tenant (pattern: ^[A-Za-z0-9_-]+$).",
     )
 
-    entries: List[PrefixListEntryModel] = Field(
+    entries: Optional[List[PrefixListEntryModel]] = Field(
+        default=None,
         alias="entries",
         description="List of prefix list entries.",
     )
@@ -229,8 +231,17 @@ class PrefixListModel(NDBaseModel):
         """
         version = str(self.ip_version)
         max_len = 32 if version == "ipv4" else 128
+        entries = self.entries or []
+        seen_sequence_numbers = set()
 
-        for idx, entry in enumerate(self.entries):
+        for idx, entry in enumerate(entries):
+            if entry.sequence_number in seen_sequence_numbers:
+                raise ValueError(
+                    f"entries[{idx}].sequenceNumber '{entry.sequence_number}' is duplicated. "
+                    "Sequence numbers must be unique within a prefix list."
+                )
+            seen_sequence_numbers.add(entry.sequence_number)
+
             # Validate prefix CIDR
             try:
                 network = ipaddress.ip_network(entry.prefix, strict=False)
@@ -261,6 +272,19 @@ class PrefixListModel(NDBaseModel):
                 val = getattr(entry, field_name, None)
                 if val is not None and not (1 <= val <= max_len):
                     raise ValueError(f"entries[{idx}].{label}={val} is out of range " f"(1-{max_len} for ip_version='{version}').")
+
+            if entry.exact_length is not None and (entry.min_prefix_length is not None or entry.max_prefix_length is not None):
+                raise ValueError(
+                    f"entries[{idx}] cannot define exactLength together with minLength/maxLength. "
+                    "Use exactLength alone, or use minLength/maxLength without exactLength."
+                )
+
+            if entry.min_prefix_length is not None and entry.max_prefix_length is not None:
+                if entry.min_prefix_length > entry.max_prefix_length:
+                    raise ValueError(
+                        f"entries[{idx}].minLength={entry.min_prefix_length} cannot be greater than "
+                        f"entries[{idx}].maxLength={entry.max_prefix_length}."
+                    )
 
         return self
 
@@ -298,7 +322,7 @@ class PrefixListModel(NDBaseModel):
                     entries=dict(
                         type="list",
                         elements="dict",
-                        required=True,
+                        required=False,
                         options=dict(
                             sequence_number=dict(
                                 type="int",

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -279,9 +279,7 @@ class PrefixListModel(NDBaseModel):
         combined value must also fit the 115-character endpoint field.
         """
         if self.tenant_name is None and len(self.name) > _DEFAULT_TENANT_NAME_MAX_LENGTH:
-            raise ValueError(
-                f"name must be {_DEFAULT_TENANT_NAME_MAX_LENGTH} characters or fewer when tenant_name is omitted; got {len(self.name)}."
-            )
+            raise ValueError(f"name must be {_DEFAULT_TENANT_NAME_MAX_LENGTH} characters or fewer when tenant_name is omitted; got {len(self.name)}.")
         if self.tenant_name is not None and len(self.api_name) > _QUALIFIED_NAME_MAX_LENGTH:
             raise ValueError(
                 f"combined tenant-qualified prefix list name '{self.api_name}' must be {_QUALIFIED_NAME_MAX_LENGTH} characters or fewer; "

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 
 import ipaddress
 import re
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Set
+from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
@@ -106,7 +106,7 @@ class PrefixListEntryModel(NDNestedModel):
         description="IP prefix in CIDR notation (e.g. '10.1.1.0/24' or '2001:db8::/32').",
     )
 
-    exact_length: Optional[int] = Field(
+    exact_length: int | None = Field(
         default=None,
         alias="exactLength",
         description="Exact prefix length to match.",
@@ -114,19 +114,19 @@ class PrefixListEntryModel(NDNestedModel):
 
     # NOTE: Python field names avoid collision with Pydantic's built-in
     # ``min_length`` / ``max_length`` Field constraints.
-    min_prefix_length: Optional[int] = Field(
+    min_prefix_length: int | None = Field(
         default=None,
         alias="minLength",
         description="Minimum prefix length to match.",
     )
 
-    max_prefix_length: Optional[int] = Field(
+    max_prefix_length: int | None = Field(
         default=None,
         alias="maxLength",
         description="Maximum prefix length to match.",
     )
 
-    mask: Optional[str] = Field(
+    mask: str | None = Field(
         default=None,
         alias="mask",
         description="Explicit match mask in dotted-decimal IPv4 or IPv6 address format.",
@@ -143,7 +143,7 @@ class PrefixListEntryModel(NDNestedModel):
 
     @field_validator("mask")
     @classmethod
-    def normalize_mask(cls, value: Optional[str]) -> Optional[str]:
+    def normalize_mask(cls, value: str | None) -> str | None:
         """Normalize explicit match masks so equivalent IPv6 spellings do not cause false diffs."""
         if value is None:
             return None
@@ -174,14 +174,14 @@ class PrefixListModel(NDBaseModel):
 
     # --- Identifier Configuration ---
 
-    identifiers: ClassVar[Optional[List[str]]] = ["ip_version", "tenant_name", "name"]
-    identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "composite"
+    identifiers: ClassVar[list[str] | None] = ["ip_version", "tenant_name", "name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
 
     # --- Serialization Configuration ---
 
-    exclude_from_diff: ClassVar[Set[str]] = {"last_update_timestamp"}
-    payload_exclude_fields: ClassVar[Set[str]] = {"ip_version", "last_update_timestamp"}
-    unwanted_keys: ClassVar[List] = []
+    exclude_from_diff: ClassVar[set[str]] = {"last_update_timestamp"}
+    payload_exclude_fields: ClassVar[set[str]] = {"ip_version", "last_update_timestamp"}
+    unwanted_keys: ClassVar[list] = []
 
     # --- Fields ---
 
@@ -204,20 +204,20 @@ class PrefixListModel(NDBaseModel):
         description="Description of the prefix list.",
     )
 
-    last_update_timestamp: Optional[str] = Field(
+    last_update_timestamp: str | None = Field(
         default=None,
         alias="lastUpdateTimestamp",
         description="Timestamp of the last update (read-only, set by ND).",
     )
 
-    tenant_name: Optional[str] = Field(
+    tenant_name: str | None = Field(
         default=None,
         alias="tenantName",
         max_length=63,
         description="Name of the tenant (pattern: ^[A-Za-z0-9_-]+$).",
     )
 
-    entries: Optional[List[PrefixListEntryModel]] = Field(
+    entries: list[PrefixListEntryModel] | None = Field(
         default=None,
         alias="entries",
         description="List of prefix list entries.",
@@ -260,7 +260,7 @@ class PrefixListModel(NDBaseModel):
 
     @field_validator("tenant_name")
     @classmethod
-    def validate_tenant_name(cls, value: Optional[str]) -> Optional[str]:
+    def validate_tenant_name(cls, value: str | None) -> str | None:
         """Enforce tenant name pattern: ^[A-Za-z0-9_-]+$."""
         if value is not None and not _TENANT_RE.match(value):
             raise ValueError(f"Tenant name '{value}' is invalid. " "Only alphanumeric characters, '_', and '-' are allowed.")
@@ -375,7 +375,7 @@ class PrefixListModel(NDBaseModel):
         return super().get_diff(other, exclude_unset=exclude_unset)
 
     @classmethod
-    def validate_config_for_state(cls, config: List[Dict[str, Any]], state: str) -> None:
+    def validate_config_for_state(cls, config: list[dict[str, Any]], state: str) -> None:
         """Validate state-dependent requirements that cannot be expressed in a static Ansible argspec."""
         if state not in {"merged", "replaced", "overridden"}:
             return
@@ -385,7 +385,7 @@ class PrefixListModel(NDBaseModel):
                 raise ValueError(f"config[{index}].entries is required and must contain at least one entry when state is '{state}'.")
 
     @classmethod
-    def get_argument_spec(cls) -> Dict[str, Any]:
+    def get_argument_spec(cls) -> dict[str, Any]:
         return dict(
             fabric_name=dict(
                 type="str",

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -55,7 +55,7 @@ __metaclass__ = type
 
 import ipaddress
 import re
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Set, Tuple
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Set
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
@@ -165,8 +165,7 @@ class PrefixListModel(NDBaseModel):
 
     ip_version: IpVersionEnum = Field(
         alias="ipVersion",
-        description="IP version of this prefix list: 'ipv4' or 'ipv6'. "
-                    "This is an Ansible-only field and is not sent to the API.",
+        description="IP version of this prefix list: 'ipv4' or 'ipv6'. " "This is an Ansible-only field and is not sent to the API.",
     )
 
     name: str = Field(
@@ -208,10 +207,7 @@ class PrefixListModel(NDBaseModel):
     def validate_name(cls, value: str) -> str:
         """Enforce API name pattern: ^[a-zA-Z0-9~_-]+$."""
         if not _NAME_RE.match(value):
-            raise ValueError(
-                f"Prefix list name '{value}' is invalid. "
-                "Only alphanumeric characters and '~', '_', '-' are allowed."
-            )
+            raise ValueError(f"Prefix list name '{value}' is invalid. " "Only alphanumeric characters and '~', '_', '-' are allowed.")
         return value
 
     @field_validator("tenant_name")
@@ -219,10 +215,7 @@ class PrefixListModel(NDBaseModel):
     def validate_tenant_name(cls, value: Optional[str]) -> Optional[str]:
         """Enforce tenant name pattern: ^[A-Za-z0-9_-]+$."""
         if value is not None and not _TENANT_RE.match(value):
-            raise ValueError(
-                f"Tenant name '{value}' is invalid. "
-                "Only alphanumeric characters, '_', and '-' are allowed."
-            )
+            raise ValueError(f"Tenant name '{value}' is invalid. " "Only alphanumeric characters, '_', and '-' are allowed.")
         return value
 
     # --- Model Validators (cross-field) ---
@@ -242,34 +235,22 @@ class PrefixListModel(NDBaseModel):
             try:
                 network = ipaddress.ip_network(entry.prefix, strict=False)
             except ValueError:
-                raise ValueError(
-                    f"entries[{idx}].prefix '{entry.prefix}' is not a valid IP network in CIDR notation."
-                )
+                raise ValueError(f"entries[{idx}].prefix '{entry.prefix}' is not a valid IP network in CIDR notation.")
             if version == "ipv4" and not isinstance(network, ipaddress.IPv4Network):
-                raise ValueError(
-                    f"entries[{idx}].prefix '{entry.prefix}' must be an IPv4 CIDR (ip_version='ipv4')."
-                )
+                raise ValueError(f"entries[{idx}].prefix '{entry.prefix}' must be an IPv4 CIDR (ip_version='ipv4').")
             if version == "ipv6" and not isinstance(network, ipaddress.IPv6Network):
-                raise ValueError(
-                    f"entries[{idx}].prefix '{entry.prefix}' must be an IPv6 CIDR (ip_version='ipv6')."
-                )
+                raise ValueError(f"entries[{idx}].prefix '{entry.prefix}' must be an IPv6 CIDR (ip_version='ipv6').")
 
             # Validate mask (when present)
             if entry.mask is not None:
                 try:
                     addr = ipaddress.ip_address(entry.mask)
                 except ValueError:
-                    raise ValueError(
-                        f"entries[{idx}].mask '{entry.mask}' is not a valid IP address."
-                    )
+                    raise ValueError(f"entries[{idx}].mask '{entry.mask}' is not a valid IP address.")
                 if version == "ipv4" and not isinstance(addr, ipaddress.IPv4Address):
-                    raise ValueError(
-                        f"entries[{idx}].mask '{entry.mask}' must be an IPv4 address (ip_version='ipv4')."
-                    )
+                    raise ValueError(f"entries[{idx}].mask '{entry.mask}' must be an IPv4 address (ip_version='ipv4').")
                 if version == "ipv6" and not isinstance(addr, ipaddress.IPv6Address):
-                    raise ValueError(
-                        f"entries[{idx}].mask '{entry.mask}' must be an IPv6 address (ip_version='ipv6')."
-                    )
+                    raise ValueError(f"entries[{idx}].mask '{entry.mask}' must be an IPv6 address (ip_version='ipv6').")
 
             # Validate length constraints
             for field_name, label in [
@@ -279,10 +260,7 @@ class PrefixListModel(NDBaseModel):
             ]:
                 val = getattr(entry, field_name, None)
                 if val is not None and not (1 <= val <= max_len):
-                    raise ValueError(
-                        f"entries[{idx}].{label}={val} is out of range "
-                        f"(1-{max_len} for ip_version='{version}')."
-                    )
+                    raise ValueError(f"entries[{idx}].{label}={val} is out of range " f"(1-{max_len} for ip_version='{version}').")
 
         return self
 

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -428,7 +428,6 @@ class PrefixListModel(NDBaseModel):
                             action=dict(
                                 type="str",
                                 required=False,
-                                default="permit",
                                 choices=["permit", "deny"],
                             ),
                             prefix=dict(

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -49,9 +49,7 @@ payload = pl.to_payload()
 ```
 """
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import ipaddress
 import re
@@ -237,8 +235,7 @@ class PrefixListModel(NDBaseModel):
         for idx, entry in enumerate(entries):
             if entry.sequence_number in seen_sequence_numbers:
                 raise ValueError(
-                    f"entries[{idx}].sequenceNumber '{entry.sequence_number}' is duplicated. "
-                    "Sequence numbers must be unique within a prefix list."
+                    f"entries[{idx}].sequenceNumber '{entry.sequence_number}' is duplicated. Sequence numbers must be unique within a prefix list."
                 )
             seen_sequence_numbers.add(entry.sequence_number)
 
@@ -282,8 +279,7 @@ class PrefixListModel(NDBaseModel):
             if entry.min_prefix_length is not None and entry.max_prefix_length is not None:
                 if entry.min_prefix_length > entry.max_prefix_length:
                     raise ValueError(
-                        f"entries[{idx}].minLength={entry.min_prefix_length} cannot be greater than "
-                        f"entries[{idx}].maxLength={entry.max_prefix_length}."
+                        f"entries[{idx}].minLength={entry.min_prefix_length} cannot be greater than entries[{idx}].maxLength={entry.max_prefix_length}."
                     )
 
         return self

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -293,6 +293,10 @@ class PrefixListModel(NDBaseModel):
                 type="str",
                 required=True,
             ),
+            cluster_name=dict(
+                type="str",
+                required=False,
+            ),
             config=dict(
                 type="list",
                 elements="dict",

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -1,0 +1,363 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+Pydantic models for Prefix List management (IPv4 and IPv6) via Nexus Dashboard.
+
+This module provides a unified set of models for creating, updating, and
+deleting both IPv4 and IPv6 prefix lists through the Nexus Dashboard Fabric
+Controller (NDFC) Manage API.
+
+## Models Overview
+
+- ``PrefixListEntryModel``  - A single prefix list entry
+  (sequenceNumber + action + prefix + optional length constraints)
+- ``PrefixListModel``       - Complete prefix list
+  (ip_version + name + entries)
+
+## Design Notes
+
+IPv4 and IPv6 prefix lists share the same JSON schema structure and are
+distinguished solely by the ``ip_version`` field (values: ``"ipv4"`` /
+``"ipv6"``). This Ansible-only field is:
+  - Injected by the orchestrator during ``query_all`` (not present in API
+    responses).
+  - Excluded from API payloads via ``payload_exclude_fields``.
+  - Used as part of the composite identifier ``(ip_version, name)`` so that
+    an IPv4 "PL-1" and an IPv6 "PL-1" coexist in the same collection.
+
+Entry-level validation checks that ``prefix`` and ``mask`` (when supplied)
+match the declared ``ip_version`` of the containing prefix list.
+
+## Usage
+
+```python
+pl = PrefixListModel.from_config({
+    "ip_version": "ipv4",
+    "name": "PL-IPV4-1",
+    "entries": [
+        {"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"},
+        {"sequence_number": 20, "action": "deny",   "prefix": "192.168.0.0/16",
+         "min_prefix_length": 24, "max_prefix_length": 32},
+    ],
+})
+payload = pl.to_payload()
+# {"name": "PL-IPV4-1", "entries": [{"sequenceNumber": 10, "action": "permit",
+#   "prefix": "10.0.0.0/8"}, ...]}
+```
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import ipaddress
+import re
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Set, Tuple
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    field_validator,
+    model_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.enums import (
+    IpVersionEnum,
+    PrefixListActionEnum,
+)
+
+# Allowed characters for prefix list / tenant names (from OpenAPI pattern)
+_NAME_RE = re.compile(r"^[a-zA-Z0-9~_-]+$")
+_TENANT_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class PrefixListEntryModel(NDNestedModel):
+    """
+    A single entry in a prefix list.
+
+    Required fields: ``sequence_number``, ``action``, ``prefix``.
+    Optional length constraints: ``exact_length``, ``min_prefix_length``,
+    ``max_prefix_length``, ``mask``.
+
+    Length-constraint ranges (validated at the PrefixListModel level):
+    - IPv4: 1-32
+    - IPv6: 1-128
+    """
+
+    sequence_number: int = Field(
+        alias="sequenceNumber",
+        ge=1,
+        le=4294967294,
+        description="Sequence number of the entry (1-4294967294).",
+    )
+
+    action: PrefixListActionEnum = Field(
+        alias="action",
+        description="Action for matching prefixes: permit or deny.",
+    )
+
+    prefix: str = Field(
+        alias="prefix",
+        description="IP prefix in CIDR notation (e.g. '10.1.1.0/24' or '2001:db8::/32').",
+    )
+
+    exact_length: Optional[int] = Field(
+        default=None,
+        alias="exactLength",
+        description="Exact prefix length to match.",
+    )
+
+    # NOTE: Python field names avoid collision with Pydantic's built-in
+    # ``min_length`` / ``max_length`` Field constraints.
+    min_prefix_length: Optional[int] = Field(
+        default=None,
+        alias="minLength",
+        description="Minimum prefix length to match.",
+    )
+
+    max_prefix_length: Optional[int] = Field(
+        default=None,
+        alias="maxLength",
+        description="Maximum prefix length to match.",
+    )
+
+    mask: Optional[str] = Field(
+        default=None,
+        alias="mask",
+        description="Network mask in dotted-decimal (IPv4) or full IPv6 format.",
+    )
+
+
+class PrefixListModel(NDBaseModel):
+    """
+    Prefix list configuration (IPv4 or IPv6) for a Nexus Dashboard fabric.
+
+    ## Identifier
+
+    ``composite`` strategy using ``(ip_version, name)``, which allows an
+    IPv4 prefix list and an IPv6 prefix list with the same name to coexist
+    in the same ``NDConfigCollection``.
+
+    ## Serialization Notes
+
+    - ``ip_version`` is an Ansible-only field; it is excluded from API payloads.
+    - ``last_update_timestamp`` is read-only and excluded from payloads and diffs.
+    - Validation ensures that ``entries[*].prefix`` and ``entries[*].mask``
+      (when set) are syntactically valid CIDRs/addresses for the declared
+      ``ip_version``.
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[Optional[List[str]]] = ["ip_version", "name"]
+    identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "composite"
+
+    # --- Serialization Configuration ---
+
+    exclude_from_diff: ClassVar[Set[str]] = {"last_update_timestamp"}
+    payload_exclude_fields: ClassVar[Set[str]] = {"ip_version", "last_update_timestamp"}
+    unwanted_keys: ClassVar[List] = []
+
+    # --- Fields ---
+
+    ip_version: IpVersionEnum = Field(
+        alias="ipVersion",
+        description="IP version of this prefix list: 'ipv4' or 'ipv6'. "
+                    "This is an Ansible-only field and is not sent to the API.",
+    )
+
+    name: str = Field(
+        alias="name",
+        min_length=1,
+        max_length=115,
+        description="Name of the prefix list (pattern: ^[a-zA-Z0-9~_-]+$).",
+    )
+
+    description: Optional[str] = Field(
+        default=None,
+        alias="description",
+        max_length=90,
+        description="Description of the prefix list.",
+    )
+
+    last_update_timestamp: Optional[str] = Field(
+        default=None,
+        alias="lastUpdateTimestamp",
+        description="Timestamp of the last update (read-only, set by ND).",
+    )
+
+    tenant_name: Optional[str] = Field(
+        default=None,
+        alias="tenantName",
+        max_length=63,
+        description="Name of the tenant (pattern: ^[A-Za-z0-9_-]+$).",
+    )
+
+    entries: List[PrefixListEntryModel] = Field(
+        alias="entries",
+        description="List of prefix list entries.",
+    )
+
+    # --- Field Validators ---
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        """Enforce API name pattern: ^[a-zA-Z0-9~_-]+$."""
+        if not _NAME_RE.match(value):
+            raise ValueError(
+                f"Prefix list name '{value}' is invalid. "
+                "Only alphanumeric characters and '~', '_', '-' are allowed."
+            )
+        return value
+
+    @field_validator("tenant_name")
+    @classmethod
+    def validate_tenant_name(cls, value: Optional[str]) -> Optional[str]:
+        """Enforce tenant name pattern: ^[A-Za-z0-9_-]+$."""
+        if value is not None and not _TENANT_RE.match(value):
+            raise ValueError(
+                f"Tenant name '{value}' is invalid. "
+                "Only alphanumeric characters, '_', and '-' are allowed."
+            )
+        return value
+
+    # --- Model Validators (cross-field) ---
+
+    @model_validator(mode="after")
+    def validate_entries_for_ip_version(self) -> "PrefixListModel":
+        """
+        Validate that every entry's ``prefix`` and ``mask`` (when set) are
+        syntactically correct for the declared ``ip_version``, and that
+        length constraints are within the valid range.
+        """
+        version = str(self.ip_version)
+        max_len = 32 if version == "ipv4" else 128
+
+        for idx, entry in enumerate(self.entries):
+            # Validate prefix CIDR
+            try:
+                network = ipaddress.ip_network(entry.prefix, strict=False)
+            except ValueError:
+                raise ValueError(
+                    f"entries[{idx}].prefix '{entry.prefix}' is not a valid IP network in CIDR notation."
+                )
+            if version == "ipv4" and not isinstance(network, ipaddress.IPv4Network):
+                raise ValueError(
+                    f"entries[{idx}].prefix '{entry.prefix}' must be an IPv4 CIDR (ip_version='ipv4')."
+                )
+            if version == "ipv6" and not isinstance(network, ipaddress.IPv6Network):
+                raise ValueError(
+                    f"entries[{idx}].prefix '{entry.prefix}' must be an IPv6 CIDR (ip_version='ipv6')."
+                )
+
+            # Validate mask (when present)
+            if entry.mask is not None:
+                try:
+                    addr = ipaddress.ip_address(entry.mask)
+                except ValueError:
+                    raise ValueError(
+                        f"entries[{idx}].mask '{entry.mask}' is not a valid IP address."
+                    )
+                if version == "ipv4" and not isinstance(addr, ipaddress.IPv4Address):
+                    raise ValueError(
+                        f"entries[{idx}].mask '{entry.mask}' must be an IPv4 address (ip_version='ipv4')."
+                    )
+                if version == "ipv6" and not isinstance(addr, ipaddress.IPv6Address):
+                    raise ValueError(
+                        f"entries[{idx}].mask '{entry.mask}' must be an IPv6 address (ip_version='ipv6')."
+                    )
+
+            # Validate length constraints
+            for field_name, label in [
+                ("exact_length", "exactLength"),
+                ("min_prefix_length", "minLength"),
+                ("max_prefix_length", "maxLength"),
+            ]:
+                val = getattr(entry, field_name, None)
+                if val is not None and not (1 <= val <= max_len):
+                    raise ValueError(
+                        f"entries[{idx}].{label}={val} is out of range "
+                        f"(1-{max_len} for ip_version='{version}')."
+                    )
+
+        return self
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> Dict[str, Any]:
+        return dict(
+            fabric_name=dict(
+                type="str",
+                required=True,
+            ),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    ip_version=dict(
+                        type="str",
+                        required=True,
+                        choices=["ipv4", "ipv6"],
+                        aliases=["ipVersion"],
+                    ),
+                    name=dict(
+                        type="str",
+                        required=True,
+                    ),
+                    description=dict(
+                        type="str",
+                    ),
+                    tenant_name=dict(
+                        type="str",
+                        aliases=["tenantName"],
+                    ),
+                    entries=dict(
+                        type="list",
+                        elements="dict",
+                        required=True,
+                        options=dict(
+                            sequence_number=dict(
+                                type="int",
+                                required=True,
+                                aliases=["sequenceNumber"],
+                            ),
+                            action=dict(
+                                type="str",
+                                required=True,
+                                choices=["permit", "deny"],
+                            ),
+                            prefix=dict(
+                                type="str",
+                                required=True,
+                            ),
+                            exact_length=dict(
+                                type="int",
+                                aliases=["exactLength"],
+                            ),
+                            min_prefix_length=dict(
+                                type="int",
+                                aliases=["minLength"],
+                            ),
+                            max_prefix_length=dict(
+                                type="int",
+                                aliases=["maxLength"],
+                            ),
+                            mask=dict(
+                                type="str",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -94,6 +94,7 @@ class PrefixListEntryModel(NDNestedModel):
     )
 
     action: PrefixListActionEnum = Field(
+        default=PrefixListActionEnum.PERMIT,
         alias="action",
         description="Action for matching prefixes: permit or deny.",
     )
@@ -390,7 +391,8 @@ class PrefixListModel(NDBaseModel):
                             ),
                             action=dict(
                                 type="str",
-                                required=True,
+                                required=False,
+                                default="permit",
                                 choices=["permit", "deny"],
                             ),
                             prefix=dict(

--- a/plugins/module_utils/models/types.py
+++ b/plugins/module_utils/models/types.py
@@ -17,6 +17,10 @@ applied consistently across model files (e.g. all `description` fields share the
   UTF-8 input. Catching this client-side gives users a clear error instead of a confusing server fault.
 - `IPv4CIDR` — `str | None` validated as an IPv4 interface address in CIDR notation (e.g. `10.1.1.1/32`).
 - `IPv6CIDR` — `str | None` validated as an IPv6 interface address in CIDR notation (e.g. `2001:db8::1/128`).
+- `IPv4NetworkCIDR` — `str | None` validated as an IPv4 network prefix in CIDR notation (e.g. `10.1.0.0/16`).
+- `IPv6NetworkCIDR` — `str | None` validated as an IPv6 network prefix in CIDR notation (e.g. `2001:db8::/32`).
+- `IPv4AddressType` — `str | None` validated as an IPv4 address (e.g. `255.255.255.0`).
+- `IPv6AddressType` — `str | None` validated as an IPv6 address (e.g. `ffff:ffff::`).
 """
 
 from __future__ import annotations
@@ -109,12 +113,116 @@ def validate_ipv6_cidr(value: str | None) -> str | None:
     return value
 
 
+def validate_ipv4_network_cidr(value: str | None) -> str | None:
+    """
+    # Summary
+
+    Validate that `value` is an IPv4 network prefix in CIDR notation. Returns the value unchanged on success.
+
+    Used as the `BeforeValidator` payload for the `IPv4NetworkCIDR` Annotated type.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `value` is not a valid IPv4 network prefix in CIDR notation.
+    """
+    if value is None:
+        return value
+    try:
+        ipaddress.IPv4Network(value, strict=False)
+    except (ipaddress.AddressValueError, ipaddress.NetmaskValueError, ValueError) as err:
+        raise ValueError(f"Invalid IPv4 network: {value!r}. Expected CIDR notation (e.g. '10.1.0.0/16').") from err
+    return value
+
+
+def validate_ipv6_network_cidr(value: str | None) -> str | None:
+    """
+    # Summary
+
+    Validate that `value` is an IPv6 network prefix in CIDR notation. Returns the value unchanged on success.
+
+    Used as the `BeforeValidator` payload for the `IPv6NetworkCIDR` Annotated type.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `value` is not a valid IPv6 network prefix in CIDR notation.
+    """
+    if value is None:
+        return value
+    try:
+        ipaddress.IPv6Network(value, strict=False)
+    except (ipaddress.AddressValueError, ipaddress.NetmaskValueError, ValueError) as err:
+        raise ValueError(f"Invalid IPv6 network: {value!r}. Expected CIDR notation (e.g. '2001:db8::/32').") from err
+    return value
+
+
+def validate_ipv4_address(value: str | None) -> str | None:
+    """
+    # Summary
+
+    Validate that `value` is a valid IPv4 address. Returns the value unchanged on success.
+
+    Used as the `BeforeValidator` payload for the `IPv4AddressType` Annotated type.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `value` is not a valid IPv4 address.
+    """
+    if value is None:
+        return value
+    try:
+        ipaddress.IPv4Address(value)
+    except (ipaddress.AddressValueError, ValueError) as err:
+        raise ValueError(f"Invalid IPv4 address: {value!r}.") from err
+    return value
+
+
+def validate_ipv6_address(value: str | None) -> str | None:
+    """
+    # Summary
+
+    Validate that `value` is a valid IPv6 address. Returns the value unchanged on success.
+
+    Used as the `BeforeValidator` payload for the `IPv6AddressType` Annotated type.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `value` is not a valid IPv6 address.
+    """
+    if value is None:
+        return value
+    try:
+        ipaddress.IPv6Address(value)
+    except (ipaddress.AddressValueError, ValueError) as err:
+        raise ValueError(f"Invalid IPv6 address: {value!r}.") from err
+    return value
+
+
 # See AsciiDescription comment above for why Optional[str] is used at runtime instead of `str | None`.
 IPv4CIDR = Annotated[Optional[str], BeforeValidator(validate_ipv4_cidr)]
 """IPv4 interface address in CIDR notation (`str | None`). Layer with `Field(...)` for alias/description as usual."""
 
 IPv6CIDR = Annotated[Optional[str], BeforeValidator(validate_ipv6_cidr)]
 """IPv6 interface address in CIDR notation (`str | None`). Layer with `Field(...)` for alias/description as usual."""
+
+IPv4NetworkCIDR = Annotated[Optional[str], BeforeValidator(validate_ipv4_network_cidr)]
+"""IPv4 network prefix in CIDR notation (`str | None`). Layer with `Field(...)` for alias/description as usual."""
+
+IPv6NetworkCIDR = Annotated[Optional[str], BeforeValidator(validate_ipv6_network_cidr)]
+"""IPv6 network prefix in CIDR notation (`str | None`). Layer with `Field(...)` for alias/description as usual."""
+
+IPv4AddressType = Annotated[Optional[str], BeforeValidator(validate_ipv4_address)]
+"""IPv4 address (`str | None`). Layer with `Field(...)` for alias/description as usual."""
+
+IPv6AddressType = Annotated[Optional[str], BeforeValidator(validate_ipv6_address)]
+"""IPv6 address (`str | None`). Layer with `Field(...)` for alias/description as usual."""
 
 # Fabric name rules (verified against ND 4.2.x GUI):
 #   - Allowed chars: a-z, A-Z, 0-9, _, -

--- a/plugins/module_utils/models/types.py
+++ b/plugins/module_utils/models/types.py
@@ -113,116 +113,12 @@ def validate_ipv6_cidr(value: str | None) -> str | None:
     return value
 
 
-def validate_ipv4_network_cidr(value: str | None) -> str | None:
-    """
-    # Summary
-
-    Validate that `value` is an IPv4 network prefix in CIDR notation. Returns the value unchanged on success.
-
-    Used as the `BeforeValidator` payload for the `IPv4NetworkCIDR` Annotated type.
-
-    ## Raises
-
-    ### ValueError
-
-    - If `value` is not a valid IPv4 network prefix in CIDR notation.
-    """
-    if value is None:
-        return value
-    try:
-        ipaddress.IPv4Network(value, strict=False)
-    except (ipaddress.AddressValueError, ipaddress.NetmaskValueError, ValueError) as err:
-        raise ValueError(f"Invalid IPv4 network: {value!r}. Expected CIDR notation (e.g. '10.1.0.0/16').") from err
-    return value
-
-
-def validate_ipv6_network_cidr(value: str | None) -> str | None:
-    """
-    # Summary
-
-    Validate that `value` is an IPv6 network prefix in CIDR notation. Returns the value unchanged on success.
-
-    Used as the `BeforeValidator` payload for the `IPv6NetworkCIDR` Annotated type.
-
-    ## Raises
-
-    ### ValueError
-
-    - If `value` is not a valid IPv6 network prefix in CIDR notation.
-    """
-    if value is None:
-        return value
-    try:
-        ipaddress.IPv6Network(value, strict=False)
-    except (ipaddress.AddressValueError, ipaddress.NetmaskValueError, ValueError) as err:
-        raise ValueError(f"Invalid IPv6 network: {value!r}. Expected CIDR notation (e.g. '2001:db8::/32').") from err
-    return value
-
-
-def validate_ipv4_address(value: str | None) -> str | None:
-    """
-    # Summary
-
-    Validate that `value` is a valid IPv4 address. Returns the value unchanged on success.
-
-    Used as the `BeforeValidator` payload for the `IPv4AddressType` Annotated type.
-
-    ## Raises
-
-    ### ValueError
-
-    - If `value` is not a valid IPv4 address.
-    """
-    if value is None:
-        return value
-    try:
-        ipaddress.IPv4Address(value)
-    except (ipaddress.AddressValueError, ValueError) as err:
-        raise ValueError(f"Invalid IPv4 address: {value!r}.") from err
-    return value
-
-
-def validate_ipv6_address(value: str | None) -> str | None:
-    """
-    # Summary
-
-    Validate that `value` is a valid IPv6 address. Returns the value unchanged on success.
-
-    Used as the `BeforeValidator` payload for the `IPv6AddressType` Annotated type.
-
-    ## Raises
-
-    ### ValueError
-
-    - If `value` is not a valid IPv6 address.
-    """
-    if value is None:
-        return value
-    try:
-        ipaddress.IPv6Address(value)
-    except (ipaddress.AddressValueError, ValueError) as err:
-        raise ValueError(f"Invalid IPv6 address: {value!r}.") from err
-    return value
-
-
 # See AsciiDescription comment above for why Optional[str] is used at runtime instead of `str | None`.
 IPv4CIDR = Annotated[Optional[str], BeforeValidator(validate_ipv4_cidr)]
 """IPv4 interface address in CIDR notation (`str | None`). Layer with `Field(...)` for alias/description as usual."""
 
 IPv6CIDR = Annotated[Optional[str], BeforeValidator(validate_ipv6_cidr)]
 """IPv6 interface address in CIDR notation (`str | None`). Layer with `Field(...)` for alias/description as usual."""
-
-IPv4NetworkCIDR = Annotated[Optional[str], BeforeValidator(validate_ipv4_network_cidr)]
-"""IPv4 network prefix in CIDR notation (`str | None`). Layer with `Field(...)` for alias/description as usual."""
-
-IPv6NetworkCIDR = Annotated[Optional[str], BeforeValidator(validate_ipv6_network_cidr)]
-"""IPv6 network prefix in CIDR notation (`str | None`). Layer with `Field(...)` for alias/description as usual."""
-
-IPv4AddressType = Annotated[Optional[str], BeforeValidator(validate_ipv4_address)]
-"""IPv4 address (`str | None`). Layer with `Field(...)` for alias/description as usual."""
-
-IPv6AddressType = Annotated[Optional[str], BeforeValidator(validate_ipv6_address)]
-"""IPv6 address (`str | None`). Layer with `Field(...)` for alias/description as usual."""
 
 # Fabric name rules (verified against ND 4.2.x GUI):
 #   - Allowed chars: a-z, A-Z, 0-9, _, -

--- a/plugins/module_utils/models/types.py
+++ b/plugins/module_utils/models/types.py
@@ -17,10 +17,6 @@ applied consistently across model files (e.g. all `description` fields share the
   UTF-8 input. Catching this client-side gives users a clear error instead of a confusing server fault.
 - `IPv4CIDR` — `str | None` validated as an IPv4 interface address in CIDR notation (e.g. `10.1.1.1/32`).
 - `IPv6CIDR` — `str | None` validated as an IPv6 interface address in CIDR notation (e.g. `2001:db8::1/128`).
-- `IPv4NetworkCIDR` — `str | None` validated as an IPv4 network prefix in CIDR notation (e.g. `10.1.0.0/16`).
-- `IPv6NetworkCIDR` — `str | None` validated as an IPv6 network prefix in CIDR notation (e.g. `2001:db8::/32`).
-- `IPv4AddressType` — `str | None` validated as an IPv4 address (e.g. `255.255.255.0`).
-- `IPv6AddressType` — `str | None` validated as an IPv6 address (e.g. `ffff:ffff::`).
 """
 
 from __future__ import annotations

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -23,10 +23,13 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageIpv6PrefixListsPost,
     EpManageIpv6PrefixListsPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.enums import OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.manage_prefix_list import PrefixListModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+_QUERY_PAGE_SIZE = 100
 
 # Per-item ``status`` values in a 207 Multi-Status body that count as a failure. Anything else --
 # ``success``, missing, empty, or future progress tokens -- is tolerated so informational rows do
@@ -127,6 +130,18 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         """
         return self.rest_send.params.get("fabric_name")
 
+    @property
+    def cluster_name(self) -> str | None:
+        """
+        Return optional ``cluster_name`` from module params.
+
+        The Manage prefix-list API exposes ``clusterName`` on every operation.
+        Keeping this as a top-level module parameter lets the orchestrator apply
+        the same query parameter consistently to list, item, create, update, and
+        bulk-delete endpoints.
+        """
+        return self.rest_send.params.get("cluster_name")
+
     def _config_for_version(self, version: str) -> dict[str, Any]:
         """Return the endpoint classes and payload keys for the given ip_version, failing fast on unknown values."""
         try:
@@ -148,6 +163,116 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
             else:
                 raise ValueError(f"Unsupported ip_version '{version}' for prefix list '{model.name}'. Expected 'ipv4' or 'ipv6'.")
         return grouped
+
+    def _configure_endpoint(
+        self,
+        api_endpoint: NDEndpointBaseModel,
+        max_records: int | None = None,
+        offset: int | None = None,
+    ) -> NDEndpointBaseModel:
+        """Attach shared fabric and query parameters before endpoint path generation."""
+        api_endpoint.fabric_name = self.fabric_name
+        endpoint_params = getattr(api_endpoint, "endpoint_params", None)
+        if endpoint_params is None:
+            return api_endpoint
+        if self.cluster_name is not None and hasattr(endpoint_params, "cluster_name"):
+            endpoint_params.cluster_name = self.cluster_name
+        if max_records is not None and hasattr(endpoint_params, "max"):
+            endpoint_params.max = max_records
+        if offset is not None and hasattr(endpoint_params, "offset"):
+            endpoint_params.offset = offset
+        return api_endpoint
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        """Return ``value`` as int when possible, otherwise ``None``."""
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _raw_items_from_params(params: dict[str, Any]) -> list[dict[str, Any]]:
+        """Return module ``config`` as a list of dictionaries."""
+        config = params.get("config") or []
+        if isinstance(config, dict):
+            config = [config]
+        return [item for item in config if isinstance(item, dict)]
+
+    def _proposed_identifiers(self) -> list[tuple[str, str]]:
+        """Return unique ``(ip_version, name)`` identifiers from raw module config."""
+        identifiers: list[tuple[str, str]] = []
+        seen: set[tuple[str, str]] = set()
+        for item in self._raw_items_from_params(self.rest_send.params):
+            model = PrefixListModel.from_config(item)
+            identifier = model.get_identifier_value()
+            if not isinstance(identifier, tuple) or len(identifier) != 2:
+                continue
+            normalized = (str(identifier[0]), str(identifier[1]))
+            if normalized not in seen:
+                seen.add(normalized)
+                identifiers.append(normalized)
+        return identifiers
+
+    def _should_use_scoped_query(self) -> bool:
+        """Return whether initialization can query only proposed prefix-list identities."""
+        state = self.rest_send.params.get("state")
+        return state in {"merged", "replaced", "deleted"} and bool(self._raw_items_from_params(self.rest_send.params))
+
+    def _query_one_existing(self, version: str, name: str) -> dict[str, Any] | None:
+        """Fetch one existing prefix list, returning ``None`` when it is absent."""
+        config = self._config_for_version(version)
+        api_endpoint = self._configure_endpoint(config["get"]())
+        api_endpoint.set_identifiers((version, name))
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        if not result:
+            return None
+        result["ipVersion"] = version
+        return result
+
+    def _query_proposed_existing(self) -> list[dict[str, Any]]:
+        """Fetch only the existing prefix lists named by module ``config``."""
+        results: list[dict[str, Any]] = []
+        for version, name in self._proposed_identifiers():
+            item = self._query_one_existing(version, name)
+            if item is not None:
+                results.append(item)
+        return results
+
+    def _has_next_page(self, result: dict[str, Any], page_count: int, offset: int) -> bool:
+        """Determine whether another offset/max page should be fetched."""
+        if page_count == 0:
+            return False
+        meta = result.get("meta") or {}
+        counts = meta.get("counts") or {}
+        total = self._coerce_int(counts.get("total"))
+        if total is not None:
+            return offset + page_count < total
+        remaining = self._coerce_int(counts.get("remaining"))
+        if remaining is not None:
+            return remaining > 0
+        return page_count == _QUERY_PAGE_SIZE
+
+    def _query_all_for_version(self, version: str) -> list[dict[str, Any]]:
+        """Fetch all prefix lists for one address family using explicit offset/max pagination."""
+        config = self._config_for_version(version)
+        results: list[dict[str, Any]] = []
+        offset = 0
+        while True:
+            api_endpoint = self._configure_endpoint(config["list"](), max_records=_QUERY_PAGE_SIZE, offset=offset)
+            raw = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            if not raw:
+                break
+            page = raw.get(config["list_key"], []) or []
+            for item in page:
+                item["ipVersion"] = version
+                results.append(item)
+            if not self._has_next_page(raw, len(page), offset):
+                break
+            offset += _QUERY_PAGE_SIZE
+        return results
 
     @staticmethod
     def _raise_on_207_failures(result: Any, operation: str) -> None:
@@ -177,20 +302,18 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
     def _bulk_create_for_version(self, version: str, items: list[PrefixListModel]) -> ResponseType:
         """Send a single bulk-create request for all items of the given ip_version and check the 207 body."""
         config = self._config_for_version(version)
-        api_endpoint = config["post"]()
-        api_endpoint.fabric_name = self.fabric_name
+        api_endpoint = self._configure_endpoint(config["post"]())
         payload = {config["list_key"]: [item.to_payload() for item in items]}
-        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload, operation_type=OperationType.CREATE)
         self._raise_on_207_failures(result, "create")
         return result
 
     def _bulk_delete_for_version(self, version: str, names: list[str]) -> ResponseType:
         """Send a single bulk-delete request for the given prefix list names and check the 207 body."""
         config = self._config_for_version(version)
-        api_endpoint = config["bulk_delete"]()
-        api_endpoint.fabric_name = self.fabric_name
+        api_endpoint = self._configure_endpoint(config["bulk_delete"]())
         payload = {config["names_key"]: names}
-        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload, operation_type=OperationType.DELETE)
         self._raise_on_207_failures(result, "delete")
         return result
 
@@ -205,10 +328,9 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         """Update an existing prefix list via the PUT endpoint."""
         try:
             config = self._config_for_version(str(model_instance.ip_version))
-            api_endpoint = config["put"]()
-            api_endpoint.fabric_name = self.fabric_name
+            api_endpoint = self._configure_endpoint(config["put"]())
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload(), operation_type=OperationType.UPDATE)
         except Exception as e:
             raise Exception(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -223,8 +345,7 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         """Retrieve a single prefix list by name and ip_version."""
         try:
             config = self._config_for_version(str(model_instance.ip_version))
-            api_endpoint = config["get"]()
-            api_endpoint.fabric_name = self.fabric_name
+            api_endpoint = self._configure_endpoint(config["get"]())
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
             return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
         except Exception as e:
@@ -238,14 +359,12 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         ``PrefixListModel.from_response()`` can populate the ``ip_version`` field.
         """
         try:
+            if self._should_use_scoped_query():
+                return self._query_proposed_existing()
+
             results = []
-            for version, config in _VERSION_CONFIG.items():
-                api_endpoint = config["list"]()
-                api_endpoint.fabric_name = self.fabric_name
-                raw = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                for item in raw.get(config["list_key"], []) or []:
-                    item["ipVersion"] = version
-                    results.append(item)
+            for version in _VERSION_CONFIG:
+                results.extend(self._query_all_for_version(version))
             return results
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from typing import ClassVar, Dict, List, Optional, Tuple, Type
+from typing import ClassVar, Dict, List, Type
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from typing import ClassVar, Dict, List, Optional, Tuple, Type
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_prefix_lists import (
+    EpManageIpv4PrefixListsBulkDelete,
+    EpManageIpv4PrefixListsDelete,
+    EpManageIpv4PrefixListsGet,
+    EpManageIpv4PrefixListsListGet,
+    EpManageIpv4PrefixListsPost,
+    EpManageIpv4PrefixListsPut,
+    EpManageIpv6PrefixListsBulkDelete,
+    EpManageIpv6PrefixListsDelete,
+    EpManageIpv6PrefixListsGet,
+    EpManageIpv6PrefixListsListGet,
+    EpManageIpv6PrefixListsPost,
+    EpManageIpv6PrefixListsPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.manage_prefix_list import PrefixListModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
+    """
+    Orchestrator for Prefix List (IPv4 and IPv6) CRUD operations.
+
+    Both IPv4 and IPv6 prefix lists are managed through a single orchestrator.
+    The ``ip_version`` field on the model determines which set of API endpoints
+    to use for each operation.
+
+    **Creation and deletion** are performed via bulk API endpoints:
+    - IPv4 create: ``POST /fabrics/{fabricName}/ipv4PrefixLists``
+      with ``{"ipv4PrefixLists": [...]}``.
+    - IPv6 create: ``POST /fabrics/{fabricName}/ipv6PrefixLists``
+      with ``{"ipv6PrefixLists": [...]}``.
+    - IPv4 bulk delete: ``POST /fabrics/{fabricName}/ipv4PrefixListActions/remove``
+      with ``{"ipv4PrefixListNames": [...]}``.
+    - IPv6 bulk delete: ``POST /fabrics/{fabricName}/ipv6PrefixListActions/remove``
+      with ``{"ipv6PrefixListNames": [...]}``.
+
+    ``query_all`` fetches both IPv4 and IPv6 prefix lists and injects the
+    ``ipVersion`` key into each raw API response dict so ``PrefixListModel``
+    can deserialise them correctly.
+
+    The ``fabric_name`` field must be supplied at construction time:
+
+    ```python
+    orchestrator = ManagePrefixListOrchestrator(
+        rest_send=rest_send,
+        fabric_name="my-fabric",
+    )
+    ```
+    """
+
+    model_class: ClassVar[Type[NDBaseModel]] = PrefixListModel
+
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+
+    # Fabric context
+    fabric_name: str = Field(description="Name of the fabric that owns these prefix lists.")
+
+    # Required stubs -- the orchestrator overrides every operation, so these
+    # just need to satisfy NDBaseOrchestrator's required fields.
+    create_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPost
+    update_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPut
+    delete_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsDelete
+    query_one_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsGet
+    query_all_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsListGet
+
+    create_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPost
+    delete_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsBulkDelete
+
+    # -------------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------------
+
+    def _endpoint_classes_for_version(self, version: str) -> Dict[str, Type[NDEndpointBaseModel]]:
+        """Return the correct endpoint class mapping for the given ip_version."""
+        if version == "ipv4":
+            return {
+                "get": EpManageIpv4PrefixListsGet,
+                "list": EpManageIpv4PrefixListsListGet,
+                "post": EpManageIpv4PrefixListsPost,
+                "put": EpManageIpv4PrefixListsPut,
+                "delete": EpManageIpv4PrefixListsDelete,
+                "bulk_delete": EpManageIpv4PrefixListsBulkDelete,
+            }
+        else:
+            return {
+                "get": EpManageIpv6PrefixListsGet,
+                "list": EpManageIpv6PrefixListsListGet,
+                "post": EpManageIpv6PrefixListsPost,
+                "put": EpManageIpv6PrefixListsPut,
+                "delete": EpManageIpv6PrefixListsDelete,
+                "bulk_delete": EpManageIpv6PrefixListsBulkDelete,
+            }
+
+    def _bulk_create_for_version(self, version: str, items: List[PrefixListModel]) -> ResponseType:
+        """Send a single bulk-create request for all items of the given ip_version."""
+        eps = self._endpoint_classes_for_version(version)
+        api_endpoint = eps["post"]()
+        api_endpoint.fabric_name = self.fabric_name
+        list_key = "ipv4PrefixLists" if version == "ipv4" else "ipv6PrefixLists"
+        payload = {list_key: [item.to_payload() for item in items]}
+        return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+
+    def _bulk_delete_for_version(self, version: str, names: List[str]) -> ResponseType:
+        """Send a single bulk-delete request for the given prefix list names."""
+        eps = self._endpoint_classes_for_version(version)
+        api_endpoint = eps["bulk_delete"]()
+        api_endpoint.fabric_name = self.fabric_name
+        names_key = "ipv4PrefixListNames" if version == "ipv4" else "ipv6PrefixListNames"
+        payload = {names_key: names}
+        return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+
+    # -------------------------------------------------------------------------
+    # Query helpers
+    # -------------------------------------------------------------------------
+
+    def query_all(self) -> ResponseType:
+        """
+        Fetch all IPv4 and IPv6 prefix lists and combine them into a single list.
+
+        The ``ipVersion`` key is injected into each raw response dict so that
+        ``PrefixListModel.from_response()`` can populate the ``ip_version`` field.
+        """
+        try:
+            results = []
+            for version in ("ipv4", "ipv6"):
+                eps = self._endpoint_classes_for_version(version)
+                api_endpoint = eps["list"]()
+                api_endpoint.fabric_name = self.fabric_name
+                raw = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                list_key = "ipv4PrefixLists" if version == "ipv4" else "ipv6PrefixLists"
+                for item in raw.get(list_key, []) or []:
+                    item["ipVersion"] = version
+                    results.append(item)
+            return results
+        except Exception as e:
+            raise Exception(f"Query all failed: {e}") from e
+
+    def query_one(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
+        """Retrieve a single prefix list by name and ip_version."""
+        try:
+            version = str(model_instance.ip_version)
+            eps = self._endpoint_classes_for_version(version)
+            api_endpoint = eps["get"]()
+            api_endpoint.fabric_name = self.fabric_name
+            api_endpoint.set_identifiers(model_instance.get_identifier_value())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise Exception(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    # -------------------------------------------------------------------------
+    # Write operations -- single item (delegate to bulk)
+    # -------------------------------------------------------------------------
+
+    def create(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
+        """Create a single prefix list via the bulk endpoint."""
+        try:
+            return self.create_bulk([model_instance])
+        except Exception as e:
+            raise Exception(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
+        """Update an existing prefix list via the PUT endpoint."""
+        try:
+            version = str(model_instance.ip_version)
+            eps = self._endpoint_classes_for_version(version)
+            api_endpoint = eps["put"]()
+            api_endpoint.fabric_name = self.fabric_name
+            api_endpoint.set_identifiers(model_instance.get_identifier_value())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload())
+        except Exception as e:
+            raise Exception(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
+        """Delete a single prefix list via the bulk-delete endpoint."""
+        try:
+            return self.delete_bulk([model_instance])
+        except Exception as e:
+            raise Exception(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    # -------------------------------------------------------------------------
+    # Write operations -- bulk
+    # -------------------------------------------------------------------------
+
+    def create_bulk(self, model_instances: List[PrefixListModel], **kwargs) -> ResponseType:
+        """
+        Bulk-create prefix lists, split by ip_version.
+
+        Items are grouped into IPv4 and IPv6 subsets, each sent in a
+        separate API request.
+        """
+        try:
+            ipv4_items = [m for m in model_instances if str(m.ip_version) == "ipv4"]
+            ipv6_items = [m for m in model_instances if str(m.ip_version) == "ipv6"]
+            result = {}
+            if ipv4_items:
+                result["ipv4"] = self._bulk_create_for_version("ipv4", ipv4_items)
+            if ipv6_items:
+                result["ipv6"] = self._bulk_create_for_version("ipv6", ipv6_items)
+            return result
+        except Exception as e:
+            raise Exception(f"Bulk create failed: {e}") from e
+
+    def delete_bulk(self, model_instances: List[PrefixListModel], **kwargs) -> ResponseType:
+        """
+        Bulk-delete prefix lists, split by ip_version.
+
+        Names are grouped into IPv4 and IPv6 subsets, each sent in a
+        separate API request.
+        """
+        try:
+            ipv4_names = [m.name for m in model_instances if str(m.ip_version) == "ipv4"]
+            ipv6_names = [m.name for m in model_instances if str(m.ip_version) == "ipv6"]
+            result = {}
+            if ipv4_names:
+                result["ipv4"] = self._bulk_delete_for_version("ipv4", ipv4_names)
+            if ipv6_names:
+                result["ipv6"] = self._bulk_delete_for_version("ipv6", ipv6_names)
+            return result
+        except Exception as e:
+            raise Exception(f"Bulk delete failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -230,6 +230,8 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         if not result:
             return None
         result["ipVersion"] = version
+        if tenant_name is not None:
+            result.setdefault("tenantName", tenant_name)
         return result
 
     def _query_proposed_existing(self, identifiers: list[tuple[str, str | None, str]]) -> list[dict[str, Any]]:
@@ -331,6 +333,8 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
             api_endpoint = self._configure_endpoint(config["put"]())
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
             payload = model_instance.to_payload()
+            if model_instance.tenant_name is not None:
+                payload["name"] = model_instance.api_name
             if self.rest_send.params.get("state") in {"replaced", "overridden"} and model_instance.description is None:
                 payload["description"] = ""
             return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload, operation_type=OperationType.UPDATE)

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-__metaclass__ = type
-
 from typing import Any, ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -148,10 +148,6 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         except KeyError:
             raise ValueError(f"Unsupported ip_version '{version}'. Expected 'ipv4' or 'ipv6'.") from None
 
-    def _endpoint_classes_for_version(self, version: str) -> dict[str, Any]:
-        """Backwards-compatible accessor returning the per-version config (endpoint classes + payload keys)."""
-        return self._config_for_version(version)
-
     def _split_by_ip_version(self, model_instances: list[PrefixListModel]) -> dict[str, list[PrefixListModel]]:
         """Split model instances into ipv4/ipv6 buckets and fail fast on unsupported versions."""
         grouped: dict[str, list[PrefixListModel]] = {"ipv4": [], "ipv6": []}
@@ -180,6 +176,12 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
             endpoint_params.max = max_records
         if offset is not None and hasattr(endpoint_params, "offset"):
             endpoint_params.offset = offset
+        lucene_params = getattr(api_endpoint, "lucene_params", None)
+        if lucene_params is not None:
+            if max_records is not None:
+                lucene_params.max = max_records
+            if offset is not None:
+                lucene_params.offset = offset
         return api_endpoint
 
     @staticmethod
@@ -354,7 +356,12 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
             config = self._config_for_version(str(model_instance.ip_version))
             api_endpoint = self._configure_endpoint(config["get"]())
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+            if result:
+                result["ipVersion"] = str(model_instance.ip_version)
+                if model_instance.tenant_name is not None:
+                    result.setdefault("tenantName", model_instance.tenant_name)
+            return result
         except Exception as e:
             raise Exception(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -4,11 +4,11 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 __metaclass__ = type
 
-from typing import ClassVar, Dict, List, Type
+from typing import Any, ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_prefix_lists import (
@@ -30,16 +30,48 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
+# Per-item ``status`` values in a 207 Multi-Status body that count as a failure. Anything else --
+# ``success``, missing, empty, or future progress tokens -- is tolerated so informational rows do
+# not surface as spurious errors. Mirrors the maintenance_mode orchestrator's denylist approach.
+_FAILURE_STATUSES = frozenset({"failed", "failure", "error"})
+
+# Single source of truth for everything that differs between the two address families: the endpoint
+# classes plus the camelCase wrapper keys used in request/response bodies. Centralising this here
+# keeps every CRUD/bulk method address-family agnostic (no scattered ``"ipv4..." if v == "ipv4"``).
+_VERSION_CONFIG: dict[str, dict[str, Any]] = {
+    "ipv4": {
+        "get": EpManageIpv4PrefixListsGet,
+        "list": EpManageIpv4PrefixListsListGet,
+        "post": EpManageIpv4PrefixListsPost,
+        "put": EpManageIpv4PrefixListsPut,
+        "delete": EpManageIpv4PrefixListsDelete,
+        "bulk_delete": EpManageIpv4PrefixListsBulkDelete,
+        "list_key": "ipv4PrefixLists",
+        "names_key": "ipv4PrefixListNames",
+    },
+    "ipv6": {
+        "get": EpManageIpv6PrefixListsGet,
+        "list": EpManageIpv6PrefixListsListGet,
+        "post": EpManageIpv6PrefixListsPost,
+        "put": EpManageIpv6PrefixListsPut,
+        "delete": EpManageIpv6PrefixListsDelete,
+        "bulk_delete": EpManageIpv6PrefixListsBulkDelete,
+        "list_key": "ipv6PrefixLists",
+        "names_key": "ipv6PrefixListNames",
+    },
+}
+
 
 class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
     """
     Orchestrator for Prefix List (IPv4 and IPv6) CRUD operations.
 
     Both IPv4 and IPv6 prefix lists are managed through a single orchestrator.
-    The ``ip_version`` field on the model determines which set of API endpoints
-    to use for each operation.
+    The ``ip_version`` field on the model selects the address-family endpoints
+    and payload keys from ``_VERSION_CONFIG`` for each operation.
 
-    **Creation and deletion** are performed via bulk API endpoints:
+    **Creation and deletion** are performed via bulk API endpoints, which return
+    HTTP 207 Multi-Status with a per-item ``results`` array:
     - IPv4 create: ``POST /fabrics/{fabricName}/ipv4PrefixLists``
       with ``{"ipv4PrefixLists": [...]}``.
     - IPv6 create: ``POST /fabrics/{fabricName}/ipv6PrefixLists``
@@ -49,91 +81,120 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
     - IPv6 bulk delete: ``POST /fabrics/{fabricName}/ipv6PrefixListActions/remove``
       with ``{"ipv6PrefixListNames": [...]}``.
 
+    Because the controller answers these bulk calls with 207 (which ``ResponseHandler``
+    treats as transport success), every bulk response body is inspected per item; any
+    entry whose ``status`` is in ``_FAILURE_STATUSES`` raises with the offending prefix
+    list names, so partial failures are not silently reported as success.
+
     ``query_all`` fetches both IPv4 and IPv6 prefix lists and injects the
     ``ipVersion`` key into each raw API response dict so ``PrefixListModel``
     can deserialise them correctly.
 
-    The ``fabric_name`` field must be supplied at construction time:
+    .. note::
+       Tenant-scoped prefix lists are not yet fully supported for idempotency. The
+       create payload carries a bare ``name`` plus ``tenantName``, but the controller
+       returns (and keys delete/update on) the composite ``"<tenantName>~<name>"``.
+       Until that round-trip is normalised, use prefix lists in the default tenant.
 
-    ```python
-    orchestrator = ManagePrefixListOrchestrator(
-        rest_send=rest_send,
-        fabric_name="my-fabric",
-    )
-    ```
+    The ``fabric_name`` field is read from ``rest_send.params`` (populated by
+    ``NDStateMachine`` from the validated module params).
     """
 
-    model_class: ClassVar[Type[NDBaseModel]] = PrefixListModel
+    model_class: ClassVar[type[NDBaseModel]] = PrefixListModel
 
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
 
-    # Required stubs -- the orchestrator overrides every operation, so these
-    # just need to satisfy NDBaseOrchestrator's required fields.
-    create_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPost
-    update_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPut
-    delete_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsDelete
-    query_one_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsGet
-    query_all_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsListGet
+    # Required by NDBaseOrchestrator, but every operation is overridden below to route by
+    # ``ip_version`` via ``_VERSION_CONFIG``. These defaults only satisfy the base contract;
+    # the IPv4 classes are arbitrary placeholders and are never invoked directly.
+    create_endpoint: type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageIpv4PrefixListsDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageIpv4PrefixListsGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageIpv4PrefixListsListGet
 
-    create_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPost
-    delete_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsBulkDelete
+    create_bulk_endpoint: type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] = EpManageIpv4PrefixListsBulkDelete
 
-    def _endpoint_classes_for_version(self, version: str) -> Dict[str, Type[NDEndpointBaseModel]]:
-        """Return the correct endpoint class mapping for the given ip_version."""
-        if version == "ipv4":
-            return {
-                "get": EpManageIpv4PrefixListsGet,
-                "list": EpManageIpv4PrefixListsListGet,
-                "post": EpManageIpv4PrefixListsPost,
-                "put": EpManageIpv4PrefixListsPut,
-                "delete": EpManageIpv4PrefixListsDelete,
-                "bulk_delete": EpManageIpv4PrefixListsBulkDelete,
-            }
-        if version == "ipv6":
-            return {
-                "get": EpManageIpv6PrefixListsGet,
-                "list": EpManageIpv6PrefixListsListGet,
-                "post": EpManageIpv6PrefixListsPost,
-                "put": EpManageIpv6PrefixListsPut,
-                "delete": EpManageIpv6PrefixListsDelete,
-                "bulk_delete": EpManageIpv6PrefixListsBulkDelete,
-            }
-        raise ValueError(f"Unsupported ip_version '{version}'. Expected 'ipv4' or 'ipv6'.")
+    @property
+    def fabric_name(self) -> str:
+        """
+        Return ``fabric_name`` from the module params.
 
-    def _split_by_ip_version(self, model_instances: List[PrefixListModel]) -> Dict[str, List[PrefixListModel]]:
+        ``ManagePrefixListOrchestrator`` extends the generic ``NDBaseOrchestrator`` -- prefix lists
+        are fabric-scoped but not switch-scoped, so the interface base's switch/deploy machinery is
+        unnecessary. The generic base does not expose ``fabric_name``, so it is surfaced here from
+        ``rest_send.params``, mirroring ``NDBaseInterfaceOrchestrator.fabric_name``.
+        """
+        return self.rest_send.params.get("fabric_name")
+
+    def _config_for_version(self, version: str) -> dict[str, Any]:
+        """Return the endpoint classes and payload keys for the given ip_version, failing fast on unknown values."""
+        try:
+            return _VERSION_CONFIG[version]
+        except KeyError:
+            raise ValueError(f"Unsupported ip_version '{version}'. Expected 'ipv4' or 'ipv6'.") from None
+
+    def _endpoint_classes_for_version(self, version: str) -> dict[str, Any]:
+        """Backwards-compatible accessor returning the per-version config (endpoint classes + payload keys)."""
+        return self._config_for_version(version)
+
+    def _split_by_ip_version(self, model_instances: list[PrefixListModel]) -> dict[str, list[PrefixListModel]]:
         """Split model instances into ipv4/ipv6 buckets and fail fast on unsupported versions."""
-        grouped = {"ipv4": [], "ipv6": []}
+        grouped: dict[str, list[PrefixListModel]] = {"ipv4": [], "ipv6": []}
         for model in model_instances:
             version = str(model.ip_version)
-            if version == "ipv4":
-                grouped["ipv4"].append(model)
-            elif version == "ipv6":
-                grouped["ipv6"].append(model)
+            if version in grouped:
+                grouped[version].append(model)
             else:
-                raise ValueError(
-                    f"Unsupported ip_version '{version}' for prefix list '{model.name}'. "
-                    "Expected 'ipv4' or 'ipv6'."
-                )
+                raise ValueError(f"Unsupported ip_version '{version}' for prefix list '{model.name}'. Expected 'ipv4' or 'ipv6'.")
         return grouped
 
-    def _bulk_create_for_version(self, version: str, items: List[PrefixListModel]) -> ResponseType:
-        """Send a single bulk-create request for all items of the given ip_version."""
-        eps = self._endpoint_classes_for_version(version)
-        api_endpoint = eps["post"]()
-        api_endpoint.fabric_name = self.fabric_name
-        list_key = "ipv4PrefixLists" if version == "ipv4" else "ipv6PrefixLists"
-        payload = {list_key: [item.to_payload() for item in items]}
-        return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+    @staticmethod
+    def _raise_on_207_failures(result: Any, operation: str) -> None:
+        """
+        Inspect a 207 Multi-Status bulk response body. If any per-item ``status`` is in
+        ``_FAILURE_STATUSES``, raise with the offending prefix list names and messages so partial
+        failures are not silently swallowed (the controller returns 207 even when some items fail).
+        """
+        if not isinstance(result, dict):
+            return
+        items = result.get("results")
+        if not isinstance(items, list) or not items:
+            return
+        failures: list[str] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            status = str(item.get("status") or "").lower()
+            if status not in _FAILURE_STATUSES:
+                continue
+            name = item.get("name") or "?"
+            message = item.get("message") or "unknown error"
+            failures.append(f"{name}: {message}")
+        if failures:
+            raise Exception(f"prefix list {operation} reported per-item failures: {'; '.join(failures)}")
 
-    def _bulk_delete_for_version(self, version: str, names: List[str]) -> ResponseType:
-        """Send a single bulk-delete request for the given prefix list names."""
-        eps = self._endpoint_classes_for_version(version)
-        api_endpoint = eps["bulk_delete"]()
+    def _bulk_create_for_version(self, version: str, items: list[PrefixListModel]) -> ResponseType:
+        """Send a single bulk-create request for all items of the given ip_version and check the 207 body."""
+        config = self._config_for_version(version)
+        api_endpoint = config["post"]()
         api_endpoint.fabric_name = self.fabric_name
-        names_key = "ipv4PrefixListNames" if version == "ipv4" else "ipv6PrefixListNames"
-        payload = {names_key: names}
-        return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+        payload = {config["list_key"]: [item.to_payload() for item in items]}
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+        self._raise_on_207_failures(result, "create")
+        return result
+
+    def _bulk_delete_for_version(self, version: str, names: list[str]) -> ResponseType:
+        """Send a single bulk-delete request for the given prefix list names and check the 207 body."""
+        config = self._config_for_version(version)
+        api_endpoint = config["bulk_delete"]()
+        api_endpoint.fabric_name = self.fabric_name
+        payload = {config["names_key"]: names}
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+        self._raise_on_207_failures(result, "delete")
+        return result
 
     def create(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
         """Create a single prefix list via the bulk endpoint."""
@@ -145,9 +206,8 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
     def update(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
         """Update an existing prefix list via the PUT endpoint."""
         try:
-            version = str(model_instance.ip_version)
-            eps = self._endpoint_classes_for_version(version)
-            api_endpoint = eps["put"]()
+            config = self._config_for_version(str(model_instance.ip_version))
+            api_endpoint = config["put"]()
             api_endpoint.fabric_name = self.fabric_name
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
             return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload())
@@ -160,13 +220,12 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
             return self.delete_bulk([model_instance])
         except Exception as e:
             raise Exception(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
-    
+
     def query_one(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
         """Retrieve a single prefix list by name and ip_version."""
         try:
-            version = str(model_instance.ip_version)
-            eps = self._endpoint_classes_for_version(version)
-            api_endpoint = eps["get"]()
+            config = self._config_for_version(str(model_instance.ip_version))
+            api_endpoint = config["get"]()
             api_endpoint.fabric_name = self.fabric_name
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
             return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
@@ -182,55 +241,47 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         """
         try:
             results = []
-            for version in ("ipv4", "ipv6"):
-                eps = self._endpoint_classes_for_version(version)
-                api_endpoint = eps["list"]()
+            for version, config in _VERSION_CONFIG.items():
+                api_endpoint = config["list"]()
                 api_endpoint.fabric_name = self.fabric_name
                 raw = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                list_key = "ipv4PrefixLists" if version == "ipv4" else "ipv6PrefixLists"
-                for item in raw.get(list_key, []) or []:
+                for item in raw.get(config["list_key"], []) or []:
                     item["ipVersion"] = version
                     results.append(item)
             return results
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
 
-    def create_bulk(self, model_instances: List[PrefixListModel], **kwargs) -> ResponseType:
+    def create_bulk(self, model_instances: list[PrefixListModel], **kwargs) -> ResponseType:
         """
         Bulk-create prefix lists, split by ip_version.
 
-        Items are grouped into IPv4 and IPv6 subsets, each sent in a
-        separate API request.
+        Items are grouped into IPv4 and IPv6 subsets, each sent in a separate API
+        request. Each 207 response body is checked for per-item failures.
         """
         try:
             grouped = self._split_by_ip_version(model_instances)
-            ipv4_items = grouped["ipv4"]
-            ipv6_items = grouped["ipv6"]
             result = {}
-            if ipv4_items:
-                result["ipv4"] = self._bulk_create_for_version("ipv4", ipv4_items)
-            if ipv6_items:
-                result["ipv6"] = self._bulk_create_for_version("ipv6", ipv6_items)
+            for version, items in grouped.items():
+                if items:
+                    result[version] = self._bulk_create_for_version(version, items)
             return result
         except Exception as e:
             raise Exception(f"Bulk create failed: {e}") from e
 
-    def delete_bulk(self, model_instances: List[PrefixListModel], **kwargs) -> ResponseType:
+    def delete_bulk(self, model_instances: list[PrefixListModel], **kwargs) -> ResponseType:
         """
         Bulk-delete prefix lists, split by ip_version.
 
-        Names are grouped into IPv4 and IPv6 subsets, each sent in a
-        separate API request.
+        Names are grouped into IPv4 and IPv6 subsets, each sent in a separate API
+        request. Each 207 response body is checked for per-item failures.
         """
         try:
             grouped = self._split_by_ip_version(model_instances)
-            ipv4_names = [m.name for m in grouped["ipv4"]]
-            ipv6_names = [m.name for m in grouped["ipv6"]]
             result = {}
-            if ipv4_names:
-                result["ipv4"] = self._bulk_delete_for_version("ipv4", ipv4_names)
-            if ipv6_names:
-                result["ipv6"] = self._bulk_delete_for_version("ipv6", ipv6_names)
+            for version, models in grouped.items():
+                if models:
+                    result[version] = self._bulk_delete_for_version(version, [m.name for m in models])
             return result
         except Exception as e:
             raise Exception(f"Bulk delete failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -269,7 +269,7 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
                 results.append(item)
             if not self._has_next_page(raw, len(page), offset):
                 break
-            offset += _QUERY_PAGE_SIZE
+            offset += len(page)
         return results
 
     @staticmethod

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -10,7 +10,6 @@ __metaclass__ = type
 
 from typing import ClassVar, Dict, List, Type
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_prefix_lists import (
     EpManageIpv4PrefixListsBulkDelete,
@@ -69,9 +68,6 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
 
-    # Fabric context
-    fabric_name: str = Field(description="Name of the fabric that owns these prefix lists.")
-
     # Required stubs -- the orchestrator overrides every operation, so these
     # just need to satisfy NDBaseOrchestrator's required fields.
     create_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPost
@@ -82,10 +78,6 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
 
     create_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsPost
     delete_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageIpv4PrefixListsBulkDelete
-
-    # -------------------------------------------------------------------------
-    # Internal helpers
-    # -------------------------------------------------------------------------
 
     def _endpoint_classes_for_version(self, version: str) -> Dict[str, Type[NDEndpointBaseModel]]:
         """Return the correct endpoint class mapping for the given ip_version."""
@@ -98,7 +90,7 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
                 "delete": EpManageIpv4PrefixListsDelete,
                 "bulk_delete": EpManageIpv4PrefixListsBulkDelete,
             }
-        else:
+        if version == "ipv6":
             return {
                 "get": EpManageIpv6PrefixListsGet,
                 "list": EpManageIpv6PrefixListsListGet,
@@ -107,6 +99,23 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
                 "delete": EpManageIpv6PrefixListsDelete,
                 "bulk_delete": EpManageIpv6PrefixListsBulkDelete,
             }
+        raise ValueError(f"Unsupported ip_version '{version}'. Expected 'ipv4' or 'ipv6'.")
+
+    def _split_by_ip_version(self, model_instances: List[PrefixListModel]) -> Dict[str, List[PrefixListModel]]:
+        """Split model instances into ipv4/ipv6 buckets and fail fast on unsupported versions."""
+        grouped = {"ipv4": [], "ipv6": []}
+        for model in model_instances:
+            version = str(model.ip_version)
+            if version == "ipv4":
+                grouped["ipv4"].append(model)
+            elif version == "ipv6":
+                grouped["ipv6"].append(model)
+            else:
+                raise ValueError(
+                    f"Unsupported ip_version '{version}' for prefix list '{model.name}'. "
+                    "Expected 'ipv4' or 'ipv6'."
+                )
+        return grouped
 
     def _bulk_create_for_version(self, version: str, items: List[PrefixListModel]) -> ResponseType:
         """Send a single bulk-create request for all items of the given ip_version."""
@@ -125,48 +134,6 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         names_key = "ipv4PrefixListNames" if version == "ipv4" else "ipv6PrefixListNames"
         payload = {names_key: names}
         return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
-
-    # -------------------------------------------------------------------------
-    # Query helpers
-    # -------------------------------------------------------------------------
-
-    def query_all(self) -> ResponseType:
-        """
-        Fetch all IPv4 and IPv6 prefix lists and combine them into a single list.
-
-        The ``ipVersion`` key is injected into each raw response dict so that
-        ``PrefixListModel.from_response()`` can populate the ``ip_version`` field.
-        """
-        try:
-            results = []
-            for version in ("ipv4", "ipv6"):
-                eps = self._endpoint_classes_for_version(version)
-                api_endpoint = eps["list"]()
-                api_endpoint.fabric_name = self.fabric_name
-                raw = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                list_key = "ipv4PrefixLists" if version == "ipv4" else "ipv6PrefixLists"
-                for item in raw.get(list_key, []) or []:
-                    item["ipVersion"] = version
-                    results.append(item)
-            return results
-        except Exception as e:
-            raise Exception(f"Query all failed: {e}") from e
-
-    def query_one(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
-        """Retrieve a single prefix list by name and ip_version."""
-        try:
-            version = str(model_instance.ip_version)
-            eps = self._endpoint_classes_for_version(version)
-            api_endpoint = eps["get"]()
-            api_endpoint.fabric_name = self.fabric_name
-            api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
-        except Exception as e:
-            raise Exception(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
-
-    # -------------------------------------------------------------------------
-    # Write operations -- single item (delegate to bulk)
-    # -------------------------------------------------------------------------
 
     def create(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
         """Create a single prefix list via the bulk endpoint."""
@@ -193,10 +160,40 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
             return self.delete_bulk([model_instance])
         except Exception as e:
             raise Exception(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
+    
+    def query_one(self, model_instance: PrefixListModel, **kwargs) -> ResponseType:
+        """Retrieve a single prefix list by name and ip_version."""
+        try:
+            version = str(model_instance.ip_version)
+            eps = self._endpoint_classes_for_version(version)
+            api_endpoint = eps["get"]()
+            api_endpoint.fabric_name = self.fabric_name
+            api_endpoint.set_identifiers(model_instance.get_identifier_value())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise Exception(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
-    # -------------------------------------------------------------------------
-    # Write operations -- bulk
-    # -------------------------------------------------------------------------
+    def query_all(self) -> ResponseType:
+        """
+        Fetch all IPv4 and IPv6 prefix lists and combine them into a single list.
+
+        The ``ipVersion`` key is injected into each raw response dict so that
+        ``PrefixListModel.from_response()`` can populate the ``ip_version`` field.
+        """
+        try:
+            results = []
+            for version in ("ipv4", "ipv6"):
+                eps = self._endpoint_classes_for_version(version)
+                api_endpoint = eps["list"]()
+                api_endpoint.fabric_name = self.fabric_name
+                raw = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                list_key = "ipv4PrefixLists" if version == "ipv4" else "ipv6PrefixLists"
+                for item in raw.get(list_key, []) or []:
+                    item["ipVersion"] = version
+                    results.append(item)
+            return results
+        except Exception as e:
+            raise Exception(f"Query all failed: {e}") from e
 
     def create_bulk(self, model_instances: List[PrefixListModel], **kwargs) -> ResponseType:
         """
@@ -206,8 +203,9 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         separate API request.
         """
         try:
-            ipv4_items = [m for m in model_instances if str(m.ip_version) == "ipv4"]
-            ipv6_items = [m for m in model_instances if str(m.ip_version) == "ipv6"]
+            grouped = self._split_by_ip_version(model_instances)
+            ipv4_items = grouped["ipv4"]
+            ipv6_items = grouped["ipv6"]
             result = {}
             if ipv4_items:
                 result["ipv4"] = self._bulk_create_for_version("ipv4", ipv4_items)
@@ -225,8 +223,9 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         separate API request.
         """
         try:
-            ipv4_names = [m.name for m in model_instances if str(m.ip_version) == "ipv4"]
-            ipv6_names = [m.name for m in model_instances if str(m.ip_version) == "ipv6"]
+            grouped = self._split_by_ip_version(model_instances)
+            ipv4_names = [m.name for m in grouped["ipv4"]]
+            ipv6_names = [m.name for m in grouped["ipv6"]]
             result = {}
             if ipv4_names:
                 result["ipv4"] = self._bulk_delete_for_version("ipv4", ipv4_names)

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -30,6 +30,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 _QUERY_PAGE_SIZE = 100
+_SCOPED_QUERY_MAX_IDENTIFIERS = 8
 
 # Per-item ``status`` values in a 207 Multi-Status body that count as a failure. Anything else --
 # ``success``, missing, empty, or future progress tokens -- is tolerated so informational rows do
@@ -204,20 +205,21 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         identifiers: list[tuple[str, str | None, str]] = []
         seen: set[tuple[str, str | None, str]] = set()
         for item in self._raw_items_from_params(self.rest_send.params):
-            model = PrefixListModel.from_config(item)
-            identifier = model.get_identifier_value()
-            if not isinstance(identifier, tuple) or len(identifier) != 3:
+            version = item.get("ip_version", item.get("ipVersion"))
+            name = item.get("name")
+            if version is None or name is None:
                 continue
-            normalized = (str(identifier[0]), identifier[1], str(identifier[2]))
+            tenant_name = item.get("tenant_name", item.get("tenantName"))
+            normalized = (str(version), tenant_name, str(name))
             if normalized not in seen:
                 seen.add(normalized)
                 identifiers.append(normalized)
         return identifiers
 
-    def _should_use_scoped_query(self) -> bool:
+    def _should_use_scoped_query(self, identifiers: list[tuple[str, str | None, str]]) -> bool:
         """Return whether initialization can query only proposed prefix-list identities."""
         state = self.rest_send.params.get("state")
-        return state in {"merged", "replaced", "deleted"} and bool(self._raw_items_from_params(self.rest_send.params))
+        return state in {"merged", "replaced", "deleted"} and 0 < len(identifiers) <= _SCOPED_QUERY_MAX_IDENTIFIERS
 
     def _query_one_existing(self, version: str, tenant_name: str | None, name: str) -> dict[str, Any] | None:
         """Fetch one existing prefix list, returning ``None`` when it is absent."""
@@ -230,10 +232,10 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         result["ipVersion"] = version
         return result
 
-    def _query_proposed_existing(self) -> list[dict[str, Any]]:
+    def _query_proposed_existing(self, identifiers: list[tuple[str, str | None, str]]) -> list[dict[str, Any]]:
         """Fetch only the existing prefix lists named by module ``config``."""
         results: list[dict[str, Any]] = []
-        for version, tenant_name, name in self._proposed_identifiers():
+        for version, tenant_name, name in identifiers:
             item = self._query_one_existing(version, tenant_name, name)
             if item is not None:
                 results.append(item)
@@ -362,8 +364,9 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         try:
             PrefixListModel.validate_config_for_state(self._raw_items_from_params(self.rest_send.params), self.rest_send.params.get("state", ""))
 
-            if self._should_use_scoped_query():
-                return self._query_proposed_existing()
+            proposed_identifiers = self._proposed_identifiers()
+            if self._should_use_scoped_query(proposed_identifiers):
+                return self._query_proposed_existing(proposed_identifiers)
 
             results = []
             for version in _VERSION_CONFIG:

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -328,7 +328,10 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
             config = self._config_for_version(str(model_instance.ip_version))
             api_endpoint = self._configure_endpoint(config["put"]())
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload(), operation_type=OperationType.UPDATE)
+            payload = model_instance.to_payload()
+            if self.rest_send.params.get("state") in {"replaced", "overridden"} and model_instance.description is None:
+                payload["description"] = ""
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload, operation_type=OperationType.UPDATE)
         except Exception as e:
             raise Exception(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
 

--- a/plugins/module_utils/orchestrators/manage_prefix_list.py
+++ b/plugins/module_utils/orchestrators/manage_prefix_list.py
@@ -91,11 +91,9 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
     ``ipVersion`` key into each raw API response dict so ``PrefixListModel``
     can deserialise them correctly.
 
-    .. note::
-       Tenant-scoped prefix lists are not yet fully supported for idempotency. The
-       create payload carries a bare ``name`` plus ``tenantName``, but the controller
-       returns (and keys delete/update on) the composite ``"<tenantName>~<name>"``.
-       Until that round-trip is normalised, use prefix lists in the default tenant.
+    Tenant-scoped prefix lists are modeled with bare ``name`` plus ``tenant_name`` for
+    Ansible config, and with the API's fully qualified ``"<tenantName>~<name>"`` form
+    for item lookups, updates, and bulk deletes.
 
     The ``fabric_name`` field is read from ``rest_send.params`` (populated by
     ``NDStateMachine`` from the validated module params).
@@ -201,16 +199,16 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
             config = [config]
         return [item for item in config if isinstance(item, dict)]
 
-    def _proposed_identifiers(self) -> list[tuple[str, str]]:
-        """Return unique ``(ip_version, name)`` identifiers from raw module config."""
-        identifiers: list[tuple[str, str]] = []
-        seen: set[tuple[str, str]] = set()
+    def _proposed_identifiers(self) -> list[tuple[str, str | None, str]]:
+        """Return unique ``(ip_version, tenant_name, name)`` identifiers from raw module config."""
+        identifiers: list[tuple[str, str | None, str]] = []
+        seen: set[tuple[str, str | None, str]] = set()
         for item in self._raw_items_from_params(self.rest_send.params):
             model = PrefixListModel.from_config(item)
             identifier = model.get_identifier_value()
-            if not isinstance(identifier, tuple) or len(identifier) != 2:
+            if not isinstance(identifier, tuple) or len(identifier) != 3:
                 continue
-            normalized = (str(identifier[0]), str(identifier[1]))
+            normalized = (str(identifier[0]), identifier[1], str(identifier[2]))
             if normalized not in seen:
                 seen.add(normalized)
                 identifiers.append(normalized)
@@ -221,11 +219,11 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         state = self.rest_send.params.get("state")
         return state in {"merged", "replaced", "deleted"} and bool(self._raw_items_from_params(self.rest_send.params))
 
-    def _query_one_existing(self, version: str, name: str) -> dict[str, Any] | None:
+    def _query_one_existing(self, version: str, tenant_name: str | None, name: str) -> dict[str, Any] | None:
         """Fetch one existing prefix list, returning ``None`` when it is absent."""
         config = self._config_for_version(version)
         api_endpoint = self._configure_endpoint(config["get"]())
-        api_endpoint.set_identifiers((version, name))
+        api_endpoint.set_identifiers((version, tenant_name, name))
         result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
         if not result:
             return None
@@ -235,8 +233,8 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
     def _query_proposed_existing(self) -> list[dict[str, Any]]:
         """Fetch only the existing prefix lists named by module ``config``."""
         results: list[dict[str, Any]] = []
-        for version, name in self._proposed_identifiers():
-            item = self._query_one_existing(version, name)
+        for version, tenant_name, name in self._proposed_identifiers():
+            item = self._query_one_existing(version, tenant_name, name)
             if item is not None:
                 results.append(item)
         return results
@@ -359,6 +357,8 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
         ``PrefixListModel.from_response()`` can populate the ``ip_version`` field.
         """
         try:
+            PrefixListModel.validate_config_for_state(self._raw_items_from_params(self.rest_send.params), self.rest_send.params.get("state", ""))
+
             if self._should_use_scoped_query():
                 return self._query_proposed_existing()
 
@@ -398,7 +398,7 @@ class ManagePrefixListOrchestrator(NDBaseOrchestrator[PrefixListModel]):
             result = {}
             for version, models in grouped.items():
                 if models:
-                    result[version] = self._bulk_delete_for_version(version, [m.name for m in models])
+                    result[version] = self._bulk_delete_for_version(version, [m.api_name for m in models])
             return result
         except Exception as e:
             raise Exception(f"Bulk delete failed: {e}") from e

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -58,6 +58,8 @@ options:
         - The name of the prefix list.
         - Allowed characters are C([a-zA-Z0-9~_-]).
         - Maximum length is 115 characters (63 for the default tenant).
+        - When O(config.tenant_name) is set, the combined C(tenant_name~name)
+          value must not exceed 115 characters.
         type: str
         required: true
       description:

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -46,6 +46,7 @@ options:
         description:
         - The IP address family of the prefix list.
         - Use C(ipv4) for IPv4 prefix lists and C(ipv6) for IPv6 prefix lists.
+        - No default is applied because the address family is part of the resource identity.
         - A prefix list named C(PL-1) with C(ip_version=ipv4) and another with
           C(ip_version=ipv6) are treated as independent resources.
         type: str
@@ -68,6 +69,8 @@ options:
         description:
         - The tenant that owns this prefix list.
         - When omitted, the default tenant is used.
+        - Prefix lists with the same O(config.ip_version) and O(config.name) but different
+          O(config.tenant_name) values are treated as independent resources.
         - Allowed characters are C([A-Za-z0-9_-]).
         type: str
         aliases: [ tenantName ]
@@ -86,12 +89,14 @@ options:
             description:
             - The sequence number of this entry (1-4294967294).
             - Entries are evaluated in ascending sequence order.
+            - Values must be unique within each prefix list.
             type: int
             required: true
             aliases: [ sequenceNumber ]
           action:
             description:
             - The action to take when the prefix matches.
+            - No default is applied because the action changes routing-policy behavior.
             type: str
             required: true
             choices: [ permit, deny ]
@@ -108,25 +113,30 @@ options:
             description:
             - Exact prefix-length to match.
             - Range 1-32 for IPv4, 1-128 for IPv6.
+            - Cannot be combined with O(config.entries.min_prefix_length) or
+              O(config.entries.max_prefix_length) in the same entry.
             type: int
             aliases: [ exactLength ]
           min_prefix_length:
             description:
             - Minimum prefix-length to match (inclusive).
             - Range 1-32 for IPv4, 1-128 for IPv6.
+            - Must be less than or equal to O(config.entries.max_prefix_length) when both are set.
             type: int
             aliases: [ minLength ]
           max_prefix_length:
             description:
             - Maximum prefix-length to match (inclusive).
             - Range 1-32 for IPv4, 1-128 for IPv6.
+            - Must be greater than or equal to O(config.entries.min_prefix_length) when both are set.
             type: int
             aliases: [ maxLength ]
           mask:
             description:
-            - Network mask in dotted-decimal format for IPv4
-              (e.g. C(255.255.255.0)) or explicit match mask in IPv6
-              format (e.g. C(ffff:ffff::)).
+            - Optional explicit match mask.
+            - For IPv4, use dotted-decimal format (e.g. C(255.255.255.0)).
+            - For IPv6, use IPv6 address format (e.g. C(ffff:ffff::)).
+            - This value is sent to the API as a separate explicit match mask and is not deduced from O(config.entries.prefix).
             - Must be a valid IPv4 address when O(config.ip_version=ipv4).
             - Must be a valid IPv6 address when O(config.ip_version=ipv6).
             type: str
@@ -151,24 +161,8 @@ notes:
 - This module is only supported on Nexus Dashboard having version 4.2.1 or higher.
 - IPv4 and IPv6 prefix lists are created and deleted in bulk via separate API endpoints.
   A single task may contain a mix of IPv4 and IPv6 entries.
-- O(config.entries.prefix) is validated locally to match the declared O(config.ip_version).
-- O(config.entries.exact_length), O(config.entries.min_prefix_length), and
-  O(config.entries.max_prefix_length) are validated to be within the
-  address-family-appropriate range (1-32 for IPv4, 1-128 for IPv6).
-- O(config.entries.exact_length) cannot be combined with
-  O(config.entries.min_prefix_length) or O(config.entries.max_prefix_length)
-  in the same entry.
-- If both O(config.entries.min_prefix_length) and
-  O(config.entries.max_prefix_length) are set, the minimum must be less than
-  or equal to the maximum.
-- O(config.entries.sequence_number) values must be unique within each
-  prefix list.
-- O(config.description) is validated as ASCII-only.
-- O(config.tenant_name) (non-default tenant) prefix lists are not yet fully
-  supported for idempotency. Nexus Dashboard stores and returns these prefix
-  lists under the composite name C(<tenant_name>~<name>), which does not match
-  the configured O(config.name), so repeated runs may not be idempotent. Use
-  prefix lists in the default tenant until this is addressed.
+- Prefix and mask values are normalized locally for stable idempotency when Nexus Dashboard returns
+  equivalent IPv6 values in compressed notation.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -1,0 +1,286 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_manage_prefix_list
+version_added: "1.6.0"
+short_description: Manage IPv4 and IPv6 prefix lists on Cisco Nexus Dashboard fabrics
+description:
+- Manage IPv4 and IPv6 routing-policy prefix lists on a Cisco Nexus Dashboard (ND) fabric.
+- Both address families are handled by this single module; set O(config.ip_version)
+  to C(ipv4) or C(ipv6) for each prefix list.
+- Prefix lists are created and deleted in bulk via dedicated API endpoints.
+- Prefix lists with the same name but different O(config.ip_version) values are treated
+  as distinct resources.
+author:
+- Gaspard Micol (@gmicol)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric that owns the prefix lists.
+    - Required for all operations.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of prefix lists to configure.
+    type: list
+    elements: dict
+    required: True
+    suboptions:
+      ip_version:
+        description:
+        - The IP address family of the prefix list.
+        - Use C(ipv4) for IPv4 prefix lists and C(ipv6) for IPv6 prefix lists.
+        - A prefix list named C(PL-1) with C(ip_version=ipv4) and another with
+          C(ip_version=ipv6) are treated as independent resources.
+        type: str
+        required: true
+        choices: [ ipv4, ipv6 ]
+        aliases: [ ipVersion ]
+      name:
+        description:
+        - The name of the prefix list.
+        - Allowed characters are C([a-zA-Z0-9~_-]).
+        - Maximum length is 115 characters (63 for the default tenant).
+        type: str
+        required: true
+      description:
+        description:
+        - A human-readable description of the prefix list.
+        - Maximum length is 90 characters.
+        type: str
+      tenant_name:
+        description:
+        - The tenant that owns this prefix list.
+        - When omitted, the default tenant is used.
+        - Allowed characters are C([A-Za-z0-9_-]).
+        type: str
+        aliases: [ tenantName ]
+      entries:
+        description:
+        - The list of prefix list entries.
+        - Each entry defines a permit/deny action for a specific IP prefix.
+        type: list
+        elements: dict
+        required: true
+        suboptions:
+          sequence_number:
+            description:
+            - The sequence number of this entry (1-4294967294).
+            - Entries are evaluated in ascending sequence order.
+            type: int
+            required: true
+            aliases: [ sequenceNumber ]
+          action:
+            description:
+            - The action to take when the prefix matches.
+            type: str
+            required: true
+            choices: [ permit, deny ]
+          prefix:
+            description:
+            - The IP prefix in CIDR notation.
+            - Must be an IPv4 CIDR (e.g. C(10.0.0.0/8)) when
+              O(config.ip_version=ipv4).
+            - Must be an IPv6 CIDR (e.g. C(2001:db8::/32)) when
+              O(config.ip_version=ipv6).
+            type: str
+            required: true
+          exact_length:
+            description:
+            - Exact prefix-length to match.
+            - Range 1-32 for IPv4, 1-128 for IPv6.
+            type: int
+            aliases: [ exactLength ]
+          min_prefix_length:
+            description:
+            - Minimum prefix-length to match (inclusive).
+            - Range 1-32 for IPv4, 1-128 for IPv6.
+            type: int
+            aliases: [ minLength ]
+          max_prefix_length:
+            description:
+            - Maximum prefix-length to match (inclusive).
+            - Range 1-32 for IPv4, 1-128 for IPv6.
+            type: int
+            aliases: [ maxLength ]
+          mask:
+            description:
+            - Network mask in dotted-decimal format for IPv4
+              (e.g. C(255.255.255.0)) or explicit match mask in IPv6
+              format (e.g. C(ffff:ffff::)).
+            - Must be a valid IPv4 address when O(config.ip_version=ipv4).
+            - Must be a valid IPv6 address when O(config.ip_version=ipv6).
+            type: str
+  state:
+    description:
+    - The desired state of the prefix list resources on Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new prefix lists and update existing ones
+      as defined in the configuration.
+      Prefix lists on ND that are not specified in the configuration are left unchanged.
+    - Use O(state=replaced) to replace the prefix lists specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      All prefix lists (both IPv4 and IPv6) on ND not present in the configuration
+      will be deleted. Use with caution.
+    - Use O(state=deleted) to remove the prefix lists specified in the configuration.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard having version 4.2.1 or higher.
+- IPv4 and IPv6 prefix lists are created and deleted in bulk via separate API endpoints.
+  A single task may contain a mix of IPv4 and IPv6 entries.
+- O(config.entries.prefix) is validated locally to match the declared O(config.ip_version).
+- O(config.entries.exact_length), O(config.entries.min_prefix_length), and
+  O(config.entries.max_prefix_length) are validated to be within the
+  address-family-appropriate range (1-32 for IPv4, 1-128 for IPv6).
+"""
+
+EXAMPLES = r"""
+- name: Create IPv4 and IPv6 prefix lists
+  cisco.nd.nd_manage_prefix_list:
+    fabric_name: my-fabric
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-BORDERS
+        description: Border router IPv4 prefixes
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: 10.0.0.0/8
+          - sequence_number: 20
+            action: permit
+            prefix: 172.16.0.0/12
+            min_prefix_length: 24
+            max_prefix_length: 32
+          - sequence_number: 30
+            action: deny
+            prefix: 0.0.0.0/0
+      - ip_version: ipv6
+        name: PL-IPV6-DATACENTER
+        description: Datacenter IPv6 prefixes
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: 2001:db8::/32
+            exact_length: 48
+          - sequence_number: 20
+            action: deny
+            prefix: ::/0
+    state: merged
+
+- name: Update an IPv4 prefix list
+  cisco.nd.nd_manage_prefix_list:
+    fabric_name: my-fabric
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-BORDERS
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: 192.168.0.0/16
+            min_prefix_length: 24
+    state: replaced
+
+- name: Delete specific prefix lists
+  cisco.nd.nd_manage_prefix_list:
+    fabric_name: my-fabric
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-BORDERS
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: 10.0.0.0/8
+      - ip_version: ipv6
+        name: PL-IPV6-DATACENTER
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: 2001:db8::/32
+    state: deleted
+
+- name: Override -- enforce exact set of prefix lists (delete all others)
+  cisco.nd.nd_manage_prefix_list:
+    fabric_name: my-fabric
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-FINAL
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: 10.0.0.0/8
+    state: overridden
+"""
+
+RETURN = r"""
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.manage_prefix_list import PrefixListModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_prefix_list import ManagePrefixListOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+
+
+def main():
+    argument_spec = nd_argument_spec()
+    argument_spec.update(PrefixListModel.get_argument_spec())
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+
+    nd_state_machine = None
+    try:
+        sender = Sender()
+        sender.ansible_module = module
+
+        rest_send = RestSend(
+            {
+                "check_mode": module.check_mode,
+                "state": module.params.get("state"),
+            }
+        )
+        rest_send.sender = sender
+        rest_send.response_handler = ResponseHandler()
+
+        orchestrator = ManagePrefixListOrchestrator(
+            rest_send=rest_send,
+            fabric_name=module.params["fabric_name"],
+        )
+
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=orchestrator,
+        )
+
+        nd_state_machine.manage_state()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except Exception as e:
+        output = nd_state_machine.output.format() if nd_state_machine is not None else {}
+        module.fail_json(msg=f"Module execution failed: {str(e)}", **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -80,6 +80,9 @@ options:
         description:
         - The list of prefix list entries.
         - Each entry defines a permit/deny action for a specific IP prefix.
+        - This list is authoritative whenever a prefix list is created or updated.
+          Existing entries that are not present in this list are removed, including
+          with O(state=merged). Restate every entry that should remain configured.
         - Required for O(state=merged), O(state=replaced), and O(state=overridden).
         - Optional for O(state=deleted), where identifier-only items
           (O(config.ip_version) + O(config.name)) are accepted.
@@ -148,6 +151,8 @@ options:
     - Use O(state=merged) to create new prefix lists and update existing ones
       as defined in the configuration.
       Prefix lists on ND that are not specified in the configuration are left unchanged.
+      For prefix lists that are specified, O(config.entries) replaces the full
+      entry list; entries omitted from O(config.entries) are removed.
     - Use O(state=replaced) to replace the prefix lists specified in the configuration.
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       All prefix lists (both IPv4 and IPv6) on ND not present in the configuration

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -243,6 +243,87 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing prefix-list configuration before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching prefix-list configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - ip_version: ipv4
+    name: PL-IPV4-BORDERS
+    description: Border router IPv4 prefixes
+    entries:
+    - sequence_number: 10
+      action: permit
+      prefix: 10.0.0.0/8
+after:
+  description:
+  - The prefix-list configuration after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - ip_version: ipv4
+    name: PL-IPV4-BORDERS
+    description: Updated border router IPv4 prefixes
+    entries:
+    - sequence_number: 10
+      action: permit
+      prefix: 10.0.0.0/8
+    - sequence_number: 20
+      action: deny
+      prefix: 0.0.0.0/0
+diff:
+  description: The per-prefix-list difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - ip_version: ipv4
+    name: PL-IPV4-BORDERS
+    description: Updated border router IPv4 prefixes
+    entries:
+    - sequence_number: 20
+      action: deny
+      prefix: 0.0.0.0/0
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - ip_version: ipv6
+    tenant_name: tenant-a
+    name: PL-IPV6-DATACENTER
+    entries:
+    - sequence_number: 10
+      action: permit
+      prefix: 2001:db8::/32
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing prefix-list configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Module execution failed: prefix-list validation failed"
 """
 
 import logging

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -4,10 +4,6 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
-
 ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
 
 DOCUMENTATION = r"""

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -6,6 +6,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+__metaclass__ = type
+
 ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
 
 DOCUMENTATION = r"""
@@ -26,7 +28,6 @@ options:
   fabric_name:
     description:
     - The name of the fabric that owns the prefix lists.
-    - Required for all operations.
     type: str
     required: true
   config:
@@ -69,9 +70,12 @@ options:
         description:
         - The list of prefix list entries.
         - Each entry defines a permit/deny action for a specific IP prefix.
+        - Required for O(state=merged), O(state=replaced), and O(state=overridden).
+        - Optional for O(state=deleted), where identifier-only items
+          (O(ip_version) + O(name)) are accepted.
         type: list
         elements: dict
-        required: true
+        required: false
         suboptions:
           sequence_number:
             description:
@@ -146,6 +150,15 @@ notes:
 - O(config.entries.exact_length), O(config.entries.min_prefix_length), and
   O(config.entries.max_prefix_length) are validated to be within the
   address-family-appropriate range (1-32 for IPv4, 1-128 for IPv6).
+- O(config.entries.exact_length) cannot be combined with
+  O(config.entries.min_prefix_length) or O(config.entries.max_prefix_length)
+  in the same entry.
+- If both O(config.entries.min_prefix_length) and
+  O(config.entries.max_prefix_length) are set, the minimum must be less than
+  or equal to the maximum.
+- O(config.entries.sequence_number) values must be unique within each
+  prefix list.
+- O(config.description) is validated as ASCII-only.
 """
 
 EXAMPLES = r"""
@@ -200,16 +213,8 @@ EXAMPLES = r"""
     config:
       - ip_version: ipv4
         name: PL-IPV4-BORDERS
-        entries:
-          - sequence_number: 10
-            action: permit
-            prefix: 10.0.0.0/8
       - ip_version: ipv6
         name: PL-IPV6-DATACENTER
-        entries:
-          - sequence_number: 10
-            action: permit
-            prefix: 2001:db8::/32
     state: deleted
 
 - name: Override -- enforce exact set of prefix lists (delete all others)
@@ -228,18 +233,35 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
+import logging
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.manage_prefix_list import PrefixListModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_prefix_list import ManagePrefixListOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 
 
 def main():
+    """
+    # Summary
+
+    Entry point for the `nd_manage_prefix_list` Ansible module.
+
+    Builds the argument spec from `PrefixListModel.get_argument_spec()` (which contributes the
+    top-level `fabric_name` option plus the `config` list of prefix lists) and hands control to
+    `NDStateMachine`, passing the `ManagePrefixListOrchestrator` *class*. The state machine builds
+    `RestSend` from the validated module params, so the orchestrator reads `fabric_name` from
+    `rest_send.params` rather than a constructor argument.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
     argument_spec = nd_argument_spec()
     argument_spec.update(PrefixListModel.get_argument_spec())
 
@@ -248,38 +270,37 @@ def main():
         supports_check_mode=True,
     )
     require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_manage_prefix_list")
 
     nd_state_machine = None
     try:
-        sender = Sender()
-        sender.ansible_module = module
-
-        rest_send = RestSend(
-            {
-                "check_mode": module.check_mode,
-                "state": module.params.get("state"),
-            }
-        )
-        rest_send.sender = sender
-        rest_send.response_handler = ResponseHandler()
-
-        orchestrator = ManagePrefixListOrchestrator(
-            rest_send=rest_send,
-            fabric_name=module.params["fabric_name"],
-        )
-
         nd_state_machine = NDStateMachine(
             module=module,
-            model_orchestrator=orchestrator,
+            model_orchestrator=ManagePrefixListOrchestrator,
         )
 
+        module_log.debug("manage_state begin state=%s check_mode=%s", module.params.get("state"), module.check_mode)
         nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
 
         module.exit_json(**nd_state_machine.output.format())
 
-    except Exception as e:
-        output = nd_state_machine.output.format() if nd_state_machine is not None else {}
-        module.fail_json(msg=f"Module execution failed: {str(e)}", **output)
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -97,9 +97,8 @@ options:
           action:
             description:
             - The action to take when the prefix matches.
-            - Defaults to C(permit), matching the Nexus Dashboard UI default.
+            - It defaults to C(permit) when unset during creation.
             type: str
-            default: permit
             choices: [ permit, deny ]
           prefix:
             description:

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -159,6 +159,11 @@ notes:
 - O(config.entries.sequence_number) values must be unique within each
   prefix list.
 - O(config.description) is validated as ASCII-only.
+- O(config.tenant_name) (non-default tenant) prefix lists are not yet fully
+  supported for idempotency. Nexus Dashboard stores and returns these prefix
+  lists under the composite name C(<tenant_name>~<name>), which does not match
+  the configured O(config.name), so repeated runs may not be idempotent. Use
+  prefix lists in the default tenant until this is addressed.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_manage_prefix_list
-version_added: "1.6.0"
+version_added: "2.0.0"
 short_description: Manage IPv4 and IPv6 prefix lists on Cisco Nexus Dashboard fabrics
 description:
 - Manage IPv4 and IPv6 routing-policy prefix lists on a Cisco Nexus Dashboard (ND) fabric.
@@ -72,7 +72,7 @@ options:
         - Each entry defines a permit/deny action for a specific IP prefix.
         - Required for O(state=merged), O(state=replaced), and O(state=overridden).
         - Optional for O(state=deleted), where identifier-only items
-          (O(ip_version) + O(name)) are accepted.
+          (O(config.ip_version) + O(config.name)) are accepted.
         type: list
         elements: dict
         required: false

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -30,6 +30,11 @@ options:
     - The name of the fabric that owns the prefix lists.
     type: str
     required: true
+  cluster_name:
+    description:
+    - The name of the Nexus Dashboard cluster where the prefix-list operation is executed.
+    - Use this option for multi-cluster deployments where the target fabric is managed by a specific cluster.
+    type: str
   config:
     description:
     - The list of prefix lists to configure.

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -96,9 +96,9 @@ options:
           action:
             description:
             - The action to take when the prefix matches.
-            - No default is applied because the action changes routing-policy behavior.
+            - Defaults to C(permit), matching the Nexus Dashboard UI default.
             type: str
-            required: true
+            default: permit
             choices: [ permit, deny ]
           prefix:
             description:

--- a/plugins/modules/nd_manage_prefix_list.py
+++ b/plugins/modules/nd_manage_prefix_list.py
@@ -104,6 +104,9 @@ options:
           prefix:
             description:
             - The IP prefix in CIDR notation.
+            - Host bits are normalized to the containing network for idempotency.
+              For example, C(10.1.1.5/24) is treated as C(10.1.1.0/24) and a
+              bare host address is treated as a host route.
             - Must be an IPv4 CIDR (e.g. C(10.0.0.0/8)) when
               O(config.ip_version=ipv4).
             - Must be an IPv6 CIDR (e.g. C(2001:db8::/32)) when
@@ -166,6 +169,8 @@ notes:
   A single task may contain a mix of IPv4 and IPv6 entries.
 - Prefix and mask values are normalized locally for stable idempotency when Nexus Dashboard returns
   equivalent IPv6 values in compressed notation.
+- Prefix normalization uses network semantics, so host bits in O(config.entries.prefix) are masked
+  to the containing network before comparison and payload generation.
 """
 
 EXAMPLES = r"""

--- a/tests/integration/targets/nd_manage_prefix_list/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_manage_prefix_list/tasks/deleted.yaml
@@ -1,0 +1,113 @@
+---
+# Deleted state tests for nd_manage_prefix_list
+# Copyright: (c) 2026, Gaspard Micol (@gmicol)
+#
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point only PL-IPV6-DATACENTER exists from overridden tests.
+
+# --- DELETED: SINGLE PREFIX LIST ---
+
+- name: "DELETED: Delete PL-IPV6-DATACENTER (check mode)"
+  cisco.nd.nd_manage_prefix_list: &delete_ipv6_datacenter
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - ip_version: ipv6
+        name: PL-IPV6-DATACENTER
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "2001:db8::/32"
+    state: deleted
+  check_mode: true
+  register: cm_deleted_ipv6
+
+- name: "DELETED: Delete PL-IPV6-DATACENTER (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *delete_ipv6_datacenter
+  register: nm_deleted_ipv6
+
+- name: "DELETED: Verify PL-IPV6-DATACENTER was deleted"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_ipv6 is changed
+      - nm_deleted_ipv6 is changed
+      - nm_deleted_ipv6.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | list | length == 0
+
+# --- DELETED: IDEMPOTENCY ---
+
+- name: "DELETED IDEMPOTENT: Delete PL-IPV6-DATACENTER again"
+  cisco.nd.nd_manage_prefix_list: *delete_ipv6_datacenter
+  register: nm_deleted_ipv6_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change when already absent"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_ipv6_idem is not changed
+
+# --- DELETED: MULTIPLE PREFIX LISTS ---
+
+# Recreate both test prefix lists for the multi-delete test.
+- name: "SETUP: Recreate PL-IPV4-BORDERS and PL-IPV6-DATACENTER for multi-delete test"
+  cisco.nd.nd_manage_prefix_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv4_borders }}"
+      - "{{ prefix_list_ipv6_datacenter }}"
+    state: merged
+
+- name: "DELETED MULTI: Delete both PL-IPV4-BORDERS and PL-IPV6-DATACENTER (check mode)"
+  cisco.nd.nd_manage_prefix_list: &delete_multi
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-BORDERS
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "10.0.0.0/8"
+      - ip_version: ipv6
+        name: PL-IPV6-DATACENTER
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "2001:db8::/32"
+    state: deleted
+  check_mode: true
+  register: cm_deleted_multi
+
+- name: "DELETED MULTI: Delete both PL-IPV4-BORDERS and PL-IPV6-DATACENTER (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *delete_multi
+  register: nm_deleted_multi
+
+- name: "DELETED MULTI: Verify all test prefix lists were deleted"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_multi is changed
+      - nm_deleted_multi is changed
+      - nm_deleted_multi.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | list | length == 0
+      - nm_deleted_multi.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | list | length == 0
+
+# --- DELETED: NON-EXISTENT PREFIX LIST ---
+
+- name: "DELETED NON-EXISTENT: Delete a prefix list that does not exist"
+  cisco.nd.nd_manage_prefix_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-NONEXISTENT
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "10.0.0.0/8"
+    state: deleted
+  register: nm_deleted_nonexistent
+
+- name: "DELETED NON-EXISTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_nonexistent is not changed

--- a/tests/integration/targets/nd_manage_prefix_list/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_manage_prefix_list/tasks/deleted.yaml
@@ -91,6 +91,54 @@
       - nm_deleted_multi.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | list | length == 0
       - nm_deleted_multi.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | list | length == 0
 
+# --- DELETED: IDENTIFIER-ONLY (NO ENTRIES) ---
+# New ergonomic feature: delete can now use identifier-only config (ip_version + name)
+# without requiring the full entries list.
+
+# Setup: recreate prefix lists for identifier-only delete test
+- name: "SETUP: Recreate PL-IPV4-BORDERS and PL-IPV6-DATACENTER for identifier-only delete test"
+  cisco.nd.nd_manage_prefix_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv4_borders }}"
+      - "{{ prefix_list_ipv6_datacenter }}"
+    state: merged
+
+- name: "DELETED IDENTIFIER-ONLY: Delete using only ip_version and name (check mode)"
+  cisco.nd.nd_manage_prefix_list: &delete_identifier_only
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-BORDERS
+      - ip_version: ipv6
+        name: PL-IPV6-DATACENTER
+    state: deleted
+  check_mode: true
+  register: cm_deleted_id_only
+
+- name: "DELETED IDENTIFIER-ONLY: Delete using only ip_version and name (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *delete_identifier_only
+  register: nm_deleted_id_only
+
+- name: "DELETED IDENTIFIER-ONLY: Verify deletion with identifier-only config"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_id_only is changed
+      - nm_deleted_id_only is changed
+      - nm_deleted_id_only.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | list | length == 0
+      - nm_deleted_id_only.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | list | length == 0
+
+- name: "DELETED IDENTIFIER-ONLY IDEMPOTENT: Re-apply identifier-only delete"
+  cisco.nd.nd_manage_prefix_list: *delete_identifier_only
+  register: nm_deleted_id_only_idem
+
+- name: "DELETED IDENTIFIER-ONLY IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_id_only_idem is not changed
+
 # --- DELETED: NON-EXISTENT PREFIX LIST ---
 
 - name: "DELETED NON-EXISTENT: Delete a prefix list that does not exist"

--- a/tests/integration/targets/nd_manage_prefix_list/tasks/main.yaml
+++ b/tests/integration/targets/nd_manage_prefix_list/tasks/main.yaml
@@ -1,0 +1,66 @@
+---
+# Test code for the nd_manage_prefix_list module
+# Copyright: (c) 2026, Gaspard Micol (@gmicol)
+#
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#
+#   ansible-test integration nd_manage_prefix_list
+#
+# --- Prerequisites ---
+#
+# A fabric matching test_fabric_name (default: SITE1) must already exist on the
+# target Nexus Dashboard before running this suite. Create it first with the
+# cisco.nd.nd_manage_fabric module if it does not yet exist.
+#
+# --- Optional test variables ---
+#
+# Set the variables below in the [nd:vars] section of tests/integration/inventory.networking
+#
+# nd_test_fabric_name (str, default: "SITE1")
+#   Name of the NDFC fabric in which prefix lists will be created and deleted.
+#
+# nd_logging_config (str, default: "")
+#   Path to a JSON file conforming to logging.config.dictConfig (see
+#   plugins/module_utils/common/log.py for an example). When set, the path is
+#   forwarded to the module subprocess via the ND_LOGGING_CONFIG environment
+#   variable, enabling file-based logging from the nd collection. Empty (the
+#   default) disables logging. ansible-test strips the controller's shell env,
+#   so the variable cannot be inherited from the user's shell. Add to
+#   inventory.networking [nd:vars]:
+#     nd_logging_config=/absolute/path/to/logging_config.json
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ nd_output_level | default("debug") }}'
+
+- name: Run nd_manage_prefix_list state tests with optional logging env
+  block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run nd_manage_prefix_list merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run nd_manage_prefix_list replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run nd_manage_prefix_list overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run nd_manage_prefix_list deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  module_defaults:
+    cisco.nd.nd_manage_prefix_list:
+      timeout: 300
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_manage_prefix_list/tasks/merged.yaml
+++ b/tests/integration/targets/nd_manage_prefix_list/tasks/merged.yaml
@@ -1,0 +1,151 @@
+---
+# Merged state tests for nd_manage_prefix_list
+# Copyright: (c) 2026, Gaspard Micol (@gmicol)
+#
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- MERGED CREATE ---
+
+- name: "MERGED CREATE: Create IPv4 prefix list PL-IPV4-BORDERS (check mode)"
+  cisco.nd.nd_manage_prefix_list: &merge_ipv4_borders
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv4_borders }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_ipv4
+
+- name: "MERGED CREATE: Create IPv4 prefix list PL-IPV4-BORDERS (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *merge_ipv4_borders
+  register: nm_merged_create_ipv4
+
+- name: "MERGED CREATE: Verify IPv4 prefix list creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_ipv4 is changed
+      - nm_merged_create_ipv4 is changed
+      - nm_merged_create_ipv4.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | list | length == 1
+
+- name: "MERGED CREATE: Create IPv6 prefix list PL-IPV6-DATACENTER (check mode)"
+  cisco.nd.nd_manage_prefix_list: &merge_ipv6_datacenter
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv6_datacenter }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_ipv6
+
+- name: "MERGED CREATE: Create IPv6 prefix list PL-IPV6-DATACENTER (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *merge_ipv6_datacenter
+  register: nm_merged_create_ipv6
+
+- name: "MERGED CREATE: Verify IPv6 prefix list creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_ipv6 is changed
+      - nm_merged_create_ipv6 is changed
+      - nm_merged_create_ipv6.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | list | length == 1
+
+- name: "MERGED CREATE MULTI: Create IPv4 and IPv6 prefix lists in a single task (check mode)"
+  cisco.nd.nd_manage_prefix_list: &merge_multi
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv4_borders }}"
+      - "{{ prefix_list_ipv6_datacenter }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_multi
+
+- name: "MERGED CREATE MULTI: Create IPv4 and IPv6 prefix lists in a single task (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *merge_multi
+  register: nm_merged_create_multi
+
+- name: "MERGED CREATE MULTI: Verify both prefix lists present (multi-task idempotent)"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_multi is not changed
+      - nm_merged_create_multi is not changed
+      - nm_merged_create_multi.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | list | length == 1
+      - nm_merged_create_multi.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | list | length == 1
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Re-apply IPv4 create (check mode)"
+  cisco.nd.nd_manage_prefix_list: *merge_ipv4_borders
+  check_mode: true
+  register: cm_merged_idem_ipv4
+
+- name: "MERGED IDEMPOTENT: Re-apply IPv4 create (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *merge_ipv4_borders
+  register: nm_merged_idem_ipv4
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem_ipv4 is not changed
+      - nm_merged_idem_ipv4 is not changed
+
+# --- MERGED UPDATE ---
+
+- name: "MERGED UPDATE: Add entry to PL-IPV4-BORDERS (check mode)"
+  cisco.nd.nd_manage_prefix_list: &merge_ipv4_borders_updated
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv4_borders_updated }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_update_ipv4
+
+- name: "MERGED UPDATE: Add entry to PL-IPV4-BORDERS (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *merge_ipv4_borders_updated
+  register: nm_merged_update_ipv4
+
+- name: "MERGED UPDATE: Verify PL-IPV4-BORDERS was updated"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_update_ipv4 is changed
+      - nm_merged_update_ipv4 is changed
+
+- name: "MERGED UPDATE: Verify updated values in after state"
+  vars:
+    ipv4_after: "{{ nm_merged_update_ipv4.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | first }}"
+  ansible.builtin.assert:
+    that:
+      - ipv4_after.description == "Ansible integration test - updated border router IPv4 prefixes"
+      - ipv4_after.entries | length == 4
+
+- name: "MERGED UPDATE: Re-apply update for idempotency"
+  cisco.nd.nd_manage_prefix_list: *merge_ipv4_borders_updated
+  register: nm_merged_update_ipv4_idem
+
+- name: "MERGED UPDATE: Verify idempotency after update"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_ipv4_idem is not changed
+
+- name: "MERGED UPDATE: Update PL-IPV6-DATACENTER with extra entry (check mode)"
+  cisco.nd.nd_manage_prefix_list: &merge_ipv6_datacenter_updated
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv6_datacenter_updated }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_update_ipv6
+
+- name: "MERGED UPDATE: Update PL-IPV6-DATACENTER with extra entry (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *merge_ipv6_datacenter_updated
+  register: nm_merged_update_ipv6
+
+- name: "MERGED UPDATE: Verify PL-IPV6-DATACENTER was updated"
+  vars:
+    ipv6_after: "{{ nm_merged_update_ipv6.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_update_ipv6 is changed
+      - nm_merged_update_ipv6 is changed
+      - ipv6_after.entries | length == 3

--- a/tests/integration/targets/nd_manage_prefix_list/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_manage_prefix_list/tasks/overridden.yaml
@@ -1,0 +1,80 @@
+---
+# Overridden state tests for nd_manage_prefix_list
+# Copyright: (c) 2026, Gaspard Micol (@gmicol)
+#
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point PL-IPV4-BORDERS and PL-IPV6-DATACENTER exist from prior tests.
+# Override will reduce the full fabric prefix-list set to only what is specified.
+
+# Create a second IPv4 prefix list so overridden has something extra to remove.
+- name: "OVERRIDDEN PRE: Add PL-IPV4-DATACENTER via merged"
+  cisco.nd.nd_manage_prefix_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv4_datacenter }}"
+    state: merged
+
+# --- OVERRIDDEN: REDUCE TO SINGLE PREFIX LIST ---
+
+- name: "OVERRIDDEN: Override to only PL-IPV4-BORDERS (check mode)"
+  cisco.nd.nd_manage_prefix_list: &override_ipv4_borders_only
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv4_borders }}"
+    state: overridden
+  check_mode: true
+  register: cm_overridden_single
+
+- name: "OVERRIDDEN: Override to only PL-IPV4-BORDERS (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *override_ipv4_borders_only
+  register: nm_overridden_single
+
+- name: "OVERRIDDEN: Verify override removed all other prefix lists"
+  ansible.builtin.assert:
+    that:
+      - cm_overridden_single is changed
+      - nm_overridden_single is changed
+      # PL-IPV4-BORDERS should be present.
+      - nm_overridden_single.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | list | length == 1
+      # PL-IPV4-DATACENTER and PL-IPV6-DATACENTER should have been removed.
+      - nm_overridden_single.after | selectattr('name', 'equalto', 'PL-IPV4-DATACENTER') | list | length == 0
+      - nm_overridden_single.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | list | length == 0
+
+# --- OVERRIDDEN: IDEMPOTENCY ---
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply same overridden config (check mode)"
+  cisco.nd.nd_manage_prefix_list: *override_ipv4_borders_only
+  check_mode: true
+  register: cm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply same overridden config (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *override_ipv4_borders_only
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_overridden_idem is not changed
+      - nm_overridden_idem is not changed
+
+# --- OVERRIDDEN: SWAP IPv4 FOR IPv6 ---
+
+- name: "OVERRIDDEN SWAP: Override to only PL-IPV6-DATACENTER, removing PL-IPV4-BORDERS"
+  cisco.nd.nd_manage_prefix_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ prefix_list_ipv6_datacenter }}"
+    state: overridden
+  register: nm_overridden_swap
+
+- name: "OVERRIDDEN SWAP: Verify PL-IPV4-BORDERS removed and PL-IPV6-DATACENTER present"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_swap is changed
+      - nm_overridden_swap.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | list | length == 0
+      - nm_overridden_swap.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | list | length == 1

--- a/tests/integration/targets/nd_manage_prefix_list/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_manage_prefix_list/tasks/replaced.yaml
@@ -1,0 +1,110 @@
+---
+# Replaced state tests for nd_manage_prefix_list
+# Copyright: (c) 2026, Gaspard Micol (@gmicol)
+#
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- SETUP ---
+# At this point PL-IPV4-BORDERS (4 entries, updated description) and
+# PL-IPV6-DATACENTER (3 entries, updated description) exist from merged tests.
+
+# --- REPLACED: FULL REPLACE ---
+
+- name: "REPLACED: Replace PL-IPV4-BORDERS with a minimal config (check mode)"
+  cisco.nd.nd_manage_prefix_list: &replace_ipv4_borders
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-BORDERS
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "10.0.0.0/8"
+    state: replaced
+  check_mode: true
+  register: cm_replaced_ipv4
+
+- name: "REPLACED: Replace PL-IPV4-BORDERS with a minimal config (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *replace_ipv4_borders
+  register: nm_replaced_ipv4
+
+- name: "REPLACED: Verify PL-IPV4-BORDERS was replaced"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_ipv4 is changed
+      - nm_replaced_ipv4 is changed
+
+- name: "REPLACED: Verify replaced values -- only 1 entry, no description"
+  vars:
+    ipv4_after: "{{ nm_replaced_ipv4.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | first }}"
+  ansible.builtin.assert:
+    that:
+      - ipv4_after.entries | length == 1
+      - ipv4_after.description is none or ipv4_after.description == ""
+
+# --- REPLACED: IDEMPOTENCY ---
+
+- name: "REPLACED IDEMPOTENT: Re-apply same replaced config (check mode)"
+  cisco.nd.nd_manage_prefix_list: *replace_ipv4_borders
+  check_mode: true
+  register: cm_replaced_ipv4_idem
+
+- name: "REPLACED IDEMPOTENT: Re-apply same replaced config (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *replace_ipv4_borders
+  register: nm_replaced_ipv4_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_ipv4_idem is not changed
+      - nm_replaced_ipv4_idem is not changed
+
+# --- REPLACED: MULTIPLE PREFIX LISTS ---
+
+- name: "REPLACED MULTI: Replace both PL-IPV4-BORDERS and PL-IPV6-DATACENTER (check mode)"
+  cisco.nd.nd_manage_prefix_list: &replace_multi
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-BORDERS
+        description: "Replaced IPv4 borders"
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "10.0.0.0/8"
+          - sequence_number: 20
+            action: deny
+            prefix: "0.0.0.0/0"
+      - ip_version: ipv6
+        name: PL-IPV6-DATACENTER
+        description: "Replaced IPv6 datacenter"
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "2001:db8::/32"
+    state: replaced
+  check_mode: true
+  register: cm_replaced_multi
+
+- name: "REPLACED MULTI: Replace both PL-IPV4-BORDERS and PL-IPV6-DATACENTER (normal mode)"
+  cisco.nd.nd_manage_prefix_list: *replace_multi
+  register: nm_replaced_multi
+
+- name: "REPLACED MULTI: Verify both prefix lists were replaced"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_multi is changed
+      - nm_replaced_multi is changed
+
+- name: "REPLACED MULTI: Verify replaced values for both prefix lists"
+  vars:
+    ipv4_after: "{{ nm_replaced_multi.after | selectattr('name', 'equalto', 'PL-IPV4-BORDERS') | first }}"
+    ipv6_after: "{{ nm_replaced_multi.after | selectattr('name', 'equalto', 'PL-IPV6-DATACENTER') | first }}"
+  ansible.builtin.assert:
+    that:
+      - ipv4_after.entries | length == 2
+      - ipv4_after.description == "Replaced IPv4 borders"
+      - ipv6_after.entries | length == 1
+      - ipv6_after.description == "Replaced IPv6 datacenter"

--- a/tests/integration/targets/nd_manage_prefix_list/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_manage_prefix_list/tasks/replaced.yaml
@@ -41,7 +41,7 @@
   ansible.builtin.assert:
     that:
       - ipv4_after.entries | length == 1
-      - ipv4_after.description is none or ipv4_after.description == ""
+      - ipv4_after.description | default("") == ""
 
 # --- REPLACED: IDEMPOTENCY ---
 

--- a/tests/integration/targets/nd_manage_prefix_list/tasks/setup.yaml
+++ b/tests/integration/targets/nd_manage_prefix_list/tasks/setup.yaml
@@ -1,0 +1,44 @@
+---
+# Pre-test cleanup for nd_manage_prefix_list
+# Copyright: (c) 2026, Gaspard Micol (@gmicol)
+#
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Called from main.yaml before the merged/replaced/overridden/deleted state blocks.
+# Ensures no test prefix lists exist on the target fabric before the state tests run.
+
+- name: "SETUP: Remove test IPv4 prefix lists before state tests"
+  cisco.nd.nd_manage_prefix_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - ip_version: ipv4
+        name: PL-IPV4-BORDERS
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "10.0.0.0/8"
+      - ip_version: ipv4
+        name: PL-IPV4-DATACENTER
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "192.168.0.0/16"
+    state: deleted
+  failed_when: false
+  tags: always
+
+- name: "SETUP: Remove test IPv6 prefix lists before state tests"
+  cisco.nd.nd_manage_prefix_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - ip_version: ipv6
+        name: PL-IPV6-DATACENTER
+        entries:
+          - sequence_number: 10
+            action: permit
+            prefix: "2001:db8::/32"
+    state: deleted
+  failed_when: false
+  tags: always

--- a/tests/integration/targets/nd_manage_prefix_list/vars/main.yaml
+++ b/tests/integration/targets/nd_manage_prefix_list/vars/main.yaml
@@ -1,0 +1,108 @@
+---
+# Variables for nd_manage_prefix_list integration tests.
+#
+# Copyright: (c) 2026, Gaspard Micol (@gmicol)
+#
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# A fabric matching test_fabric_name must already exist on the target Nexus Dashboard.
+# Use cisco.nd.nd_manage_fabric to create it before running this suite.
+#
+# Override the following in your inventory or extra-vars to match a real ND 4.2 testbed:
+#
+#   nd_test_fabric_name   (str, default: "SITE1")
+#     Name of the NDFC fabric in which to create and delete prefix lists.
+#
+# Prefix list names used across tests (PL-IPV4-BORDERS, PL-IPV4-DATACENTER,
+# PL-IPV6-DATACENTER) are reserved for this test suite and cleaned up by setup.yaml.
+# Do NOT re-use these names in other concurrent test runs.
+
+test_fabric_name: "{{ nd_test_fabric_name | default('SITE1') }}"
+
+# ---------------------------------------------------------------------------
+# IPv4 prefix list configs
+# ---------------------------------------------------------------------------
+
+prefix_list_ipv4_borders:
+  ip_version: ipv4
+  name: PL-IPV4-BORDERS
+  description: "Ansible integration test - border router IPv4 prefixes"
+  entries:
+    - sequence_number: 10
+      action: permit
+      prefix: "10.0.0.0/8"
+    - sequence_number: 20
+      action: permit
+      prefix: "172.16.0.0/12"
+      min_prefix_length: 24
+      max_prefix_length: 32
+    - sequence_number: 30
+      action: deny
+      prefix: "0.0.0.0/0"
+
+# Updated version: description changed + extra entry added (seq 40).
+prefix_list_ipv4_borders_updated:
+  ip_version: ipv4
+  name: PL-IPV4-BORDERS
+  description: "Ansible integration test - updated border router IPv4 prefixes"
+  entries:
+    - sequence_number: 10
+      action: permit
+      prefix: "10.0.0.0/8"
+    - sequence_number: 20
+      action: permit
+      prefix: "172.16.0.0/12"
+      min_prefix_length: 24
+      max_prefix_length: 32
+    - sequence_number: 30
+      action: deny
+      prefix: "0.0.0.0/0"
+    - sequence_number: 40
+      action: permit
+      prefix: "192.168.0.0/16"
+      exact_length: 32
+
+# Second IPv4 prefix list - used in overridden tests to provide an object
+# that must be removed when overriding with only PL-IPV4-BORDERS.
+prefix_list_ipv4_datacenter:
+  ip_version: ipv4
+  name: PL-IPV4-DATACENTER
+  description: "Ansible integration test - datacenter IPv4 prefixes"
+  entries:
+    - sequence_number: 10
+      action: permit
+      prefix: "192.168.0.0/16"
+
+# ---------------------------------------------------------------------------
+# IPv6 prefix list configs
+# ---------------------------------------------------------------------------
+
+prefix_list_ipv6_datacenter:
+  ip_version: ipv6
+  name: PL-IPV6-DATACENTER
+  description: "Ansible integration test - datacenter IPv6 prefixes"
+  entries:
+    - sequence_number: 10
+      action: permit
+      prefix: "2001:db8::/32"
+      exact_length: 48
+    - sequence_number: 20
+      action: deny
+      prefix: "::/0"
+
+# Updated version: extra entry added (seq 30).
+prefix_list_ipv6_datacenter_updated:
+  ip_version: ipv6
+  name: PL-IPV6-DATACENTER
+  description: "Ansible integration test - updated datacenter IPv6 prefixes"
+  entries:
+    - sequence_number: 10
+      action: permit
+      prefix: "2001:db8::/32"
+      exact_length: 48
+    - sequence_number: 20
+      action: deny
+      prefix: "::/0"
+    - sequence_number: 30
+      action: permit
+      prefix: "fc00::/7"

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
@@ -1,0 +1,425 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for manage_prefix_lists.py endpoint classes.
+
+Tests the endpoint definitions for IPv4 and IPv6 prefix list API operations.
+Verifies fabric_name and prefix_list_name requirements, path construction with URL encoding,
+and query parameter handling.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_prefix_lists import (
+    EpManageIpv4PrefixListsDelete,
+    EpManageIpv4PrefixListsGet,
+    EpManageIpv4PrefixListsListGet,
+    EpManageIpv4PrefixListsPost,
+    EpManageIpv4PrefixListsPut,
+    EpManageIpv6PrefixListsDelete,
+    EpManageIpv6PrefixListsGet,
+    EpManageIpv6PrefixListsListGet,
+    EpManageIpv6PrefixListsPost,
+    EpManageIpv6PrefixListsPut,
+    EpManageIpv4PrefixListsBulkDelete,
+    EpManageIpv6PrefixListsBulkDelete,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test: IPv4 Endpoints
+# =============================================================================
+
+
+def test_endpoints_ipv4_prefix_lists_00010():
+    """
+    # Summary
+
+    Verify EpManageIpv4PrefixListsGet instantiation and basic properties.
+
+    ## Test
+
+    - Instance can be created
+    - class_name is set correctly
+    - verb is GET
+    - fabric_name and prefix_list_name default to None
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsGet.__init__()
+    - EpManageIpv4PrefixListsGet.verb
+    - EpManageIpv4PrefixListsGet.class_name
+    """
+    with does_not_raise():
+        instance = EpManageIpv4PrefixListsGet()
+    assert instance.class_name == "EpManageIpv4PrefixListsGet"
+    assert instance.verb == HttpVerbEnum.GET
+    assert instance.fabric_name is None
+    assert instance.prefix_list_name is None
+
+
+def test_endpoints_ipv4_prefix_lists_00020():
+    """
+    # Summary
+
+    Verify path raises ValueError when fabric_name is None (fail-fast requirement).
+
+    ## Test
+
+    - fabric_name is not set
+    - Accessing path raises ValueError with descriptive message
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsGet.path
+    """
+    instance = EpManageIpv4PrefixListsGet()
+    with pytest.raises(ValueError, match="fabric_name must be set"):
+        _ = instance.path
+
+
+def test_endpoints_ipv4_prefix_lists_00030():
+    """
+    # Summary
+
+    Verify path raises ValueError when prefix_list_name is None (fabric_name set).
+
+    ## Test
+
+    - fabric_name is set, prefix_list_name is not
+    - Accessing path raises ValueError
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsGet.path
+    """
+    instance = EpManageIpv4PrefixListsGet()
+    instance.fabric_name = "SITE1"
+    with pytest.raises(ValueError, match="prefix_list_name must be set"):
+        _ = instance.path
+
+
+def test_endpoints_ipv4_prefix_lists_00040():
+    """
+    # Summary
+
+    Verify path returns correct URL with all params set and special characters URL-encoded.
+
+    ## Test
+
+    - fabric_name and prefix_list_name are set
+    - path returns expected URL with percent-encoded names
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsGet.path
+    """
+    with does_not_raise():
+        instance = EpManageIpv4PrefixListsGet()
+        instance.fabric_name = "SITE-1"
+        instance.prefix_list_name = "PL-IPV4-BORDERS"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/SITE-1/ipv4PrefixLists/PL-IPV4-BORDERS"
+
+
+def test_endpoints_ipv4_prefix_lists_00050():
+    """
+    # Summary
+
+    Verify path URL-encodes special characters in fabric_name and prefix_list_name.
+
+    ## Test
+
+    - Spaces and special chars are percent-encoded
+    - Path is correctly formed
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsGet.path (quote with safe="")
+    """
+    with does_not_raise():
+        instance = EpManageIpv4PrefixListsGet()
+        instance.fabric_name = "SITE 1/2"
+        instance.prefix_list_name = "PL-NAME?"
+        result = instance.path
+    # quote with safe="" encodes everything including / and ?
+    assert "SITE%201%2F2" in result
+    assert "PL-NAME%3F" in result
+
+
+def test_endpoints_ipv4_prefix_lists_00060():
+    """
+    # Summary
+
+    Verify EpManageIpv4PrefixListsListGet requires only fabric_name (no prefix_list_name).
+
+    ## Test
+
+    - fabric_name is set, prefix_list_name is not required
+    - path ends with /ipv4PrefixLists (list endpoint)
+    - verb is GET
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsListGet.path / .verb
+    """
+    with does_not_raise():
+        instance = EpManageIpv4PrefixListsListGet()
+        instance.fabric_name = "SITE1"
+        result = instance.path
+    assert result.endswith("/ipv4PrefixLists")
+    assert instance.verb == HttpVerbEnum.GET
+
+
+def test_endpoints_ipv4_prefix_lists_00070():
+    """
+    # Summary
+
+    Verify set_identifiers sets prefix_list_name.
+
+    ## Test
+
+    - set_identifiers("PL-IPV4-BORDERS") sets prefix_list_name
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsGet.set_identifiers()
+    """
+    with does_not_raise():
+        instance = EpManageIpv4PrefixListsGet()
+        instance.set_identifiers("PL-IPV4-BORDERS")
+    assert instance.prefix_list_name == "PL-IPV4-BORDERS"
+
+
+def test_endpoints_ipv4_prefix_lists_00080():
+    """
+    # Summary
+
+    Verify EpManageIpv4PrefixListsPost, Put, Delete verbs.
+
+    ## Test
+
+    - Post verb is POST
+    - Put verb is PUT
+    - Delete verb is DELETE
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsPost.verb
+    - EpManageIpv4PrefixListsPut.verb
+    - EpManageIpv4PrefixListsDelete.verb
+    """
+    post = EpManageIpv4PrefixListsPost()
+    assert post.verb == HttpVerbEnum.POST
+    assert post.class_name == "EpManageIpv4PrefixListsPost"
+
+    put = EpManageIpv4PrefixListsPut()
+    assert put.verb == HttpVerbEnum.PUT
+    assert put.class_name == "EpManageIpv4PrefixListsPut"
+
+    delete = EpManageIpv4PrefixListsDelete()
+    assert delete.verb == HttpVerbEnum.DELETE
+    assert delete.class_name == "EpManageIpv4PrefixListsDelete"
+
+
+def test_endpoints_ipv4_prefix_lists_00090():
+    """
+    # Summary
+
+    Verify EpManageIpv4PrefixListsBulkDelete requires fabric_name and uses POST to action endpoint.
+
+    ## Test
+
+    - fabric_name must be set
+    - prefix_list_name is not required (action endpoint)
+    - verb is POST (not DELETE)
+    - path ends with /remove (action endpoint)
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsBulkDelete.path / .verb
+    """
+    instance = EpManageIpv4PrefixListsBulkDelete()
+    with pytest.raises(ValueError, match="fabric_name must be set"):
+        _ = instance.path
+
+    instance.fabric_name = "SITE1"
+    path = instance.path
+    assert "ipv4PrefixListActions/remove" in path
+    assert instance.verb == HttpVerbEnum.POST
+
+
+# =============================================================================
+# Test: IPv6 Endpoints
+# =============================================================================
+
+
+def test_endpoints_ipv6_prefix_lists_00010():
+    """
+    # Summary
+
+    Verify EpManageIpv6PrefixListsGet instantiation and basic properties.
+
+    ## Test
+
+    - Instance can be created
+    - class_name is set correctly
+    - verb is GET
+
+    ## Classes and Methods
+
+    - EpManageIpv6PrefixListsGet.__init__()
+    - EpManageIpv6PrefixListsGet.verb
+    """
+    with does_not_raise():
+        instance = EpManageIpv6PrefixListsGet()
+    assert instance.class_name == "EpManageIpv6PrefixListsGet"
+    assert instance.verb == HttpVerbEnum.GET
+
+
+def test_endpoints_ipv6_prefix_lists_00020():
+    """
+    # Summary
+
+    Verify IPv6 path uses ipv6PrefixLists endpoint.
+
+    ## Test
+
+    - path contains "ipv6PrefixLists" not "ipv4PrefixLists"
+
+    ## Classes and Methods
+
+    - EpManageIpv6PrefixListsGet.path
+    """
+    with does_not_raise():
+        instance = EpManageIpv6PrefixListsGet()
+        instance.fabric_name = "SITE1"
+        instance.prefix_list_name = "PL-IPV6-DATACENTER"
+        result = instance.path
+    assert "/ipv6PrefixLists/" in result
+    assert "/ipv4PrefixLists" not in result
+
+
+def test_endpoints_ipv6_prefix_lists_00030():
+    """
+    # Summary
+
+    Verify EpManageIpv6PrefixListsListGet requires only fabric_name.
+
+    ## Test
+
+    - fabric_name is set, prefix_list_name is not required
+    - path ends with /ipv6PrefixLists
+
+    ## Classes and Methods
+
+    - EpManageIpv6PrefixListsListGet.path
+    """
+    with does_not_raise():
+        instance = EpManageIpv6PrefixListsListGet()
+        instance.fabric_name = "SITE1"
+        result = instance.path
+    assert result.endswith("/ipv6PrefixLists")
+
+
+def test_endpoints_ipv6_prefix_lists_00040():
+    """
+    # Summary
+
+    Verify EpManageIpv6PrefixListsBulkDelete uses POST verb to action endpoint.
+
+    ## Test
+
+    - verb is POST (action endpoint, not DELETE)
+    - class_name is correct
+    - path contains /ipv6PrefixListActions/remove
+
+    ## Classes and Methods
+
+    - EpManageIpv6PrefixListsBulkDelete.verb / .path
+    """
+    instance = EpManageIpv6PrefixListsBulkDelete()
+    assert instance.verb == HttpVerbEnum.POST
+    assert instance.class_name == "EpManageIpv6PrefixListsBulkDelete"
+    
+    instance.fabric_name = "SITE1"
+    path = instance.path
+    assert "ipv6PrefixListActions/remove" in path
+
+
+# =============================================================================
+# Test: Query Parameters
+# =============================================================================
+
+
+def test_endpoints_prefix_lists_00050():
+    """
+    # Summary
+
+    Verify list endpoint accepts optional query parameters (cluster_name, filter, max, offset, sort).
+
+    ## Test
+
+    - endpoint_params can be set with query parameters
+    - path includes query string when params are present
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsListGet.endpoint_params
+    - EpManageIpv4PrefixListsListGet.path (with query string)
+    """
+    with does_not_raise():
+        instance = EpManageIpv4PrefixListsListGet()
+        instance.fabric_name = "SITE1"
+        instance.endpoint_params.cluster_name = "CLUSTER-1"
+        instance.endpoint_params.filter = "name=PL-*"
+        instance.endpoint_params.max = 100
+        path = instance.path
+    # Query string should be present
+    assert "?" in path
+    assert "clusterName=CLUSTER-1" in path or "cluster_name=CLUSTER-1" in path
+
+
+# =============================================================================
+# Test: Mixin Composition
+# =============================================================================
+
+
+def test_endpoints_prefix_lists_00060():
+    """
+    # Summary
+
+    Verify FabricNameMixin is properly composed.
+
+    ## Test
+
+    - Endpoints inherit from FabricNameMixin
+    - fabric_name attribute is available and enforced
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsGet (inherits FabricNameMixin)
+    """
+    instance = EpManageIpv4PrefixListsGet()
+    # FabricNameMixin should provide fabric_name attribute
+    assert hasattr(instance, "fabric_name")
+    assert instance.fabric_name is None
+
+    instance.fabric_name = "SITE1"
+    assert instance.fabric_name == "SITE1"

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
@@ -254,6 +254,23 @@ def test_endpoints_ipv4_prefix_lists_00090():
     assert instance.verb == HttpVerbEnum.POST
 
 
+def test_endpoints_ipv4_prefix_lists_00100():
+    """
+    # Summary
+
+    Verify bulk-delete action endpoints include optional clusterName query params.
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsBulkDelete.path
+    """
+    instance = EpManageIpv4PrefixListsBulkDelete()
+    instance.fabric_name = "SITE1"
+    instance.endpoint_params.cluster_name = "CLUSTER-1"
+
+    assert instance.path.endswith("/ipv4PrefixListActions/remove?clusterName=CLUSTER-1")
+
+
 # =============================================================================
 # Test: IPv6 Endpoints
 # =============================================================================

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
@@ -23,17 +23,13 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageIpv4PrefixListsListGet,
     EpManageIpv4PrefixListsPost,
     EpManageIpv4PrefixListsPut,
-    EpManageIpv6PrefixListsDelete,
     EpManageIpv6PrefixListsGet,
     EpManageIpv6PrefixListsListGet,
-    EpManageIpv6PrefixListsPost,
-    EpManageIpv6PrefixListsPut,
     EpManageIpv4PrefixListsBulkDelete,
     EpManageIpv6PrefixListsBulkDelete,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
-
 
 # =============================================================================
 # Test: IPv4 Endpoints
@@ -84,7 +80,7 @@ def test_endpoints_ipv4_prefix_lists_00020():
     """
     instance = EpManageIpv4PrefixListsGet()
     with pytest.raises(ValueError, match="fabric_name must be set"):
-        _ = instance.path
+        result = instance.path  # pylint: disable=unused-variable
 
 
 def test_endpoints_ipv4_prefix_lists_00030():
@@ -105,7 +101,7 @@ def test_endpoints_ipv4_prefix_lists_00030():
     instance = EpManageIpv4PrefixListsGet()
     instance.fabric_name = "SITE1"
     with pytest.raises(ValueError, match="prefix_list_name must be set"):
-        _ = instance.path
+        result = instance.path  # pylint: disable=unused-variable
 
 
 def test_endpoints_ipv4_prefix_lists_00040():
@@ -250,7 +246,7 @@ def test_endpoints_ipv4_prefix_lists_00090():
     """
     instance = EpManageIpv4PrefixListsBulkDelete()
     with pytest.raises(ValueError, match="fabric_name must be set"):
-        _ = instance.path
+        result = instance.path  # pylint: disable=unused-variable
 
     instance.fabric_name = "SITE1"
     path = instance.path

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
@@ -12,9 +12,7 @@ Verifies fabric_name and prefix_list_name requirements, path construction with U
 and query parameter handling.
 """
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type  # pylint: disable=invalid-name
+from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_prefix_lists import (

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
@@ -196,6 +196,22 @@ def test_endpoints_ipv4_prefix_lists_00070():
     assert instance.prefix_list_name == "PL-IPV4-BORDERS"
 
 
+def test_endpoints_ipv4_prefix_lists_00075():
+    """
+    # Summary
+
+    Verify tenant-aware identifiers set the fully qualified API prefix-list name.
+
+    ## Classes and Methods
+
+    - EpManageIpv4PrefixListsGet.set_identifiers()
+    """
+    with does_not_raise():
+        instance = EpManageIpv4PrefixListsGet()
+        instance.set_identifiers(("ipv4", "TENANT1", "PL-IPV4-BORDERS"))
+    assert instance.prefix_list_name == "TENANT1~PL-IPV4-BORDERS"
+
+
 def test_endpoints_ipv4_prefix_lists_00080():
     """
     # Summary

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type  # pylint: disable=invalid-name
 
-from contextlib import contextmanager
-
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_prefix_lists import (
     EpManageIpv4PrefixListsDelete,
@@ -34,12 +32,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageIpv6PrefixListsBulkDelete,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
-
-
-@contextmanager
-def does_not_raise():
-    """A context manager that does not raise an exception."""
-    yield
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
 
 
 # =============================================================================
@@ -357,7 +350,7 @@ def test_endpoints_ipv6_prefix_lists_00040():
     instance = EpManageIpv6PrefixListsBulkDelete()
     assert instance.verb == HttpVerbEnum.POST
     assert instance.class_name == "EpManageIpv6PrefixListsBulkDelete"
-    
+
     instance.fabric_name = "SITE1"
     path = instance.path
     assert "ipv6PrefixListActions/remove" in path

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_prefix_lists.py
@@ -408,12 +408,14 @@ def test_endpoints_prefix_lists_00050():
         instance = EpManageIpv4PrefixListsListGet()
         instance.fabric_name = "SITE1"
         instance.endpoint_params.cluster_name = "CLUSTER-1"
-        instance.endpoint_params.filter = "name=PL-*"
-        instance.endpoint_params.max = 100
+        instance.lucene_params.filter = "name:PL-1 AND tenantName:TENANT1"
+        instance.lucene_params.max = 100
         path = instance.path
     # Query string should be present
     assert "?" in path
-    assert "clusterName=CLUSTER-1" in path or "cluster_name=CLUSTER-1" in path
+    assert "clusterName=CLUSTER-1" in path
+    assert "filter=name:PL-1%20AND%20tenantName:TENANT1" in path
+    assert "max=100" in path
 
 
 # =============================================================================

--- a/tests/unit/module_utils/fixtures/fixture_data/test_manage_prefix_list.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_manage_prefix_list.json
@@ -1,14 +1,16 @@
 {
     "TEST_NOTES": [
         "Fixture data for test_manage_prefix_list.py (orchestrator tests).",
-        "Keys follow the test_<module>_<NNNNN><a|b|c|...> convention.",
-        "Suffix order matches the order RestSend.commit() will consume responses within each test.",
-        "IPv4 and IPv6 prefix list fixtures with full semantic examples.",
-        "Each query_all() call fetches both IPv4 and IPv6 list endpoints separately."
+        "Response shapes mirror the ND Manage Routing Policies prefix list API:",
+        "  - List GET returns {\"ipv4PrefixLists\": [...]} / {\"ipv6PrefixLists\": [...]} with an 'entries' key per item.",
+        "  - Bulk create (POST .../ipv4PrefixLists) returns HTTP 207 with {\"results\": [{name, status, message}]}.",
+        "  - Bulk delete (POST .../ipv4PrefixListActions/remove) returns HTTP 207 with {\"results\": [...]}.",
+        "Suffix order within a test matches the order RestSend.commit() consumes responses.",
+        "query_all() fetches the IPv4 list endpoint first, then the IPv6 list endpoint."
     ],
 
     "ipv4_prefix_lists_ok": {
-        "TEST_NOTES": ["Reusable IPv4 prefix list response from list endpoint"],
+        "TEST_NOTES": ["Reusable IPv4 prefix list response from the list endpoint"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
@@ -16,11 +18,9 @@
         "DATA": {
             "ipv4PrefixLists": [
                 {
-                    "ipVersion": "ipv4",
                     "name": "PL-IPV4-BORDERS",
                     "description": "IPv4 Border Router Prefixes",
-                    "tenantName": "TENANT1",
-                    "prefixListEntries": [
+                    "entries": [
                         {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
                         {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"}
                     ],
@@ -31,7 +31,7 @@
     },
 
     "ipv6_prefix_lists_ok": {
-        "TEST_NOTES": ["Reusable IPv6 prefix list response from list endpoint"],
+        "TEST_NOTES": ["Reusable IPv6 prefix list response from the list endpoint"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists",
@@ -39,17 +39,15 @@
         "DATA": {
             "ipv6PrefixLists": [
                 {
-                    "ipVersion": "ipv6",
                     "name": "PL-IPV6-DATACENTER",
                     "description": "IPv6 Datacenter Prefixes",
-                    "tenantName": "TENANT1",
-                    "prefixListEntries": [
+                    "entries": [
                         {
                             "sequenceNumber": 10,
                             "action": "permit",
                             "prefix": "2001:db8::/32",
-                            "minPrefixLength": 32,
-                            "maxPrefixLength": 48
+                            "minLength": 32,
+                            "maxLength": 48
                         }
                     ],
                     "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
@@ -58,143 +56,8 @@
         }
     },
 
-    "ipv4_single_prefix_list": {
-        "TEST_NOTES": ["Single IPv4 prefix list via GET endpoint"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists/PL-IPV4-BORDERS",
-        "MESSAGE": "OK",
-        "DATA": {
-            "ipVersion": "ipv4",
-            "name": "PL-IPV4-BORDERS",
-            "description": "IPv4 Border Router Prefixes",
-            "tenantName": "TENANT1",
-            "prefixListEntries": [
-                {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
-                {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"}
-            ],
-            "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
-        }
-    },
-
-    "ipv6_single_prefix_list": {
-        "TEST_NOTES": ["Single IPv6 prefix list via GET endpoint"],
-        "RETURN_CODE": 200,
-        "METHOD": "GET",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists/PL-IPV6-DATACENTER",
-        "MESSAGE": "OK",
-        "DATA": {
-            "ipVersion": "ipv6",
-            "name": "PL-IPV6-DATACENTER",
-            "description": "IPv6 Datacenter Prefixes",
-            "tenantName": "TENANT1",
-            "prefixListEntries": [
-                {
-                    "sequenceNumber": 10,
-                    "action": "permit",
-                    "prefix": "2001:db8::/32",
-                    "minPrefixLength": 32,
-                    "maxPrefixLength": 48
-                }
-            ],
-            "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
-        }
-    },
-
-    "create_ipv4_prefix_list": {
-        "TEST_NOTES": ["POST response for IPv4 prefix list creation"],
-        "RETURN_CODE": 201,
-        "METHOD": "POST",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
-        "MESSAGE": "OK",
-        "DATA": {
-            "ipVersion": "ipv4",
-            "name": "PL-IPV4-NEW",
-            "description": "New IPv4 Prefix List",
-            "tenantName": "TENANT1",
-            "prefixListEntries": [
-                {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.0.0/8"}
-            ],
-            "lastUpdateTimestamp": "2026-06-12T11:00:00Z"
-        }
-    },
-
-    "create_ipv6_prefix_list": {
-        "TEST_NOTES": ["POST response for IPv6 prefix list creation"],
-        "RETURN_CODE": 201,
-        "METHOD": "POST",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists",
-        "MESSAGE": "OK",
-        "DATA": {
-            "ipVersion": "ipv6",
-            "name": "PL-IPV6-NEW",
-            "description": "New IPv6 Prefix List",
-            "tenantName": "TENANT1",
-            "prefixListEntries": [
-                {
-                    "sequenceNumber": 10,
-                    "action": "permit",
-                    "prefix": "2001:db8:1::/48"
-                }
-            ],
-            "lastUpdateTimestamp": "2026-06-12T11:00:00Z"
-        }
-    },
-
-    "update_ipv4_prefix_list": {
-        "TEST_NOTES": ["PUT response for IPv4 prefix list update"],
-        "RETURN_CODE": 200,
-        "METHOD": "PUT",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists/PL-IPV4-BORDERS",
-        "MESSAGE": "OK",
-        "DATA": {
-            "ipVersion": "ipv4",
-            "name": "PL-IPV4-BORDERS",
-            "description": "Updated IPv4 Border Router Prefixes",
-            "tenantName": "TENANT1",
-            "prefixListEntries": [
-                {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
-                {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"},
-                {"sequenceNumber": 30, "action": "permit", "prefix": "172.16.0.0/12"}
-            ],
-            "lastUpdateTimestamp": "2026-06-12T12:00:00Z"
-        }
-    },
-
-    "delete_ipv4_success": {
-        "TEST_NOTES": ["DELETE response for successful IPv4 prefix list deletion"],
-        "RETURN_CODE": 204,
-        "METHOD": "DELETE",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists/PL-IPV4-BORDERS",
-        "MESSAGE": "No Content"
-    },
-
-    "delete_ipv6_success": {
-        "TEST_NOTES": ["DELETE response for successful IPv6 prefix list deletion"],
-        "RETURN_CODE": 204,
-        "METHOD": "DELETE",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists/PL-IPV6-DATACENTER",
-        "MESSAGE": "No Content"
-    },
-
-    "bulk_delete_ipv4": {
-        "TEST_NOTES": ["Bulk DELETE response for IPv4 prefix lists"],
-        "RETURN_CODE": 204,
-        "METHOD": "DELETE",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
-        "MESSAGE": "No Content"
-    },
-
-    "bulk_delete_ipv6": {
-        "TEST_NOTES": ["Bulk DELETE response for IPv6 prefix lists"],
-        "RETURN_CODE": 204,
-        "METHOD": "DELETE",
-        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists",
-        "MESSAGE": "No Content"
-    },
-
     "empty_ipv4_lists": {
-        "TEST_NOTES": ["Empty response from IPv4 prefix list query_all"],
+        "TEST_NOTES": ["Empty response from the IPv4 prefix list query_all"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
@@ -205,13 +68,150 @@
     },
 
     "empty_ipv6_lists": {
-        "TEST_NOTES": ["Empty response from IPv6 prefix list query_all"],
+        "TEST_NOTES": ["Empty response from the IPv6 prefix list query_all"],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists",
         "MESSAGE": "OK",
         "DATA": {
             "ipv6PrefixLists": []
+        }
+    },
+
+    "ipv4_single_prefix_list": {
+        "TEST_NOTES": ["Single IPv4 prefix list via the GET item endpoint"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists/PL-IPV4-BORDERS",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "PL-IPV4-BORDERS",
+            "description": "IPv4 Border Router Prefixes",
+            "entries": [
+                {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
+                {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"}
+            ],
+            "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
+        }
+    },
+
+    "ipv6_single_prefix_list": {
+        "TEST_NOTES": ["Single IPv6 prefix list via the GET item endpoint"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists/PL-IPV6-DATACENTER",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "PL-IPV6-DATACENTER",
+            "description": "IPv6 Datacenter Prefixes",
+            "entries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "prefix": "2001:db8::/32",
+                    "minLength": 32,
+                    "maxLength": 48
+                }
+            ],
+            "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
+        }
+    },
+
+    "create_ipv4_207_success": {
+        "TEST_NOTES": ["Bulk create IPv4 prefix lists -- 207 Multi-Status, all success"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "PL-IPV4-BORDERS", "status": "success", "message": "Successfully created IPv4 prefix list PL-IPV4-BORDERS"}
+            ]
+        }
+    },
+
+    "create_ipv6_207_success": {
+        "TEST_NOTES": ["Bulk create IPv6 prefix lists -- 207 Multi-Status, all success"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "PL-IPV6-DATACENTER", "status": "success", "message": "Successfully created IPv6 prefix list PL-IPV6-DATACENTER"}
+            ]
+        }
+    },
+
+    "create_ipv4_207_partial_failure": {
+        "TEST_NOTES": ["Bulk create IPv4 prefix lists -- 207 Multi-Status with one per-item failure"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "PL-IPV4-OK", "status": "success", "message": "Successfully created IPv4 prefix list PL-IPV4-OK"},
+                {"name": "PL-IPV4-BAD", "status": "failed", "message": "Failed to create IPv4 prefix list PL-IPV4-BAD"}
+            ]
+        }
+    },
+
+    "update_ipv4_prefix_list": {
+        "TEST_NOTES": ["PUT response for an IPv4 prefix list update"],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists/PL-IPV4-BORDERS",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "PL-IPV4-BORDERS",
+            "description": "Updated IPv4 Border Router Prefixes",
+            "entries": [
+                {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
+                {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"},
+                {"sequenceNumber": 30, "action": "permit", "prefix": "172.16.0.0/12"}
+            ],
+            "lastUpdateTimestamp": "2026-06-12T12:00:00Z"
+        }
+    },
+
+    "bulk_delete_ipv4_207_success": {
+        "TEST_NOTES": ["Bulk delete IPv4 prefix lists -- POST .../ipv4PrefixListActions/remove, 207 success"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixListActions/remove",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "PL-IPV4-BORDERS", "status": "success", "message": "Successfully deleted IPv4 prefix list PL-IPV4-BORDERS"}
+            ]
+        }
+    },
+
+    "bulk_delete_ipv6_207_success": {
+        "TEST_NOTES": ["Bulk delete IPv6 prefix lists -- POST .../ipv6PrefixListActions/remove, 207 success"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixListActions/remove",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "PL-IPV6-DATACENTER", "status": "success", "message": "Successfully deleted IPv6 prefix list PL-IPV6-DATACENTER"}
+            ]
+        }
+    },
+
+    "bulk_delete_ipv4_207_partial_failure": {
+        "TEST_NOTES": ["Bulk delete IPv4 prefix lists -- 207 Multi-Status with one per-item failure"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixListActions/remove",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "PL-IPV4-OK", "status": "success", "message": "Successfully deleted IPv4 prefix list PL-IPV4-OK"},
+                {"name": "PL-IPV4-BAD", "status": "failed", "message": "Failed to delete IPv4 prefix list PL-IPV4-BAD"}
+            ]
         }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_manage_prefix_list.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_manage_prefix_list.json
@@ -1,0 +1,217 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for test_manage_prefix_list.py (orchestrator tests).",
+        "Keys follow the test_<module>_<NNNNN><a|b|c|...> convention.",
+        "Suffix order matches the order RestSend.commit() will consume responses within each test.",
+        "IPv4 and IPv6 prefix list fixtures with full semantic examples.",
+        "Each query_all() call fetches both IPv4 and IPv6 list endpoints separately."
+    ],
+
+    "ipv4_prefix_lists_ok": {
+        "TEST_NOTES": ["Reusable IPv4 prefix list response from list endpoint"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
+        "MESSAGE": "OK",
+        "DATA": {
+            "ipv4PrefixLists": [
+                {
+                    "ipVersion": "ipv4",
+                    "name": "PL-IPV4-BORDERS",
+                    "description": "IPv4 Border Router Prefixes",
+                    "tenantName": "TENANT1",
+                    "prefixListEntries": [
+                        {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
+                        {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"}
+                    ],
+                    "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
+                }
+            ]
+        }
+    },
+
+    "ipv6_prefix_lists_ok": {
+        "TEST_NOTES": ["Reusable IPv6 prefix list response from list endpoint"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists",
+        "MESSAGE": "OK",
+        "DATA": {
+            "ipv6PrefixLists": [
+                {
+                    "ipVersion": "ipv6",
+                    "name": "PL-IPV6-DATACENTER",
+                    "description": "IPv6 Datacenter Prefixes",
+                    "tenantName": "TENANT1",
+                    "prefixListEntries": [
+                        {
+                            "sequenceNumber": 10,
+                            "action": "permit",
+                            "prefix": "2001:db8::/32",
+                            "minPrefixLength": 32,
+                            "maxPrefixLength": 48
+                        }
+                    ],
+                    "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
+                }
+            ]
+        }
+    },
+
+    "ipv4_single_prefix_list": {
+        "TEST_NOTES": ["Single IPv4 prefix list via GET endpoint"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists/PL-IPV4-BORDERS",
+        "MESSAGE": "OK",
+        "DATA": {
+            "ipVersion": "ipv4",
+            "name": "PL-IPV4-BORDERS",
+            "description": "IPv4 Border Router Prefixes",
+            "tenantName": "TENANT1",
+            "prefixListEntries": [
+                {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
+                {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"}
+            ],
+            "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
+        }
+    },
+
+    "ipv6_single_prefix_list": {
+        "TEST_NOTES": ["Single IPv6 prefix list via GET endpoint"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists/PL-IPV6-DATACENTER",
+        "MESSAGE": "OK",
+        "DATA": {
+            "ipVersion": "ipv6",
+            "name": "PL-IPV6-DATACENTER",
+            "description": "IPv6 Datacenter Prefixes",
+            "tenantName": "TENANT1",
+            "prefixListEntries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "prefix": "2001:db8::/32",
+                    "minPrefixLength": 32,
+                    "maxPrefixLength": 48
+                }
+            ],
+            "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
+        }
+    },
+
+    "create_ipv4_prefix_list": {
+        "TEST_NOTES": ["POST response for IPv4 prefix list creation"],
+        "RETURN_CODE": 201,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
+        "MESSAGE": "OK",
+        "DATA": {
+            "ipVersion": "ipv4",
+            "name": "PL-IPV4-NEW",
+            "description": "New IPv4 Prefix List",
+            "tenantName": "TENANT1",
+            "prefixListEntries": [
+                {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.0.0/8"}
+            ],
+            "lastUpdateTimestamp": "2026-06-12T11:00:00Z"
+        }
+    },
+
+    "create_ipv6_prefix_list": {
+        "TEST_NOTES": ["POST response for IPv6 prefix list creation"],
+        "RETURN_CODE": 201,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists",
+        "MESSAGE": "OK",
+        "DATA": {
+            "ipVersion": "ipv6",
+            "name": "PL-IPV6-NEW",
+            "description": "New IPv6 Prefix List",
+            "tenantName": "TENANT1",
+            "prefixListEntries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "prefix": "2001:db8:1::/48"
+                }
+            ],
+            "lastUpdateTimestamp": "2026-06-12T11:00:00Z"
+        }
+    },
+
+    "update_ipv4_prefix_list": {
+        "TEST_NOTES": ["PUT response for IPv4 prefix list update"],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists/PL-IPV4-BORDERS",
+        "MESSAGE": "OK",
+        "DATA": {
+            "ipVersion": "ipv4",
+            "name": "PL-IPV4-BORDERS",
+            "description": "Updated IPv4 Border Router Prefixes",
+            "tenantName": "TENANT1",
+            "prefixListEntries": [
+                {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
+                {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"},
+                {"sequenceNumber": 30, "action": "permit", "prefix": "172.16.0.0/12"}
+            ],
+            "lastUpdateTimestamp": "2026-06-12T12:00:00Z"
+        }
+    },
+
+    "delete_ipv4_success": {
+        "TEST_NOTES": ["DELETE response for successful IPv4 prefix list deletion"],
+        "RETURN_CODE": 204,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists/PL-IPV4-BORDERS",
+        "MESSAGE": "No Content"
+    },
+
+    "delete_ipv6_success": {
+        "TEST_NOTES": ["DELETE response for successful IPv6 prefix list deletion"],
+        "RETURN_CODE": 204,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists/PL-IPV6-DATACENTER",
+        "MESSAGE": "No Content"
+    },
+
+    "bulk_delete_ipv4": {
+        "TEST_NOTES": ["Bulk DELETE response for IPv4 prefix lists"],
+        "RETURN_CODE": 204,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
+        "MESSAGE": "No Content"
+    },
+
+    "bulk_delete_ipv6": {
+        "TEST_NOTES": ["Bulk DELETE response for IPv6 prefix lists"],
+        "RETURN_CODE": 204,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists",
+        "MESSAGE": "No Content"
+    },
+
+    "empty_ipv4_lists": {
+        "TEST_NOTES": ["Empty response from IPv4 prefix list query_all"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists",
+        "MESSAGE": "OK",
+        "DATA": {
+            "ipv4PrefixLists": []
+        }
+    },
+
+    "empty_ipv6_lists": {
+        "TEST_NOTES": ["Empty response from IPv6 prefix list query_all"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv6PrefixLists",
+        "MESSAGE": "OK",
+        "DATA": {
+            "ipv6PrefixLists": []
+        }
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_manage_prefix_list.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_manage_prefix_list.json
@@ -95,6 +95,23 @@
         }
     },
 
+    "ipv4_single_tenant_prefix_list_without_tenant_name": {
+        "TEST_NOTES": ["Tenant-scoped IPv4 prefix list item GET where the API omits tenantName"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/SITE1/ipv4PrefixLists/TENANT1~PL-IPV4-BORDERS",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "TENANT1~PL-IPV4-BORDERS",
+            "description": "IPv4 Border Router Prefixes",
+            "entries": [
+                {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
+                {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"}
+            ],
+            "lastUpdateTimestamp": "2026-06-12T10:00:00Z"
+        }
+    },
+
     "ipv6_single_prefix_list": {
         "TEST_NOTES": ["Single IPv6 prefix list via the GET item endpoint"],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -27,7 +27,6 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list
 )
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
 
-
 SAMPLE_IPV4_CONFIG = {
     "ip_version": "ipv4",
     "name": "PL-IPV4-BORDERS",

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -18,15 +18,14 @@ from __future__ import absolute_import, annotations, division, print_function
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import copy
-from contextlib import contextmanager
 
 import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ValidationError
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.manage_prefix_list import (
     PrefixListEntryModel,
     PrefixListModel,
 )
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
-from pydantic import ValidationError
 
 
 SAMPLE_IPV4_CONFIG = {
@@ -534,7 +533,7 @@ def test_manage_prefix_list_00170() -> None:
     assert opts["ip_version"]["required"] is True
     assert opts["ip_version"]["choices"] == ["ipv4", "ipv6"]
     assert "aliases" in opts["ip_version"]  # Has aliases key
-    
+
     assert opts["name"]["type"] == "str"
     assert opts["name"]["required"] is True
     assert opts["description"]["type"] == "str"

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -519,6 +519,7 @@ def test_manage_prefix_list_00170() -> None:
 
     # Top-level fields
     assert spec["fabric_name"] == {"type": "str", "required": True}
+    assert spec["cluster_name"] == {"type": "str", "required": False}
 
     # Config structure
     config = spec["config"]

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -92,6 +92,21 @@ def test_manage_prefix_list_00010() -> None:
     assert entry.mask is None
 
 
+def test_manage_prefix_list_00015() -> None:
+    """
+    # Summary
+
+    Verify PrefixListEntryModel defaults action to permit.
+
+    ## Classes and Methods
+
+    - PrefixListEntryModel.__init__()
+    """
+    entry = PrefixListEntryModel(sequence_number=10, prefix="10.0.1.0/24")
+
+    assert entry.action == "permit"
+
+
 def test_manage_prefix_list_00020() -> None:
     """
     # Summary
@@ -602,6 +617,8 @@ def test_manage_prefix_list_00170() -> None:
     assert entries["type"] == "list"
     assert entries["elements"] == "dict"
     assert entries["required"] is False
+    assert entries["options"]["action"]["default"] == "permit"
+    assert entries["options"]["action"]["required"] is False
 
 
 def test_manage_prefix_list_00175() -> None:

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -13,9 +13,7 @@ Tests the Pydantic model classes for managing IPv4 and IPv6 prefix lists.
 # pylint: disable=disallowed-name,protected-access,redefined-outer-name
 # pylint: disable=use-implicit-booleaness-not-comparison
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type  # pylint: disable=invalid-name
+from __future__ import annotations
 
 import copy
 

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -564,6 +564,33 @@ def test_manage_prefix_list_00160() -> None:
     # prefixListEntries should not be present or should be None/excluded
 
 
+def test_manage_prefix_list_00165() -> None:
+    """
+    # Summary
+
+    Verify replace-style diff detects stale descriptions when config omits description.
+
+    ## Classes and Methods
+
+    - PrefixListModel.get_diff
+    """
+    existing = PrefixListModel.from_response(copy.deepcopy(SAMPLE_IPV4_API_RESPONSE))
+    proposed = PrefixListModel.from_config(
+        {
+            "ip_version": "ipv4",
+            "tenant_name": "TENANT1",
+            "name": "PL-IPV4-BORDERS",
+            "entries": copy.deepcopy(SAMPLE_IPV4_CONFIG["entries"]),
+        }
+    )
+
+    assert existing.get_diff(proposed, exclude_unset=True) is True
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+    existing.description = ""
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
 # =============================================================================
 # Test: argument spec
 # =============================================================================

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -1,0 +1,581 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for `PrefixListModel`, `PrefixListEntryModel`.
+
+Tests the Pydantic model classes for managing IPv4 and IPv6 prefix lists.
+"""
+
+# pylint: disable=disallowed-name,protected-access,redefined-outer-name
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.manage_prefix_list import (
+    PrefixListEntryModel,
+    PrefixListModel,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from pydantic import ValidationError
+
+
+SAMPLE_IPV4_CONFIG = {
+    "ip_version": "ipv4",
+    "name": "PL-IPV4-BORDERS",
+    "description": "IPv4 Border Router Prefixes",
+    "tenant_name": "TENANT1",
+    "entries": [
+        {"sequence_number": 10, "action": "permit", "prefix": "10.0.1.0/24"},
+        {"sequence_number": 20, "action": "deny", "prefix": "192.168.0.0/16"},
+    ],
+}
+
+SAMPLE_IPV6_CONFIG = {
+    "ip_version": "ipv6",
+    "name": "PL-IPV6-DATACENTER",
+    "description": "IPv6 Datacenter Prefixes",
+    "tenant_name": "TENANT1",
+    "entries": [
+        {"sequence_number": 10, "action": "permit", "prefix": "2001:db8::/32", "min_prefix_length": 32, "max_prefix_length": 48},
+    ],
+}
+
+SAMPLE_IPV4_API_RESPONSE = {
+    "ipVersion": "ipv4",
+    "name": "PL-IPV4-BORDERS",
+    "description": "IPv4 Border Router Prefixes",
+    "tenantName": "TENANT1",
+    "entries": [
+        {"sequenceNumber": 10, "action": "permit", "prefix": "10.0.1.0/24"},
+        {"sequenceNumber": 20, "action": "deny", "prefix": "192.168.0.0/16"},
+    ],
+    "lastUpdateTimestamp": "2026-06-12T10:00:00Z",
+}
+
+
+# =============================================================================
+# Test: PrefixListEntryModel validation
+# =============================================================================
+
+
+def test_manage_prefix_list_00010() -> None:
+    """
+    # Summary
+
+    Verify PrefixListEntryModel instantiates with minimal required fields.
+
+    ## Test
+
+    - Entry can be created with sequence_number, action, and prefix
+    - Optional fields default to None
+
+    ## Classes and Methods
+
+    - PrefixListEntryModel.__init__()
+    """
+    with does_not_raise():
+        entry = PrefixListEntryModel(sequence_number=10, action="permit", prefix="10.0.1.0/24")
+    assert entry.sequence_number == 10
+    assert entry.action == "permit"
+    assert entry.prefix == "10.0.1.0/24"
+    assert entry.exact_length is None
+    assert entry.min_prefix_length is None
+    assert entry.max_prefix_length is None
+    assert entry.mask is None
+
+
+def test_manage_prefix_list_00020() -> None:
+    """
+    # Summary
+
+    Verify sequence_number must be in valid range [1, 4294967294].
+
+    ## Test
+
+    - sequence_number=0 raises ValidationError
+    - sequence_number=4294967295 raises ValidationError
+
+    ## Classes and Methods
+
+    - PrefixListEntryModel validators
+    """
+    bad_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    bad_config["entries"] = [{"sequence_number": 0, "action": "permit", "prefix": "10.0.1.0/24"}]
+    with pytest.raises(ValidationError, match="sequence_number"):
+        PrefixListModel(**bad_config)
+
+    bad_config["entries"] = [{"sequence_number": 4294967295, "action": "permit", "prefix": "10.0.1.0/24"}]
+    with pytest.raises(ValidationError, match="sequence_number"):
+        PrefixListModel(**bad_config)
+
+
+def test_manage_prefix_list_00030() -> None:
+    """
+    # Summary
+
+    Verify IPv4 prefix validates and rejects invalid CIDR.
+
+    ## Test
+
+    - Valid IPv4 CIDR "10.0.1.0/24" is accepted
+    - Invalid CIDR "999.999.999.999/24" raises ValidationError
+
+    ## Classes and Methods
+
+    - IPv4NetworkCIDR validator (shared types)
+    """
+    with does_not_raise():
+        entry = PrefixListEntryModel(sequence_number=10, action="permit", prefix="10.0.1.0/24")
+    assert entry.prefix == "10.0.1.0/24"
+
+    bad_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    bad_config["entries"] = [{"sequence_number": 10, "action": "permit", "prefix": "999.999.999.999/24"}]
+    with pytest.raises(ValidationError, match="not a valid IP network"):
+        PrefixListModel(**bad_config)
+
+
+def test_manage_prefix_list_00040() -> None:
+    """
+    # Summary
+
+    Verify IPv6 prefix validates and rejects invalid CIDR.
+
+    ## Test
+
+    - Valid IPv6 CIDR "2001:db8::/32" is accepted
+    - Invalid CIDR "gggg::/32" raises ValidationError
+
+    ## Classes and Methods
+
+    - IPv6NetworkCIDR validator (shared types)
+    """
+    with does_not_raise():
+        entry = PrefixListEntryModel(sequence_number=10, action="permit", prefix="2001:db8::/32")
+    assert entry.prefix == "2001:db8::/32"
+
+    bad_config = copy.deepcopy(SAMPLE_IPV6_CONFIG)
+    bad_config["entries"] = [{"sequence_number": 10, "action": "permit", "prefix": "gggg::/32"}]
+    with pytest.raises(ValidationError, match="not a valid IP network"):
+        PrefixListModel(**bad_config)
+
+
+# =============================================================================
+# Test: PrefixListModel semantic validators
+# =============================================================================
+
+
+def test_manage_prefix_list_00050() -> None:
+    """
+    # Summary
+
+    Verify duplicate sequence_number entries are rejected.
+
+    ## Test
+
+    - Two entries with same sequence_number raises ValidationError
+
+    ## Classes and Methods
+
+    - PrefixListModel.validate_entries_for_ip_version
+    """
+    bad_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    bad_config["entries"] = [
+        {"sequence_number": 10, "action": "permit", "prefix": "10.0.1.0/24"},
+        {"sequence_number": 10, "action": "deny", "prefix": "192.168.0.0/16"},
+    ]
+    with pytest.raises(ValidationError, match="duplicated"):
+        PrefixListModel(**bad_config)
+
+
+def test_manage_prefix_list_00060() -> None:
+    """
+    # Summary
+
+    Verify exact_length is mutually exclusive with min/max_prefix_length.
+
+    ## Test
+
+    - Entry with both exact_length and min_prefix_length raises ValidationError
+
+    ## Classes and Methods
+
+    - PrefixListModel.validate_entries_for_ip_version
+    """
+    bad_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    bad_config["entries"] = [
+        {
+            "sequence_number": 10,
+            "action": "permit",
+            "prefix": "10.0.0.0/8",
+            "exact_length": 24,
+            "min_prefix_length": 16,
+        },
+    ]
+    with pytest.raises(ValidationError, match="cannot define exactLength together"):
+        PrefixListModel(**bad_config)
+
+
+def test_manage_prefix_list_00070() -> None:
+    """
+    # Summary
+
+    Verify min_prefix_length <= max_prefix_length.
+
+    ## Test
+
+    - min_prefix_length > max_prefix_length raises ValidationError
+
+    ## Classes and Methods
+
+    - PrefixListModel.validate_entries_for_ip_version
+    """
+    bad_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    bad_config["entries"] = [
+        {
+            "sequence_number": 10,
+            "action": "permit",
+            "prefix": "10.0.0.0/8",
+            "min_prefix_length": 30,
+            "max_prefix_length": 24,
+        },
+    ]
+    with pytest.raises(ValidationError, match="cannot be greater than"):
+        PrefixListModel(**bad_config)
+
+
+def test_manage_prefix_list_00080() -> None:
+    """
+    # Summary
+
+    Verify IPv4 exact_length is in valid range [1, 32].
+
+    ## Test
+
+    - exact_length=0 raises ValidationError
+    - exact_length=33 raises ValidationError
+
+    ## Classes and Methods
+
+    - PrefixListModel.validate_entries_for_ip_version
+    """
+    bad_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    bad_config["entries"] = [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8", "exact_length": 0}]
+    with pytest.raises(ValidationError, match="exactLength.*out of range"):
+        PrefixListModel(**bad_config)
+
+    bad_config["entries"] = [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8", "exact_length": 33}]
+    with pytest.raises(ValidationError, match="exactLength.*out of range"):
+        PrefixListModel(**bad_config)
+
+
+def test_manage_prefix_list_00090() -> None:
+    """
+    # Summary
+
+    Verify IPv6 exact_length is in valid range [1, 128].
+
+    ## Test
+
+    - exact_length=0 raises ValidationError
+    - exact_length=129 raises ValidationError
+
+    ## Classes and Methods
+
+    - PrefixListModel.validate_entries_for_ip_version
+    """
+    bad_config = copy.deepcopy(SAMPLE_IPV6_CONFIG)
+    bad_config["entries"] = [{"sequence_number": 10, "action": "permit", "prefix": "2001:db8::/32", "exact_length": 0}]
+    with pytest.raises(ValidationError, match="exactLength.*out of range"):
+        PrefixListModel(**bad_config)
+
+    bad_config["entries"] = [{"sequence_number": 10, "action": "permit", "prefix": "2001:db8::/32", "exact_length": 129}]
+    with pytest.raises(ValidationError, match="exactLength.*out of range"):
+        PrefixListModel(**bad_config)
+
+
+def test_manage_prefix_list_00100() -> None:
+    """
+    # Summary
+
+    Verify IPv4 min/max_prefix_length are in valid range [1, 32].
+
+    ## Test
+
+    - min_prefix_length=0 raises ValidationError
+    - max_prefix_length=33 raises ValidationError
+
+    ## Classes and Methods
+
+    - PrefixListModel.validate_entries_for_ip_version
+    """
+    bad_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    bad_config["entries"] = [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8", "min_prefix_length": 0}]
+    with pytest.raises(ValidationError, match="minLength.*out of range"):
+        PrefixListModel(**bad_config)
+
+    bad_config["entries"] = [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8", "max_prefix_length": 33}]
+    with pytest.raises(ValidationError, match="maxLength.*out of range"):
+        PrefixListModel(**bad_config)
+
+
+def test_manage_prefix_list_00110() -> None:
+    """
+    # Summary
+
+    Verify description accepts only ASCII characters.
+
+    ## Test
+
+    - ASCII description is accepted
+    - Non-ASCII description raises ValidationError
+
+    ## Classes and Methods
+
+    - AsciiDescription validator (shared types)
+    """
+    good_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    good_config["description"] = "ASCII-only description 123"
+    with does_not_raise():
+        model = PrefixListModel(**good_config)
+    assert model.description == "ASCII-only description 123"
+
+    bad_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    bad_config["description"] = "Non-ASCII: café"
+    with pytest.raises(ValidationError, match="ASCII"):
+        PrefixListModel(**bad_config)
+
+
+# =============================================================================
+# Test: PrefixListModel identifier strategy
+# =============================================================================
+
+
+def test_manage_prefix_list_00120() -> None:
+    """
+    # Summary
+
+    Verify identifier strategy is composite (ip_version + name).
+
+    ## Test
+
+    - identifier_strategy is "composite"
+    - identifiers is ["ip_version", "name"]
+    - get_identifier_value() returns (ip_version, name) tuple
+
+    ## Classes and Methods
+
+    - PrefixListModel.identifier_strategy
+    - PrefixListModel.identifiers
+    - PrefixListModel.get_identifier_value
+    """
+    assert PrefixListModel.identifier_strategy == "composite"
+    assert PrefixListModel.identifiers == ["ip_version", "name"]
+
+    model = PrefixListModel(**SAMPLE_IPV4_CONFIG)
+    assert model.get_identifier_value() == ("ipv4", "PL-IPV4-BORDERS")
+
+
+# =============================================================================
+# Test: from_response / from_config factories
+# =============================================================================
+
+
+def test_manage_prefix_list_00130() -> None:
+    """
+    # Summary
+
+    Verify from_response accepts ND API camelCase keys.
+
+    ## Test
+
+    - from_response() accepts ipVersion, prefixListEntries, camelCase keys
+    - Snake_case fields are populated correctly
+
+    ## Classes and Methods
+
+    - PrefixListModel.from_response
+    """
+    with does_not_raise():
+        model = PrefixListModel.from_response(copy.deepcopy(SAMPLE_IPV4_API_RESPONSE))
+    assert model.ip_version == "ipv4"
+    assert model.name == "PL-IPV4-BORDERS"
+    assert model.description == "IPv4 Border Router Prefixes"
+    assert model.tenant_name == "TENANT1"
+    # prefixListEntries in response maps to entries field
+    assert model.entries is not None
+    assert len(model.entries) == 2
+    assert model.entries[0].sequence_number == 10
+    assert model.last_update_timestamp == "2026-06-12T10:00:00Z"
+
+
+def test_manage_prefix_list_00140() -> None:
+    """
+    # Summary
+
+    Verify from_config accepts Ansible snake_case keys.
+
+    ## Test
+
+    - from_config() accepts snake_case keys
+    - Nested entries are instantiated as PrefixListEntryModel
+
+    ## Classes and Methods
+
+    - PrefixListModel.from_config
+    """
+    with does_not_raise():
+        model = PrefixListModel.from_config(copy.deepcopy(SAMPLE_IPV4_CONFIG))
+    assert model.ip_version == "ipv4"
+    assert model.name == "PL-IPV4-BORDERS"
+    assert len(model.entries) == 2
+    assert all(isinstance(e, PrefixListEntryModel) for e in model.entries)
+
+
+# =============================================================================
+# Test: to_payload serialization
+# =============================================================================
+
+
+def test_manage_prefix_list_00150() -> None:
+    """
+    # Summary
+
+    Verify to_payload() excludes ip_version and last_update_timestamp.
+
+    ## Test
+
+    - to_payload() returns payload with entries
+    - ip_version and last_update_timestamp are not in payload
+
+    ## Classes and Methods
+
+    - PrefixListModel.to_payload
+    """
+    model = PrefixListModel.from_config(copy.deepcopy(SAMPLE_IPV4_CONFIG))
+    payload = model.to_payload()
+
+    assert "name" in payload
+    assert "description" in payload
+    assert "tenantName" in payload
+    # entries key is present (may be serialized as prefixListEntries by API layer)
+    assert "entries" in payload or "prefixListEntries" in payload
+    assert "ipVersion" not in payload
+    assert "lastUpdateTimestamp" not in payload
+
+
+def test_manage_prefix_list_00160() -> None:
+    """
+    # Summary
+
+    Verify to_payload() with entries=None produces valid payload (delete operations).
+
+    ## Test
+
+    - to_payload() with None entries returns payload without entries key
+    - Other fields are still present
+
+    ## Classes and Methods
+
+    - PrefixListModel.to_payload
+    """
+    model = PrefixListModel(ip_version="ipv4", name="PL-IPV4-BORDERS", entries=None)
+    payload = model.to_payload()
+
+    assert payload.get("name") == "PL-IPV4-BORDERS"
+    # prefixListEntries should not be present or should be None/excluded
+
+
+# =============================================================================
+# Test: argument spec
+# =============================================================================
+
+
+def test_manage_prefix_list_00170() -> None:
+    """
+    # Summary
+
+    Verify argument spec shape matches module documentation.
+
+    ## Test
+
+    - fabric_name is top-level required field
+    - config is a list of dicts
+    - ip_version and name are required in config (with aliases)
+    - entries is required=false (semantic enforcement)
+
+    ## Classes and Methods
+
+    - PrefixListModel.get_argument_spec
+    """
+    spec = PrefixListModel.get_argument_spec()
+
+    # Top-level fields
+    assert spec["fabric_name"] == {"type": "str", "required": True}
+
+    # Config structure
+    config = spec["config"]
+    assert config["type"] == "list"
+    assert config["elements"] == "dict"
+
+    # Config options
+    opts = config["options"]
+    # ip_version includes aliases
+    assert opts["ip_version"]["type"] == "str"
+    assert opts["ip_version"]["required"] is True
+    assert opts["ip_version"]["choices"] == ["ipv4", "ipv6"]
+    assert "aliases" in opts["ip_version"]  # Has aliases key
+    
+    assert opts["name"]["type"] == "str"
+    assert opts["name"]["required"] is True
+    assert opts["description"]["type"] == "str"
+    # tenant_name has aliases
+    assert opts["tenant_name"]["type"] == "str"
+    assert "aliases" in opts["tenant_name"]
+
+    # Entries (required=false for delete semantic flexibility)
+    entries = opts["entries"]
+    assert entries["type"] == "list"
+    assert entries["elements"] == "dict"
+    assert entries["required"] is False
+
+
+# =============================================================================
+# Test: edge cases
+# =============================================================================
+
+
+def test_manage_prefix_list_00180() -> None:
+    """
+    # Summary
+
+    Verify IPv4 and IPv6 prefix lists can have the same name (composite key).
+
+    ## Test
+
+    - Two models with same name but different ip_version are distinct
+    - Both deserialize without conflict
+
+    ## Classes and Methods
+
+    - PrefixListModel composite identifier handling
+    """
+    ipv4 = PrefixListModel.from_config(
+        {"ip_version": "ipv4", "name": "PL-SHARED", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}]}
+    )
+    ipv6 = PrefixListModel.from_config(
+        {"ip_version": "ipv6", "name": "PL-SHARED", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "2001:db8::/32"}]}
+    )
+
+    assert ipv4.get_identifier_value() != ipv6.get_identifier_value()
+    assert ipv4.get_identifier_value() == ("ipv4", "PL-SHARED")
+    assert ipv6.get_identifier_value() == ("ipv6", "PL-SHARED")

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -702,3 +702,48 @@ def test_manage_prefix_list_00190() -> None:
     assert tenant_a.get_identifier_value() != tenant_b.get_identifier_value()
     assert tenant_a.api_name == "TENANT_A~PL-SHARED"
     assert tenant_b.api_name == "TENANT_B~PL-SHARED"
+
+
+def test_manage_prefix_list_00200() -> None:
+    """
+    # Summary
+
+    Verify default-tenant prefix list names are limited to 63 characters.
+
+    ## Classes and Methods
+
+    - PrefixListModel.validate_name_length_for_tenant_scope
+    """
+    good_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    good_config.pop("tenant_name")
+    good_config["name"] = "P" * 63
+    with does_not_raise():
+        PrefixListModel.from_config(good_config)
+
+    bad_config = copy.deepcopy(good_config)
+    bad_config["name"] = "P" * 64
+    with pytest.raises(ValidationError, match="tenant_name is omitted"):
+        PrefixListModel.from_config(bad_config)
+
+
+def test_manage_prefix_list_00210() -> None:
+    """
+    # Summary
+
+    Verify tenant-qualified prefix list names are limited to 115 characters.
+
+    ## Classes and Methods
+
+    - PrefixListModel.validate_name_length_for_tenant_scope
+    """
+    good_config = copy.deepcopy(SAMPLE_IPV4_CONFIG)
+    good_config["tenant_name"] = "T" * 8
+    good_config["name"] = "P" * 106
+    with does_not_raise():
+        model = PrefixListModel.from_config(good_config)
+    assert len(model.api_name) == 115
+
+    bad_config = copy.deepcopy(good_config)
+    bad_config["name"] = "P" * 107
+    with pytest.raises(ValidationError, match="combined tenant-qualified"):
+        PrefixListModel.from_config(bad_config)

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -642,8 +642,9 @@ def test_manage_prefix_list_00170() -> None:
     assert entries["type"] == "list"
     assert entries["elements"] == "dict"
     assert entries["required"] is False
-    assert entries["options"]["action"]["default"] == "permit"
     assert entries["options"]["action"]["required"] is False
+    assert "default" not in entries["options"]["action"]
+    assert PrefixListEntryModel(sequence_number=10, prefix="10.0.0.0/8").action == "permit"
 
 
 def test_manage_prefix_list_00175() -> None:

--- a/tests/unit/module_utils/models/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/models/test_manage_prefix_list.py
@@ -167,6 +167,36 @@ def test_manage_prefix_list_00040() -> None:
         PrefixListModel(**bad_config)
 
 
+def test_manage_prefix_list_00045() -> None:
+    """
+    # Summary
+
+    Verify IPv6 prefixes and masks are normalized for stable diff comparison.
+
+    ## Classes and Methods
+
+    - PrefixListEntryModel.normalize_prefix
+    - PrefixListEntryModel.normalize_mask
+    """
+    model = PrefixListModel.from_config(
+        {
+            "ip_version": "ipv6",
+            "name": "PL-IPV6-NORMALIZE",
+            "entries": [
+                {
+                    "sequence_number": 10,
+                    "action": "permit",
+                    "prefix": "2001:0db8:0000:0000:0000:0000:0000:0000/32",
+                    "mask": "ffff:ffff:0000:0000:0000:0000:0000:0000",
+                }
+            ],
+        }
+    )
+
+    assert model.entries[0].prefix == "2001:db8::/32"
+    assert model.entries[0].mask == "ffff:ffff::"
+
+
 # =============================================================================
 # Test: PrefixListModel semantic validators
 # =============================================================================
@@ -367,8 +397,8 @@ def test_manage_prefix_list_00120() -> None:
     ## Test
 
     - identifier_strategy is "composite"
-    - identifiers is ["ip_version", "name"]
-    - get_identifier_value() returns (ip_version, name) tuple
+    - identifiers is ["ip_version", "tenant_name", "name"]
+    - get_identifier_value() returns (ip_version, tenant_name, name) tuple
 
     ## Classes and Methods
 
@@ -377,10 +407,10 @@ def test_manage_prefix_list_00120() -> None:
     - PrefixListModel.get_identifier_value
     """
     assert PrefixListModel.identifier_strategy == "composite"
-    assert PrefixListModel.identifiers == ["ip_version", "name"]
+    assert PrefixListModel.identifiers == ["ip_version", "tenant_name", "name"]
 
     model = PrefixListModel(**SAMPLE_IPV4_CONFIG)
-    assert model.get_identifier_value() == ("ipv4", "PL-IPV4-BORDERS")
+    assert model.get_identifier_value() == ("ipv4", "TENANT1", "PL-IPV4-BORDERS")
 
 
 # =============================================================================
@@ -414,6 +444,32 @@ def test_manage_prefix_list_00130() -> None:
     assert len(model.entries) == 2
     assert model.entries[0].sequence_number == 10
     assert model.last_update_timestamp == "2026-06-12T10:00:00Z"
+
+
+def test_manage_prefix_list_00135() -> None:
+    """
+    # Summary
+
+    Verify tenant-scoped API names are normalized from tenant~name to bare name plus tenant_name.
+
+    ## Classes and Methods
+
+    - PrefixListModel.normalize_tenant_scoped_name
+    - PrefixListModel.api_name
+    """
+    model = PrefixListModel.from_response(
+        {
+            "ipVersion": "ipv4",
+            "name": "TENANT1~PL-SHARED",
+            "tenantName": "TENANT1",
+            "entries": [{"sequenceNumber": 10, "action": "permit", "prefix": "10.0.0.0/8"}],
+        }
+    )
+
+    assert model.name == "PL-SHARED"
+    assert model.tenant_name == "TENANT1"
+    assert model.api_name == "TENANT1~PL-SHARED"
+    assert model.get_identifier_value() == ("ipv4", "TENANT1", "PL-SHARED")
 
 
 def test_manage_prefix_list_00140() -> None:
@@ -548,6 +604,25 @@ def test_manage_prefix_list_00170() -> None:
     assert entries["required"] is False
 
 
+def test_manage_prefix_list_00175() -> None:
+    """
+    # Summary
+
+    Verify state-dependent entries validation.
+
+    ## Classes and Methods
+
+    - PrefixListModel.validate_config_for_state
+    """
+    config = [{"ip_version": "ipv4", "name": "PL-IPV4-BORDERS"}]
+
+    with pytest.raises(ValueError, match="entries is required"):
+        PrefixListModel.validate_config_for_state(config, "merged")
+
+    with does_not_raise():
+        PrefixListModel.validate_config_for_state(config, "deleted")
+
+
 # =============================================================================
 # Test: edge cases
 # =============================================================================
@@ -576,5 +651,37 @@ def test_manage_prefix_list_00180() -> None:
     )
 
     assert ipv4.get_identifier_value() != ipv6.get_identifier_value()
-    assert ipv4.get_identifier_value() == ("ipv4", "PL-SHARED")
-    assert ipv6.get_identifier_value() == ("ipv6", "PL-SHARED")
+    assert ipv4.get_identifier_value() == ("ipv4", None, "PL-SHARED")
+    assert ipv6.get_identifier_value() == ("ipv6", None, "PL-SHARED")
+
+
+def test_manage_prefix_list_00190() -> None:
+    """
+    # Summary
+
+    Verify same prefix list name can coexist across tenants.
+
+    ## Classes and Methods
+
+    - PrefixListModel composite identifier handling
+    """
+    tenant_a = PrefixListModel.from_config(
+        {
+            "ip_version": "ipv4",
+            "tenant_name": "TENANT_A",
+            "name": "PL-SHARED",
+            "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}],
+        }
+    )
+    tenant_b = PrefixListModel.from_config(
+        {
+            "ip_version": "ipv4",
+            "tenant_name": "TENANT_B",
+            "name": "PL-SHARED",
+            "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}],
+        }
+    )
+
+    assert tenant_a.get_identifier_value() != tenant_b.get_identifier_value()
+    assert tenant_a.api_name == "TENANT_A~PL-SHARED"
+    assert tenant_b.api_name == "TENANT_B~PL-SHARED"

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -617,13 +617,16 @@ def test_manage_prefix_list_00136() -> None:
 
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses, state="overridden")
-    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    results = Results()
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send, results=results)
 
     with does_not_raise():
         result = instance.query_all()
 
     assert [row["name"] for row in result] == ["PL-IPV4-PAGE-1", "PL-IPV4-PAGE-2"]
     assert {row["ipVersion"] for row in result} == {"ipv4"}
+    assert results.path[0].endswith("/ipv4PrefixLists?max=100&offset=0")
+    assert results.path[1].endswith("/ipv4PrefixLists?max=100&offset=1")
 
 
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -18,9 +18,7 @@ own base-class test module.
 # pylint: disable=disallowed-name,protected-access,redefined-outer-name,too-many-lines
 # pylint: disable=use-implicit-booleaness-not-comparison
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type  # pylint: disable=invalid-name
+from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -558,6 +558,41 @@ def test_manage_prefix_list_00135() -> None:
     assert rest_send.path.endswith("/ipv4PrefixLists/PL-IPV4-BORDERS")
 
 
+def test_manage_prefix_list_00132() -> None:
+    """
+    # Summary
+
+    Verify scoped tenant item lookups inject tenantName when the API omits it.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.query_all
+    - ManagePrefixListOrchestrator._query_one_existing
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("ipv4_single_tenant_prefix_list_without_tenant_name")
+
+    config = {
+        "ip_version": "ipv4",
+        "tenant_name": "TENANT1",
+        "name": "PL-IPV4-BORDERS",
+        "entries": [{"sequence_number": 10, "prefix": "10.0.1.0/24"}],
+    }
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, config=[config], state="merged")
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    model = PrefixListModel.from_response(result[0])
+    assert rest_send.path.endswith("/ipv4PrefixLists/TENANT1~PL-IPV4-BORDERS")
+    assert model.tenant_name == "TENANT1"
+    assert model.name == "PL-IPV4-BORDERS"
+    assert model.get_identifier_value() == ("ipv4", "TENANT1", "PL-IPV4-BORDERS")
+
+
 def test_manage_prefix_list_00134() -> None:
     """
     # Summary
@@ -904,6 +939,39 @@ def test_manage_prefix_list_00185() -> None:
         instance.update(model)
 
     assert rest_send.committed_payload["description"] == ""
+
+
+def test_manage_prefix_list_00186() -> None:
+    """
+    # Summary
+
+    Verify tenant-scoped updates send the qualified API name in the PUT body.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.update
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("update_ipv4_prefix_list")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {
+        "ip_version": "ipv4",
+        "tenant_name": "TENANT1",
+        "name": "PL-IPV4-BORDERS",
+        "entries": [{"sequence_number": 10, "prefix": "10.0.1.0/24"}],
+    }
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.path.endswith("/ipv4PrefixLists/TENANT1~PL-IPV4-BORDERS")
+    assert rest_send.committed_payload["name"] == "TENANT1~PL-IPV4-BORDERS"
+    assert rest_send.committed_payload["tenantName"] == "TENANT1"
 
 
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -25,7 +25,7 @@ __metaclass__ = type  # pylint: disable=invalid-name
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.manage_prefix_list import PrefixListModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_prefix_list import ManagePrefixListOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_prefix_list import ManagePrefixListOrchestrator, _SCOPED_QUERY_MAX_IDENTIFIERS
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
@@ -558,6 +558,28 @@ def test_manage_prefix_list_00135() -> None:
     assert rest_send.path.endswith("/ipv4PrefixLists/PL-IPV4-BORDERS")
 
 
+def test_manage_prefix_list_00134() -> None:
+    """
+    # Summary
+
+    Verify proposed identifier extraction does not validate full prefix-list entries.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator._proposed_identifiers
+    """
+
+    def responses():
+        yield {}
+
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "prefix": "not-a-cidr"}]}
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, config=[config], state="merged")
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    assert instance._proposed_identifiers() == [("ipv4", None, "PL-IPV4-BORDERS")]
+
+
 def test_manage_prefix_list_00137() -> None:
     """
     # Summary
@@ -580,6 +602,43 @@ def test_manage_prefix_list_00137() -> None:
 
     with pytest.raises(Exception, match="entries is required"):
         instance.query_all()
+
+
+def test_manage_prefix_list_00138() -> None:
+    """
+    # Summary
+
+    Verify large item-state configs fall back to paginated collection scans.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.query_all
+    - ManagePrefixListOrchestrator._should_use_scoped_query
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("ipv4_prefix_lists_ok")
+        yield responses_manage_prefix_list("ipv6_prefix_lists_ok")
+
+    configs = [
+        {
+            "ip_version": "ipv4",
+            "name": f"PL-IPV4-{idx}",
+            "entries": [{"sequence_number": 10, "prefix": "10.0.0.0/8"}],
+        }
+        for idx in range(_SCOPED_QUERY_MAX_IDENTIFIERS + 1)
+    ]
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, config=configs, state="merged")
+    results = Results()
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send, results=results)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    assert len(result) == 2
+    assert results.path[0].endswith("/ipv4PrefixLists?max=100&offset=0")
+    assert results.path[1].endswith("/ipv6PrefixLists?max=100&offset=0")
 
 
 def test_manage_prefix_list_00136() -> None:

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -821,6 +821,32 @@ def test_manage_prefix_list_00180() -> None:
     assert results.metadata[-1]["action"] == OperationType.UPDATE.value
 
 
+def test_manage_prefix_list_00185() -> None:
+    """
+    # Summary
+
+    Verify replace-style updates send an empty description when config omits it.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.update
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("update_ipv4_prefix_list")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "prefix": "10.0.1.0/24"}]}
+    rest_send = _build_rest_send(gen_responses, config=[config], state="replaced")
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.committed_payload["description"] == ""
+
+
 # =============================================================================
 # Test: delete / delete_bulk (207 Multi-Status)
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -108,7 +108,7 @@ def test_manage_prefix_list_00010() -> None:
 
 
 # =============================================================================
-# Test: _endpoint_classes_for_version helper (explicit routing + fail-fast)
+# Test: _config_for_version helper (explicit routing + fail-fast)
 # =============================================================================
 
 
@@ -116,16 +116,16 @@ def test_manage_prefix_list_00020() -> None:
     """
     # Summary
 
-    Verify _endpoint_classes_for_version returns correct endpoint classes for ipv4.
+    Verify _config_for_version returns correct endpoint classes for ipv4.
 
     ## Test
 
-    - _endpoint_classes_for_version("ipv4") returns IPv4 endpoint class dict
+    - _config_for_version("ipv4") returns IPv4 endpoint class dict
     - Dict includes get, list, post, put, delete, bulk_delete keys
 
     ## Classes and Methods
 
-    - ManagePrefixListOrchestrator._endpoint_classes_for_version()
+    - ManagePrefixListOrchestrator._config_for_version()
     """
 
     def responses():
@@ -136,7 +136,7 @@ def test_manage_prefix_list_00020() -> None:
     instance = ManagePrefixListOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
-        ep_classes = instance._endpoint_classes_for_version("ipv4")
+        ep_classes = instance._config_for_version("ipv4")
 
     assert "get" in ep_classes
     assert "list" in ep_classes
@@ -150,16 +150,16 @@ def test_manage_prefix_list_00030() -> None:
     """
     # Summary
 
-    Verify _endpoint_classes_for_version returns correct endpoint classes for ipv6.
+    Verify _config_for_version returns correct endpoint classes for ipv6.
 
     ## Test
 
-    - _endpoint_classes_for_version("ipv6") returns IPv6 endpoint class dict
+    - _config_for_version("ipv6") returns IPv6 endpoint class dict
     - Dict includes get, list, post, put, delete, bulk_delete keys
 
     ## Classes and Methods
 
-    - ManagePrefixListOrchestrator._endpoint_classes_for_version()
+    - ManagePrefixListOrchestrator._config_for_version()
     """
 
     def responses():
@@ -170,7 +170,7 @@ def test_manage_prefix_list_00030() -> None:
     instance = ManagePrefixListOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
-        ep_classes = instance._endpoint_classes_for_version("ipv6")
+        ep_classes = instance._config_for_version("ipv6")
 
     assert "get" in ep_classes
     assert "list" in ep_classes
@@ -180,16 +180,16 @@ def test_manage_prefix_list_00040() -> None:
     """
     # Summary
 
-    Verify _endpoint_classes_for_version raises ValueError for unknown ip_version (fail-fast routing).
+    Verify _config_for_version raises ValueError for unknown ip_version (fail-fast routing).
 
     ## Test
 
-    - _endpoint_classes_for_version("invalid") raises ValueError
+    - _config_for_version("invalid") raises ValueError
     - Error message identifies the unknown version
 
     ## Classes and Methods
 
-    - ManagePrefixListOrchestrator._endpoint_classes_for_version()
+    - ManagePrefixListOrchestrator._config_for_version()
     """
 
     def responses():
@@ -200,7 +200,7 @@ def test_manage_prefix_list_00040() -> None:
     instance = ManagePrefixListOrchestrator(rest_send=rest_send)
 
     with pytest.raises(ValueError, match="Unsupported ip_version.*invalid"):
-        instance._endpoint_classes_for_version("invalid")
+        instance._config_for_version("invalid")
 
 
 # =============================================================================
@@ -406,7 +406,7 @@ def test_manage_prefix_list_00100() -> None:
 
     ## Classes and Methods
 
-    - ManagePrefixListOrchestrator._endpoint_classes_for_version()
+    - ManagePrefixListOrchestrator._config_for_version()
     """
 
     def responses():
@@ -416,8 +416,8 @@ def test_manage_prefix_list_00100() -> None:
     rest_send = _build_rest_send(gen_responses)
     instance = ManagePrefixListOrchestrator(rest_send=rest_send)
 
-    ipv4_classes = instance._endpoint_classes_for_version("ipv4")
-    ipv6_classes = instance._endpoint_classes_for_version("ipv6")
+    ipv4_classes = instance._config_for_version("ipv4")
+    ipv6_classes = instance._config_for_version("ipv6")
 
     # Verify they are different classes
     assert ipv4_classes["get"] is not ipv6_classes["get"]
@@ -1120,6 +1120,7 @@ def test_manage_prefix_list_00220() -> None:
     assert rest_send.verb == HttpVerbEnum.GET.value
     assert rest_send.path.endswith("/ipv4PrefixLists/PL-IPV4-BORDERS")
     assert result["name"] == "PL-IPV4-BORDERS"
+    assert result["ipVersion"] == "ipv4"
 
 
 def test_manage_prefix_list_00230() -> None:
@@ -1143,6 +1144,8 @@ def test_manage_prefix_list_00230() -> None:
     model = PrefixListModel.from_config(config)
 
     with does_not_raise():
-        instance.query_one(model)
+        result = instance.query_one(model)
 
     assert rest_send.path.endswith("/ipv4PrefixLists/TENANT1~PL-IPV4-BORDERS")
+    assert result["ipVersion"] == "ipv4"
+    assert result["tenantName"] == "TENANT1"

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -414,3 +414,388 @@ def test_manage_prefix_list_00100() -> None:
     assert ipv4_classes["get"] is not ipv6_classes["get"]
     assert ipv4_classes["list"] is not ipv6_classes["list"]
     assert ipv4_classes["post"] is not ipv6_classes["post"]
+
+
+# =============================================================================
+# Test: fabric_name resolution
+# =============================================================================
+
+
+def test_manage_prefix_list_00110() -> None:
+    """
+    # Summary
+
+    Verify the orchestrator exposes ``fabric_name`` from ``rest_send.params``.
+
+    ## Test
+
+    - ``fabric_name`` resolves to the value supplied in the module params (regression guard: the
+      generic ``NDBaseOrchestrator`` does not define it, so the orchestrator must surface it itself).
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.fabric_name
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    assert instance.fabric_name == "SITE1"
+
+
+# =============================================================================
+# Test: query_all (RestSend-driven)
+# =============================================================================
+
+
+def test_manage_prefix_list_00120() -> None:
+    """
+    # Summary
+
+    Verify ``query_all`` fetches IPv4 then IPv6, injects ``ipVersion`` into each raw row, and that
+    the rows carry the ``entries`` key so ``PrefixListModel.from_response`` can parse them.
+
+    ## Test
+
+    - IPv4 list GET is consumed first, then the IPv6 list GET (``_VERSION_CONFIG`` insertion order).
+    - The combined result has one IPv4 and one IPv6 row, each tagged with ``ipVersion``.
+    - A model built from the IPv4 row exposes its entries (validates the response ``entries`` key).
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.query_all
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("ipv4_prefix_lists_ok")
+        yield responses_manage_prefix_list("ipv6_prefix_lists_ok")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    by_version = {row["ipVersion"]: row for row in result}
+    assert by_version["ipv4"]["name"] == "PL-IPV4-BORDERS"
+    assert by_version["ipv6"]["name"] == "PL-IPV6-DATACENTER"
+
+    # The raw rows must carry the 'entries' key so the model deserialises correctly.
+    ipv4_model = PrefixListModel.from_response(by_version["ipv4"])
+    assert str(ipv4_model.ip_version) == "ipv4"
+    assert ipv4_model.entries is not None
+    assert len(ipv4_model.entries) == 2
+
+
+def test_manage_prefix_list_00130() -> None:
+    """
+    # Summary
+
+    Verify ``query_all`` returns an empty list when both address families are empty.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.query_all
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("empty_ipv4_lists")
+        yield responses_manage_prefix_list("empty_ipv6_lists")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    assert result == []
+
+
+# =============================================================================
+# Test: create / create_bulk (207 Multi-Status)
+# =============================================================================
+
+
+def test_manage_prefix_list_00140() -> None:
+    """
+    # Summary
+
+    Verify ``create_bulk`` (IPv4 only) POSTs to the IPv4 collection endpoint with the
+    ``ipv4PrefixLists`` wrapper key and succeeds on a 207 with all-success results.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.create_bulk
+    - ManagePrefixListOrchestrator._bulk_create_for_version
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("create_ipv4_207_success")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}]}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        result = instance.create_bulk([model])
+
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert rest_send.path.endswith("/ipv4PrefixLists")
+    body = rest_send.committed_payload
+    assert "ipv4PrefixLists" in body
+    assert body["ipv4PrefixLists"][0]["name"] == "PL-IPV4-BORDERS"
+    assert body["ipv4PrefixLists"][0]["entries"][0]["sequenceNumber"] == 10
+    assert "ipv4" in result
+
+
+def test_manage_prefix_list_00150() -> None:
+    """
+    # Summary
+
+    Verify ``create_bulk`` with a mixed IPv4/IPv6 batch issues two POSTs (IPv4 first, then IPv6),
+    each with its own wrapper key.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.create_bulk
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("create_ipv4_207_success")
+        yield responses_manage_prefix_list("create_ipv6_207_success")
+
+    gen_responses = ResponseGenerator(responses())
+    configs = [
+        {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}]},
+        {"ip_version": "ipv6", "name": "PL-IPV6-DATACENTER", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "2001:db8::/32"}]},
+    ]
+    rest_send = _build_rest_send(gen_responses, config=configs)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    models = [PrefixListModel.from_config(c) for c in configs]
+
+    with does_not_raise():
+        result = instance.create_bulk(models)
+
+    # The last request is the IPv6 POST.
+    assert rest_send.path.endswith("/ipv6PrefixLists")
+    assert rest_send.committed_payload["ipv6PrefixLists"][0]["name"] == "PL-IPV6-DATACENTER"
+    assert set(result.keys()) == {"ipv4", "ipv6"}
+
+
+def test_manage_prefix_list_00160() -> None:
+    """
+    # Summary
+
+    Verify ``create_bulk`` raises when the 207 body reports a per-item failure (the controller
+    returns 207 -- transport success -- even when some items fail).
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.create_bulk
+    - ManagePrefixListOrchestrator._raise_on_207_failures
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("create_ipv4_207_partial_failure")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-OK", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}]}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with pytest.raises(Exception, match="per-item failures.*PL-IPV4-BAD"):
+        instance.create_bulk([model])
+
+
+def test_manage_prefix_list_00170() -> None:
+    """
+    # Summary
+
+    Verify ``create`` (single) routes through the bulk create endpoint.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.create
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("create_ipv4_207_success")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}]}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        instance.create(model)
+
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert rest_send.path.endswith("/ipv4PrefixLists")
+    assert rest_send.committed_payload["ipv4PrefixLists"][0]["name"] == "PL-IPV4-BORDERS"
+
+
+# =============================================================================
+# Test: update (PUT)
+# =============================================================================
+
+
+def test_manage_prefix_list_00180() -> None:
+    """
+    # Summary
+
+    Verify ``update`` PUTs to the IPv4 item endpoint using the composite identifier name and the
+    model payload.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.update
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("update_ipv4_prefix_list")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.1.0/24"}]}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.verb == HttpVerbEnum.PUT.value
+    assert rest_send.path.endswith("/ipv4PrefixLists/PL-IPV4-BORDERS")
+    assert rest_send.committed_payload["name"] == "PL-IPV4-BORDERS"
+
+
+# =============================================================================
+# Test: delete / delete_bulk (207 Multi-Status)
+# =============================================================================
+
+
+def test_manage_prefix_list_00190() -> None:
+    """
+    # Summary
+
+    Verify ``delete_bulk`` POSTs the names to the IPv4 bulk-delete action endpoint with the
+    ``ipv4PrefixListNames`` wrapper key and succeeds on a 207 with all-success results.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.delete_bulk
+    - ManagePrefixListOrchestrator._bulk_delete_for_version
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("bulk_delete_ipv4_207_success")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS"}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        result = instance.delete_bulk([model])
+
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert rest_send.path.endswith("/ipv4PrefixListActions/remove")
+    assert rest_send.committed_payload == {"ipv4PrefixListNames": ["PL-IPV4-BORDERS"]}
+    assert "ipv4" in result
+
+
+def test_manage_prefix_list_00200() -> None:
+    """
+    # Summary
+
+    Verify ``delete_bulk`` raises when the 207 body reports a per-item failure.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.delete_bulk
+    - ManagePrefixListOrchestrator._raise_on_207_failures
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("bulk_delete_ipv4_207_partial_failure")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-OK"}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with pytest.raises(Exception, match="per-item failures.*PL-IPV4-BAD"):
+        instance.delete_bulk([model])
+
+
+def test_manage_prefix_list_00210() -> None:
+    """
+    # Summary
+
+    Verify ``delete`` (single) routes through the bulk-delete endpoint.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.delete
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("bulk_delete_ipv4_207_success")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS"}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        instance.delete(model)
+
+    assert rest_send.path.endswith("/ipv4PrefixListActions/remove")
+    assert rest_send.committed_payload == {"ipv4PrefixListNames": ["PL-IPV4-BORDERS"]}
+
+
+# =============================================================================
+# Test: query_one (GET item)
+# =============================================================================
+
+
+def test_manage_prefix_list_00220() -> None:
+    """
+    # Summary
+
+    Verify ``query_one`` GETs the IPv4 item endpoint using the composite identifier name.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.query_one
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("ipv4_single_prefix_list")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS"}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        result = instance.query_one(model)
+
+    assert rest_send.verb == HttpVerbEnum.GET.value
+    assert rest_send.path.endswith("/ipv4PrefixLists/PL-IPV4-BORDERS")
+    assert result["name"] == "PL-IPV4-BORDERS"

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -1,0 +1,416 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for `ManagePrefixListOrchestrator`.
+
+Verifies the orchestrator drives RestSend correctly for prefix list operations.
+Focus: explicit routing with fail-fast for unknown ip_version, centralized split-by-version helper,
+IPv4/IPv6 endpoint delegation, and composite (ip_version, name) identifiers.
+
+Scope: methods defined in manage_prefix_list.py only. Inherited base methods belong in their
+own base-class test module.
+"""
+
+# pylint: disable=disallowed-name,protected-access,redefined-outer-name,too-many-lines
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.manage_prefix_list import PrefixListModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_prefix_list import ManagePrefixListOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_manage_prefix_list(key: str):
+    """Load fixture data for test_manage_prefix_list tests."""
+    return load_fixture("test_manage_prefix_list")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, config: list | None = None) -> RestSend:
+    """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    params = {"check_mode": False, "fabric_name": "SITE1", "config": config or []}
+    rest_send = RestSend(params)
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+# =============================================================================
+# Test: initialization
+# =============================================================================
+
+
+def test_manage_prefix_list_00010() -> None:
+    """
+    # Summary
+
+    Verify `ManagePrefixListOrchestrator` instantiates and exposes expected ClassVars.
+
+    ## Test
+
+    - model_class is PrefixListModel
+    - supports_bulk_create is True
+    - supports_bulk_delete is True
+    - Instance can be created with rest_send
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.__init__()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    assert instance.model_class is PrefixListModel
+    assert instance.supports_bulk_create is True
+    assert instance.supports_bulk_delete is True
+    # rest_send should be accessible
+    assert instance.rest_send is rest_send
+
+
+# =============================================================================
+# Test: _endpoint_classes_for_version helper (explicit routing + fail-fast)
+# =============================================================================
+
+
+def test_manage_prefix_list_00020() -> None:
+    """
+    # Summary
+
+    Verify _endpoint_classes_for_version returns correct endpoint classes for ipv4.
+
+    ## Test
+
+    - _endpoint_classes_for_version("ipv4") returns IPv4 endpoint class dict
+    - Dict includes get, list, post, put, delete, bulk_delete keys
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator._endpoint_classes_for_version()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        ep_classes = instance._endpoint_classes_for_version("ipv4")
+
+    assert "get" in ep_classes
+    assert "list" in ep_classes
+    assert "post" in ep_classes
+    assert "put" in ep_classes
+    assert "delete" in ep_classes
+    assert "bulk_delete" in ep_classes
+
+
+def test_manage_prefix_list_00030() -> None:
+    """
+    # Summary
+
+    Verify _endpoint_classes_for_version returns correct endpoint classes for ipv6.
+
+    ## Test
+
+    - _endpoint_classes_for_version("ipv6") returns IPv6 endpoint class dict
+    - Dict includes get, list, post, put, delete, bulk_delete keys
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator._endpoint_classes_for_version()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        ep_classes = instance._endpoint_classes_for_version("ipv6")
+
+    assert "get" in ep_classes
+    assert "list" in ep_classes
+
+
+def test_manage_prefix_list_00040() -> None:
+    """
+    # Summary
+
+    Verify _endpoint_classes_for_version raises ValueError for unknown ip_version (fail-fast routing).
+
+    ## Test
+
+    - _endpoint_classes_for_version("invalid") raises ValueError
+    - Error message identifies the unknown version
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator._endpoint_classes_for_version()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    with pytest.raises(ValueError, match="Unsupported ip_version.*invalid"):
+        instance._endpoint_classes_for_version("invalid")
+
+
+# =============================================================================
+# Test: _split_by_ip_version helper (centralized grouping + fail-fast)
+# =============================================================================
+
+
+def test_manage_prefix_list_00050() -> None:
+    """
+    # Summary
+
+    Verify _split_by_ip_version groups models by ip_version.
+
+    ## Test
+
+    - Mixed IPv4/IPv6 list is split into two groups
+    - Each group contains only models of that version
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator._split_by_ip_version()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    models = [
+        PrefixListModel(ip_version="ipv4", name="PL-IPV4-1"),
+        PrefixListModel(ip_version="ipv6", name="PL-IPV6-1"),
+        PrefixListModel(ip_version="ipv4", name="PL-IPV4-2"),
+    ]
+
+    with does_not_raise():
+        grouped = instance._split_by_ip_version(models)
+
+    assert "ipv4" in grouped
+    assert "ipv6" in grouped
+    assert len(grouped["ipv4"]) == 2
+    assert len(grouped["ipv6"]) == 1
+    assert grouped["ipv4"][0].name == "PL-IPV4-1"
+    assert grouped["ipv6"][0].name == "PL-IPV6-1"
+
+
+def test_manage_prefix_list_00060() -> None:
+    """
+    # Summary
+
+    Verify _split_by_ip_version groups models by ip_version correctly.
+
+    ## Test
+
+    - Empty list returns empty groups
+    - Mixed models are grouped correctly
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator._split_by_ip_version()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    # Empty list should return empty groups
+    result = instance._split_by_ip_version([])
+    assert result["ipv4"] == []
+    assert result["ipv6"] == []
+
+
+# =============================================================================
+# Test: composite identifier handling
+# =============================================================================
+
+
+def test_manage_prefix_list_00070() -> None:
+    """
+    # Summary
+
+    Verify orchestrator recognizes composite (ip_version, name) identifier.
+
+    ## Test
+
+    - Two models with same name but different ip_version have different identifier values
+    - get_identifier_value() returns (ip_version, name) tuple
+
+    ## Classes and Methods
+
+    - PrefixListModel.get_identifier_value()
+    """
+    ipv4 = PrefixListModel(ip_version="ipv4", name="PL-SHARED")
+    ipv6 = PrefixListModel(ip_version="ipv6", name="PL-SHARED")
+
+    assert ipv4.get_identifier_value() == ("ipv4", "PL-SHARED")
+    assert ipv6.get_identifier_value() == ("ipv6", "PL-SHARED")
+    assert ipv4.get_identifier_value() != ipv6.get_identifier_value()
+
+
+# =============================================================================
+# Test: single model operations (set_identifiers flow)
+# =============================================================================
+
+
+def test_manage_prefix_list_00080() -> None:
+    """
+    # Summary
+
+    Verify model composite identifier is passed correctly to endpoint via set_identifiers.
+
+    ## Test
+
+    - Composite identifier tuple (ip_version, name) is passed to endpoint
+    - Endpoint receives identifier correctly
+
+    ## Classes and Methods
+
+    - PrefixListModel.get_identifier_value()
+    - Endpoint.set_identifiers()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    model = PrefixListModel(ip_version="ipv4", name="PL-TEST")
+    identifier = model.get_identifier_value()
+
+    # Verify identifier is a tuple (ip_version, name)
+    assert isinstance(identifier, tuple)
+    assert len(identifier) == 2
+    assert identifier[0] == "ipv4"
+    assert identifier[1] == "PL-TEST"
+
+
+# =============================================================================
+# Test: bulk operation grouping
+# =============================================================================
+
+
+def test_manage_prefix_list_00090() -> None:
+    """
+    # Summary
+
+    Verify bulk delete groups models by ip_version and calls separate endpoints.
+
+    ## Test
+
+    - Multiple models are grouped by family
+    - Orchestrator would route each group to appropriate endpoint
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator._split_by_ip_version()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    models = [
+        PrefixListModel(ip_version="ipv4", name="PL-IPV4-BORDERS"),
+        PrefixListModel(ip_version="ipv6", name="PL-IPV6-DATACENTER"),
+        PrefixListModel(ip_version="ipv4", name="PL-IPV4-PEERS"),
+    ]
+
+    grouped = instance._split_by_ip_version(models)
+
+    # Verify grouping
+    assert len(grouped["ipv4"]) == 2
+    assert len(grouped["ipv6"]) == 1
+    assert [m.name for m in grouped["ipv4"]] == ["PL-IPV4-BORDERS", "PL-IPV4-PEERS"]
+    assert [m.name for m in grouped["ipv6"]] == ["PL-IPV6-DATACENTER"]
+
+
+# =============================================================================
+# Test: endpoint class correctness
+# =============================================================================
+
+
+def test_manage_prefix_list_00100() -> None:
+    """
+    # Summary
+
+    Verify IPv4 and IPv6 endpoint classes are distinct (ipv4PrefixLists vs ipv6PrefixLists).
+
+    ## Test
+
+    - IPv4 endpoints use ipv4PrefixLists path segment
+    - IPv6 endpoints use ipv6PrefixLists path segment
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator._endpoint_classes_for_version()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    ipv4_classes = instance._endpoint_classes_for_version("ipv4")
+    ipv6_classes = instance._endpoint_classes_for_version("ipv6")
+
+    # Verify they are different classes
+    assert ipv4_classes["get"] is not ipv6_classes["get"]
+    assert ipv4_classes["list"] is not ipv6_classes["list"]
+    assert ipv4_classes["post"] is not ipv6_classes["post"]

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -23,11 +23,12 @@ from __future__ import absolute_import, annotations, division, print_function
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import pytest
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.manage_prefix_list import PrefixListModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_prefix_list import ManagePrefixListOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
 from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
 from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
@@ -40,7 +41,12 @@ def responses_manage_prefix_list(key: str):
     return load_fixture("test_manage_prefix_list")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, config: list | None = None) -> RestSend:
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    config: list | None = None,
+    state: str | None = None,
+    cluster_name: str | None = None,
+) -> RestSend:
     """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
@@ -52,6 +58,10 @@ def _build_rest_send(gen_responses: ResponseGenerator, config: list | None = Non
     response_handler.commit()
 
     params = {"check_mode": False, "fabric_name": "SITE1", "config": config or []}
+    if state is not None:
+        params["state"] = state
+    if cluster_name is not None:
+        params["cluster_name"] = cluster_name
     rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
@@ -519,6 +529,78 @@ def test_manage_prefix_list_00130() -> None:
     assert result == []
 
 
+def test_manage_prefix_list_00135() -> None:
+    """
+    # Summary
+
+    Verify ``query_all`` uses scoped single-item lookups for item states.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.query_all
+    - ManagePrefixListOrchestrator._query_proposed_existing
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("ipv4_single_prefix_list")
+
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS"}
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, config=[config], state="merged")
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    assert len(result) == 1
+    assert result[0]["ipVersion"] == "ipv4"
+    assert rest_send.path.endswith("/ipv4PrefixLists/PL-IPV4-BORDERS")
+
+
+def test_manage_prefix_list_00136() -> None:
+    """
+    # Summary
+
+    Verify full ``query_all`` scans follow offset/max pagination for overridden state.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.query_all
+    - ManagePrefixListOrchestrator._query_all_for_version
+    """
+
+    def responses():
+        yield {
+            "RETURN_CODE": 200,
+            "METHOD": "GET",
+            "MESSAGE": "OK",
+            "DATA": {
+                "ipv4PrefixLists": [{"name": "PL-IPV4-PAGE-1", "entries": []}],
+                "meta": {"counts": {"remaining": 1}},
+            },
+        }
+        yield {
+            "RETURN_CODE": 200,
+            "METHOD": "GET",
+            "MESSAGE": "OK",
+            "DATA": {
+                "ipv4PrefixLists": [{"name": "PL-IPV4-PAGE-2", "entries": []}],
+                "meta": {"counts": {"remaining": 0}},
+            },
+        }
+        yield responses_manage_prefix_list("empty_ipv6_lists")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, state="overridden")
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    assert [row["name"] for row in result] == ["PL-IPV4-PAGE-1", "PL-IPV4-PAGE-2"]
+    assert {row["ipVersion"] for row in result} == {"ipv4"}
+
+
 # =============================================================================
 # Test: create / create_bulk (207 Multi-Status)
 # =============================================================================
@@ -543,7 +625,8 @@ def test_manage_prefix_list_00140() -> None:
     gen_responses = ResponseGenerator(responses())
     config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}]}
     rest_send = _build_rest_send(gen_responses, config=[config])
-    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    results = Results()
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send, results=results)
     model = PrefixListModel.from_config(config)
 
     with does_not_raise():
@@ -556,6 +639,34 @@ def test_manage_prefix_list_00140() -> None:
     assert body["ipv4PrefixLists"][0]["name"] == "PL-IPV4-BORDERS"
     assert body["ipv4PrefixLists"][0]["entries"][0]["sequenceNumber"] == 10
     assert "ipv4" in result
+    assert results.metadata[-1]["action"] == OperationType.CREATE.value
+
+
+def test_manage_prefix_list_00145() -> None:
+    """
+    # Summary
+
+    Verify ``cluster_name`` is applied to mutating endpoint query params.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator._configure_endpoint
+    - ManagePrefixListOrchestrator.create_bulk
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("create_ipv4_207_success")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}]}
+    rest_send = _build_rest_send(gen_responses, config=[config], cluster_name="CLUSTER-1")
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        instance.create_bulk([model])
+
+    assert rest_send.path.endswith("/ipv4PrefixLists?clusterName=CLUSTER-1")
 
 
 def test_manage_prefix_list_00150() -> None:
@@ -669,7 +780,8 @@ def test_manage_prefix_list_00180() -> None:
     gen_responses = ResponseGenerator(responses())
     config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.1.0/24"}]}
     rest_send = _build_rest_send(gen_responses, config=[config])
-    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    results = Results()
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send, results=results)
     model = PrefixListModel.from_config(config)
 
     with does_not_raise():
@@ -678,6 +790,7 @@ def test_manage_prefix_list_00180() -> None:
     assert rest_send.verb == HttpVerbEnum.PUT.value
     assert rest_send.path.endswith("/ipv4PrefixLists/PL-IPV4-BORDERS")
     assert rest_send.committed_payload["name"] == "PL-IPV4-BORDERS"
+    assert results.metadata[-1]["action"] == OperationType.UPDATE.value
 
 
 # =============================================================================
@@ -704,7 +817,8 @@ def test_manage_prefix_list_00190() -> None:
     gen_responses = ResponseGenerator(responses())
     config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS"}
     rest_send = _build_rest_send(gen_responses, config=[config])
-    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    results = Results()
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send, results=results)
     model = PrefixListModel.from_config(config)
 
     with does_not_raise():
@@ -714,6 +828,7 @@ def test_manage_prefix_list_00190() -> None:
     assert rest_send.path.endswith("/ipv4PrefixListActions/remove")
     assert rest_send.committed_payload == {"ipv4PrefixListNames": ["PL-IPV4-BORDERS"]}
     assert "ipv4" in result
+    assert results.metadata[-1]["action"] == OperationType.DELETE.value
 
 
 def test_manage_prefix_list_00200() -> None:

--- a/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_prefix_list.py
@@ -293,7 +293,7 @@ def test_manage_prefix_list_00070() -> None:
     ## Test
 
     - Two models with same name but different ip_version have different identifier values
-    - get_identifier_value() returns (ip_version, name) tuple
+    - get_identifier_value() returns (ip_version, tenant_name, name) tuple
 
     ## Classes and Methods
 
@@ -302,8 +302,8 @@ def test_manage_prefix_list_00070() -> None:
     ipv4 = PrefixListModel(ip_version="ipv4", name="PL-SHARED")
     ipv6 = PrefixListModel(ip_version="ipv6", name="PL-SHARED")
 
-    assert ipv4.get_identifier_value() == ("ipv4", "PL-SHARED")
-    assert ipv6.get_identifier_value() == ("ipv6", "PL-SHARED")
+    assert ipv4.get_identifier_value() == ("ipv4", None, "PL-SHARED")
+    assert ipv6.get_identifier_value() == ("ipv6", None, "PL-SHARED")
     assert ipv4.get_identifier_value() != ipv6.get_identifier_value()
 
 
@@ -339,11 +339,12 @@ def test_manage_prefix_list_00080() -> None:
     model = PrefixListModel(ip_version="ipv4", name="PL-TEST")
     identifier = model.get_identifier_value()
 
-    # Verify identifier is a tuple (ip_version, name)
+    # Verify identifier is a tuple (ip_version, tenant_name, name)
     assert isinstance(identifier, tuple)
-    assert len(identifier) == 2
+    assert len(identifier) == 3
     assert identifier[0] == "ipv4"
-    assert identifier[1] == "PL-TEST"
+    assert identifier[1] is None
+    assert identifier[2] == "PL-TEST"
 
 
 # =============================================================================
@@ -544,7 +545,7 @@ def test_manage_prefix_list_00135() -> None:
     def responses():
         yield responses_manage_prefix_list("ipv4_single_prefix_list")
 
-    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS"}
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS", "entries": [{"sequence_number": 10, "action": "permit", "prefix": "10.0.0.0/8"}]}
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses, config=[config], state="merged")
     instance = ManagePrefixListOrchestrator(rest_send=rest_send)
@@ -555,6 +556,30 @@ def test_manage_prefix_list_00135() -> None:
     assert len(result) == 1
     assert result[0]["ipVersion"] == "ipv4"
     assert rest_send.path.endswith("/ipv4PrefixLists/PL-IPV4-BORDERS")
+
+
+def test_manage_prefix_list_00137() -> None:
+    """
+    # Summary
+
+    Verify ``query_all`` rejects write-state configs without entries before API reads.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.query_all
+    - PrefixListModel.validate_config_for_state
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("ipv4_single_prefix_list")
+
+    config = {"ip_version": "ipv4", "name": "PL-IPV4-BORDERS"}
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, config=[config], state="merged")
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+
+    with pytest.raises(Exception, match="entries is required"):
+        instance.query_all()
 
 
 def test_manage_prefix_list_00136() -> None:
@@ -883,6 +908,33 @@ def test_manage_prefix_list_00210() -> None:
     assert rest_send.committed_payload == {"ipv4PrefixListNames": ["PL-IPV4-BORDERS"]}
 
 
+def test_manage_prefix_list_00215() -> None:
+    """
+    # Summary
+
+    Verify tenant-scoped bulk delete sends fully qualified prefix list names.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.delete_bulk
+    - PrefixListModel.api_name
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("bulk_delete_ipv4_207_success")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "tenant_name": "TENANT1", "name": "PL-IPV4-BORDERS"}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        instance.delete_bulk([model])
+
+    assert rest_send.committed_payload == {"ipv4PrefixListNames": ["TENANT1~PL-IPV4-BORDERS"]}
+
+
 # =============================================================================
 # Test: query_one (GET item)
 # =============================================================================
@@ -914,3 +966,29 @@ def test_manage_prefix_list_00220() -> None:
     assert rest_send.verb == HttpVerbEnum.GET.value
     assert rest_send.path.endswith("/ipv4PrefixLists/PL-IPV4-BORDERS")
     assert result["name"] == "PL-IPV4-BORDERS"
+
+
+def test_manage_prefix_list_00230() -> None:
+    """
+    # Summary
+
+    Verify ``query_one`` GETs tenant-scoped prefix lists by fully qualified API name.
+
+    ## Classes and Methods
+
+    - ManagePrefixListOrchestrator.query_one
+    """
+
+    def responses():
+        yield responses_manage_prefix_list("ipv4_single_prefix_list")
+
+    gen_responses = ResponseGenerator(responses())
+    config = {"ip_version": "ipv4", "tenant_name": "TENANT1", "name": "PL-IPV4-BORDERS"}
+    rest_send = _build_rest_send(gen_responses, config=[config])
+    instance = ManagePrefixListOrchestrator(rest_send=rest_send)
+    model = PrefixListModel.from_config(config)
+
+    with does_not_raise():
+        instance.query_one(model)
+
+    assert rest_send.path.endswith("/ipv4PrefixLists/TENANT1~PL-IPV4-BORDERS")

--- a/tests/unit/modules/test_nd_manage_prefix_list.py
+++ b/tests/unit/modules/test_nd_manage_prefix_list.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+
+from ansible_collections.cisco.nd.plugins.modules import nd_manage_prefix_list
+
+
+EXPECTED_RETURN_KEYS = (
+    "changed",
+    "output_level",
+    "before",
+    "after",
+    "diff",
+    "proposed",
+    "logs",
+    "msg",
+)
+
+
+def _return_entry(name: str) -> str:
+    pattern = rf"^{name}:\n(?P<body>(?:  .+\n)+)"
+    match = re.search(pattern, nd_manage_prefix_list.RETURN, re.MULTILINE)
+    assert match is not None, f"{name!r} is missing from RETURN"
+    return match.group("body")
+
+
+def test_nd_manage_prefix_list_return_documents_state_machine_contract() -> None:
+    for key in EXPECTED_RETURN_KEYS:
+        body = _return_entry(key)
+        assert "description:" in body
+        assert "returned:" in body
+        assert "type:" in body
+
+    assert "elements: dict" in _return_entry("before")
+    assert "elements: dict" in _return_entry("after")
+    assert "elements: dict" in _return_entry("diff")
+    assert "elements: dict" in _return_entry("proposed")
+    assert "elements: str" in _return_entry("logs")

--- a/tests/unit/modules/test_nd_manage_prefix_list.py
+++ b/tests/unit/modules/test_nd_manage_prefix_list.py
@@ -4,7 +4,6 @@ import re
 
 from ansible_collections.cisco.nd.plugins.modules import nd_manage_prefix_list
 
-
 EXPECTED_RETURN_KEYS = (
     "changed",
     "output_level",


### PR DESCRIPTION
## Related Issue(s)

- CiscoDevNet/ansible-nd#239

## Proposed Changes
Add new module `nd_manage_prefix_list` to manage IPv4 and IPv6 Routing Policies prefix lists on Cisco Nexus Dashboard fabrics. A single module handles both address families via `config.ip_version`, supporting `merged`, `replaced`, `overridden`, and `deleted` states with check mode.

Full module stack added under the current Pydantic/orchestrator architecture:
- Module: `plugins/modules/nd_manage_prefix_list.py`
- Endpoints: `endpoints/v1/manage/manage_prefix_lists.py` (IPv4/IPv6 CRUD + bulk-create/bulk-delete actions, shared bases) and a new `PrefixListNameMixin` in `endpoints/mixins.py`
- Models: `models/manage_prefix_list/` (model + enums, reusing shared CIDR/ASCII validated types, with entry-level semantic guardrails)
- Orchestrator: `orchestrators/manage_prefix_list.py` (per-version routing, bulk create/delete, HTTP 207 multi-status per-item failure parsing)

Notes: bulk create/delete are issued per address family; tenant-scoped prefix lists are documented as a known idempotency limitation.

## Test Notes
- Unit tests for endpoint, model, and orchestrator (RestSend-driven CRUD/bulk/207/query_all) plus fixtures; full `module_utils` unit suite passes.
- Integration target `nd_manage_prefix_list` covering setup/merged/replaced/overridden/deleted (incl. idempotency, identifier-only delete, multi-family in one task).
- `ansible-test sanity` passes (pep8, pylint, etc.).

## Cisco Nexus Dashboard Version
Nexus Dashboard 4.2.1+

## Related ND API Resource Category
<!-- Please select ND API resource category, please specify -->
* [ ] analyze
* [ ] infa
* [x] manage
* [ ] onemanage
* [ ] other


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers