### PR TITLE
[ND 4.2+] Add modules for both Routing Policies Community Lists and Extended Community Lists (NDA-28)

### DIFF
--- a/plugins/module_utils/endpoints/mixins.py
+++ b/plugins/module_utils/endpoints/mixins.py
@@ -131,6 +131,17 @@ class RouteMapNameMixin(BaseModel):
 
     route_map_name: str | None = Field(default=None, min_length=1, max_length=115, description="Route map name")
 
+class CommunityListNameMixin(BaseModel):
+    """Mixin for endpoints that require community_list_name parameter."""
+
+    community_list_name: str | None = Field(default=None, min_length=1, max_length=115, description="Community list name")
+
+
+class ExtendedCommunityListNameMixin(BaseModel):
+    """Mixin for endpoints that require extended_community_list_name parameter."""
+
+    extended_community_list_name: str | None = Field(default=None, min_length=1, max_length=115, description="Extended community list name")
+
 
 class TenantNameMixin(BaseModel):
     """Mixin for endpoints that require tenant_name parameter."""

--- a/plugins/module_utils/endpoints/mixins.py
+++ b/plugins/module_utils/endpoints/mixins.py
@@ -131,6 +131,7 @@ class RouteMapNameMixin(BaseModel):
 
     route_map_name: str | None = Field(default=None, min_length=1, max_length=115, description="Route map name")
 
+
 class CommunityListNameMixin(BaseModel):
     """Mixin for endpoints that require community_list_name parameter."""
 

--- a/plugins/module_utils/endpoints/mixins.py
+++ b/plugins/module_utils/endpoints/mixins.py
@@ -9,7 +9,7 @@ This module provides mixin classes that can be composed to add common
 fields to endpoint models without duplication.
 """
 
-from __future__ import absolute_import, annotations, division, print_function
+from __future__ import annotations
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     BaseModel,

--- a/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
@@ -27,8 +27,6 @@ in the ND Manage API.
 
 from __future__ import annotations
 
-__metaclass__ = type
-
 from typing import ClassVar, Literal
 from urllib.parse import quote
 

--- a/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
@@ -32,24 +32,17 @@ from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ConfigDict, Field
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import CommunityListNameMixin, FabricNameMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import ClusterNameMixin, CommunityListNameMixin, FabricNameMixin
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import CompositeQueryParams, EndpointQueryParams, LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
 
-class CommunityListsEndpointParams(EndpointQueryParams):
+class CommunityListsEndpointParams(ClusterNameMixin, EndpointQueryParams):
     """Query parameters common to community list endpoints."""
 
     model_config = ConfigDict(extra="forbid")
-
-    cluster_name: str | None = Field(
-        default=None,
-        min_length=1,
-        description="Name of the target Nexus Dashboard cluster in a multi-cluster deployment",
-    )
-
 
 class _EpManageCommunityListsBase(FabricNameMixin, CommunityListNameMixin, NDEndpointBaseModel):
     """

--- a/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
@@ -44,6 +44,7 @@ class CommunityListsEndpointParams(ClusterNameMixin, EndpointQueryParams):
 
     model_config = ConfigDict(extra="forbid")
 
+
 class _EpManageCommunityListsBase(FabricNameMixin, CommunityListNameMixin, NDEndpointBaseModel):
     """
     Base class for ND Manage Community Lists endpoints.

--- a/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+ND Manage Community Lists endpoint models.
+
+This module contains endpoint definitions for community list operations
+in the ND Manage API.
+
+## Endpoints
+
+- `EpManageCommunityListsGet` - Get a specific community list by name
+  (GET /api/v1/manage/fabrics/{fabricName}/communityLists/{communityListName})
+- `EpManageCommunityListsListGet` - List all community lists for a fabric
+  (GET /api/v1/manage/fabrics/{fabricName}/communityLists)
+- `EpManageCommunityListsPost` - Bulk create community lists
+  (POST /api/v1/manage/fabrics/{fabricName}/communityLists)
+- `EpManageCommunityListsPut` - Update a specific community list
+  (PUT /api/v1/manage/fabrics/{fabricName}/communityLists/{communityListName})
+- `EpManageCommunityListsDelete` - Delete a specific community list
+  (DELETE /api/v1/manage/fabrics/{fabricName}/communityLists/{communityListName})
+- `EpManageCommunityListsBulkDelete` - Bulk delete community lists via action endpoint
+  (POST /api/v1/manage/fabrics/{fabricName}/communityListActions/remove)
+"""
+
+from __future__ import annotations
+
+__metaclass__ = type
+
+from typing import ClassVar, Literal
+from urllib.parse import quote
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import CommunityListNameMixin, FabricNameMixin, FromClusterMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import CompositeQueryParams, EndpointQueryParams, LuceneQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
+
+
+class CommunityListsEndpointParams(FromClusterMixin, EndpointQueryParams):
+    """Query parameters common to community list endpoints."""
+
+
+class _EpManageCommunityListsBase(FabricNameMixin, CommunityListNameMixin, NDEndpointBaseModel):
+    """
+    Base class for ND Manage Community Lists endpoints.
+
+    Provides common functionality for all HTTP methods on the
+    /api/v1/manage/fabrics/{fabricName}/communityLists endpoint.
+
+    Subclasses may override:
+    - ``_require_community_list_name``: set to ``False`` for collection-level
+      endpoints (list, bulk create) that do not include the list name in the path.
+    """
+
+    _require_community_list_name: ClassVar[bool] = True
+
+    endpoint_params: CommunityListsEndpointParams = Field(
+        default_factory=CommunityListsEndpointParams,
+        description="Endpoint-specific query parameters",
+    )
+
+    def set_identifiers(self, identifier: IdentifierKey = None):
+        """Assign the community list name from the model identifier."""
+        self.community_list_name = identifier
+
+    @property
+    def path(self) -> str:
+        """
+        Build the endpoint path for community list operations.
+
+        Raises:
+            ValueError: if ``fabric_name`` is not set.
+            ValueError: if ``community_list_name`` is required but not set.
+        """
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        if self._require_community_list_name and self.community_list_name is None:
+            raise ValueError(f"{type(self).__name__}.path: community_list_name must be set before accessing path.")
+        segments = ["fabrics", quote(self.fabric_name, safe=""), "communityLists"]
+        if self._require_community_list_name and self.community_list_name is not None:
+            segments.append(quote(self.community_list_name, safe=""))
+        base_path = BasePath.path(*segments)
+        query_params = CompositeQueryParams().add(self.endpoint_params)
+        lucene_params = getattr(self, "lucene_params", None)
+        if lucene_params is not None:
+            query_params.add(lucene_params)
+        query_string = query_params.to_query_string()
+        if query_string:
+            return f"{base_path}?{query_string}"
+        return base_path
+
+
+class EpManageCommunityListsGet(_EpManageCommunityListsBase):
+    """
+    ND Manage Community Lists GET Endpoint.
+
+    Retrieves details for a specific community list by name.
+
+    Path: GET /api/v1/manage/fabrics/{fabricName}/communityLists/{communityListName}
+    """
+
+    class_name: Literal["EpManageCommunityListsGet"] = Field(
+        default="EpManageCommunityListsGet",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.GET
+
+
+class EpManageCommunityListsListGet(_EpManageCommunityListsBase):
+    """
+    ND Manage Community Lists List GET Endpoint.
+
+    Retrieves all community lists for a given fabric.
+
+    Path: GET /api/v1/manage/fabrics/{fabricName}/communityLists
+    """
+
+    _require_community_list_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageCommunityListsListGet"] = Field(
+        default="EpManageCommunityListsListGet",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+    lucene_params: LuceneQueryParams = Field(default_factory=LuceneQueryParams, description="Lucene-style query parameters for filtering")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.GET
+
+
+class EpManageCommunityListsPost(_EpManageCommunityListsBase):
+    """
+    ND Manage Community Lists POST Endpoint.
+
+    Bulk-creates one or more community lists.
+    Request body: ``{"communityLists": [...]}``
+
+    Path: POST /api/v1/manage/fabrics/{fabricName}/communityLists
+    """
+
+    _require_community_list_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageCommunityListsPost"] = Field(
+        default="EpManageCommunityListsPost",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.POST
+
+
+class EpManageCommunityListsPut(_EpManageCommunityListsBase):
+    """
+    ND Manage Community Lists PUT Endpoint.
+
+    Updates an existing community list.
+
+    Path: PUT /api/v1/manage/fabrics/{fabricName}/communityLists/{communityListName}
+    """
+
+    class_name: Literal["EpManageCommunityListsPut"] = Field(
+        default="EpManageCommunityListsPut",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.PUT
+
+
+class EpManageCommunityListsDelete(_EpManageCommunityListsBase):
+    """
+    ND Manage Community Lists DELETE Endpoint.
+
+    Deletes a specific community list by name.
+
+    Path: DELETE /api/v1/manage/fabrics/{fabricName}/communityLists/{communityListName}
+    """
+
+    class_name: Literal["EpManageCommunityListsDelete"] = Field(
+        default="EpManageCommunityListsDelete",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.DELETE
+
+
+class _EpManageCommunityListsBulkDeleteBase(FabricNameMixin, NDEndpointBaseModel):
+    """
+    Base class for the community list bulk-delete action endpoint.
+
+    Path: /api/v1/manage/fabrics/{fabricName}/communityListActions/remove
+    """
+
+    endpoint_params: CommunityListsEndpointParams = Field(
+        default_factory=CommunityListsEndpointParams,
+        description="Endpoint-specific query parameters",
+    )
+
+    def set_identifiers(self, identifier: IdentifierKey = None):
+        """No-op: bulk delete endpoint has no per-resource identifier in the path."""
+
+    @property
+    def path(self) -> str:
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        base_path = BasePath.path("fabrics", quote(self.fabric_name, safe=""), "communityListActions", "remove")
+        query_string = self.endpoint_params.to_query_string()
+        if query_string:
+            return f"{base_path}?{query_string}"
+        return base_path
+
+
+class EpManageCommunityListsBulkDelete(_EpManageCommunityListsBulkDeleteBase):
+    """
+    ND Manage Community Lists Bulk Delete Endpoint.
+
+    Bulk-deletes community lists by name.
+    Request body: ``{"communityListNames": [...]}``
+
+    Path: POST /api/v1/manage/fabrics/{fabricName}/communityListActions/remove
+    """
+
+    class_name: Literal["EpManageCommunityListsBulkDelete"] = Field(
+        default="EpManageCommunityListsBulkDelete",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.POST

--- a/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_community_lists.py
@@ -30,17 +30,25 @@ from __future__ import annotations
 from typing import ClassVar, Literal
 from urllib.parse import quote
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ConfigDict, Field
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import CommunityListNameMixin, FabricNameMixin, FromClusterMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import CommunityListNameMixin, FabricNameMixin
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import CompositeQueryParams, EndpointQueryParams, LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
 
-class CommunityListsEndpointParams(FromClusterMixin, EndpointQueryParams):
+class CommunityListsEndpointParams(EndpointQueryParams):
     """Query parameters common to community list endpoints."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    cluster_name: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Name of the target Nexus Dashboard cluster in a multi-cluster deployment",
+    )
 
 
 class _EpManageCommunityListsBase(FabricNameMixin, CommunityListNameMixin, NDEndpointBaseModel):

--- a/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
@@ -27,8 +27,6 @@ in the ND Manage API.
 
 from __future__ import annotations
 
-__metaclass__ = type
-
 from typing import ClassVar, Literal
 from urllib.parse import quote
 

--- a/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
@@ -32,24 +32,17 @@ from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ConfigDict, Field
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import ExtendedCommunityListNameMixin, FabricNameMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import ClusterNameMixin, ExtendedCommunityListNameMixin, FabricNameMixin
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import CompositeQueryParams, EndpointQueryParams, LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
 
-class ExtendedCommunityListsEndpointParams(EndpointQueryParams):
+class ExtendedCommunityListsEndpointParams(ClusterNameMixin, EndpointQueryParams):
     """Query parameters common to extended community list endpoints."""
 
     model_config = ConfigDict(extra="forbid")
-
-    cluster_name: str | None = Field(
-        default=None,
-        min_length=1,
-        description="Name of the target Nexus Dashboard cluster in a multi-cluster deployment",
-    )
-
 
 class _EpManageExtendedCommunityListsBase(FabricNameMixin, ExtendedCommunityListNameMixin, NDEndpointBaseModel):
     """

--- a/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+ND Manage Extended Community Lists endpoint models.
+
+This module contains endpoint definitions for extended community list operations
+in the ND Manage API.
+
+## Endpoints
+
+- `EpManageExtendedCommunityListsGet` - Get a specific extended community list by name
+  (GET /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists/{extendedCommunityListName})
+- `EpManageExtendedCommunityListsListGet` - List all extended community lists for a fabric
+  (GET /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists)
+- `EpManageExtendedCommunityListsPost` - Bulk create extended community lists
+  (POST /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists)
+- `EpManageExtendedCommunityListsPut` - Update a specific extended community list
+  (PUT /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists/{extendedCommunityListName})
+- `EpManageExtendedCommunityListsDelete` - Delete a specific extended community list
+  (DELETE /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists/{extendedCommunityListName})
+- `EpManageExtendedCommunityListsBulkDelete` - Bulk delete via action endpoint
+  (POST /api/v1/manage/fabrics/{fabricName}/extendedCommunityListActions/remove)
+"""
+
+from __future__ import annotations
+
+__metaclass__ = type
+
+from typing import ClassVar, Literal
+from urllib.parse import quote
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import ExtendedCommunityListNameMixin, FabricNameMixin, FromClusterMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import CompositeQueryParams, EndpointQueryParams, LuceneQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
+
+
+class ExtendedCommunityListsEndpointParams(FromClusterMixin, EndpointQueryParams):
+    """Query parameters common to extended community list endpoints."""
+
+
+class _EpManageExtendedCommunityListsBase(FabricNameMixin, ExtendedCommunityListNameMixin, NDEndpointBaseModel):
+    """
+    Base class for ND Manage Extended Community Lists endpoints.
+
+    Provides common path-building logic for all HTTP methods on the
+    /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists endpoint.
+
+    Subclasses may override:
+    - ``_require_extended_community_list_name``: set to ``False`` for
+      collection-level endpoints (list, bulk create) that do not include
+      the list name in the path.
+    """
+
+    _require_extended_community_list_name: ClassVar[bool] = True
+
+    endpoint_params: ExtendedCommunityListsEndpointParams = Field(
+        default_factory=ExtendedCommunityListsEndpointParams,
+        description="Endpoint-specific query parameters",
+    )
+
+    def set_identifiers(self, identifier: IdentifierKey = None):
+        """Assign the extended community list name from the model identifier."""
+        self.extended_community_list_name = identifier
+
+    @property
+    def path(self) -> str:
+        """
+        Build the endpoint path for extended community list operations.
+
+        Raises:
+            ValueError: if ``fabric_name`` is not set.
+            ValueError: if ``extended_community_list_name`` is required but not set.
+        """
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        if self._require_extended_community_list_name and self.extended_community_list_name is None:
+            raise ValueError(f"{type(self).__name__}.path: extended_community_list_name must be set before accessing path.")
+        segments = ["fabrics", quote(self.fabric_name, safe=""), "extendedCommunityLists"]
+        if self._require_extended_community_list_name and self.extended_community_list_name is not None:
+            segments.append(quote(self.extended_community_list_name, safe=""))
+        base_path = BasePath.path(*segments)
+        query_params = CompositeQueryParams().add(self.endpoint_params)
+        lucene_params = getattr(self, "lucene_params", None)
+        if lucene_params is not None:
+            query_params.add(lucene_params)
+        query_string = query_params.to_query_string()
+        if query_string:
+            return f"{base_path}?{query_string}"
+        return base_path
+
+
+class EpManageExtendedCommunityListsGet(_EpManageExtendedCommunityListsBase):
+    """
+    ND Manage Extended Community Lists GET Endpoint.
+
+    Retrieves details for a specific extended community list by name.
+
+    Path: GET /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists/{extendedCommunityListName}
+    """
+
+    class_name: Literal["EpManageExtendedCommunityListsGet"] = Field(
+        default="EpManageExtendedCommunityListsGet",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.GET
+
+
+class EpManageExtendedCommunityListsListGet(_EpManageExtendedCommunityListsBase):
+    """
+    ND Manage Extended Community Lists List GET Endpoint.
+
+    Retrieves all extended community lists for a given fabric.
+
+    Path: GET /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists
+    """
+
+    _require_extended_community_list_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageExtendedCommunityListsListGet"] = Field(
+        default="EpManageExtendedCommunityListsListGet",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+    lucene_params: LuceneQueryParams = Field(default_factory=LuceneQueryParams, description="Lucene-style query parameters for filtering")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.GET
+
+
+class EpManageExtendedCommunityListsPost(_EpManageExtendedCommunityListsBase):
+    """
+    ND Manage Extended Community Lists POST Endpoint.
+
+    Bulk-creates one or more extended community lists.
+    Request body: ``{"extendedCommunityLists": [...]}``
+
+    Path: POST /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists
+    """
+
+    _require_extended_community_list_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageExtendedCommunityListsPost"] = Field(
+        default="EpManageExtendedCommunityListsPost",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.POST
+
+
+class EpManageExtendedCommunityListsPut(_EpManageExtendedCommunityListsBase):
+    """
+    ND Manage Extended Community Lists PUT Endpoint.
+
+    Updates an existing extended community list.
+
+    Path: PUT /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists/{extendedCommunityListName}
+    """
+
+    class_name: Literal["EpManageExtendedCommunityListsPut"] = Field(
+        default="EpManageExtendedCommunityListsPut",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.PUT
+
+
+class EpManageExtendedCommunityListsDelete(_EpManageExtendedCommunityListsBase):
+    """
+    ND Manage Extended Community Lists DELETE Endpoint.
+
+    Deletes a specific extended community list by name.
+
+    Path: DELETE /api/v1/manage/fabrics/{fabricName}/extendedCommunityLists/{extendedCommunityListName}
+    """
+
+    class_name: Literal["EpManageExtendedCommunityListsDelete"] = Field(
+        default="EpManageExtendedCommunityListsDelete",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.DELETE
+
+
+class _EpManageExtendedCommunityListsBulkDeleteBase(FabricNameMixin, NDEndpointBaseModel):
+    """
+    Base for the extended community list bulk-delete action endpoint.
+
+    Path: /api/v1/manage/fabrics/{fabricName}/extendedCommunityListActions/remove
+    """
+
+    endpoint_params: ExtendedCommunityListsEndpointParams = Field(
+        default_factory=ExtendedCommunityListsEndpointParams,
+        description="Endpoint-specific query parameters",
+    )
+
+    def set_identifiers(self, identifier: IdentifierKey = None):
+        """No-op: bulk delete endpoint has no per-resource identifier in the path."""
+
+    @property
+    def path(self) -> str:
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        base_path = BasePath.path("fabrics", quote(self.fabric_name, safe=""), "extendedCommunityListActions", "remove")
+        query_string = self.endpoint_params.to_query_string()
+        if query_string:
+            return f"{base_path}?{query_string}"
+        return base_path
+
+
+class EpManageExtendedCommunityListsBulkDelete(_EpManageExtendedCommunityListsBulkDeleteBase):
+    """
+    ND Manage Extended Community Lists Bulk Delete Endpoint.
+
+    Bulk-deletes extended community lists by name.
+    Request body: ``{"extendedCommunityListNames": [...]}``
+
+    Path: POST /api/v1/manage/fabrics/{fabricName}/extendedCommunityListActions/remove
+    """
+
+    class_name: Literal["EpManageExtendedCommunityListsBulkDelete"] = Field(
+        default="EpManageExtendedCommunityListsBulkDelete",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.POST

--- a/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
@@ -44,6 +44,7 @@ class ExtendedCommunityListsEndpointParams(ClusterNameMixin, EndpointQueryParams
 
     model_config = ConfigDict(extra="forbid")
 
+
 class _EpManageExtendedCommunityListsBase(FabricNameMixin, ExtendedCommunityListNameMixin, NDEndpointBaseModel):
     """
     Base class for ND Manage Extended Community Lists endpoints.

--- a/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_extended_community_lists.py
@@ -30,17 +30,25 @@ from __future__ import annotations
 from typing import ClassVar, Literal
 from urllib.parse import quote
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ConfigDict, Field
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import ExtendedCommunityListNameMixin, FabricNameMixin, FromClusterMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import ExtendedCommunityListNameMixin, FabricNameMixin
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import CompositeQueryParams, EndpointQueryParams, LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
 
-class ExtendedCommunityListsEndpointParams(FromClusterMixin, EndpointQueryParams):
+class ExtendedCommunityListsEndpointParams(EndpointQueryParams):
     """Query parameters common to extended community list endpoints."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    cluster_name: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Name of the target Nexus Dashboard cluster in a multi-cluster deployment",
+    )
 
 
 class _EpManageExtendedCommunityListsBase(FabricNameMixin, ExtendedCommunityListNameMixin, NDEndpointBaseModel):

--- a/plugins/module_utils/models/manage_community_list/enums.py
+++ b/plugins/module_utils/models/manage_community_list/enums.py
@@ -9,8 +9,6 @@ Enum definitions for the nd_manage_community_list module.
 
 from __future__ import annotations
 
-__metaclass__ = type
-
 from enum import Enum
 
 

--- a/plugins/module_utils/models/manage_community_list/enums.py
+++ b/plugins/module_utils/models/manage_community_list/enums.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+Enum definitions for the nd_manage_community_list module.
+"""
+
+from __future__ import annotations
+
+__metaclass__ = type
+
+from enum import Enum
+
+
+class CommunityListTypeEnum(str, Enum):
+    """
+    Enumeration of community list types.
+
+    - STANDARD: Standard community list - matches well-known communities and/or
+      ASN:NN community numbers.
+    - EXPANDED: Expanded community list - matches communities using a regular
+      expression on the community string.
+    """
+
+    STANDARD = "standard"
+    EXPANDED = "expanded"
+
+
+class CommunityListActionEnum(str, Enum):
+    """
+    Enumeration of permit/deny actions for community list entries.
+
+    - PERMIT: Allow routes matching the entry.
+    - DENY: Reject routes matching the entry.
+    """
+
+    PERMIT = "permit"
+    DENY = "deny"

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -58,6 +58,14 @@ _STANDARD_FALSE_DEFAULT_ALIASES = (
     "gracefulShutdown",
     "localAsn",
 )
+_STANDARD_WELL_KNOWN_FIELDS = (
+    "no_advertise",
+    "blackhole",
+    "no_export",
+    "internet",
+    "graceful_shutdown",
+    "local_asn",
+)
 
 
 class CommunityListEntryModel(NDNestedModel):
@@ -334,6 +342,14 @@ class CommunityListModel(NDBaseModel):
                         f"entries[{i}].community_number_regex must not be set "
                         "for type='standard'. Use community_numbers or "
                         "well-known community flags instead."
+                    )
+                has_community_number = bool(entry.community_numbers)
+                has_well_known_flag = any(getattr(entry, field_name) is True for field_name in _STANDARD_WELL_KNOWN_FIELDS)
+                if not has_community_number and not has_well_known_flag:
+                    raise ValueError(
+                        f"entries[{i}] must set at least one community number or "
+                        "enable at least one well-known community flag for "
+                        "type='standard'."
                     )
         return self
 

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -30,6 +30,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNe
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     ConfigDict,
     Field,
+    ValidationInfo,
     field_validator,
     model_validator,
 )
@@ -267,7 +268,7 @@ class CommunityListModel(NDBaseModel):
         return self
 
     @model_validator(mode="after")
-    def validate_entries_match_type(self):
+    def validate_entries_match_type(self, info: ValidationInfo):
         """
         Cross-validate entries against the declared community list type.
 
@@ -275,6 +276,9 @@ class CommunityListModel(NDBaseModel):
           Standard-only fields (community_numbers, well-known flags) MUST NOT be set.
         - For *standard* lists entries MUST NOT have community_number_regex set.
         """
+        if (info.context or {}).get("mode") == "response":
+            return self
+
         standard_only_fields = {
             "no_advertise",
             "blackhole",

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -268,6 +268,17 @@ class CommunityListModel(NDBaseModel):
         return self
 
     @model_validator(mode="after")
+    def validate_required_for_write_states(self, info: ValidationInfo) -> "CommunityListModel":
+        """Require the API body fields for write states while allowing name-only deletes."""
+        state = (info.context or {}).get("state")
+        if state in ("merged", "replaced", "overridden"):
+            missing = [field_name for field_name in ("type", "entries") if getattr(self, field_name) is None]
+            if missing:
+                verb = "is" if len(missing) == 1 else "are"
+                raise ValueError(f"community list '{self.api_name}': '{', '.join(missing)}' {verb} required for state '{state}'.")
+        return self
+
+    @model_validator(mode="after")
     def validate_entries_match_type(self, info: ValidationInfo):
         """
         Cross-validate entries against the declared community list type.

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -343,6 +343,7 @@ class CommunityListModel(NDBaseModel):
     def get_argument_spec(cls) -> dict:
         return dict(
             fabric_name=dict(type="str", required=True),
+            cluster_name=dict(type="str"),
             config=dict(
                 type="list",
                 elements="dict",

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -23,7 +23,7 @@ entry constraints.
 from __future__ import annotations
 
 import re
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
@@ -47,6 +47,8 @@ _COMMUNITY_NUMBER_RE = re.compile(
 
 # Regex for expanded community-list entries: must not start with [a-zA-Z~!#%@`;]
 _COMMUNITY_REGEX_RE = re.compile(r"^[^a-zA-Z~!#%@`;].*$")
+DEFAULT_TENANT_COMMUNITY_LIST_NAME_MAX_LENGTH = 63
+TENANT_COMMUNITY_LIST_API_NAME_MAX_LENGTH = 115
 
 
 class CommunityListEntryModel(NDNestedModel):
@@ -159,10 +161,10 @@ class CommunityListModel(NDBaseModel):
     discriminates between them and a ``model_validator`` enforces the
     type-specific entry constraints.
 
-    Identifier strategy: ``single`` on ``name``.
+    Identifier strategy: ``single`` on the fully qualified ``api_name``.
     """
 
-    identifiers: ClassVar[list[str] | None] = ["name"]
+    identifiers: ClassVar[list[str] | None] = ["api_name"]
     identifier_strategy: ClassVar[str] = "single"
 
     # Read-only timestamp excluded from payloads and diffs
@@ -211,6 +213,20 @@ class CommunityListModel(NDBaseModel):
         min_length=1,
     )
 
+    @property
+    def api_name(self) -> str:
+        """Return the community-list name used in API paths and delete payloads."""
+        if self.tenant_name and not self.name.startswith(f"{self.tenant_name}~"):
+            return f"{self.tenant_name}~{self.name}"
+        return self.name
+
+    def to_payload(self, **kwargs) -> dict[str, Any]:
+        """Export an API payload with a fully qualified tenant-scoped name."""
+        data = super().to_payload(**kwargs)
+        if self.tenant_name:
+            data["name"] = self.api_name
+        return data
+
     @field_validator("name", mode="before")
     @classmethod
     def validate_name(cls, v):
@@ -230,6 +246,25 @@ class CommunityListModel(NDBaseModel):
         if not pattern.match(str(v)):
             raise ValueError(f"tenant_name '{v}' contains invalid characters. " "Allowed: [A-Za-z0-9_-].")
         return v
+
+    @model_validator(mode="after")
+    def normalize_and_validate_name(self) -> "CommunityListModel":
+        """Store tenant-scoped lists with a bare config name and validate API name limits."""
+        if self.tenant_name:
+            prefix = f"{self.tenant_name}~"
+            if self.name.startswith(prefix):
+                self.name = self.name[len(prefix) :]
+            if len(self.api_name) > TENANT_COMMUNITY_LIST_API_NAME_MAX_LENGTH:
+                raise ValueError(
+                    f"tenant-scoped community list API name '{self.api_name}' must be "
+                    f"{TENANT_COMMUNITY_LIST_API_NAME_MAX_LENGTH} characters or fewer."
+                )
+        elif len(self.name) > DEFAULT_TENANT_COMMUNITY_LIST_NAME_MAX_LENGTH:
+            raise ValueError(
+                f"default-tenant community list name '{self.name}' must be "
+                f"{DEFAULT_TENANT_COMMUNITY_LIST_NAME_MAX_LENGTH} characters or fewer."
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_entries_match_type(self):

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -50,6 +50,14 @@ _COMMUNITY_NUMBER_RE = re.compile(
 _COMMUNITY_REGEX_RE = re.compile(r"^[^a-zA-Z~!#%@`;].*$")
 DEFAULT_TENANT_COMMUNITY_LIST_NAME_MAX_LENGTH = 63
 TENANT_COMMUNITY_LIST_API_NAME_MAX_LENGTH = 115
+_STANDARD_FALSE_DEFAULT_ALIASES = (
+    "noAdvertise",
+    "blackhole",
+    "noExport",
+    "internet",
+    "gracefulShutdown",
+    "localAsn",
+)
 
 
 class CommunityListEntryModel(NDNestedModel):
@@ -226,6 +234,17 @@ class CommunityListModel(NDBaseModel):
         data = super().to_payload(**kwargs)
         if self.tenant_name:
             data["name"] = self.api_name
+        return data
+
+    def to_diff_dict(self, **kwargs) -> dict[str, Any]:
+        """Ignore false and empty defaults ND adds to standard entry responses."""
+        data = super().to_diff_dict(**kwargs)
+        for entry in data.get("entries") or []:
+            for field_name in _STANDARD_FALSE_DEFAULT_ALIASES:
+                if entry.get(field_name) is False:
+                    entry.pop(field_name)
+            if entry.get("communityNumbers") == []:
+                entry.pop("communityNumbers")
         return data
 
     @field_validator("name", mode="before")

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -347,9 +347,7 @@ class CommunityListModel(NDBaseModel):
                 has_well_known_flag = any(getattr(entry, field_name) is True for field_name in _STANDARD_WELL_KNOWN_FIELDS)
                 if not has_community_number and not has_well_known_flag:
                     raise ValueError(
-                        f"entries[{i}] must set at least one community number or "
-                        "enable at least one well-known community flag for "
-                        "type='standard'."
+                        f"entries[{i}] must set at least one community number or " "enable at least one well-known community flag for " "type='standard'."
                     )
         return self
 

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -276,13 +276,11 @@ class CommunityListModel(NDBaseModel):
                 self.name = self.name[len(prefix) :]
             if len(self.api_name) > TENANT_COMMUNITY_LIST_API_NAME_MAX_LENGTH:
                 raise ValueError(
-                    f"tenant-scoped community list API name '{self.api_name}' must be "
-                    f"{TENANT_COMMUNITY_LIST_API_NAME_MAX_LENGTH} characters or fewer."
+                    f"tenant-scoped community list API name '{self.api_name}' must be " f"{TENANT_COMMUNITY_LIST_API_NAME_MAX_LENGTH} characters or fewer."
                 )
         elif len(self.name) > DEFAULT_TENANT_COMMUNITY_LIST_NAME_MAX_LENGTH:
             raise ValueError(
-                f"default-tenant community list name '{self.name}' must be "
-                f"{DEFAULT_TENANT_COMMUNITY_LIST_NAME_MAX_LENGTH} characters or fewer."
+                f"default-tenant community list name '{self.name}' must be " f"{DEFAULT_TENANT_COMMUNITY_LIST_NAME_MAX_LENGTH} characters or fewer."
             )
         return self
 

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -246,6 +246,8 @@ class CommunityListModel(NDBaseModel):
 
     def to_diff_dict(self, **kwargs) -> dict[str, Any]:
         """Ignore false and empty defaults ND adds to standard entry responses."""
+        # TODO(4.2.1) TBD
+        # ND echoes false/empty defaults for unset standard-entry fields on GET; strip them so diffs stay idempotent.
         data = super().to_diff_dict(**kwargs)
         for entry in data.get("entries") or []:
             for field_name in _STANDARD_FALSE_DEFAULT_ALIASES:

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+Pydantic models for the nd_manage_community_list module.
+
+Community lists come in two flavours that share the same top-level schema but
+differ in their entry structure:
+
+- **standard** - entries may reference well-known communities (noAdvertise,
+  blackhole, noExport, internet, gracefulShutdown, localAsn) and/or explicit
+  community numbers in ASN:NN format (communityNumbers).
+- **expanded** - entries match communities via a regular expression
+  (communityNumberRegex, required).
+
+A single flat ``CommunityListEntryModel`` covers both flavours.  A
+``model_validator`` on ``CommunityListModel`` enforces the type-specific
+entry constraints.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import re
+from typing import ClassVar, Dict, List, Optional, Set
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_community_list.enums import (
+    CommunityListTypeEnum,
+    CommunityListActionEnum,
+)
+
+# Regex: ASN:NN where each part is 0-65535
+_COMMUNITY_NUMBER_RE = re.compile(
+    r"^(0|[1-9]\d{0,3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])"
+    r":"
+    r"(0|[1-9]\d{0,3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$"
+)
+
+# Regex for expanded community-list entries: must not start with [a-zA-Z~!#%@`;]
+_COMMUNITY_REGEX_RE = re.compile(r"^[^a-zA-Z~!#%@`;].*$")
+
+
+class CommunityListEntryModel(NDNestedModel):
+    """
+    A single entry inside a community list.
+
+    For **standard** community lists the entry may set any combination of:
+    - ``no_advertise``, ``blackhole``, ``no_export``, ``internet``,
+      ``graceful_shutdown``, ``local_asn`` (well-known community flags)
+    - ``community_numbers`` (list of ASN:NN strings)
+
+    For **expanded** community lists the entry must set:
+    - ``community_number_regex`` (regular-expression string, required)
+    """
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        use_enum_values=True,
+        validate_assignment=True,
+        populate_by_name=True,
+        extra="ignore",
+    )
+
+    # --- Required fields (both standard and expanded) ---
+    sequence_number: int = Field(
+        alias="sequenceNumber",
+        description="Sequence number of the entry (1-4294967294).",
+        ge=1,
+        le=4294967294,
+    )
+    action: CommunityListActionEnum = Field(
+        alias="action",
+        description="Permit or deny operation.",
+    )
+
+    # --- Standard-only: well-known community flags ---
+    no_advertise: Optional[bool] = Field(
+        default=None,
+        alias="noAdvertise",
+        description=("Do not advertise the route to any iBGP or eBGP neighbors " "(well-known community 65535:65282)."),
+    )
+    blackhole: Optional[bool] = Field(
+        default=None,
+        alias="blackhole",
+        description=("Used to drop traffic to a specified destination " "(well-known community 65535:666)."),
+    )
+    no_export: Optional[bool] = Field(
+        default=None,
+        alias="noExport",
+        description="Do not export to next AS (well-known community).",
+    )
+    internet: Optional[bool] = Field(
+        default=None,
+        alias="internet",
+        description="Internet (well-known community).",
+    )
+    graceful_shutdown: Optional[bool] = Field(
+        default=None,
+        alias="gracefulShutdown",
+        description="Graceful shutdown (well-known community).",
+    )
+    local_asn: Optional[bool] = Field(
+        default=None,
+        alias="localAsn",
+        description=(
+            "Do not advertise the route to an iBGP neighbor if the route " "is received from another iBGP neighbor " "(well-known community 65535:65284)."
+        ),
+    )
+    community_numbers: Optional[List[str]] = Field(
+        default=None,
+        alias="communityNumbers",
+        description="List of community numbers in ASN:NN format (0-65535:0-65535).",
+    )
+
+    # --- Expanded-only ---
+    community_number_regex: Optional[str] = Field(
+        default=None,
+        alias="communityNumberRegex",
+        description=("Regular expression in aa:nn format for matching community strings. " "Max length 63. Must not start with [a-zA-Z~!#%@`;]."),
+        max_length=63,
+    )
+
+    @field_validator("community_numbers", mode="before")
+    @classmethod
+    def validate_community_numbers(cls, v):
+        """Validate each community number matches ASN:NN format (0-65535:0-65535)."""
+        if v is None:
+            return v
+        for num in v:
+            if not _COMMUNITY_NUMBER_RE.match(str(num)):
+                raise ValueError(f"community_numbers entry '{num}' must be in ASN:NN format " "(each part 0-65535).")
+        return v
+
+    @field_validator("community_number_regex", mode="before")
+    @classmethod
+    def validate_community_number_regex(cls, v):
+        """Validate communityNumberRegex does not start with a disallowed character."""
+        if v is None:
+            return v
+        if not _COMMUNITY_REGEX_RE.match(str(v)):
+            raise ValueError(f"community_number_regex '{v}' must not start with " "[a-zA-Z~!#%@`;].")
+        return v
+
+
+class CommunityListModel(NDBaseModel):
+    """
+    Model for a Nexus Dashboard community list resource.
+
+    Supports both **standard** and **expanded** types; the ``type`` field
+    discriminates between them and a ``model_validator`` enforces the
+    type-specific entry constraints.
+
+    Identifier strategy: ``single`` on ``name``.
+    """
+
+    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifier_strategy: ClassVar[str] = "single"
+
+    # Read-only timestamp excluded from payloads and diffs
+    exclude_from_diff: ClassVar[Set[str]] = {"last_update_timestamp"}
+    payload_exclude_fields: ClassVar[Set[str]] = {"last_update_timestamp"}
+
+    # Strip any summary-only keys that appear in the list response but are
+    # not part of the full item schema
+    unwanted_keys: ClassVar[List[str]] = [
+        "numberOfEntries",
+        "numberOfAssociations",
+        "associations",
+    ]
+
+    # --- Fields ---
+    name: str = Field(
+        alias="name",
+        description=(
+            "Name of the community list. Allowed characters: [a-zA-Z0-9~_-]. "
+            "Max 63 characters for the default tenant, 115 when using a "
+            "non-default tenant."
+        ),
+        min_length=1,
+        max_length=115,
+    )
+    type: Optional[CommunityListTypeEnum] = Field(
+        default=None,
+        alias="type",
+        description="Type of community list: standard or expanded.",
+    )
+    last_update_timestamp: Optional[str] = Field(
+        default=None,
+        alias="lastUpdateTimestamp",
+        description="Timestamp of the last update (read-only, set by the API).",
+    )
+    tenant_name: Optional[str] = Field(
+        default=None,
+        alias="tenantName",
+        description=("Name of the tenant that owns this community list. " "Allowed characters: [A-Za-z0-9_-]. Max 63 characters."),
+        max_length=63,
+    )
+    entries: Optional[List[CommunityListEntryModel]] = Field(
+        default=None,
+        alias="entries",
+        description="Collection of community list entries.",
+        min_length=1,
+    )
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def validate_name(cls, v):
+        """Validate community list name matches [a-zA-Z0-9~_-]+."""
+        pattern = re.compile(r"^[a-zA-Z0-9~_-]+$")
+        if not pattern.match(str(v)):
+            raise ValueError(f"name '{v}' contains invalid characters. " "Allowed: [a-zA-Z0-9~_-].")
+        return v
+
+    @field_validator("tenant_name", mode="before")
+    @classmethod
+    def validate_tenant_name(cls, v):
+        """Validate tenant name matches [A-Za-z0-9_-]+."""
+        if v is None:
+            return v
+        pattern = re.compile(r"^[A-Za-z0-9_-]+$")
+        if not pattern.match(str(v)):
+            raise ValueError(f"tenant_name '{v}' contains invalid characters. " "Allowed: [A-Za-z0-9_-].")
+        return v
+
+    @model_validator(mode="after")
+    def validate_entries_match_type(self):
+        """
+        Cross-validate entries against the declared community list type.
+
+        - For *expanded* lists every entry MUST have community_number_regex set.
+          Standard-only fields (community_numbers, well-known flags) MUST NOT be set.
+        - For *standard* lists entries MUST NOT have community_number_regex set.
+        """
+        standard_only_fields = {
+            "no_advertise",
+            "blackhole",
+            "no_export",
+            "internet",
+            "graceful_shutdown",
+            "local_asn",
+            "community_numbers",
+        }
+
+        if self.type is None or self.entries is None:
+            return self
+
+        for i, entry in enumerate(self.entries):
+            if self.type == CommunityListTypeEnum.EXPANDED:
+                if not entry.community_number_regex:
+                    raise ValueError(f"entries[{i}].community_number_regex is required " "for type='expanded'.")
+                for field in standard_only_fields:
+                    if getattr(entry, field) is not None:
+                        raise ValueError(f"entries[{i}].{field} must not be set for " "type='expanded'. Use community_number_regex instead.")
+            else:
+                # standard
+                if entry.community_number_regex is not None:
+                    raise ValueError(
+                        f"entries[{i}].community_number_regex must not be set "
+                        "for type='standard'. Use community_numbers or "
+                        "well-known community flags instead."
+                    )
+        return self
+
+    @classmethod
+    def get_argument_spec(cls) -> Dict:
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    name=dict(type="str", required=True),
+                    type=dict(
+                        type="str",
+                        choices=["standard", "expanded"],
+                    ),
+                    tenant_name=dict(
+                        type="str",
+                        aliases=["tenantName"],
+                    ),
+                    entries=dict(
+                        type="list",
+                        elements="dict",
+                        options=dict(
+                            sequence_number=dict(
+                                type="int",
+                                required=True,
+                                aliases=["sequenceNumber"],
+                            ),
+                            action=dict(
+                                type="str",
+                                required=True,
+                                choices=["permit", "deny"],
+                            ),
+                            no_advertise=dict(
+                                type="bool",
+                                aliases=["noAdvertise"],
+                            ),
+                            blackhole=dict(type="bool"),
+                            no_export=dict(
+                                type="bool",
+                                aliases=["noExport"],
+                            ),
+                            internet=dict(type="bool"),
+                            graceful_shutdown=dict(
+                                type="bool",
+                                aliases=["gracefulShutdown"],
+                            ),
+                            local_asn=dict(
+                                type="bool",
+                                aliases=["localAsn"],
+                            ),
+                            community_numbers=dict(
+                                type="list",
+                                elements="str",
+                                aliases=["communityNumbers"],
+                            ),
+                            community_number_regex=dict(
+                                type="str",
+                                aliases=["communityNumberRegex"],
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/manage_community_list/manage_community_list.py
+++ b/plugins/module_utils/models/manage_community_list/manage_community_list.py
@@ -20,12 +20,10 @@ A single flat ``CommunityListEntryModel`` covers both flavours.  A
 entry constraints.
 """
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import re
-from typing import ClassVar, Dict, List, Optional, Set
+from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
@@ -85,46 +83,46 @@ class CommunityListEntryModel(NDNestedModel):
     )
 
     # --- Standard-only: well-known community flags ---
-    no_advertise: Optional[bool] = Field(
+    no_advertise: bool | None = Field(
         default=None,
         alias="noAdvertise",
         description=("Do not advertise the route to any iBGP or eBGP neighbors " "(well-known community 65535:65282)."),
     )
-    blackhole: Optional[bool] = Field(
+    blackhole: bool | None = Field(
         default=None,
         alias="blackhole",
         description=("Used to drop traffic to a specified destination " "(well-known community 65535:666)."),
     )
-    no_export: Optional[bool] = Field(
+    no_export: bool | None = Field(
         default=None,
         alias="noExport",
         description="Do not export to next AS (well-known community).",
     )
-    internet: Optional[bool] = Field(
+    internet: bool | None = Field(
         default=None,
         alias="internet",
         description="Internet (well-known community).",
     )
-    graceful_shutdown: Optional[bool] = Field(
+    graceful_shutdown: bool | None = Field(
         default=None,
         alias="gracefulShutdown",
         description="Graceful shutdown (well-known community).",
     )
-    local_asn: Optional[bool] = Field(
+    local_asn: bool | None = Field(
         default=None,
         alias="localAsn",
         description=(
             "Do not advertise the route to an iBGP neighbor if the route " "is received from another iBGP neighbor " "(well-known community 65535:65284)."
         ),
     )
-    community_numbers: Optional[List[str]] = Field(
+    community_numbers: list[str] | None = Field(
         default=None,
         alias="communityNumbers",
         description="List of community numbers in ASN:NN format (0-65535:0-65535).",
     )
 
     # --- Expanded-only ---
-    community_number_regex: Optional[str] = Field(
+    community_number_regex: str | None = Field(
         default=None,
         alias="communityNumberRegex",
         description=("Regular expression in aa:nn format for matching community strings. " "Max length 63. Must not start with [a-zA-Z~!#%@`;]."),
@@ -164,16 +162,16 @@ class CommunityListModel(NDBaseModel):
     Identifier strategy: ``single`` on ``name``.
     """
 
-    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifiers: ClassVar[list[str] | None] = ["name"]
     identifier_strategy: ClassVar[str] = "single"
 
     # Read-only timestamp excluded from payloads and diffs
-    exclude_from_diff: ClassVar[Set[str]] = {"last_update_timestamp"}
-    payload_exclude_fields: ClassVar[Set[str]] = {"last_update_timestamp"}
+    exclude_from_diff: ClassVar[set[str]] = {"last_update_timestamp"}
+    payload_exclude_fields: ClassVar[set[str]] = {"last_update_timestamp"}
 
     # Strip any summary-only keys that appear in the list response but are
     # not part of the full item schema
-    unwanted_keys: ClassVar[List[str]] = [
+    unwanted_keys: ClassVar[list[str]] = [
         "numberOfEntries",
         "numberOfAssociations",
         "associations",
@@ -190,23 +188,23 @@ class CommunityListModel(NDBaseModel):
         min_length=1,
         max_length=115,
     )
-    type: Optional[CommunityListTypeEnum] = Field(
+    type: CommunityListTypeEnum | None = Field(
         default=None,
         alias="type",
         description="Type of community list: standard or expanded.",
     )
-    last_update_timestamp: Optional[str] = Field(
+    last_update_timestamp: str | None = Field(
         default=None,
         alias="lastUpdateTimestamp",
         description="Timestamp of the last update (read-only, set by the API).",
     )
-    tenant_name: Optional[str] = Field(
+    tenant_name: str | None = Field(
         default=None,
         alias="tenantName",
         description=("Name of the tenant that owns this community list. " "Allowed characters: [A-Za-z0-9_-]. Max 63 characters."),
         max_length=63,
     )
-    entries: Optional[List[CommunityListEntryModel]] = Field(
+    entries: list[CommunityListEntryModel] | None = Field(
         default=None,
         alias="entries",
         description="Collection of community list entries.",
@@ -273,7 +271,7 @@ class CommunityListModel(NDBaseModel):
         return self
 
     @classmethod
-    def get_argument_spec(cls) -> Dict:
+    def get_argument_spec(cls) -> dict:
         return dict(
             fabric_name=dict(type="str", required=True),
             config=dict(

--- a/plugins/module_utils/models/manage_extended_community_list/enums.py
+++ b/plugins/module_utils/models/manage_extended_community_list/enums.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+Enum definitions for the nd_manage_extended_community_list module.
+"""
+
+from __future__ import annotations
+
+__metaclass__ = type
+
+from enum import Enum
+
+
+class ExtendedCommunityListTypeEnum(str, Enum):
+    """
+    Enumeration of extended community list types.
+
+    - STANDARD: Standard extended community list - matches extended communities
+      using explicit route targets, router MACs, site-of-origin, or generic
+      extended community values.
+    - EXPANDED: Expanded extended community list - matches extended communities
+      using a regular expression.
+    """
+
+    STANDARD = "standard"
+    EXPANDED = "expanded"
+
+
+class ExtendedCommunityListActionEnum(str, Enum):
+    """
+    Enumeration of permit/deny actions for extended community list entries.
+
+    - PERMIT: Allow routes matching the entry.
+    - DENY: Reject routes matching the entry.
+    """
+
+    PERMIT = "permit"
+    DENY = "deny"

--- a/plugins/module_utils/models/manage_extended_community_list/enums.py
+++ b/plugins/module_utils/models/manage_extended_community_list/enums.py
@@ -9,8 +9,6 @@ Enum definitions for the nd_manage_extended_community_list module.
 
 from __future__ import annotations
 
-__metaclass__ = type
-
 from enum import Enum
 
 

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -297,6 +297,8 @@ class ExtendedCommunityListModel(NDBaseModel):
 
     def to_diff_dict(self, **kwargs) -> dict[str, Any]:
         """Ignore empty collection defaults ND adds to standard entry responses."""
+        # TODO(4.2.1) TBD
+        # ND echoes empty defaults for unset standard-entry fields on GET; strip them so diffs stay idempotent.
         data = super().to_diff_dict(**kwargs)
         for entry in data.get("entries") or []:
             for field_name in _STANDARD_EMPTY_COLLECTION_ALIASES:

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -324,6 +324,19 @@ class ExtendedCommunityListModel(NDBaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def validate_required_for_write_states(self, info: ValidationInfo) -> "ExtendedCommunityListModel":
+        """Require the API body fields for write states while allowing name-only deletes."""
+        state = (info.context or {}).get("state")
+        if state in ("merged", "replaced", "overridden"):
+            missing = [field_name for field_name in ("type", "entries") if getattr(self, field_name) is None]
+            if missing:
+                verb = "is" if len(missing) == 1 else "are"
+                raise ValueError(
+                    f"extended community list '{self.api_name}': '{', '.join(missing)}' {verb} required for state '{state}'."
+                )
+        return self
+
     # ------------------------------------------------------------------
     # Cross-field model validator
     # ------------------------------------------------------------------

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -71,6 +71,13 @@ _GENERIC_EXTENDED_RE = re.compile(r"^[1-9]\d{0,9}:\d+$")
 _COMMUNITY_REGEX_RE = re.compile(r"^[^a-zA-Z~!#%@`;].*$")
 DEFAULT_TENANT_EXTENDED_COMMUNITY_LIST_NAME_MAX_LENGTH = 63
 TENANT_EXTENDED_COMMUNITY_LIST_API_NAME_MAX_LENGTH = 115
+_STANDARD_EMPTY_COLLECTION_ALIASES = (
+    "routerMacCollection",
+    "routeTargetCollection",
+    "siteOfOriginCollection",
+    "transitiveGenericExtendedCollection",
+    "nonTransitiveGenericExtendedCollection",
+)
 
 
 class ExtendedCommunityListEntryModel(NDNestedModel):
@@ -279,6 +286,15 @@ class ExtendedCommunityListModel(NDBaseModel):
         data = super().to_payload(**kwargs)
         if self.tenant_name:
             data["name"] = self.api_name
+        return data
+
+    def to_diff_dict(self, **kwargs) -> dict[str, Any]:
+        """Ignore empty collection defaults ND adds to standard entry responses."""
+        data = super().to_diff_dict(**kwargs)
+        for entry in data.get("entries") or []:
+            for field_name in _STANDARD_EMPTY_COLLECTION_ALIASES:
+                if entry.get(field_name) == []:
+                    entry.pop(field_name)
         return data
 
     # ------------------------------------------------------------------

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -9,7 +9,7 @@ Pydantic models for the nd_manage_extended_community_list module.
 Extended community lists come in two flavours that share the same top-level
 schema but differ in their entry structure:
 
-- **standard** - entries may specify any combination of:
+- **standard** - entries must specify at least one of:
     - routerMacCollection: MAC addresses in eeee.eeee.eeee, ee:ee:ee:ee:ee:ee,
       or ee-ee-ee-ee-ee-ee format.
     - routeTargetCollection: route targets in ASN2:NN, ASN4:NN, or IPv4:NN format.
@@ -78,13 +78,20 @@ _STANDARD_EMPTY_COLLECTION_ALIASES = (
     "transitiveGenericExtendedCollection",
     "nonTransitiveGenericExtendedCollection",
 )
+_STANDARD_SELECTOR_FIELDS = (
+    "router_mac_collection",
+    "route_target_collection",
+    "site_of_origin_collection",
+    "transitive_generic_extended_collection",
+    "non_transitive_generic_extended_collection",
+)
 
 
 class ExtendedCommunityListEntryModel(NDNestedModel):
     """
     A single entry inside an extended community list.
 
-    For **standard** extended community lists the entry may set any combination
+    For **standard** extended community lists the entry must set at least one
     of:
     - ``router_mac_collection``
     - ``route_target_collection``
@@ -376,14 +383,6 @@ class ExtendedCommunityListModel(NDBaseModel):
         if (info.context or {}).get("mode") == "response":
             return self
 
-        standard_only_fields = {
-            "router_mac_collection",
-            "route_target_collection",
-            "site_of_origin_collection",
-            "transitive_generic_extended_collection",
-            "non_transitive_generic_extended_collection",
-        }
-
         if self.type is None or self.entries is None:
             return self
 
@@ -391,13 +390,15 @@ class ExtendedCommunityListModel(NDBaseModel):
             if self.type == ExtendedCommunityListTypeEnum.EXPANDED:
                 if not entry.community_number_regex:
                     raise ValueError(f"entries[{i}].community_number_regex is required " "for type='expanded'.")
-                for field in standard_only_fields:
+                for field in _STANDARD_SELECTOR_FIELDS:
                     if getattr(entry, field) is not None:
                         raise ValueError(f"entries[{i}].{field} must not be set for " "type='expanded'. Use community_number_regex instead.")
             else:
                 # standard
                 if entry.community_number_regex is not None:
                     raise ValueError(f"entries[{i}].community_number_regex must not be set " "for type='standard'. Use standard-only fields instead.")
+                if not any(getattr(entry, field) for field in _STANDARD_SELECTOR_FIELDS):
+                    raise ValueError(f"entries[{i}] must set at least one standard selector collection " "for type='standard'.")
         return self
 
     # ------------------------------------------------------------------

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -401,6 +401,7 @@ class ExtendedCommunityListModel(NDBaseModel):
     def get_argument_spec(cls) -> dict:
         return dict(
             fabric_name=dict(type="str", required=True),
+            cluster_name=dict(type="str"),
             config=dict(
                 type="list",
                 elements="dict",

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -54,7 +54,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_co
 # MAC: eeee.eeee.eeee  OR  ee:ee:ee:ee:ee:ee  OR  ee-ee-ee-ee-ee-ee
 _ROUTER_MAC_RE = re.compile(r"^(?:[a-fA-F0-9]{4}\.[a-fA-F0-9]{4}\.[a-fA-F0-9]{4}" + r"|([a-fA-F0-9]{2}[:\-]){5}[a-fA-F0-9]{2})$")
 
-# Route target: ASN2:NN  |  ASN4:NN  |  IPv4:NN  (single value, no commas)
+# Canonical route-target token: ASN2:NN  |  ASN4:NN  |  IPv4:NN
 _ROUTE_TARGET_RE = re.compile(
     r"^((\d{1,5}:\d{1,9})|(\d{1,10}:\d{1,9})"
     r"|((25[0-5]|2[0-4]\d|1\d{2}|\d{1,2})\.(25[0-5]|2[0-4]\d|1\d{2}|\d{1,2})"
@@ -167,13 +167,23 @@ class ExtendedCommunityListEntryModel(NDNestedModel):
 
     @field_validator("route_target_collection", mode="before")
     @classmethod
-    def validate_route_target_collection(cls, v):
+    def validate_route_target_collection(cls, v: Any) -> Any:
+        """Validate route targets and flatten OpenAPI-compatible comma-packed items."""
         if v is None:
             return v
-        for rt in v:
-            if not _ROUTE_TARGET_RE.match(str(rt)):
-                raise ValueError(f"route_target_collection entry '{rt}' must be in " "ASN2:NN, ASN4:NN, or IPv4:NN format.")
-        return v
+        if not isinstance(v, list):
+            return v
+
+        normalized: list[str] = []
+        for packed_route_targets in v:
+            for route_target in str(packed_route_targets).split(","):
+                if not _ROUTE_TARGET_RE.match(route_target):
+                    raise ValueError(
+                        f"route_target_collection entry '{packed_route_targets}' "
+                        "must contain only ASN2:NN, ASN4:NN, or IPv4:NN values."
+                    )
+                normalized.append(route_target)
+        return normalized
 
     @field_validator("site_of_origin_collection", mode="before")
     @classmethod

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -178,10 +178,7 @@ class ExtendedCommunityListEntryModel(NDNestedModel):
         for packed_route_targets in v:
             for route_target in str(packed_route_targets).split(","):
                 if not _ROUTE_TARGET_RE.match(route_target):
-                    raise ValueError(
-                        f"route_target_collection entry '{packed_route_targets}' "
-                        "must contain only ASN2:NN, ASN4:NN, or IPv4:NN values."
-                    )
+                    raise ValueError(f"route_target_collection entry '{packed_route_targets}' " "must contain only ASN2:NN, ASN4:NN, or IPv4:NN values.")
                 normalized.append(route_target)
         return normalized
 

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -1,0 +1,405 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+Pydantic models for the nd_manage_extended_community_list module.
+
+Extended community lists come in two flavours that share the same top-level
+schema but differ in their entry structure:
+
+- **standard** - entries may specify any combination of:
+    - routerMacCollection: MAC addresses in eeee.eeee.eeee, ee:ee:ee:ee:ee:ee,
+      or ee-ee-ee-ee-ee-ee format.
+    - routeTargetCollection: route targets in ASN2:NN, ASN4:NN, or IPv4:NN format.
+    - siteOfOriginCollection: site-of-origin values in ASN2:NN, ASN4:NN, or
+      IPv4:NN format.
+    - transitiveGenericExtendedCollection: transitive generic extended communities
+      in ASN4:NN format.
+    - nonTransitiveGenericExtendedCollection: non-transitive generic extended
+      communities in ASN4:NN format.
+
+- **expanded** - entries must specify:
+    - communityNumberRegex (required): regular expression in aa:nn format.
+
+A single flat ``ExtendedCommunityListEntryModel`` covers both flavours.
+A ``model_validator`` on ``ExtendedCommunityListModel`` enforces the
+type-specific entry constraints at validation time.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import re
+from typing import ClassVar, Dict, List, Optional, Set
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_community_list.enums import (
+    ExtendedCommunityListTypeEnum,
+    ExtendedCommunityListActionEnum,
+)
+
+# ---------------------------------------------------------------------------
+# Compiled validation regexes (from OpenAPI spec patterns)
+# ---------------------------------------------------------------------------
+
+# MAC: eeee.eeee.eeee  OR  ee:ee:ee:ee:ee:ee  OR  ee-ee-ee-ee-ee-ee
+_ROUTER_MAC_RE = re.compile(r"^(?:[a-fA-F0-9]{4}\.[a-fA-F0-9]{4}\.[a-fA-F0-9]{4}" + r"|([a-fA-F0-9]{2}[:\-]){5}[a-fA-F0-9]{2})$")
+
+# Route target: ASN2:NN  |  ASN4:NN  |  IPv4:NN  (single value, no commas)
+_ROUTE_TARGET_RE = re.compile(
+    r"^((\d{1,5}:\d{1,9})|(\d{1,10}:\d{1,9})"
+    r"|((25[0-5]|2[0-4]\d|1\d{2}|\d{1,2})\.(25[0-5]|2[0-4]\d|1\d{2}|\d{1,2})"
+    r"\.(25[0-5]|2[0-4]\d|1\d{2}|\d{1,2})\.(25[0-5]|2[0-4]\d|1\d{2}|\d{1,2}):\d{1,9}))$"
+)
+
+# Site of origin: ASN2:NN  |  ASN4:NN  |  IPv4:NN
+_SITE_OF_ORIGIN_RE = re.compile(r"^(\d{1,5}|\d{1,10}|(?:\d{1,3}\.){3}\d{1,3}):\d+$")
+
+# Transitive/non-transitive generic extended: ASN4:NN (starts with 1-9)
+_GENERIC_EXTENDED_RE = re.compile(r"^[1-9]\d{0,9}:\d+$")
+
+# Expanded community-number regex: must not start with [a-zA-Z~!#%@`;]
+_COMMUNITY_REGEX_RE = re.compile(r"^[^a-zA-Z~!#%@`;].*$")
+
+
+class ExtendedCommunityListEntryModel(NDNestedModel):
+    """
+    A single entry inside an extended community list.
+
+    For **standard** extended community lists the entry may set any combination
+    of:
+    - ``router_mac_collection``
+    - ``route_target_collection``
+    - ``site_of_origin_collection``
+    - ``transitive_generic_extended_collection``
+    - ``non_transitive_generic_extended_collection``
+
+    For **expanded** extended community lists the entry must set:
+    - ``community_number_regex`` (required)
+    """
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        use_enum_values=True,
+        validate_assignment=True,
+        populate_by_name=True,
+        extra="ignore",
+    )
+
+    # --- Required fields (both standard and expanded) ---
+    sequence_number: int = Field(
+        alias="sequenceNumber",
+        description="Sequence number of the entry (1-4294967294).",
+        ge=1,
+        le=4294967294,
+    )
+    action: ExtendedCommunityListActionEnum = Field(
+        alias="action",
+        description="Permit or deny operation.",
+    )
+
+    # --- Standard-only fields ---
+    router_mac_collection: Optional[List[str]] = Field(
+        default=None,
+        alias="routerMacCollection",
+        description=("One or more router MAC addresses in eeee.eeee.eeee, " "ee:ee:ee:ee:ee:ee, or ee-ee-ee-ee-ee-ee format."),
+    )
+    route_target_collection: Optional[List[str]] = Field(
+        default=None,
+        alias="routeTargetCollection",
+        description=("One or more route targets in ASN2:NN, ASN4:NN, or IPv4:NN format."),
+    )
+    site_of_origin_collection: Optional[List[str]] = Field(
+        default=None,
+        alias="siteOfOriginCollection",
+        description=("One or more site-of-origin values in ASN2:NN, ASN4:NN, or " "IPv4:NN format."),
+    )
+    transitive_generic_extended_collection: Optional[List[str]] = Field(
+        default=None,
+        alias="transitiveGenericExtendedCollection",
+        description=("One or more transitive generic extended community values " "in ASN4:NN format (e.g. 65000:123)."),
+    )
+    non_transitive_generic_extended_collection: Optional[List[str]] = Field(
+        default=None,
+        alias="nonTransitiveGenericExtendedCollection",
+        description=("One or more non-transitive generic extended community values " "in ASN4:NN format (e.g. 64512:789)."),
+    )
+
+    # --- Expanded-only ---
+    community_number_regex: Optional[str] = Field(
+        default=None,
+        alias="communityNumberRegex",
+        description=("Regular expression in aa:nn format for matching extended community " "strings. Max 63 characters. Must not start with [a-zA-Z~!#%@`;]."),
+        max_length=63,
+    )
+
+    # ------------------------------------------------------------------
+    # Field validators
+    # ------------------------------------------------------------------
+
+    @field_validator("router_mac_collection", mode="before")
+    @classmethod
+    def validate_router_mac_collection(cls, v):
+        if v is None:
+            return v
+        for mac in v:
+            if not _ROUTER_MAC_RE.match(str(mac)):
+                raise ValueError(f"router_mac_collection entry '{mac}' must be in " "eeee.eeee.eeee, ee:ee:ee:ee:ee:ee, or ee-ee-ee-ee-ee-ee format.")
+        return v
+
+    @field_validator("route_target_collection", mode="before")
+    @classmethod
+    def validate_route_target_collection(cls, v):
+        if v is None:
+            return v
+        for rt in v:
+            if not _ROUTE_TARGET_RE.match(str(rt)):
+                raise ValueError(f"route_target_collection entry '{rt}' must be in " "ASN2:NN, ASN4:NN, or IPv4:NN format.")
+        return v
+
+    @field_validator("site_of_origin_collection", mode="before")
+    @classmethod
+    def validate_site_of_origin_collection(cls, v):
+        if v is None:
+            return v
+        for soo in v:
+            if not _SITE_OF_ORIGIN_RE.match(str(soo)):
+                raise ValueError(f"site_of_origin_collection entry '{soo}' must be in " "ASN2:NN, ASN4:NN, or IPv4:NN format.")
+        return v
+
+    @field_validator("transitive_generic_extended_collection", mode="before")
+    @classmethod
+    def validate_transitive_generic_extended_collection(cls, v):
+        if v is None:
+            return v
+        for val in v:
+            if not _GENERIC_EXTENDED_RE.match(str(val)):
+                raise ValueError(f"transitive_generic_extended_collection entry '{val}' " "must be in ASN4:NN format (e.g. 65000:123).")
+        return v
+
+    @field_validator("non_transitive_generic_extended_collection", mode="before")
+    @classmethod
+    def validate_non_transitive_generic_extended_collection(cls, v):
+        if v is None:
+            return v
+        for val in v:
+            if not _GENERIC_EXTENDED_RE.match(str(val)):
+                raise ValueError(f"non_transitive_generic_extended_collection entry '{val}' " "must be in ASN4:NN format (e.g. 64512:789).")
+        return v
+
+    @field_validator("community_number_regex", mode="before")
+    @classmethod
+    def validate_community_number_regex(cls, v):
+        if v is None:
+            return v
+        if not _COMMUNITY_REGEX_RE.match(str(v)):
+            raise ValueError(f"community_number_regex '{v}' must not start with " "[a-zA-Z~!#%@`;].")
+        return v
+
+
+class ExtendedCommunityListModel(NDBaseModel):
+    """
+    Model for a Nexus Dashboard extended community list resource.
+
+    Supports both **standard** and **expanded** types; the ``type`` field
+    discriminates between them and a ``model_validator`` enforces the
+    type-specific entry constraints at validation time.
+
+    Identifier strategy: ``single`` on ``name`` - extended community list names
+    are unique per fabric with no address-family dimension.
+    """
+
+    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifier_strategy: ClassVar[str] = "single"
+
+    # Read-only timestamp excluded from payloads and diffs
+    exclude_from_diff: ClassVar[Set[str]] = {"last_update_timestamp"}
+    payload_exclude_fields: ClassVar[Set[str]] = {"last_update_timestamp"}
+
+    # Strip summary-only keys returned by the list/summary endpoints
+    unwanted_keys: ClassVar[List[str]] = [
+        "numberOfEntries",
+        "numberOfAssociations",
+        "associations",
+    ]
+
+    # --- Top-level fields ---
+    name: str = Field(
+        alias="name",
+        description=(
+            "Name of the extended community list. Allowed characters: "
+            "[a-zA-Z0-9~_-]. Max 63 characters for the default tenant, "
+            "115 when using a non-default tenant."
+        ),
+        min_length=1,
+        max_length=115,
+    )
+    type: Optional[ExtendedCommunityListTypeEnum] = Field(
+        default=None,
+        alias="type",
+        description="Type of extended community list: standard or expanded.",
+    )
+    last_update_timestamp: Optional[str] = Field(
+        default=None,
+        alias="lastUpdateTimestamp",
+        description="Timestamp of the last update (read-only, set by the API).",
+    )
+    tenant_name: Optional[str] = Field(
+        default=None,
+        alias="tenantName",
+        description=("Name of the tenant that owns this extended community list. " "Allowed characters: [A-Za-z0-9_-]. Max 63 characters."),
+        max_length=63,
+    )
+    entries: Optional[List[ExtendedCommunityListEntryModel]] = Field(
+        default=None,
+        alias="entries",
+        description="Collection of extended community list entries.",
+        min_length=1,
+    )
+
+    # ------------------------------------------------------------------
+    # Field validators
+    # ------------------------------------------------------------------
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def validate_name(cls, v):
+        """Validate extended community list name matches [a-zA-Z0-9~_-]+."""
+        pattern = re.compile(r"^[a-zA-Z0-9~_-]+$")
+        if not pattern.match(str(v)):
+            raise ValueError(f"name '{v}' contains invalid characters. " "Allowed: [a-zA-Z0-9~_-].")
+        return v
+
+    @field_validator("tenant_name", mode="before")
+    @classmethod
+    def validate_tenant_name(cls, v):
+        """Validate tenant name matches [A-Za-z0-9_-]+."""
+        if v is None:
+            return v
+        pattern = re.compile(r"^[A-Za-z0-9_-]+$")
+        if not pattern.match(str(v)):
+            raise ValueError(f"tenant_name '{v}' contains invalid characters. " "Allowed: [A-Za-z0-9_-].")
+        return v
+
+    # ------------------------------------------------------------------
+    # Cross-field model validator
+    # ------------------------------------------------------------------
+
+    @model_validator(mode="after")
+    def validate_entries_match_type(self):
+        """
+        Cross-validate entries against the declared extended community list type.
+
+        - For *expanded* lists every entry MUST have community_number_regex set.
+          Standard-only fields MUST NOT be set.
+        - For *standard* lists entries MUST NOT have community_number_regex set.
+        """
+        standard_only_fields = {
+            "router_mac_collection",
+            "route_target_collection",
+            "site_of_origin_collection",
+            "transitive_generic_extended_collection",
+            "non_transitive_generic_extended_collection",
+        }
+
+        if self.type is None or self.entries is None:
+            return self
+
+        for i, entry in enumerate(self.entries):
+            if self.type == ExtendedCommunityListTypeEnum.EXPANDED:
+                if not entry.community_number_regex:
+                    raise ValueError(f"entries[{i}].community_number_regex is required " "for type='expanded'.")
+                for field in standard_only_fields:
+                    if getattr(entry, field) is not None:
+                        raise ValueError(f"entries[{i}].{field} must not be set for " "type='expanded'. Use community_number_regex instead.")
+            else:
+                # standard
+                if entry.community_number_regex is not None:
+                    raise ValueError(f"entries[{i}].community_number_regex must not be set " "for type='standard'. Use standard-only fields instead.")
+        return self
+
+    # ------------------------------------------------------------------
+    # Argument spec
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_argument_spec(cls) -> Dict:
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    name=dict(type="str", required=True),
+                    type=dict(
+                        type="str",
+                        choices=["standard", "expanded"],
+                    ),
+                    tenant_name=dict(
+                        type="str",
+                        aliases=["tenantName"],
+                    ),
+                    entries=dict(
+                        type="list",
+                        elements="dict",
+                        options=dict(
+                            sequence_number=dict(
+                                type="int",
+                                required=True,
+                                aliases=["sequenceNumber"],
+                            ),
+                            action=dict(
+                                type="str",
+                                required=True,
+                                choices=["permit", "deny"],
+                            ),
+                            router_mac_collection=dict(
+                                type="list",
+                                elements="str",
+                                aliases=["routerMacCollection"],
+                            ),
+                            route_target_collection=dict(
+                                type="list",
+                                elements="str",
+                                aliases=["routeTargetCollection"],
+                            ),
+                            site_of_origin_collection=dict(
+                                type="list",
+                                elements="str",
+                                aliases=["siteOfOriginCollection"],
+                            ),
+                            transitive_generic_extended_collection=dict(
+                                type="list",
+                                elements="str",
+                                aliases=["transitiveGenericExtendedCollection"],
+                            ),
+                            non_transitive_generic_extended_collection=dict(
+                                type="list",
+                                elements="str",
+                                aliases=["nonTransitiveGenericExtendedCollection"],
+                            ),
+                            community_number_regex=dict(
+                                type="str",
+                                aliases=["communityNumberRegex"],
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -38,6 +38,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNe
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     ConfigDict,
     Field,
+    ValidationInfo,
     field_validator,
     model_validator,
 )
@@ -328,7 +329,7 @@ class ExtendedCommunityListModel(NDBaseModel):
     # ------------------------------------------------------------------
 
     @model_validator(mode="after")
-    def validate_entries_match_type(self):
+    def validate_entries_match_type(self, info: ValidationInfo):
         """
         Cross-validate entries against the declared extended community list type.
 
@@ -336,6 +337,9 @@ class ExtendedCommunityListModel(NDBaseModel):
           Standard-only fields MUST NOT be set.
         - For *standard* lists entries MUST NOT have community_number_regex set.
         """
+        if (info.context or {}).get("mode") == "response":
+            return self
+
         standard_only_fields = {
             "router_mac_collection",
             "route_target_collection",

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -31,7 +31,7 @@ type-specific entry constraints at validation time.
 from __future__ import annotations
 
 import re
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
@@ -68,6 +68,8 @@ _GENERIC_EXTENDED_RE = re.compile(r"^[1-9]\d{0,9}:\d+$")
 
 # Expanded community-number regex: must not start with [a-zA-Z~!#%@`;]
 _COMMUNITY_REGEX_RE = re.compile(r"^[^a-zA-Z~!#%@`;].*$")
+DEFAULT_TENANT_EXTENDED_COMMUNITY_LIST_NAME_MAX_LENGTH = 63
+TENANT_EXTENDED_COMMUNITY_LIST_API_NAME_MAX_LENGTH = 115
 
 
 class ExtendedCommunityListEntryModel(NDNestedModel):
@@ -213,11 +215,10 @@ class ExtendedCommunityListModel(NDBaseModel):
     discriminates between them and a ``model_validator`` enforces the
     type-specific entry constraints at validation time.
 
-    Identifier strategy: ``single`` on ``name`` - extended community list names
-    are unique per fabric with no address-family dimension.
+    Identifier strategy: ``single`` on the fully qualified ``api_name``.
     """
 
-    identifiers: ClassVar[list[str] | None] = ["name"]
+    identifiers: ClassVar[list[str] | None] = ["api_name"]
     identifier_strategy: ClassVar[str] = "single"
 
     # Read-only timestamp excluded from payloads and diffs
@@ -265,6 +266,20 @@ class ExtendedCommunityListModel(NDBaseModel):
         min_length=1,
     )
 
+    @property
+    def api_name(self) -> str:
+        """Return the extended-community-list name used in API paths and delete payloads."""
+        if self.tenant_name and not self.name.startswith(f"{self.tenant_name}~"):
+            return f"{self.tenant_name}~{self.name}"
+        return self.name
+
+    def to_payload(self, **kwargs) -> dict[str, Any]:
+        """Export an API payload with a fully qualified tenant-scoped name."""
+        data = super().to_payload(**kwargs)
+        if self.tenant_name:
+            data["name"] = self.api_name
+        return data
+
     # ------------------------------------------------------------------
     # Field validators
     # ------------------------------------------------------------------
@@ -288,6 +303,25 @@ class ExtendedCommunityListModel(NDBaseModel):
         if not pattern.match(str(v)):
             raise ValueError(f"tenant_name '{v}' contains invalid characters. " "Allowed: [A-Za-z0-9_-].")
         return v
+
+    @model_validator(mode="after")
+    def normalize_and_validate_name(self) -> "ExtendedCommunityListModel":
+        """Store tenant-scoped lists with a bare config name and validate API name limits."""
+        if self.tenant_name:
+            prefix = f"{self.tenant_name}~"
+            if self.name.startswith(prefix):
+                self.name = self.name[len(prefix) :]
+            if len(self.api_name) > TENANT_EXTENDED_COMMUNITY_LIST_API_NAME_MAX_LENGTH:
+                raise ValueError(
+                    f"tenant-scoped extended community list API name '{self.api_name}' must be "
+                    f"{TENANT_EXTENDED_COMMUNITY_LIST_API_NAME_MAX_LENGTH} characters or fewer."
+                )
+        elif len(self.name) > DEFAULT_TENANT_EXTENDED_COMMUNITY_LIST_NAME_MAX_LENGTH:
+            raise ValueError(
+                f"default-tenant extended community list name '{self.name}' must be "
+                f"{DEFAULT_TENANT_EXTENDED_COMMUNITY_LIST_NAME_MAX_LENGTH} characters or fewer."
+            )
+        return self
 
     # ------------------------------------------------------------------
     # Cross-field model validator

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -28,12 +28,10 @@ A ``model_validator`` on ``ExtendedCommunityListModel`` enforces the
 type-specific entry constraints at validation time.
 """
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import re
-from typing import ClassVar, Dict, List, Optional, Set
+from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
@@ -109,34 +107,34 @@ class ExtendedCommunityListEntryModel(NDNestedModel):
     )
 
     # --- Standard-only fields ---
-    router_mac_collection: Optional[List[str]] = Field(
+    router_mac_collection: list[str] | None = Field(
         default=None,
         alias="routerMacCollection",
         description=("One or more router MAC addresses in eeee.eeee.eeee, " "ee:ee:ee:ee:ee:ee, or ee-ee-ee-ee-ee-ee format."),
     )
-    route_target_collection: Optional[List[str]] = Field(
+    route_target_collection: list[str] | None = Field(
         default=None,
         alias="routeTargetCollection",
         description=("One or more route targets in ASN2:NN, ASN4:NN, or IPv4:NN format."),
     )
-    site_of_origin_collection: Optional[List[str]] = Field(
+    site_of_origin_collection: list[str] | None = Field(
         default=None,
         alias="siteOfOriginCollection",
         description=("One or more site-of-origin values in ASN2:NN, ASN4:NN, or " "IPv4:NN format."),
     )
-    transitive_generic_extended_collection: Optional[List[str]] = Field(
+    transitive_generic_extended_collection: list[str] | None = Field(
         default=None,
         alias="transitiveGenericExtendedCollection",
         description=("One or more transitive generic extended community values " "in ASN4:NN format (e.g. 65000:123)."),
     )
-    non_transitive_generic_extended_collection: Optional[List[str]] = Field(
+    non_transitive_generic_extended_collection: list[str] | None = Field(
         default=None,
         alias="nonTransitiveGenericExtendedCollection",
         description=("One or more non-transitive generic extended community values " "in ASN4:NN format (e.g. 64512:789)."),
     )
 
     # --- Expanded-only ---
-    community_number_regex: Optional[str] = Field(
+    community_number_regex: str | None = Field(
         default=None,
         alias="communityNumberRegex",
         description=("Regular expression in aa:nn format for matching extended community " "strings. Max 63 characters. Must not start with [a-zA-Z~!#%@`;]."),
@@ -219,15 +217,15 @@ class ExtendedCommunityListModel(NDBaseModel):
     are unique per fabric with no address-family dimension.
     """
 
-    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifiers: ClassVar[list[str] | None] = ["name"]
     identifier_strategy: ClassVar[str] = "single"
 
     # Read-only timestamp excluded from payloads and diffs
-    exclude_from_diff: ClassVar[Set[str]] = {"last_update_timestamp"}
-    payload_exclude_fields: ClassVar[Set[str]] = {"last_update_timestamp"}
+    exclude_from_diff: ClassVar[set[str]] = {"last_update_timestamp"}
+    payload_exclude_fields: ClassVar[set[str]] = {"last_update_timestamp"}
 
     # Strip summary-only keys returned by the list/summary endpoints
-    unwanted_keys: ClassVar[List[str]] = [
+    unwanted_keys: ClassVar[list[str]] = [
         "numberOfEntries",
         "numberOfAssociations",
         "associations",
@@ -244,23 +242,23 @@ class ExtendedCommunityListModel(NDBaseModel):
         min_length=1,
         max_length=115,
     )
-    type: Optional[ExtendedCommunityListTypeEnum] = Field(
+    type: ExtendedCommunityListTypeEnum | None = Field(
         default=None,
         alias="type",
         description="Type of extended community list: standard or expanded.",
     )
-    last_update_timestamp: Optional[str] = Field(
+    last_update_timestamp: str | None = Field(
         default=None,
         alias="lastUpdateTimestamp",
         description="Timestamp of the last update (read-only, set by the API).",
     )
-    tenant_name: Optional[str] = Field(
+    tenant_name: str | None = Field(
         default=None,
         alias="tenantName",
         description=("Name of the tenant that owns this extended community list. " "Allowed characters: [A-Za-z0-9_-]. Max 63 characters."),
         max_length=63,
     )
-    entries: Optional[List[ExtendedCommunityListEntryModel]] = Field(
+    entries: list[ExtendedCommunityListEntryModel] | None = Field(
         default=None,
         alias="entries",
         description="Collection of extended community list entries.",
@@ -333,7 +331,7 @@ class ExtendedCommunityListModel(NDBaseModel):
     # ------------------------------------------------------------------
 
     @classmethod
-    def get_argument_spec(cls) -> Dict:
+    def get_argument_spec(cls) -> dict:
         return dict(
             fabric_name=dict(type="str", required=True),
             config=dict(

--- a/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
+++ b/plugins/module_utils/models/manage_extended_community_list/manage_extended_community_list.py
@@ -348,9 +348,7 @@ class ExtendedCommunityListModel(NDBaseModel):
             missing = [field_name for field_name in ("type", "entries") if getattr(self, field_name) is None]
             if missing:
                 verb = "is" if len(missing) == 1 else "are"
-                raise ValueError(
-                    f"extended community list '{self.api_name}': '{', '.join(missing)}' {verb} required for state '{state}'."
-                )
+                raise ValueError(f"extended community list '{self.api_name}': '{', '.join(missing)}' {verb} required for state '{state}'.")
         return self
 
     # ------------------------------------------------------------------

--- a/plugins/module_utils/orchestrators/manage_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_community_list.py
@@ -130,11 +130,7 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
         items = result.get("results")
         if not isinstance(items, list):
             return
-        failures = [
-            item
-            for item in items
-            if isinstance(item, dict) and str(item.get("status") or "").lower() in _FAILURE_STATUSES
-        ]
+        failures = [item for item in items if isinstance(item, dict) and str(item.get("status") or "").lower() in _FAILURE_STATUSES]
         if failures:
             details = ", ".join(f"{item.get('name')}: {item.get('status')} - {item.get('message')}" for item in failures)
             raise RuntimeError(f"Per-item failures in community list response: {details}")

--- a/plugins/module_utils/orchestrators/manage_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_community_list.py
@@ -4,11 +4,9 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, annotations, division, print_function
+from __future__ import annotations
 
-__metaclass__ = type
-
-from typing import Any, ClassVar, Type
+from typing import Any, ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_community_lists import (
@@ -39,19 +37,19 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
     here and assigned to every endpoint instance before use.
     """
 
-    model_class: ClassVar[Type[NDBaseModel]] = CommunityListModel
+    model_class: ClassVar[type[NDBaseModel]] = CommunityListModel
 
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
 
     # Stub assignments satisfy NDBaseOrchestrator.validate_bulk_endpoints
-    create_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsPost
-    update_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsPut
-    delete_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsDelete
-    query_one_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsGet
-    query_all_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsListGet
-    create_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsPost
-    delete_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsBulkDelete
+    create_endpoint: type[NDEndpointBaseModel] = EpManageCommunityListsPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageCommunityListsPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageCommunityListsDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageCommunityListsGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageCommunityListsListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] = EpManageCommunityListsPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] = EpManageCommunityListsBulkDelete
 
     _fabric_context: FabricContext | None = None
 

--- a/plugins/module_utils/orchestrators/manage_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_community_list.py
@@ -17,6 +17,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageCommunityListsPost,
     EpManageCommunityListsPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.enums import OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_community_list.manage_community_list import CommunityListModel
@@ -169,7 +170,7 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
                 self._validate_write_model(model_instance)
             ep = self._configure_endpoint(self.create_bulk_endpoint())
             payload = {"communityLists": [m.to_payload() for m in model_instances]}
-            result = self._request(path=ep.path, verb=ep.verb, data=payload)
+            result = self._request(path=ep.path, verb=ep.verb, data=payload, operation_type=OperationType.CREATE)
             self._raise_on_207_action_errors(result)
             return result
         except Exception as e:
@@ -182,7 +183,12 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
             self._validate_write_model(model_instance)
             ep = self._configure_endpoint(self.update_endpoint())
             ep.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=ep.path, verb=ep.verb, data=model_instance.to_payload())
+            return self._request(
+                path=ep.path,
+                verb=ep.verb,
+                data=model_instance.to_payload(),
+                operation_type=OperationType.UPDATE,
+            )
         except Exception as e:
             raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -200,7 +206,7 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
         try:
             ep = self._configure_endpoint(self.delete_bulk_endpoint())
             payload = {"communityListNames": [m.get_identifier_value() for m in model_instances]}
-            result = self._request(path=ep.path, verb=ep.verb, data=payload)
+            result = self._request(path=ep.path, verb=ep.verb, data=payload, operation_type=OperationType.DELETE)
             self._raise_on_207_action_errors(result)
             return result
         except Exception as e:

--- a/plugins/module_utils/orchestrators/manage_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_community_list.py
@@ -199,7 +199,7 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
         """
         try:
             ep = self._configure_endpoint(self.delete_bulk_endpoint())
-            payload = {"communityListNames": [m.name for m in model_instances]}
+            payload = {"communityListNames": [m.get_identifier_value() for m in model_instances]}
             result = self._request(path=ep.path, verb=ep.verb, data=payload)
             self._raise_on_207_action_errors(result)
             return result

--- a/plugins/module_utils/orchestrators/manage_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_community_list.py
@@ -24,6 +24,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_community_l
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
+_FAILURE_STATUSES = frozenset({"failed", "failure", "error"})
+
 
 class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
     """
@@ -115,20 +117,24 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
         """
         # Summary
 
-        Inspect a bulk create/delete response and raise when any per-item status is not `success`.
+        Inspect a bulk create/delete response and raise on explicit per-item failure tokens.
 
         ## Raises
 
         ### RuntimeError
 
-        - If a `results` item is missing `status` or reports a non-success status.
+        - If a `results` item reports failed, failure, or error.
         """
         if not isinstance(result, dict):
             return
         items = result.get("results")
         if not isinstance(items, list):
             return
-        failures = [item for item in items if isinstance(item, dict) and item.get("status") != "success"]
+        failures = [
+            item
+            for item in items
+            if isinstance(item, dict) and str(item.get("status") or "").lower() in _FAILURE_STATUSES
+        ]
         if failures:
             details = ", ".join(f"{item.get('name')}: {item.get('status')} - {item.get('message')}" for item in failures)
             raise RuntimeError(f"Per-item failures in community list response: {details}")

--- a/plugins/module_utils/orchestrators/manage_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_community_list.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+from typing import Any, ClassVar, Type
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_community_lists import (
+    EpManageCommunityListsBulkDelete,
+    EpManageCommunityListsDelete,
+    EpManageCommunityListsGet,
+    EpManageCommunityListsListGet,
+    EpManageCommunityListsPost,
+    EpManageCommunityListsPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_community_list.manage_community_list import CommunityListModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
+    """
+    Orchestrator for community list CRUD operations on Nexus Dashboard.
+
+    Community lists are created and deleted in bulk via dedicated API endpoints:
+    - Create: POST /fabrics/{fabricName}/communityLists with {"communityLists": [...]}
+    - Delete: POST /fabrics/{fabricName}/communityListActions/remove with
+      {"communityListNames": [...]}
+
+    The ``fabric_name`` is not part of the CommunityListModel; it is injected
+    here and assigned to every endpoint instance before use.
+    """
+
+    model_class: ClassVar[Type[NDBaseModel]] = CommunityListModel
+
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+
+    # Stub assignments satisfy NDBaseOrchestrator.validate_bulk_endpoints
+    create_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsPost
+    update_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsPut
+    delete_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsDelete
+    query_one_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsGet
+    query_all_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsListGet
+    create_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsPost
+    delete_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageCommunityListsBulkDelete
+
+    _fabric_context: FabricContext | None = None
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        # Summary
+
+        Return `fabric_name` from module params.
+
+        ## Raises
+
+        None
+        """
+        return self.rest_send.params.get("fabric_name")
+
+    @property
+    def fabric_context(self) -> FabricContext:
+        """
+        # Summary
+
+        Return a lazily initialized `FabricContext` for this orchestrator's fabric.
+
+        ## Raises
+
+        None
+        """
+        if self._fabric_context is None:
+            self._fabric_context = FabricContext(rest_send=self.rest_send, fabric_name=self.fabric_name)
+        return self._fabric_context
+
+    def validate_prerequisites(self) -> None:
+        """
+        # Summary
+
+        Validate that the target fabric exists, is local, and is not deployment-frozen.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric cannot be safely mutated.
+        """
+        self.fabric_context.validate_for_mutation()
+
+    def _configure_endpoint(self, api_endpoint: NDEndpointBaseModel) -> NDEndpointBaseModel:
+        """
+        # Summary
+
+        Set `fabric_name` on an endpoint instance before path generation.
+
+        ## Raises
+
+        None
+        """
+        api_endpoint.fabric_name = self.fabric_name
+        return api_endpoint
+
+    @staticmethod
+    def _raise_on_207_action_errors(result: Any) -> None:
+        """
+        # Summary
+
+        Inspect a bulk create/delete response and raise when any per-item status is not `success`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If a `results` item is missing `status` or reports a non-success status.
+        """
+        if not isinstance(result, dict):
+            return
+        items = result.get("results")
+        if not isinstance(items, list):
+            return
+        failures = [item for item in items if isinstance(item, dict) and item.get("status") != "success"]
+        if failures:
+            details = ", ".join(f"{item.get('name')}: {item.get('status')} - {item.get('message')}" for item in failures)
+            raise RuntimeError(f"Per-item failures in community list response: {details}")
+
+    @staticmethod
+    def _validate_write_model(model_instance: CommunityListModel) -> None:
+        """
+        # Summary
+
+        Require the fields Nexus Dashboard needs for create/update bodies while still allowing
+        name-only models for deletes.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If `type` or `entries` is omitted for a write operation.
+        """
+        missing = []
+        if model_instance.type is None:
+            missing.append("type")
+        if not model_instance.entries:
+            missing.append("entries")
+        if missing:
+            raise RuntimeError(f"community list '{model_instance.name}' requires {', '.join(missing)} for create/update operations.")
+
+    def create(self, model_instance: CommunityListModel, **kwargs) -> ResponseType:
+        """Delegate single create to bulk create."""
+        return self.create_bulk([model_instance], **kwargs)
+
+    def create_bulk(self, model_instances: list[CommunityListModel], **kwargs) -> ResponseType:
+        """
+        Bulk-create community lists.
+
+        POST /fabrics/{fabricName}/communityLists
+        Body: {"communityLists": [...]}
+        """
+        try:
+            for model_instance in model_instances:
+                self._validate_write_model(model_instance)
+            ep = self._configure_endpoint(self.create_bulk_endpoint())
+            payload = {"communityLists": [m.to_payload() for m in model_instances]}
+            result = self._request(path=ep.path, verb=ep.verb, data=payload)
+            self._raise_on_207_action_errors(result)
+            return result
+        except Exception as e:
+            names = [m.name for m in model_instances]
+            raise RuntimeError(f"Bulk create failed for {names}: {e}") from e
+
+    def update(self, model_instance: CommunityListModel, **kwargs) -> ResponseType:
+        """Update a single community list by name."""
+        try:
+            self._validate_write_model(model_instance)
+            ep = self._configure_endpoint(self.update_endpoint())
+            ep.set_identifiers(model_instance.get_identifier_value())
+            return self._request(path=ep.path, verb=ep.verb, data=model_instance.to_payload())
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: CommunityListModel, **kwargs) -> ResponseType:
+        """Delegate single delete to bulk delete."""
+        return self.delete_bulk([model_instance], **kwargs)
+
+    def delete_bulk(self, model_instances: list[CommunityListModel], **kwargs) -> ResponseType:
+        """
+        Bulk-delete community lists by name.
+
+        POST /fabrics/{fabricName}/communityListActions/remove
+        Body: {"communityListNames": [...]}
+        """
+        try:
+            ep = self._configure_endpoint(self.delete_bulk_endpoint())
+            payload = {"communityListNames": [m.name for m in model_instances]}
+            result = self._request(path=ep.path, verb=ep.verb, data=payload)
+            self._raise_on_207_action_errors(result)
+            return result
+        except Exception as e:
+            names = [m.name for m in model_instances]
+            raise RuntimeError(f"Bulk delete failed for {names}: {e}") from e
+
+    def query_one(self, model_instance: CommunityListModel, **kwargs) -> ResponseType:
+        """Retrieve a single community list by name."""
+        try:
+            ep = self._configure_endpoint(self.query_one_endpoint())
+            ep.set_identifiers(model_instance.get_identifier_value())
+            return self._request(path=ep.path, verb=ep.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: CommunityListModel | None = None, **kwargs) -> ResponseType:
+        """
+        Retrieve all community lists for the fabric.
+
+        Extracts the ``communityLists`` wrapper key from the list response.
+        """
+        try:
+            self.validate_prerequisites()
+            ep = self._configure_endpoint(self.query_all_endpoint())
+            result = self._request(path=ep.path, verb=ep.verb, not_found_ok=True)
+            if isinstance(result, dict):
+                return result.get("communityLists", []) or []
+            return []
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_community_list.py
@@ -89,19 +89,10 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
             self._fabric_context = FabricContext(rest_send=self.rest_send, fabric_name=self.fabric_name)
         return self._fabric_context
 
-    def validate_prerequisites(self) -> None:
-        """
-        # Summary
-
-        Validate that the target fabric exists, is local, and is not deployment-frozen.
-
-        ## Raises
-
-        ### RuntimeError
-
-        - If the fabric cannot be safely mutated.
-        """
-        self.fabric_context.validate_for_mutation()
+    def preflight(self, model_instances: list[CommunityListModel]) -> None:
+        """Validate that the target fabric can be mutated before writes."""
+        if model_instances:
+            self.fabric_context.validate_for_mutation()
 
     def _configure_endpoint(self, api_endpoint: NDEndpointBaseModel) -> NDEndpointBaseModel:
         """
@@ -239,7 +230,6 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
         Extracts the ``communityLists`` wrapper key from the list response.
         """
         try:
-            self.validate_prerequisites()
             collected: list[dict] = []
             seen: set[str] = set()
             offset = 0

--- a/plugins/module_utils/orchestrators/manage_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_community_list.py
@@ -42,6 +42,8 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
 
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
+    query_all_page_size: ClassVar[int] = 100
+    query_all_max_pages: ClassVar[int] = 10000
 
     # Stub assignments satisfy NDBaseOrchestrator.validate_bulk_endpoints
     create_endpoint: type[NDEndpointBaseModel] = EpManageCommunityListsPost
@@ -66,6 +68,11 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
         None
         """
         return self.rest_send.params.get("fabric_name")
+
+    @property
+    def cluster_name(self) -> str | None:
+        """Return the optional target cluster name from module params."""
+        return self.rest_send.params.get("cluster_name")
 
     @property
     def fabric_context(self) -> FabricContext:
@@ -107,6 +114,9 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
         None
         """
         api_endpoint.fabric_name = self.fabric_name
+        params = getattr(api_endpoint, "endpoint_params", None)
+        if self.cluster_name and params is not None and hasattr(params, "cluster_name"):
+            params.cluster_name = self.cluster_name
         return api_endpoint
 
     @staticmethod
@@ -230,10 +240,33 @@ class ManageCommunityListOrchestrator(NDBaseOrchestrator[CommunityListModel]):
         """
         try:
             self.validate_prerequisites()
-            ep = self._configure_endpoint(self.query_all_endpoint())
-            result = self._request(path=ep.path, verb=ep.verb, not_found_ok=True)
-            if isinstance(result, dict):
-                return result.get("communityLists", []) or []
-            return []
+            collected: list[dict] = []
+            seen: set[str] = set()
+            offset = 0
+            pages_fetched = 0
+            while pages_fetched < self.query_all_max_pages:
+                pages_fetched += 1
+                ep = self._configure_endpoint(self.query_all_endpoint())
+                ep.lucene_params.max = self.query_all_page_size
+                ep.lucene_params.offset = offset
+                result = self._request(path=ep.path, verb=ep.verb, not_found_ok=True)
+                page = result.get("communityLists", []) or [] if isinstance(result, dict) else (result or [])
+                if not page:
+                    break
+
+                new_rows = 0
+                for row in page:
+                    name = row.get("name") if isinstance(row, dict) else None
+                    if name is not None:
+                        if name in seen:
+                            continue
+                        seen.add(name)
+                    collected.append(row)
+                    new_rows += 1
+
+                if len(page) < self.query_all_page_size or new_rows == 0:
+                    break
+                offset += self.query_all_page_size
+            return collected
         except Exception as e:
             raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_extended_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_extended_community_list.py
@@ -93,19 +93,10 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
             self._fabric_context = FabricContext(rest_send=self.rest_send, fabric_name=self.fabric_name)
         return self._fabric_context
 
-    def validate_prerequisites(self) -> None:
-        """
-        # Summary
-
-        Validate that the target fabric exists, is local, and is not deployment-frozen.
-
-        ## Raises
-
-        ### RuntimeError
-
-        - If the fabric cannot be safely mutated.
-        """
-        self.fabric_context.validate_for_mutation()
+    def preflight(self, model_instances: list[ExtendedCommunityListModel]) -> None:
+        """Validate that the target fabric can be mutated before writes."""
+        if model_instances:
+            self.fabric_context.validate_for_mutation()
 
     def _configure_endpoint(self, api_endpoint: NDEndpointBaseModel) -> NDEndpointBaseModel:
         """
@@ -243,7 +234,6 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
         Extracts the ``extendedCommunityLists`` wrapper key from the list response.
         """
         try:
-            self.validate_prerequisites()
             collected: list[dict] = []
             seen: set[str] = set()
             offset = 0

--- a/plugins/module_utils/orchestrators/manage_extended_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_extended_community_list.py
@@ -46,6 +46,8 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
 
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
+    query_all_page_size: ClassVar[int] = 100
+    query_all_max_pages: ClassVar[int] = 10000
 
     # Satisfy NDBaseOrchestrator.validate_bulk_endpoints
     create_endpoint: type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPost
@@ -70,6 +72,11 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
         None
         """
         return self.rest_send.params.get("fabric_name")
+
+    @property
+    def cluster_name(self) -> str | None:
+        """Return the optional target cluster name from module params."""
+        return self.rest_send.params.get("cluster_name")
 
     @property
     def fabric_context(self) -> FabricContext:
@@ -111,6 +118,9 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
         None
         """
         api_endpoint.fabric_name = self.fabric_name
+        params = getattr(api_endpoint, "endpoint_params", None)
+        if self.cluster_name and params is not None and hasattr(params, "cluster_name"):
+            params.cluster_name = self.cluster_name
         return api_endpoint
 
     @staticmethod
@@ -234,10 +244,33 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
         """
         try:
             self.validate_prerequisites()
-            ep = self._configure_endpoint(self.query_all_endpoint())
-            result = self._request(path=ep.path, verb=ep.verb, not_found_ok=True)
-            if isinstance(result, dict):
-                return result.get("extendedCommunityLists", []) or []
-            return []
+            collected: list[dict] = []
+            seen: set[str] = set()
+            offset = 0
+            pages_fetched = 0
+            while pages_fetched < self.query_all_max_pages:
+                pages_fetched += 1
+                ep = self._configure_endpoint(self.query_all_endpoint())
+                ep.lucene_params.max = self.query_all_page_size
+                ep.lucene_params.offset = offset
+                result = self._request(path=ep.path, verb=ep.verb, not_found_ok=True)
+                page = result.get("extendedCommunityLists", []) or [] if isinstance(result, dict) else (result or [])
+                if not page:
+                    break
+
+                new_rows = 0
+                for row in page:
+                    name = row.get("name") if isinstance(row, dict) else None
+                    if name is not None:
+                        if name in seen:
+                            continue
+                        seen.add(name)
+                    collected.append(row)
+                    new_rows += 1
+
+                if len(page) < self.query_all_page_size or new_rows == 0:
+                    break
+                offset += self.query_all_page_size
+            return collected
         except Exception as e:
             raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_extended_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_extended_community_list.py
@@ -134,11 +134,7 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
         items = result.get("results")
         if not isinstance(items, list):
             return
-        failures = [
-            item
-            for item in items
-            if isinstance(item, dict) and str(item.get("status") or "").lower() in _FAILURE_STATUSES
-        ]
+        failures = [item for item in items if isinstance(item, dict) and str(item.get("status") or "").lower() in _FAILURE_STATUSES]
         if failures:
             details = ", ".join(f"{item.get('name')}: {item.get('status')} - {item.get('message')}" for item in failures)
             raise RuntimeError(f"Per-item failures in extended community list response: {details}")

--- a/plugins/module_utils/orchestrators/manage_extended_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_extended_community_list.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+from typing import Any, ClassVar, Type
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_extended_community_lists import (
+    EpManageExtendedCommunityListsBulkDelete,
+    EpManageExtendedCommunityListsDelete,
+    EpManageExtendedCommunityListsGet,
+    EpManageExtendedCommunityListsListGet,
+    EpManageExtendedCommunityListsPost,
+    EpManageExtendedCommunityListsPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_community_list.manage_extended_community_list import (
+    ExtendedCommunityListModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommunityListModel]):
+    """
+    Orchestrator for extended community list CRUD operations on Nexus Dashboard.
+
+    Extended community lists are created and deleted in bulk via dedicated
+    API endpoints:
+    - Create: POST /fabrics/{fabricName}/extendedCommunityLists
+              body: {"extendedCommunityLists": [...]}
+    - Delete: POST /fabrics/{fabricName}/extendedCommunityListActions/remove
+              body: {"extendedCommunityListNames": [...]}
+
+    The ``fabric_name`` is not part of ExtendedCommunityListModel; it is
+    injected here and assigned to every endpoint instance before use.
+    """
+
+    model_class: ClassVar[Type[NDBaseModel]] = ExtendedCommunityListModel
+
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+
+    # Satisfy NDBaseOrchestrator.validate_bulk_endpoints
+    create_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPost
+    update_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPut
+    delete_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsDelete
+    query_one_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsGet
+    query_all_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsListGet
+    create_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPost
+    delete_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsBulkDelete
+
+    _fabric_context: FabricContext | None = None
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        # Summary
+
+        Return `fabric_name` from module params.
+
+        ## Raises
+
+        None
+        """
+        return self.rest_send.params.get("fabric_name")
+
+    @property
+    def fabric_context(self) -> FabricContext:
+        """
+        # Summary
+
+        Return a lazily initialized `FabricContext` for this orchestrator's fabric.
+
+        ## Raises
+
+        None
+        """
+        if self._fabric_context is None:
+            self._fabric_context = FabricContext(rest_send=self.rest_send, fabric_name=self.fabric_name)
+        return self._fabric_context
+
+    def validate_prerequisites(self) -> None:
+        """
+        # Summary
+
+        Validate that the target fabric exists, is local, and is not deployment-frozen.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric cannot be safely mutated.
+        """
+        self.fabric_context.validate_for_mutation()
+
+    def _configure_endpoint(self, api_endpoint: NDEndpointBaseModel) -> NDEndpointBaseModel:
+        """
+        # Summary
+
+        Set `fabric_name` on an endpoint instance before path generation.
+
+        ## Raises
+
+        None
+        """
+        api_endpoint.fabric_name = self.fabric_name
+        return api_endpoint
+
+    @staticmethod
+    def _raise_on_207_action_errors(result: Any) -> None:
+        """
+        # Summary
+
+        Inspect a bulk create/delete response and raise when any per-item status is not `success`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If a `results` item is missing `status` or reports a non-success status.
+        """
+        if not isinstance(result, dict):
+            return
+        items = result.get("results")
+        if not isinstance(items, list):
+            return
+        failures = [item for item in items if isinstance(item, dict) and item.get("status") != "success"]
+        if failures:
+            details = ", ".join(f"{item.get('name')}: {item.get('status')} - {item.get('message')}" for item in failures)
+            raise RuntimeError(f"Per-item failures in extended community list response: {details}")
+
+    @staticmethod
+    def _validate_write_model(model_instance: ExtendedCommunityListModel) -> None:
+        """
+        # Summary
+
+        Require the fields Nexus Dashboard needs for create/update bodies while still allowing
+        name-only models for deletes.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If `type` or `entries` is omitted for a write operation.
+        """
+        missing = []
+        if model_instance.type is None:
+            missing.append("type")
+        if not model_instance.entries:
+            missing.append("entries")
+        if missing:
+            raise RuntimeError(f"extended community list '{model_instance.name}' requires {', '.join(missing)} for create/update operations.")
+
+    def create(self, model_instance: ExtendedCommunityListModel, **kwargs) -> ResponseType:
+        """Delegate single create to bulk create."""
+        return self.create_bulk([model_instance], **kwargs)
+
+    def create_bulk(self, model_instances: list[ExtendedCommunityListModel], **kwargs) -> ResponseType:
+        """
+        Bulk-create extended community lists.
+
+        POST /fabrics/{fabricName}/extendedCommunityLists
+        Body: {"extendedCommunityLists": [...]}
+        """
+        try:
+            for model_instance in model_instances:
+                self._validate_write_model(model_instance)
+            ep = self._configure_endpoint(self.create_bulk_endpoint())
+            payload = {"extendedCommunityLists": [m.to_payload() for m in model_instances]}
+            result = self._request(path=ep.path, verb=ep.verb, data=payload)
+            self._raise_on_207_action_errors(result)
+            return result
+        except Exception as e:
+            names = [m.name for m in model_instances]
+            raise RuntimeError(f"Bulk create failed for {names}: {e}") from e
+
+    def update(self, model_instance: ExtendedCommunityListModel, **kwargs) -> ResponseType:
+        """Update a single extended community list by name."""
+        try:
+            self._validate_write_model(model_instance)
+            ep = self._configure_endpoint(self.update_endpoint())
+            ep.set_identifiers(model_instance.get_identifier_value())
+            return self._request(path=ep.path, verb=ep.verb, data=model_instance.to_payload())
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: ExtendedCommunityListModel, **kwargs) -> ResponseType:
+        """Delegate single delete to bulk delete."""
+        return self.delete_bulk([model_instance], **kwargs)
+
+    def delete_bulk(self, model_instances: list[ExtendedCommunityListModel], **kwargs) -> ResponseType:
+        """
+        Bulk-delete extended community lists by name.
+
+        POST /fabrics/{fabricName}/extendedCommunityListActions/remove
+        Body: {"extendedCommunityListNames": [...]}
+        """
+        try:
+            ep = self._configure_endpoint(self.delete_bulk_endpoint())
+            payload = {"extendedCommunityListNames": [m.name for m in model_instances]}
+            result = self._request(path=ep.path, verb=ep.verb, data=payload)
+            self._raise_on_207_action_errors(result)
+            return result
+        except Exception as e:
+            names = [m.name for m in model_instances]
+            raise RuntimeError(f"Bulk delete failed for {names}: {e}") from e
+
+    def query_one(self, model_instance: ExtendedCommunityListModel, **kwargs) -> ResponseType:
+        """Retrieve a single extended community list by name."""
+        try:
+            ep = self._configure_endpoint(self.query_one_endpoint())
+            ep.set_identifiers(model_instance.get_identifier_value())
+            return self._request(path=ep.path, verb=ep.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: ExtendedCommunityListModel | None = None, **kwargs) -> ResponseType:
+        """
+        Retrieve all extended community lists for the fabric.
+
+        Extracts the ``extendedCommunityLists`` wrapper key from the list response.
+        """
+        try:
+            self.validate_prerequisites()
+            ep = self._configure_endpoint(self.query_all_endpoint())
+            result = self._request(path=ep.path, verb=ep.verb, not_found_ok=True)
+            if isinstance(result, dict):
+                return result.get("extendedCommunityLists", []) or []
+            return []
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_extended_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_extended_community_list.py
@@ -4,11 +4,9 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, annotations, division, print_function
+from __future__ import annotations
 
-__metaclass__ = type
-
-from typing import Any, ClassVar, Type
+from typing import Any, ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_extended_community_lists import (
@@ -43,19 +41,19 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
     injected here and assigned to every endpoint instance before use.
     """
 
-    model_class: ClassVar[Type[NDBaseModel]] = ExtendedCommunityListModel
+    model_class: ClassVar[type[NDBaseModel]] = ExtendedCommunityListModel
 
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
 
     # Satisfy NDBaseOrchestrator.validate_bulk_endpoints
-    create_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPost
-    update_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPut
-    delete_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsDelete
-    query_one_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsGet
-    query_all_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsListGet
-    create_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPost
-    delete_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageExtendedCommunityListsBulkDelete
+    create_endpoint: type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageExtendedCommunityListsDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageExtendedCommunityListsGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageExtendedCommunityListsListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] = EpManageExtendedCommunityListsPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] = EpManageExtendedCommunityListsBulkDelete
 
     _fabric_context: FabricContext | None = None
 

--- a/plugins/module_utils/orchestrators/manage_extended_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_extended_community_list.py
@@ -17,6 +17,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageExtendedCommunityListsPost,
     EpManageExtendedCommunityListsPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.enums import OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_community_list.manage_extended_community_list import (
@@ -173,7 +174,7 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
                 self._validate_write_model(model_instance)
             ep = self._configure_endpoint(self.create_bulk_endpoint())
             payload = {"extendedCommunityLists": [m.to_payload() for m in model_instances]}
-            result = self._request(path=ep.path, verb=ep.verb, data=payload)
+            result = self._request(path=ep.path, verb=ep.verb, data=payload, operation_type=OperationType.CREATE)
             self._raise_on_207_action_errors(result)
             return result
         except Exception as e:
@@ -186,7 +187,12 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
             self._validate_write_model(model_instance)
             ep = self._configure_endpoint(self.update_endpoint())
             ep.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=ep.path, verb=ep.verb, data=model_instance.to_payload())
+            return self._request(
+                path=ep.path,
+                verb=ep.verb,
+                data=model_instance.to_payload(),
+                operation_type=OperationType.UPDATE,
+            )
         except Exception as e:
             raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -204,7 +210,7 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
         try:
             ep = self._configure_endpoint(self.delete_bulk_endpoint())
             payload = {"extendedCommunityListNames": [m.get_identifier_value() for m in model_instances]}
-            result = self._request(path=ep.path, verb=ep.verb, data=payload)
+            result = self._request(path=ep.path, verb=ep.verb, data=payload, operation_type=OperationType.DELETE)
             self._raise_on_207_action_errors(result)
             return result
         except Exception as e:

--- a/plugins/module_utils/orchestrators/manage_extended_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_extended_community_list.py
@@ -26,6 +26,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_co
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
+_FAILURE_STATUSES = frozenset({"failed", "failure", "error"})
+
 
 class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommunityListModel]):
     """
@@ -119,20 +121,24 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
         """
         # Summary
 
-        Inspect a bulk create/delete response and raise when any per-item status is not `success`.
+        Inspect a bulk create/delete response and raise on explicit per-item failure tokens.
 
         ## Raises
 
         ### RuntimeError
 
-        - If a `results` item is missing `status` or reports a non-success status.
+        - If a `results` item reports failed, failure, or error.
         """
         if not isinstance(result, dict):
             return
         items = result.get("results")
         if not isinstance(items, list):
             return
-        failures = [item for item in items if isinstance(item, dict) and item.get("status") != "success"]
+        failures = [
+            item
+            for item in items
+            if isinstance(item, dict) and str(item.get("status") or "").lower() in _FAILURE_STATUSES
+        ]
         if failures:
             details = ", ".join(f"{item.get('name')}: {item.get('status')} - {item.get('message')}" for item in failures)
             raise RuntimeError(f"Per-item failures in extended community list response: {details}")

--- a/plugins/module_utils/orchestrators/manage_extended_community_list.py
+++ b/plugins/module_utils/orchestrators/manage_extended_community_list.py
@@ -203,7 +203,7 @@ class ManageExtendedCommunityListOrchestrator(NDBaseOrchestrator[ExtendedCommuni
         """
         try:
             ep = self._configure_endpoint(self.delete_bulk_endpoint())
-            payload = {"extendedCommunityListNames": [m.name for m in model_instances]}
+            payload = {"extendedCommunityListNames": [m.get_identifier_value() for m in model_instances]}
             result = self._request(path=ep.path, verb=ep.verb, data=payload)
             self._raise_on_207_action_errors(result)
             return result

--- a/plugins/modules/nd_manage_community_list.py
+++ b/plugins/modules/nd_manage_community_list.py
@@ -10,7 +10,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_manage_community_list
-version_added: "1.6.0"
+version_added: "2.0.0"
 short_description: Manage BGP community lists on Cisco Nexus Dashboard fabrics
 description:
 - Manage BGP routing-policy community lists on a Cisco Nexus Dashboard (ND) fabric.
@@ -25,6 +25,10 @@ options:
     - Required for all operations.
     type: str
     required: true
+  cluster_name:
+    description:
+    - The target cluster name in a multi-cluster deployment.
+    type: str
   config:
     description:
     - The list of community lists to configure.
@@ -53,6 +57,8 @@ options:
         - The tenant that owns this community list.
         - When omitted the default tenant is used.
         - Allowed characters are C([A-Za-z0-9_-]). Max 63 characters.
+        - When set, O(config.name) may be the bare list name or the fully qualified C(tenant~name) API name.
+        - The module reports the bare O(config.name) and uses C(tenant~name) for API lookups, updates, and deletes.
         type: str
         aliases: [ tenantName ]
       entries:
@@ -168,7 +174,6 @@ EXAMPLES = r"""
     config:
       - name: CL-STANDARD-PROD
         type: standard
-        description: Production community list
         entries:
           - sequence_number: 10
             action: permit
@@ -234,6 +239,89 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The community list configuration before the module ran, structured the same as O(config).
+  - An empty list when no community lists existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - name: CL_EXPORT
+    tenant_name: tenantSales
+    type: standard
+    entries:
+    - sequence_number: 10
+      action: permit
+      community_numbers:
+      - "65000:100"
+after:
+  description:
+  - The community list configuration after the module ran, structured the same as O(config).
+  - This is the predicted post-write state and is not re-read from the controller after writes.
+  - In check mode, this is the configuration that would result outside check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - name: CL_EXPORT
+    tenant_name: tenantSales
+    type: standard
+    entries:
+    - sequence_number: 10
+      action: permit
+      community_numbers:
+      - "65000:200"
+diff:
+  description: The per-community-list difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - name: CL_EXPORT
+    tenant_name: tenantSales
+    type: standard
+    entries:
+    - sequence_number: 10
+      action: permit
+      community_numbers:
+      - "65000:200"
+proposed:
+  description: The community list configuration proposed before reconciliation with existing state.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - name: CL_EXPORT
+    tenant_name: tenantSales
+    type: standard
+    entries:
+    - sequence_number: 10
+      action: permit
+      community_numbers:
+      - "65000:200"
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "manage_state begin state=merged check_mode=False"
+msg:
+  description: A human-readable error message present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "community list 'CL_EXPORT': 'type, entries' are required for state 'merged'."
 """
 
 import logging

--- a/plugins/modules/nd_manage_community_list.py
+++ b/plugins/modules/nd_manage_community_list.py
@@ -5,10 +5,6 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
-
 ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
 
 DOCUMENTATION = r"""

--- a/plugins/modules/nd_manage_community_list.py
+++ b/plugins/modules/nd_manage_community_list.py
@@ -1,0 +1,299 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_manage_community_list
+version_added: "1.6.0"
+short_description: Manage BGP community lists on Cisco Nexus Dashboard fabrics
+description:
+- Manage BGP routing-policy community lists on a Cisco Nexus Dashboard (ND) fabric.
+- Both C(standard) and C(expanded) community list types are supported by this module.
+- Community lists are created and deleted in bulk via dedicated API endpoints.
+author:
+- Gaspard Micol (@gmicol)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric that owns the community lists.
+    - Required for all operations.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of community lists to configure.
+    type: list
+    elements: dict
+    required: True
+    suboptions:
+      name:
+        description:
+        - The name of the community list.
+        - Allowed characters are C([a-zA-Z0-9~_-]).
+        - Maximum length is 115 characters (63 for the default tenant).
+        type: str
+        required: true
+      type:
+        description:
+        - The type of community list.
+        - Required for create and update operations; not required when O(state=deleted).
+        - C(standard) - matches well-known communities and/or explicit community
+          numbers in ASN:NN format.
+        - C(expanded) - matches community strings using a regular expression.
+        type: str
+        choices: [ standard, expanded ]
+      tenant_name:
+        description:
+        - The tenant that owns this community list.
+        - When omitted the default tenant is used.
+        - Allowed characters are C([A-Za-z0-9_-]). Max 63 characters.
+        type: str
+        aliases: [ tenantName ]
+      entries:
+        description:
+        - The ordered list of community list entries.
+        - Required for create and update operations; not required when O(state=deleted).
+        - Each entry defines a permit/deny action and the community or regular
+          expression to match.
+        type: list
+        elements: dict
+        suboptions:
+          sequence_number:
+            description:
+            - Sequence number of this entry (1-4294967294).
+            - Entries are evaluated in ascending order.
+            type: int
+            required: true
+            aliases: [ sequenceNumber ]
+          action:
+            description:
+            - The action to take when a community matches this entry.
+            type: str
+            required: true
+            choices: [ permit, deny ]
+          no_advertise:
+            description:
+            - Match the well-known C(NO_ADVERTISE) community (65535:65282).
+            - Do not advertise the route to any iBGP or eBGP neighbors.
+            - Only valid when O(config.type=standard).
+            type: bool
+            aliases: [ noAdvertise ]
+          blackhole:
+            description:
+            - Match the well-known C(BLACKHOLE) community (65535:666).
+            - Used to drop traffic to a specified destination.
+            - Only valid when O(config.type=standard).
+            type: bool
+            aliases: [ blackhole ]
+          no_export:
+            description:
+            - Match the well-known C(NO_EXPORT) community.
+            - Do not export the route to the next AS.
+            - Only valid when O(config.type=standard).
+            type: bool
+            aliases: [ noExport ]
+          internet:
+            description:
+            - Match the well-known C(INTERNET) community.
+            - Only valid when O(config.type=standard).
+            type: bool
+            aliases: [ internet ]
+          graceful_shutdown:
+            description:
+            - Match the well-known C(GRACEFUL_SHUTDOWN) community.
+            - Only valid when O(config.type=standard).
+            type: bool
+            aliases: [ gracefulShutdown ]
+          local_asn:
+            description:
+            - Match the well-known C(NO_ADVERTISE_TO_IBGP) community (65535:65284).
+            - Do not advertise the route to an iBGP neighbor if the route was
+              received from another iBGP neighbor.
+            - Only valid when O(config.type=standard).
+            type: bool
+            aliases: [ localAsn ]
+          community_numbers:
+            description:
+            - List of explicit community numbers in ASN:NN format.
+            - Each part must be in the range 0-65535 (e.g. C(100:200)).
+            - Only valid when O(config.type=standard).
+            type: list
+            elements: str
+            aliases: [ communityNumbers ]
+          community_number_regex:
+            description:
+            - Regular expression in aa:nn format for matching community strings.
+            - Must not start with C([a-zA-Z~!#%@`;]). Max 63 characters.
+            - Required and only valid when O(config.type=expanded).
+            type: str
+            aliases: [ communityNumberRegex ]
+  state:
+    description:
+    - The desired state of the community list resources on Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new community lists and update existing ones
+      as defined in the configuration.
+      Community lists not specified in the configuration are left unchanged.
+    - Use O(state=replaced) to replace the community lists specified in the
+      configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source
+      of truth. All community lists on ND not present in the configuration will
+      be deleted. Use with caution.
+    - Use O(state=deleted) to remove the community lists specified in the
+      configuration.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard version 4.2.1 or higher.
+- Community lists are created and deleted in bulk via separate API endpoints.
+- Standard entries that set none of the well-known community flags and leave
+  O(config.entries.community_numbers) empty are valid (match all communities).
+- O(config.entries.community_number_regex) is required for every entry when
+  O(config.type=expanded); standard-only fields must not be set on expanded entries.
+"""
+
+EXAMPLES = r"""
+- name: Create a standard community list
+  cisco.nd.nd_manage_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: CL-STANDARD-PROD
+        type: standard
+        description: Production community list
+        entries:
+          - sequence_number: 10
+            action: permit
+            community_numbers:
+              - "100:200"
+              - "65000:1"
+          - sequence_number: 20
+            action: permit
+            no_advertise: true
+            no_export: true
+          - sequence_number: 30
+            action: deny
+            blackhole: true
+    state: merged
+
+- name: Create an expanded community list
+  cisco.nd.nd_manage_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: CL-EXPANDED-REGEX
+        type: expanded
+        entries:
+          - sequence_number: 10
+            action: permit
+            community_number_regex: "100:.*"
+          - sequence_number: 20
+            action: deny
+            community_number_regex: "65000:.*"
+    state: merged
+
+- name: Update a standard community list (replace its entries)
+  cisco.nd.nd_manage_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: CL-STANDARD-PROD
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            community_numbers:
+              - "200:300"
+    state: replaced
+
+- name: Delete specific community lists
+  cisco.nd.nd_manage_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: CL-STANDARD-PROD
+      - name: CL-EXPANDED-REGEX
+    state: deleted
+
+- name: Override -- enforce exact set of community lists (delete all others)
+  cisco.nd.nd_manage_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: CL-FINAL
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            internet: true
+    state: overridden
+"""
+
+RETURN = r"""
+"""
+
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_community_list.manage_community_list import CommunityListModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_community_list import ManageCommunityListOrchestrator
+
+
+def main():
+    argument_spec = nd_argument_spec()
+    argument_spec.update(CommunityListModel.get_argument_spec())
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_manage_community_list")
+
+    nd_state_machine = None
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=ManageCommunityListOrchestrator,
+        )
+
+        module_log.debug("manage_state begin state=%s check_mode=%s", module.params.get("state"), module.check_mode)
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_manage_community_list.py
+++ b/plugins/modules/nd_manage_community_list.py
@@ -67,6 +67,7 @@ options:
         - Required for create and update operations; not required when O(state=deleted).
         - Each entry defines a permit/deny action and the community or regular
           expression to match.
+        - Every standard entry must set at least one explicit community number or enable at least one well-known community flag.
         type: list
         elements: dict
         suboptions:
@@ -161,8 +162,8 @@ extends_documentation_fragment:
 notes:
 - This module is only supported on Nexus Dashboard version 4.2.1 or higher.
 - Community lists are created and deleted in bulk via separate API endpoints.
-- Standard entries that set none of the well-known community flags and leave
-  O(config.entries.community_numbers) empty are valid (match all communities).
+- Every standard entry must set at least one explicit community number or enable
+  at least one well-known community flag.
 - O(config.entries.community_number_regex) is required for every entry when
   O(config.type=expanded); standard-only fields must not be set on expanded entries.
 """

--- a/plugins/modules/nd_manage_extended_community_list.py
+++ b/plugins/modules/nd_manage_extended_community_list.py
@@ -10,7 +10,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_manage_extended_community_list
-version_added: "1.6.0"
+version_added: "2.0.0"
 short_description: Manage BGP extended community lists on Cisco Nexus Dashboard fabrics
 description:
 - Manage BGP routing-policy extended community lists on a Cisco Nexus Dashboard
@@ -27,6 +27,10 @@ options:
     - Required for all operations.
     type: str
     required: true
+  cluster_name:
+    description:
+    - The target cluster name in a multi-cluster deployment.
+    type: str
   config:
     description:
     - The list of extended community lists to configure.
@@ -56,6 +60,8 @@ options:
         - The tenant that owns this extended community list.
         - When omitted the default tenant is used.
         - Allowed characters are C([A-Za-z0-9_-]). Max 63 characters.
+        - When set, O(config.name) may be the bare list name or the fully qualified C(tenant~name) API name.
+        - The module reports the bare O(config.name) and uses C(tenant~name) for API lookups, updates, and deletes.
         type: str
         aliases: [ tenantName ]
       entries:
@@ -260,6 +266,89 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The extended community list configuration before the module ran, structured the same as O(config).
+  - An empty list when no extended community lists existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - name: ECL_EXPORT
+    tenant_name: tenantSales
+    type: standard
+    entries:
+    - sequence_number: 10
+      action: permit
+      route_target_collection:
+      - "65000:100"
+after:
+  description:
+  - The extended community list configuration after the module ran, structured the same as O(config).
+  - This is the predicted post-write state and is not re-read from the controller after writes.
+  - In check mode, this is the configuration that would result outside check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - name: ECL_EXPORT
+    tenant_name: tenantSales
+    type: standard
+    entries:
+    - sequence_number: 10
+      action: permit
+      route_target_collection:
+      - "65000:200"
+diff:
+  description: The per-extended-community-list difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - name: ECL_EXPORT
+    tenant_name: tenantSales
+    type: standard
+    entries:
+    - sequence_number: 10
+      action: permit
+      route_target_collection:
+      - "65000:200"
+proposed:
+  description: The extended community list configuration proposed before reconciliation with existing state.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - name: ECL_EXPORT
+    tenant_name: tenantSales
+    type: standard
+    entries:
+    - sequence_number: 10
+      action: permit
+      route_target_collection:
+      - "65000:200"
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "manage_state begin state=merged check_mode=False"
+msg:
+  description: A human-readable error message present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "extended community list 'ECL_EXPORT': 'type, entries' are required for state 'merged'."
 """
 
 import logging

--- a/plugins/modules/nd_manage_extended_community_list.py
+++ b/plugins/modules/nd_manage_extended_community_list.py
@@ -70,6 +70,7 @@ options:
         - Required for create and update operations; not required when O(state=deleted).
         - Each entry defines a permit/deny action and one or more extended
           communities to match.
+        - Standard entries require at least one non-empty selector collection.
         type: list
         elements: dict
         suboptions:
@@ -164,7 +165,8 @@ notes:
 - This module is only supported on Nexus Dashboard version 4.2.1 or higher.
 - Extended community lists are created and deleted in bulk via separate API
   endpoints.
-- Standard-type entries may set any combination of O(config.entries.router_mac_collection),
+- Standard-type entries must set at least one non-empty selector collection from
+  O(config.entries.router_mac_collection),
   O(config.entries.route_target_collection), O(config.entries.site_of_origin_collection),
   O(config.entries.transitive_generic_extended_collection), and
   O(config.entries.non_transitive_generic_extended_collection).

--- a/plugins/modules/nd_manage_extended_community_list.py
+++ b/plugins/modules/nd_manage_extended_community_list.py
@@ -5,10 +5,6 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
-
 ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
 
 DOCUMENTATION = r"""

--- a/plugins/modules/nd_manage_extended_community_list.py
+++ b/plugins/modules/nd_manage_extended_community_list.py
@@ -100,6 +100,7 @@ options:
             - One or more route targets to match.
             - Each value must be in C(ASN2:NN), C(ASN4:NN), or C(IPv4:NN)
               format (e.g. C(65000:100) or C(192.168.1.1:200)).
+            - Comma-separated route targets in one list item are accepted and normalized to separate values.
             - Only valid when O(config.type=standard).
             type: list
             elements: str
@@ -182,8 +183,7 @@ EXAMPLES = r"""
           - sequence_number: 10
             action: permit
             route_target_collection:
-              - "65000:100"
-              - "65000:200"
+              - "65000:100,65000:200"
               - "192.168.1.1:300"
           - sequence_number: 20
             action: permit

--- a/plugins/modules/nd_manage_extended_community_list.py
+++ b/plugins/modules/nd_manage_extended_community_list.py
@@ -1,0 +1,329 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_manage_extended_community_list
+version_added: "1.6.0"
+short_description: Manage BGP extended community lists on Cisco Nexus Dashboard fabrics
+description:
+- Manage BGP routing-policy extended community lists on a Cisco Nexus Dashboard
+  (ND) fabric.
+- Both C(standard) and C(expanded) extended community list types are supported.
+- Extended community lists are created and deleted in bulk via dedicated API
+  endpoints.
+author:
+- Gaspard Micol (@gmicol)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric that owns the extended community lists.
+    - Required for all operations.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of extended community lists to configure.
+    type: list
+    elements: dict
+    required: True
+    suboptions:
+      name:
+        description:
+        - The name of the extended community list.
+        - Allowed characters are C([a-zA-Z0-9~_-]).
+        - Maximum length is 115 characters (63 for the default tenant).
+        type: str
+        required: true
+      type:
+        description:
+        - The type of extended community list.
+        - Required for create and update operations; not required when O(state=deleted).
+        - C(standard) - matches extended communities using explicit values such
+          as route targets, router MACs, site-of-origin, or generic extended
+          community values.
+        - C(expanded) - matches extended communities using a regular expression.
+        type: str
+        choices: [ standard, expanded ]
+      tenant_name:
+        description:
+        - The tenant that owns this extended community list.
+        - When omitted the default tenant is used.
+        - Allowed characters are C([A-Za-z0-9_-]). Max 63 characters.
+        type: str
+        aliases: [ tenantName ]
+      entries:
+        description:
+        - The ordered list of extended community list entries.
+        - Required for create and update operations; not required when O(state=deleted).
+        - Each entry defines a permit/deny action and one or more extended
+          communities to match.
+        type: list
+        elements: dict
+        suboptions:
+          sequence_number:
+            description:
+            - Sequence number of this entry (1-4294967294).
+            - Entries are evaluated in ascending order.
+            type: int
+            required: true
+            aliases: [ sequenceNumber ]
+          action:
+            description:
+            - The action to take when a community matches this entry.
+            type: str
+            required: true
+            choices: [ permit, deny ]
+          router_mac_collection:
+            description:
+            - One or more router MAC addresses to match.
+            - Each value must be in C(eeee.eeee.eeee), C(ee:ee:ee:ee:ee:ee),
+              or C(ee-ee-ee-ee-ee-ee) format.
+            - Only valid when O(config.type=standard).
+            type: list
+            elements: str
+            aliases: [ routerMacCollection ]
+          route_target_collection:
+            description:
+            - One or more route targets to match.
+            - Each value must be in C(ASN2:NN), C(ASN4:NN), or C(IPv4:NN)
+              format (e.g. C(65000:100) or C(192.168.1.1:200)).
+            - Only valid when O(config.type=standard).
+            type: list
+            elements: str
+            aliases: [ routeTargetCollection ]
+          site_of_origin_collection:
+            description:
+            - One or more site-of-origin values to match.
+            - Each value must be in C(ASN2:NN), C(ASN4:NN), or C(IPv4:NN)
+              format (e.g. C(64512:300) or C(10.0.0.1:500)).
+            - Only valid when O(config.type=standard).
+            type: list
+            elements: str
+            aliases: [ siteOfOriginCollection ]
+          transitive_generic_extended_collection:
+            description:
+            - One or more transitive generic extended community values to match.
+            - Each value must be in C(ASN4:NN) format where the ASN starts with
+              a digit 1-9 (e.g. C(65000:123)).
+            - Only valid when O(config.type=standard).
+            type: list
+            elements: str
+            aliases: [ transitiveGenericExtendedCollection ]
+          non_transitive_generic_extended_collection:
+            description:
+            - One or more non-transitive generic extended community values to match.
+            - Each value must be in C(ASN4:NN) format where the ASN starts with
+              a digit 1-9 (e.g. C(64512:789)).
+            - Only valid when O(config.type=standard).
+            type: list
+            elements: str
+            aliases: [ nonTransitiveGenericExtendedCollection ]
+          community_number_regex:
+            description:
+            - Regular expression in aa:nn format for matching extended community
+              strings.
+            - Max 63 characters. Must not start with C([a-zA-Z~!#%@`;]).
+            - Required and only valid when O(config.type=expanded).
+            type: str
+            aliases: [ communityNumberRegex ]
+  state:
+    description:
+    - The desired state of the extended community list resources on Cisco Nexus
+      Dashboard.
+    - Use O(state=merged) to create new extended community lists and update
+      existing ones as defined in the configuration.
+      Extended community lists not specified in the configuration are left unchanged.
+    - Use O(state=replaced) to replace the extended community lists specified
+      in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source
+      of truth. All extended community lists on ND not present in the
+      configuration will be deleted. Use with caution.
+    - Use O(state=deleted) to remove the extended community lists specified in
+      the configuration.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard version 4.2.1 or higher.
+- Extended community lists are created and deleted in bulk via separate API
+  endpoints.
+- Standard-type entries may set any combination of O(config.entries.router_mac_collection),
+  O(config.entries.route_target_collection), O(config.entries.site_of_origin_collection),
+  O(config.entries.transitive_generic_extended_collection), and
+  O(config.entries.non_transitive_generic_extended_collection).
+- O(config.entries.community_number_regex) is required for every entry when
+  O(config.type=expanded); standard-only fields must not be set on expanded entries.
+"""
+
+EXAMPLES = r"""
+- name: Create a standard extended community list matching route targets
+  cisco.nd.nd_manage_extended_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: ECL-RT-PROD
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            route_target_collection:
+              - "65000:100"
+              - "65000:200"
+              - "192.168.1.1:300"
+          - sequence_number: 20
+            action: permit
+            router_mac_collection:
+              - "d478.1111.57b8"
+              - "d4:78:11:11:57:b9"
+          - sequence_number: 30
+            action: deny
+            site_of_origin_collection:
+              - "64512:300"
+              - "10.0.0.1:500"
+    state: merged
+
+- name: Create a standard extended community list with generic extended communities
+  cisco.nd.nd_manage_extended_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: ECL-GENERIC
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            transitive_generic_extended_collection:
+              - "65000:123"
+              - "12345:99"
+          - sequence_number: 20
+            action: permit
+            non_transitive_generic_extended_collection:
+              - "64512:789"
+    state: merged
+
+- name: Create an expanded extended community list
+  cisco.nd.nd_manage_extended_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: ECL-EXPANDED-REGEX
+        type: expanded
+        entries:
+          - sequence_number: 10
+            action: permit
+            community_number_regex: "65000:.*"
+          - sequence_number: 20
+            action: deny
+            community_number_regex: "64512:.*"
+    state: merged
+
+- name: Update an extended community list (replace its entries)
+  cisco.nd.nd_manage_extended_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: ECL-RT-PROD
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            route_target_collection:
+              - "65001:999"
+    state: replaced
+
+- name: Delete specific extended community lists
+  cisco.nd.nd_manage_extended_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: ECL-RT-PROD
+      - name: ECL-EXPANDED-REGEX
+    state: deleted
+
+- name: Override -- enforce exact set of extended community lists (delete all others)
+  cisco.nd.nd_manage_extended_community_list:
+    fabric_name: my-fabric
+    config:
+      - name: ECL-FINAL
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            route_target_collection:
+              - "65000:1"
+    state: overridden
+"""
+
+RETURN = r"""
+"""
+
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_community_list.manage_extended_community_list import (
+    ExtendedCommunityListModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_extended_community_list import (
+    ManageExtendedCommunityListOrchestrator,
+)
+
+
+def main():
+    argument_spec = nd_argument_spec()
+    argument_spec.update(ExtendedCommunityListModel.get_argument_spec())
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_manage_extended_community_list")
+
+    nd_state_machine = None
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=ManageExtendedCommunityListOrchestrator,
+        )
+
+        module_log.debug("manage_state begin state=%s check_mode=%s", module.params.get("state"), module.check_mode)
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/nd_manage_community_list/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/deleted.yaml
@@ -1,0 +1,32 @@
+---
+# Deleted state tests for nd_manage_community_list.
+
+- name: "DELETED: Delete community lists with name-only config (check mode)"
+  cisco.nd.nd_manage_community_list: &delete_lists
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ community_list_standard.name }}"
+      - name: "{{ community_list_expanded.name }}"
+    state: deleted
+  check_mode: true
+  register: cm_deleted_lists
+
+- name: "DELETED: Delete community lists with name-only config (normal mode)"
+  cisco.nd.nd_manage_community_list: *delete_lists
+  register: nm_deleted_lists
+
+- name: "DELETED: Verify delete changed"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_lists is changed
+      - nm_deleted_lists is changed
+
+- name: "DELETED IDEMPOTENT: Re-apply delete"
+  cisco.nd.nd_manage_community_list: *delete_lists
+  register: nm_deleted_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_idem is not changed

--- a/tests/integration/targets/nd_manage_community_list/tasks/main.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/main.yaml
@@ -9,6 +9,7 @@
 #
 # Optional variables:
 #   nd_test_fabric_name - fabric in which to create test community lists
+#   nd_test_tenant_name_a / nd_test_tenant_name_b - enable tenant identity coverage
 #   nd_test_community_lists_run_overridden=true - opt in to destructive overridden-state coverage
 
 - name: Test that we have a Nexus Dashboard host, username and password
@@ -28,6 +29,12 @@
 
     - name: Run merged state tests
       ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run tenant identity tests
+      ansible.builtin.include_tasks: tenant_identity.yaml
+      when:
+        - nd_test_tenant_name_a is defined
+        - nd_test_tenant_name_b is defined
 
     - name: Run replaced state tests
       ansible.builtin.include_tasks: replaced.yaml

--- a/tests/integration/targets/nd_manage_community_list/tasks/main.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/main.yaml
@@ -27,6 +27,9 @@
     - name: Pre-test cleanup
       ansible.builtin.include_tasks: setup.yaml
 
+    - name: Run validation tests
+      ansible.builtin.include_tasks: validation.yaml
+
     - name: Run merged state tests
       ansible.builtin.include_tasks: merged.yaml
 

--- a/tests/integration/targets/nd_manage_community_list/tasks/main.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/main.yaml
@@ -1,0 +1,46 @@
+---
+# Test code for the nd_manage_community_list module
+# Copyright: (c) 2026, Gaspard Micol (@gmicol)
+#
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Run with:
+#   ansible-test integration nd_manage_community_list
+#
+# Optional variables:
+#   nd_test_fabric_name - fabric in which to create test community lists
+#   nd_test_community_lists_run_overridden=true - opt in to destructive overridden-state coverage
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ nd_output_level | default("debug") }}'
+
+- name: Run nd_manage_community_list state tests
+  block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+
+    - name: Run overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+      when: nd_test_community_lists_run_overridden | default(false) | bool
+  always:
+    - name: Post-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+  module_defaults:
+    cisco.nd.nd_manage_community_list:
+      timeout: 300

--- a/tests/integration/targets/nd_manage_community_list/tasks/merged.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/merged.yaml
@@ -33,11 +33,17 @@
       - nm_merged_create_standard.after | selectattr('name', 'equalto', community_list_standard.name) | list | length == 1
       - nm_merged_create_expanded.after | selectattr('name', 'equalto', community_list_expanded.name) | list | length == 1
 
-- name: "MERGED IDEMPOTENT: Re-apply standard community list"
+- name: "MERGED IDEMPOTENT: Re-apply standard community list (check mode)"
+  cisco.nd.nd_manage_community_list: *merge_standard
+  check_mode: true
+  register: cm_merged_idem_standard
+
+- name: "MERGED IDEMPOTENT: Re-apply standard community list (normal mode)"
   cisco.nd.nd_manage_community_list: *merge_standard
   register: nm_merged_idem_standard
 
 - name: "MERGED IDEMPOTENT: Verify no change on second run"
   ansible.builtin.assert:
     that:
+      - cm_merged_idem_standard is not changed
       - nm_merged_idem_standard is not changed

--- a/tests/integration/targets/nd_manage_community_list/tasks/merged.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/merged.yaml
@@ -1,0 +1,43 @@
+---
+# Merged state tests for nd_manage_community_list.
+
+- name: "MERGED CREATE: Create standard community list (check mode)"
+  cisco.nd.nd_manage_community_list: &merge_standard
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ community_list_standard }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_standard
+
+- name: "MERGED CREATE: Create standard community list (normal mode)"
+  cisco.nd.nd_manage_community_list: *merge_standard
+  register: nm_merged_create_standard
+
+- name: "MERGED CREATE: Create expanded community list"
+  cisco.nd.nd_manage_community_list: &merge_expanded
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ community_list_expanded }}"
+    state: merged
+  register: nm_merged_create_expanded
+
+- name: "MERGED CREATE: Verify community list creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_standard is changed
+      - nm_merged_create_standard is changed
+      - nm_merged_create_expanded is changed
+      - nm_merged_create_standard.after | selectattr('name', 'equalto', community_list_standard.name) | list | length == 1
+      - nm_merged_create_expanded.after | selectattr('name', 'equalto', community_list_expanded.name) | list | length == 1
+
+- name: "MERGED IDEMPOTENT: Re-apply standard community list"
+  cisco.nd.nd_manage_community_list: *merge_standard
+  register: nm_merged_idem_standard
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_idem_standard is not changed

--- a/tests/integration/targets/nd_manage_community_list/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/overridden.yaml
@@ -1,0 +1,30 @@
+---
+# Overridden state tests for nd_manage_community_list.
+# This is opt-in from tasks/main.yaml because state=overridden deletes community lists
+# not present in config.
+
+- name: "OVERRIDDEN SETUP: Create extra community lists"
+  cisco.nd.nd_manage_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ community_list_standard }}"
+      - "{{ community_list_expanded }}"
+    state: merged
+
+- name: "OVERRIDDEN: Keep only overridden community list"
+  cisco.nd.nd_manage_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ community_list_overridden }}"
+    state: overridden
+  register: nm_overridden
+
+- name: "OVERRIDDEN: Verify only requested test list remains"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden is changed
+      - nm_overridden.after | selectattr('name', 'equalto', community_list_overridden.name) | list | length == 1
+      - nm_overridden.after | selectattr('name', 'equalto', community_list_standard.name) | list | length == 0
+      - nm_overridden.after | selectattr('name', 'equalto', community_list_expanded.name) | list | length == 0

--- a/tests/integration/targets/nd_manage_community_list/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/replaced.yaml
@@ -1,0 +1,31 @@
+---
+# Replaced state tests for nd_manage_community_list.
+
+- name: "REPLACED UPDATE: Replace standard community list entries (check mode)"
+  cisco.nd.nd_manage_community_list: &replace_standard
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ community_list_standard_updated }}"
+    state: replaced
+  check_mode: true
+  register: cm_replaced_standard
+
+- name: "REPLACED UPDATE: Replace standard community list entries (normal mode)"
+  cisco.nd.nd_manage_community_list: *replace_standard
+  register: nm_replaced_standard
+
+- name: "REPLACED UPDATE: Verify replaced state changed"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_standard is changed
+      - nm_replaced_standard is changed
+
+- name: "REPLACED IDEMPOTENT: Re-apply replaced config"
+  cisco.nd.nd_manage_community_list: *replace_standard
+  register: nm_replaced_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_idem is not changed

--- a/tests/integration/targets/nd_manage_community_list/tasks/setup.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/setup.yaml
@@ -1,0 +1,12 @@
+---
+# Cleanup for nd_manage_community_list integration tests.
+
+- name: "SETUP: Remove test community lists"
+  cisco.nd.nd_manage_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ community_list_standard.name }}"
+      - name: "{{ community_list_expanded.name }}"
+      - name: "{{ community_list_overridden.name }}"
+    state: deleted

--- a/tests/integration/targets/nd_manage_community_list/tasks/setup.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/setup.yaml
@@ -10,3 +10,23 @@
       - name: "{{ community_list_expanded.name }}"
       - name: "{{ community_list_overridden.name }}"
     state: deleted
+
+- name: "SETUP: Remove tenant-scoped test community list from tenant A"
+  cisco.nd.nd_manage_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ community_list_tenant_identity_name }}"
+        tenant_name: "{{ nd_test_tenant_name_a }}"
+    state: deleted
+  when: nd_test_tenant_name_a is defined
+
+- name: "SETUP: Remove tenant-scoped test community list from tenant B"
+  cisco.nd.nd_manage_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ community_list_tenant_identity_name }}"
+        tenant_name: "{{ nd_test_tenant_name_b }}"
+    state: deleted
+  when: nd_test_tenant_name_b is defined

--- a/tests/integration/targets/nd_manage_community_list/tasks/tenant_identity.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/tenant_identity.yaml
@@ -1,0 +1,41 @@
+---
+# Optional tenant-scoped identity coverage for nd_manage_community_list.
+
+- name: "TENANT IDENTITY: Create same-name community lists in two tenants"
+  cisco.nd.nd_manage_community_list: &tenant_identity
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ community_list_tenant_identity_name }}"
+        tenant_name: "{{ nd_test_tenant_name_a }}"
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            community_numbers:
+              - "65000:101"
+      - name: "{{ community_list_tenant_identity_name }}"
+        tenant_name: "{{ nd_test_tenant_name_b }}"
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            community_numbers:
+              - "65000:102"
+    state: merged
+  register: nm_tenant_identity_create
+
+- name: "TENANT IDENTITY: Re-apply same-name community lists"
+  cisco.nd.nd_manage_community_list: *tenant_identity
+  register: nm_tenant_identity_idempotent
+
+- name: "TENANT IDENTITY: Verify distinct tenant objects and idempotency"
+  ansible.builtin.assert:
+    that:
+      - nm_tenant_identity_create is changed
+      - nm_tenant_identity_idempotent is not changed
+      - >-
+        nm_tenant_identity_idempotent.after
+        | selectattr('name', 'equalto', community_list_tenant_identity_name)
+        | selectattr('tenant_name', 'in', [nd_test_tenant_name_a, nd_test_tenant_name_b])
+        | list | length == 2

--- a/tests/integration/targets/nd_manage_community_list/tasks/validation.yaml
+++ b/tests/integration/targets/nd_manage_community_list/tasks/validation.yaml
@@ -1,0 +1,25 @@
+---
+# Validation tests for nd_manage_community_list.
+
+- name: "VALIDATION: Reject a flagless standard community-list entry in check mode"
+  cisco.nd.nd_manage_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: ANSIBLE_CL_INVALID_FLAGLESS
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+    state: merged
+  check_mode: true
+  register: cm_invalid_flagless_standard
+  ignore_errors: true
+
+- name: "VALIDATION: Verify flagless standard entry was rejected locally"
+  ansible.builtin.assert:
+    that:
+      - cm_invalid_flagless_standard is failed
+      - >-
+        'must set at least one community number or enable at least one
+        well-known community flag' in cm_invalid_flagless_standard.msg

--- a/tests/integration/targets/nd_manage_community_list/vars/main.yaml
+++ b/tests/integration/targets/nd_manage_community_list/vars/main.yaml
@@ -4,6 +4,7 @@
 # Override nd_test_fabric_name in inventory or extra-vars to match the ND 4.2 testbed.
 
 test_fabric_name: "{{ nd_test_fabric_name | default('SITE1') }}"
+community_list_tenant_identity_name: ANSIBLE_CL_TENANT_IDENTITY
 
 community_list_standard:
   name: ANSIBLE_CL_STANDARD

--- a/tests/integration/targets/nd_manage_community_list/vars/main.yaml
+++ b/tests/integration/targets/nd_manage_community_list/vars/main.yaml
@@ -1,0 +1,50 @@
+---
+# Variables for nd_manage_community_list integration tests.
+#
+# Override nd_test_fabric_name in inventory or extra-vars to match the ND 4.2 testbed.
+
+test_fabric_name: "{{ nd_test_fabric_name | default('SITE1') }}"
+
+community_list_standard:
+  name: ANSIBLE_CL_STANDARD
+  type: standard
+  entries:
+    - sequence_number: 10
+      action: permit
+      community_numbers:
+        - "100:200"
+    - sequence_number: 20
+      action: deny
+      no_export: true
+
+community_list_standard_updated:
+  name: ANSIBLE_CL_STANDARD
+  type: standard
+  entries:
+    - sequence_number: 10
+      action: permit
+      community_numbers:
+        - "200:300"
+    - sequence_number: 30
+      action: permit
+      internet: true
+
+community_list_expanded:
+  name: ANSIBLE_CL_EXPANDED
+  type: expanded
+  entries:
+    - sequence_number: 10
+      action: permit
+      community_number_regex: "100:.*"
+    - sequence_number: 20
+      action: deny
+      community_number_regex: "65000:.*"
+
+community_list_overridden:
+  name: ANSIBLE_CL_OVERRIDDEN
+  type: standard
+  entries:
+    - sequence_number: 10
+      action: permit
+      community_numbers:
+        - "300:400"

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/deleted.yaml
@@ -1,0 +1,32 @@
+---
+# Deleted state tests for nd_manage_extended_community_list.
+
+- name: "DELETED: Delete extended community lists with name-only config (check mode)"
+  cisco.nd.nd_manage_extended_community_list: &delete_lists
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ extended_community_list_standard.name }}"
+      - name: "{{ extended_community_list_expanded.name }}"
+    state: deleted
+  check_mode: true
+  register: cm_deleted_lists
+
+- name: "DELETED: Delete extended community lists with name-only config (normal mode)"
+  cisco.nd.nd_manage_extended_community_list: *delete_lists
+  register: nm_deleted_lists
+
+- name: "DELETED: Verify delete changed"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_lists is changed
+      - nm_deleted_lists is changed
+
+- name: "DELETED IDEMPOTENT: Re-apply delete"
+  cisco.nd.nd_manage_extended_community_list: *delete_lists
+  register: nm_deleted_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_idem is not changed

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/main.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/main.yaml
@@ -9,6 +9,7 @@
 #
 # Optional variables:
 #   nd_test_fabric_name - fabric in which to create test extended community lists
+#   nd_test_tenant_name_a / nd_test_tenant_name_b - enable tenant identity coverage
 #   nd_test_community_lists_run_overridden=true - opt in to destructive overridden-state coverage
 
 - name: Test that we have a Nexus Dashboard host, username and password
@@ -28,6 +29,12 @@
 
     - name: Run merged state tests
       ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run tenant identity tests
+      ansible.builtin.include_tasks: tenant_identity.yaml
+      when:
+        - nd_test_tenant_name_a is defined
+        - nd_test_tenant_name_b is defined
 
     - name: Run replaced state tests
       ansible.builtin.include_tasks: replaced.yaml

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/main.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/main.yaml
@@ -1,0 +1,46 @@
+---
+# Test code for the nd_manage_extended_community_list module
+# Copyright: (c) 2026, Gaspard Micol (@gmicol)
+#
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Run with:
+#   ansible-test integration nd_manage_extended_community_list
+#
+# Optional variables:
+#   nd_test_fabric_name - fabric in which to create test extended community lists
+#   nd_test_community_lists_run_overridden=true - opt in to destructive overridden-state coverage
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ nd_output_level | default("debug") }}'
+
+- name: Run nd_manage_extended_community_list state tests
+  block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+
+    - name: Run overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+      when: nd_test_community_lists_run_overridden | default(false) | bool
+  always:
+    - name: Post-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+  module_defaults:
+    cisco.nd.nd_manage_extended_community_list:
+      timeout: 300

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/merged.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/merged.yaml
@@ -33,11 +33,17 @@
       - nm_merged_create_standard.after | selectattr('name', 'equalto', extended_community_list_standard.name) | list | length == 1
       - nm_merged_create_expanded.after | selectattr('name', 'equalto', extended_community_list_expanded.name) | list | length == 1
 
-- name: "MERGED IDEMPOTENT: Re-apply standard extended community list"
+- name: "MERGED IDEMPOTENT: Re-apply standard extended community list (check mode)"
+  cisco.nd.nd_manage_extended_community_list: *merge_standard
+  check_mode: true
+  register: cm_merged_idem_standard
+
+- name: "MERGED IDEMPOTENT: Re-apply standard extended community list (normal mode)"
   cisco.nd.nd_manage_extended_community_list: *merge_standard
   register: nm_merged_idem_standard
 
 - name: "MERGED IDEMPOTENT: Verify no change on second run"
   ansible.builtin.assert:
     that:
+      - cm_merged_idem_standard is not changed
       - nm_merged_idem_standard is not changed

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/merged.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/merged.yaml
@@ -1,0 +1,43 @@
+---
+# Merged state tests for nd_manage_extended_community_list.
+
+- name: "MERGED CREATE: Create standard extended community list (check mode)"
+  cisco.nd.nd_manage_extended_community_list: &merge_standard
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ extended_community_list_standard }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_standard
+
+- name: "MERGED CREATE: Create standard extended community list (normal mode)"
+  cisco.nd.nd_manage_extended_community_list: *merge_standard
+  register: nm_merged_create_standard
+
+- name: "MERGED CREATE: Create expanded extended community list"
+  cisco.nd.nd_manage_extended_community_list: &merge_expanded
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ extended_community_list_expanded }}"
+    state: merged
+  register: nm_merged_create_expanded
+
+- name: "MERGED CREATE: Verify extended community list creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_standard is changed
+      - nm_merged_create_standard is changed
+      - nm_merged_create_expanded is changed
+      - nm_merged_create_standard.after | selectattr('name', 'equalto', extended_community_list_standard.name) | list | length == 1
+      - nm_merged_create_expanded.after | selectattr('name', 'equalto', extended_community_list_expanded.name) | list | length == 1
+
+- name: "MERGED IDEMPOTENT: Re-apply standard extended community list"
+  cisco.nd.nd_manage_extended_community_list: *merge_standard
+  register: nm_merged_idem_standard
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_idem_standard is not changed

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/overridden.yaml
@@ -1,0 +1,30 @@
+---
+# Overridden state tests for nd_manage_extended_community_list.
+# This is opt-in from tasks/main.yaml because state=overridden deletes extended
+# community lists not present in config.
+
+- name: "OVERRIDDEN SETUP: Create extra extended community lists"
+  cisco.nd.nd_manage_extended_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ extended_community_list_standard }}"
+      - "{{ extended_community_list_expanded }}"
+    state: merged
+
+- name: "OVERRIDDEN: Keep only overridden extended community list"
+  cisco.nd.nd_manage_extended_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ extended_community_list_overridden }}"
+    state: overridden
+  register: nm_overridden
+
+- name: "OVERRIDDEN: Verify only requested test list remains"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden is changed
+      - nm_overridden.after | selectattr('name', 'equalto', extended_community_list_overridden.name) | list | length == 1
+      - nm_overridden.after | selectattr('name', 'equalto', extended_community_list_standard.name) | list | length == 0
+      - nm_overridden.after | selectattr('name', 'equalto', extended_community_list_expanded.name) | list | length == 0

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/replaced.yaml
@@ -1,0 +1,31 @@
+---
+# Replaced state tests for nd_manage_extended_community_list.
+
+- name: "REPLACED UPDATE: Replace standard extended community list entries (check mode)"
+  cisco.nd.nd_manage_extended_community_list: &replace_standard
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ extended_community_list_standard_updated }}"
+    state: replaced
+  check_mode: true
+  register: cm_replaced_standard
+
+- name: "REPLACED UPDATE: Replace standard extended community list entries (normal mode)"
+  cisco.nd.nd_manage_extended_community_list: *replace_standard
+  register: nm_replaced_standard
+
+- name: "REPLACED UPDATE: Verify replaced state changed"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_standard is changed
+      - nm_replaced_standard is changed
+
+- name: "REPLACED IDEMPOTENT: Re-apply replaced config"
+  cisco.nd.nd_manage_extended_community_list: *replace_standard
+  register: nm_replaced_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_idem is not changed

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/setup.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/setup.yaml
@@ -1,0 +1,12 @@
+---
+# Cleanup for nd_manage_extended_community_list integration tests.
+
+- name: "SETUP: Remove test extended community lists"
+  cisco.nd.nd_manage_extended_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ extended_community_list_standard.name }}"
+      - name: "{{ extended_community_list_expanded.name }}"
+      - name: "{{ extended_community_list_overridden.name }}"
+    state: deleted

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/setup.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/setup.yaml
@@ -10,3 +10,23 @@
       - name: "{{ extended_community_list_expanded.name }}"
       - name: "{{ extended_community_list_overridden.name }}"
     state: deleted
+
+- name: "SETUP: Remove tenant-scoped test extended community list from tenant A"
+  cisco.nd.nd_manage_extended_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ extended_community_list_tenant_identity_name }}"
+        tenant_name: "{{ nd_test_tenant_name_a }}"
+    state: deleted
+  when: nd_test_tenant_name_a is defined
+
+- name: "SETUP: Remove tenant-scoped test extended community list from tenant B"
+  cisco.nd.nd_manage_extended_community_list:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ extended_community_list_tenant_identity_name }}"
+        tenant_name: "{{ nd_test_tenant_name_b }}"
+    state: deleted
+  when: nd_test_tenant_name_b is defined

--- a/tests/integration/targets/nd_manage_extended_community_list/tasks/tenant_identity.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/tasks/tenant_identity.yaml
@@ -1,0 +1,41 @@
+---
+# Optional tenant-scoped identity coverage for nd_manage_extended_community_list.
+
+- name: "TENANT IDENTITY: Create same-name extended community lists in two tenants"
+  cisco.nd.nd_manage_extended_community_list: &tenant_identity
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ extended_community_list_tenant_identity_name }}"
+        tenant_name: "{{ nd_test_tenant_name_a }}"
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            route_target_collection:
+              - "65000:101"
+      - name: "{{ extended_community_list_tenant_identity_name }}"
+        tenant_name: "{{ nd_test_tenant_name_b }}"
+        type: standard
+        entries:
+          - sequence_number: 10
+            action: permit
+            route_target_collection:
+              - "65000:102"
+    state: merged
+  register: nm_tenant_identity_create
+
+- name: "TENANT IDENTITY: Re-apply same-name extended community lists"
+  cisco.nd.nd_manage_extended_community_list: *tenant_identity
+  register: nm_tenant_identity_idempotent
+
+- name: "TENANT IDENTITY: Verify distinct tenant objects and idempotency"
+  ansible.builtin.assert:
+    that:
+      - nm_tenant_identity_create is changed
+      - nm_tenant_identity_idempotent is not changed
+      - >-
+        nm_tenant_identity_idempotent.after
+        | selectattr('name', 'equalto', extended_community_list_tenant_identity_name)
+        | selectattr('tenant_name', 'in', [nd_test_tenant_name_a, nd_test_tenant_name_b])
+        | list | length == 2

--- a/tests/integration/targets/nd_manage_extended_community_list/vars/main.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/vars/main.yaml
@@ -4,6 +4,7 @@
 # Override nd_test_fabric_name in inventory or extra-vars to match the ND 4.2 testbed.
 
 test_fabric_name: "{{ nd_test_fabric_name | default('SITE1') }}"
+extended_community_list_tenant_identity_name: ANSIBLE_ECL_TENANT_IDENTITY
 
 extended_community_list_standard:
   name: ANSIBLE_ECL_STANDARD

--- a/tests/integration/targets/nd_manage_extended_community_list/vars/main.yaml
+++ b/tests/integration/targets/nd_manage_extended_community_list/vars/main.yaml
@@ -1,0 +1,54 @@
+---
+# Variables for nd_manage_extended_community_list integration tests.
+#
+# Override nd_test_fabric_name in inventory or extra-vars to match the ND 4.2 testbed.
+
+test_fabric_name: "{{ nd_test_fabric_name | default('SITE1') }}"
+
+extended_community_list_standard:
+  name: ANSIBLE_ECL_STANDARD
+  type: standard
+  entries:
+    - sequence_number: 10
+      action: permit
+      route_target_collection:
+        - "65000:100"
+      router_mac_collection:
+        - "d478.1111.57b8"
+    - sequence_number: 20
+      action: deny
+      site_of_origin_collection:
+        - "64512:300"
+
+extended_community_list_standard_updated:
+  name: ANSIBLE_ECL_STANDARD
+  type: standard
+  entries:
+    - sequence_number: 10
+      action: permit
+      route_target_collection:
+        - "65001:200"
+    - sequence_number: 30
+      action: permit
+      transitive_generic_extended_collection:
+        - "65000:123"
+
+extended_community_list_expanded:
+  name: ANSIBLE_ECL_EXPANDED
+  type: expanded
+  entries:
+    - sequence_number: 10
+      action: permit
+      community_number_regex: "65000:.*"
+    - sequence_number: 20
+      action: deny
+      community_number_regex: "64512:.*"
+
+extended_community_list_overridden:
+  name: ANSIBLE_ECL_OVERRIDDEN
+  type: standard
+  entries:
+    - sequence_number: 10
+      action: permit
+      non_transitive_generic_extended_collection:
+        - "64512:789"

--- a/tests/unit/module_utils/endpoints/test_manage_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_community_lists.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for endpoints/v1/manage/manage_community_lists.py."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_community_lists import (
+    EpManageCommunityListsBulkDelete,
+    EpManageCommunityListsDelete,
+    EpManageCommunityListsGet,
+    EpManageCommunityListsListGet,
+    EpManageCommunityListsPost,
+    EpManageCommunityListsPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+def test_manage_community_lists_00010() -> None:
+    """
+    # Summary
+
+    Verify the list endpoint builds the collection path and supports Lucene query params.
+
+    ## Classes and Methods
+
+    - EpManageCommunityListsListGet.path
+    """
+    instance = EpManageCommunityListsListGet()
+    instance.fabric_name = "SITE1"
+    instance.lucene_params.max = 50
+    instance.lucene_params.offset = 10
+
+    assert instance.verb == HttpVerbEnum.GET
+    assert instance.path == "/api/v1/manage/fabrics/SITE1/communityLists?max=50&offset=10"
+
+
+def test_manage_community_lists_00020() -> None:
+    """
+    # Summary
+
+    Verify dynamic path segments are percent-encoded.
+
+    ## Classes and Methods
+
+    - EpManageCommunityListsGet.path
+    - EpManageCommunityListsGet.set_identifiers()
+    """
+    instance = EpManageCommunityListsGet()
+    instance.fabric_name = "fab/one"
+    instance.set_identifiers("tenantA~CL/one")
+
+    assert instance.path == "/api/v1/manage/fabrics/fab%2Fone/communityLists/tenantA~CL%2Fone"
+
+
+def test_manage_community_lists_00030() -> None:
+    """
+    # Summary
+
+    Verify item endpoints reject missing required identifiers.
+
+    ## Classes and Methods
+
+    - EpManageCommunityListsGet.path
+    """
+    instance = EpManageCommunityListsGet()
+    instance.fabric_name = "SITE1"
+
+    with pytest.raises(ValueError, match="community_list_name must be set"):
+        instance.path
+
+
+def test_manage_community_lists_00040() -> None:
+    """
+    # Summary
+
+    Verify all write endpoint verbs and paths.
+
+    ## Classes and Methods
+
+    - EpManageCommunityListsPost.path
+    - EpManageCommunityListsPut.path
+    - EpManageCommunityListsDelete.path
+    - EpManageCommunityListsBulkDelete.path
+    """
+    post = EpManageCommunityListsPost()
+    post.fabric_name = "SITE1"
+    put = EpManageCommunityListsPut()
+    put.fabric_name = "SITE1"
+    put.set_identifiers("CL1")
+    delete = EpManageCommunityListsDelete()
+    delete.fabric_name = "SITE1"
+    delete.set_identifiers("CL1")
+    bulk_delete = EpManageCommunityListsBulkDelete()
+    bulk_delete.fabric_name = "SITE1"
+
+    assert post.verb == HttpVerbEnum.POST
+    assert post.path == "/api/v1/manage/fabrics/SITE1/communityLists"
+    assert put.verb == HttpVerbEnum.PUT
+    assert put.path == "/api/v1/manage/fabrics/SITE1/communityLists/CL1"
+    assert delete.verb == HttpVerbEnum.DELETE
+    assert delete.path == "/api/v1/manage/fabrics/SITE1/communityLists/CL1"
+    assert bulk_delete.verb == HttpVerbEnum.POST
+    assert bulk_delete.path == "/api/v1/manage/fabrics/SITE1/communityListActions/remove"

--- a/tests/unit/module_utils/endpoints/test_manage_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_community_lists.py
@@ -6,9 +6,7 @@
 
 """Unit tests for endpoints/v1/manage/manage_community_lists.py."""
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_community_lists import (

--- a/tests/unit/module_utils/endpoints/test_manage_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_community_lists.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_community_lists import (
+    CommunityListsEndpointParams,
     EpManageCommunityListsBulkDelete,
     EpManageCommunityListsDelete,
     EpManageCommunityListsGet,
@@ -17,6 +18,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageCommunityListsPost,
     EpManageCommunityListsPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 
@@ -106,3 +108,28 @@ def test_manage_community_lists_00040() -> None:
     assert delete.path == "/api/v1/manage/fabrics/SITE1/communityLists/CL1"
     assert bulk_delete.verb == HttpVerbEnum.POST
     assert bulk_delete.path == "/api/v1/manage/fabrics/SITE1/communityListActions/remove"
+
+
+def test_manage_community_lists_00050() -> None:
+    """Verify clusterName and Lucene parameters compose on list and item paths."""
+    list_endpoint = EpManageCommunityListsListGet(
+        endpoint_params=CommunityListsEndpointParams(cluster_name="cluster-1"),
+        lucene_params=LuceneQueryParams(filter="name:CL SALES", max=50, offset=10, sort="name:desc"),
+    )
+    list_endpoint.fabric_name = "SITE1"
+    item_endpoint = EpManageCommunityListsGet(endpoint_params=CommunityListsEndpointParams(cluster_name="cluster-1"))
+    item_endpoint.fabric_name = "SITE1"
+    item_endpoint.set_identifiers("CL1")
+
+    assert list_endpoint.path == (
+        "/api/v1/manage/fabrics/SITE1/communityLists?"
+        "clusterName=cluster-1&filter=name:CL%20SALES&max=50&offset=10&sort=name%3Adesc"
+    )
+    assert item_endpoint.path == "/api/v1/manage/fabrics/SITE1/communityLists/CL1?clusterName=cluster-1"
+
+
+@pytest.mark.parametrize("lucene_config", [{"max": 10001}, {"sort": "name:sideways"}])
+def test_manage_community_lists_00060(lucene_config: dict) -> None:
+    """Verify collection endpoints inherit shared Lucene validation."""
+    with pytest.raises(ValueError):
+        EpManageCommunityListsListGet(lucene_params=LuceneQueryParams(**lucene_config))

--- a/tests/unit/module_utils/endpoints/test_manage_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_community_lists.py
@@ -19,6 +19,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageCommunityListsPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import ClusterNameMixin
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 
@@ -132,3 +133,8 @@ def test_manage_community_lists_00060(lucene_config: dict) -> None:
     """Verify collection endpoints inherit shared Lucene validation."""
     with pytest.raises(ValueError):
         EpManageCommunityListsListGet(lucene_params=LuceneQueryParams(**lucene_config))
+
+
+def test_manage_community_lists_00070() -> None:
+    """Verify endpoint parameters reuse the shared cluster-name contract."""
+    assert ClusterNameMixin in CommunityListsEndpointParams.__bases__

--- a/tests/unit/module_utils/endpoints/test_manage_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_community_lists.py
@@ -122,8 +122,7 @@ def test_manage_community_lists_00050() -> None:
     item_endpoint.set_identifiers("CL1")
 
     assert list_endpoint.path == (
-        "/api/v1/manage/fabrics/SITE1/communityLists?"
-        "clusterName=cluster-1&filter=name:CL%20SALES&max=50&offset=10&sort=name%3Adesc"
+        "/api/v1/manage/fabrics/SITE1/communityLists?" "clusterName=cluster-1&filter=name:CL%20SALES&max=50&offset=10&sort=name%3Adesc"
     )
     assert item_endpoint.path == "/api/v1/manage/fabrics/SITE1/communityLists/CL1?clusterName=cluster-1"
 

--- a/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
@@ -19,6 +19,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageExtendedCommunityListsPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import ClusterNameMixin
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 
@@ -132,3 +133,8 @@ def test_manage_extended_community_lists_00060(lucene_config: dict) -> None:
     """Verify collection endpoints inherit shared Lucene validation."""
     with pytest.raises(ValueError):
         EpManageExtendedCommunityListsListGet(lucene_params=LuceneQueryParams(**lucene_config))
+
+
+def test_manage_extended_community_lists_00070() -> None:
+    """Verify endpoint parameters reuse the shared cluster-name contract."""
+    assert ClusterNameMixin in ExtendedCommunityListsEndpointParams.__bases__

--- a/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for endpoints/v1/manage/manage_extended_community_lists.py."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_extended_community_lists import (
+    EpManageExtendedCommunityListsBulkDelete,
+    EpManageExtendedCommunityListsDelete,
+    EpManageExtendedCommunityListsGet,
+    EpManageExtendedCommunityListsListGet,
+    EpManageExtendedCommunityListsPost,
+    EpManageExtendedCommunityListsPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+
+def test_manage_extended_community_lists_00010() -> None:
+    """
+    # Summary
+
+    Verify the list endpoint builds the collection path and supports Lucene query params.
+
+    ## Classes and Methods
+
+    - EpManageExtendedCommunityListsListGet.path
+    """
+    instance = EpManageExtendedCommunityListsListGet()
+    instance.fabric_name = "SITE1"
+    instance.lucene_params.filter = "name:ECL*"
+    instance.lucene_params.sort = "name:asc"
+
+    assert instance.verb == HttpVerbEnum.GET
+    assert instance.path == "/api/v1/manage/fabrics/SITE1/extendedCommunityLists?filter=name:ECL%2A&sort=name%3Aasc"
+
+
+def test_manage_extended_community_lists_00020() -> None:
+    """
+    # Summary
+
+    Verify dynamic path segments are percent-encoded.
+
+    ## Classes and Methods
+
+    - EpManageExtendedCommunityListsGet.path
+    - EpManageExtendedCommunityListsGet.set_identifiers()
+    """
+    instance = EpManageExtendedCommunityListsGet()
+    instance.fabric_name = "fab/one"
+    instance.set_identifiers("tenantA~ECL/one")
+
+    assert instance.path == "/api/v1/manage/fabrics/fab%2Fone/extendedCommunityLists/tenantA~ECL%2Fone"
+
+
+def test_manage_extended_community_lists_00030() -> None:
+    """
+    # Summary
+
+    Verify item endpoints reject missing required identifiers.
+
+    ## Classes and Methods
+
+    - EpManageExtendedCommunityListsGet.path
+    """
+    instance = EpManageExtendedCommunityListsGet()
+    instance.fabric_name = "SITE1"
+
+    with pytest.raises(ValueError, match="extended_community_list_name must be set"):
+        instance.path
+
+
+def test_manage_extended_community_lists_00040() -> None:
+    """
+    # Summary
+
+    Verify all write endpoint verbs and paths.
+
+    ## Classes and Methods
+
+    - EpManageExtendedCommunityListsPost.path
+    - EpManageExtendedCommunityListsPut.path
+    - EpManageExtendedCommunityListsDelete.path
+    - EpManageExtendedCommunityListsBulkDelete.path
+    """
+    post = EpManageExtendedCommunityListsPost()
+    post.fabric_name = "SITE1"
+    put = EpManageExtendedCommunityListsPut()
+    put.fabric_name = "SITE1"
+    put.set_identifiers("ECL1")
+    delete = EpManageExtendedCommunityListsDelete()
+    delete.fabric_name = "SITE1"
+    delete.set_identifiers("ECL1")
+    bulk_delete = EpManageExtendedCommunityListsBulkDelete()
+    bulk_delete.fabric_name = "SITE1"
+
+    assert post.verb == HttpVerbEnum.POST
+    assert post.path == "/api/v1/manage/fabrics/SITE1/extendedCommunityLists"
+    assert put.verb == HttpVerbEnum.PUT
+    assert put.path == "/api/v1/manage/fabrics/SITE1/extendedCommunityLists/ECL1"
+    assert delete.verb == HttpVerbEnum.DELETE
+    assert delete.path == "/api/v1/manage/fabrics/SITE1/extendedCommunityLists/ECL1"
+    assert bulk_delete.verb == HttpVerbEnum.POST
+    assert bulk_delete.path == "/api/v1/manage/fabrics/SITE1/extendedCommunityListActions/remove"

--- a/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
@@ -6,9 +6,7 @@
 
 """Unit tests for endpoints/v1/manage/manage_extended_community_lists.py."""
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_extended_community_lists import (

--- a/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_extended_community_lists import (
+    ExtendedCommunityListsEndpointParams,
     EpManageExtendedCommunityListsBulkDelete,
     EpManageExtendedCommunityListsDelete,
     EpManageExtendedCommunityListsGet,
@@ -17,6 +18,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageExtendedCommunityListsPost,
     EpManageExtendedCommunityListsPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 
@@ -106,3 +108,30 @@ def test_manage_extended_community_lists_00040() -> None:
     assert delete.path == "/api/v1/manage/fabrics/SITE1/extendedCommunityLists/ECL1"
     assert bulk_delete.verb == HttpVerbEnum.POST
     assert bulk_delete.path == "/api/v1/manage/fabrics/SITE1/extendedCommunityListActions/remove"
+
+
+def test_manage_extended_community_lists_00050() -> None:
+    """Verify clusterName and Lucene parameters compose on list and item paths."""
+    list_endpoint = EpManageExtendedCommunityListsListGet(
+        endpoint_params=ExtendedCommunityListsEndpointParams(cluster_name="cluster-1"),
+        lucene_params=LuceneQueryParams(filter="name:ECL SALES", max=50, offset=10, sort="name:desc"),
+    )
+    list_endpoint.fabric_name = "SITE1"
+    item_endpoint = EpManageExtendedCommunityListsGet(
+        endpoint_params=ExtendedCommunityListsEndpointParams(cluster_name="cluster-1")
+    )
+    item_endpoint.fabric_name = "SITE1"
+    item_endpoint.set_identifiers("ECL1")
+
+    assert list_endpoint.path == (
+        "/api/v1/manage/fabrics/SITE1/extendedCommunityLists?"
+        "clusterName=cluster-1&filter=name:ECL%20SALES&max=50&offset=10&sort=name%3Adesc"
+    )
+    assert item_endpoint.path == "/api/v1/manage/fabrics/SITE1/extendedCommunityLists/ECL1?clusterName=cluster-1"
+
+
+@pytest.mark.parametrize("lucene_config", [{"max": 10001}, {"sort": "name:sideways"}])
+def test_manage_extended_community_lists_00060(lucene_config: dict) -> None:
+    """Verify collection endpoints inherit shared Lucene validation."""
+    with pytest.raises(ValueError):
+        EpManageExtendedCommunityListsListGet(lucene_params=LuceneQueryParams(**lucene_config))

--- a/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
+++ b/tests/unit/module_utils/endpoints/test_manage_extended_community_lists.py
@@ -117,15 +117,12 @@ def test_manage_extended_community_lists_00050() -> None:
         lucene_params=LuceneQueryParams(filter="name:ECL SALES", max=50, offset=10, sort="name:desc"),
     )
     list_endpoint.fabric_name = "SITE1"
-    item_endpoint = EpManageExtendedCommunityListsGet(
-        endpoint_params=ExtendedCommunityListsEndpointParams(cluster_name="cluster-1")
-    )
+    item_endpoint = EpManageExtendedCommunityListsGet(endpoint_params=ExtendedCommunityListsEndpointParams(cluster_name="cluster-1"))
     item_endpoint.fabric_name = "SITE1"
     item_endpoint.set_identifiers("ECL1")
 
     assert list_endpoint.path == (
-        "/api/v1/manage/fabrics/SITE1/extendedCommunityLists?"
-        "clusterName=cluster-1&filter=name:ECL%20SALES&max=50&offset=10&sort=name%3Adesc"
+        "/api/v1/manage/fabrics/SITE1/extendedCommunityLists?" "clusterName=cluster-1&filter=name:ECL%20SALES&max=50&offset=10&sort=name%3Adesc"
     )
     assert item_endpoint.path == "/api/v1/manage/fabrics/SITE1/extendedCommunityLists/ECL1?clusterName=cluster-1"
 

--- a/tests/unit/module_utils/fixtures/fixture_data/test_manage_community_list.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_manage_community_list.json
@@ -1,0 +1,84 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for test_manage_community_list.py.",
+        "Keys follow test_manage_community_list_NNNNN[a|b|c]."
+    ],
+    "test_manage_community_list_00030a": {
+        "TEST_NOTES": ["query_all happy path"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/communityLists",
+        "MESSAGE": "OK",
+        "DATA": {
+            "communityLists": [
+                {
+                    "name": "CL1",
+                    "type": "standard",
+                    "entries": [
+                        {
+                            "sequenceNumber": 10,
+                            "action": "permit",
+                            "communityNumbers": ["100:200"]
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "test_manage_community_list_00100a": {
+        "TEST_NOTES": ["create_bulk happy path"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/communityLists",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {
+                    "name": "CL1",
+                    "status": "success",
+                    "message": "Successfully created community list CL1"
+                }
+            ]
+        }
+    },
+    "test_manage_community_list_00110a": {
+        "TEST_NOTES": ["create_bulk per-item failure"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/communityLists",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {
+                    "name": "CL1",
+                    "status": "failed",
+                    "message": "duplicate name"
+                }
+            ]
+        }
+    },
+    "test_manage_community_list_00200a": {
+        "TEST_NOTES": ["update happy path"],
+        "RETURN_CODE": 204,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/communityLists/CL1",
+        "MESSAGE": "No Content",
+        "DATA": {}
+    },
+    "test_manage_community_list_00300a": {
+        "TEST_NOTES": ["delete_bulk happy path"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/communityListActions/remove",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {
+                    "name": "CL1",
+                    "status": "success",
+                    "message": "Successfully deleted community list CL1"
+                }
+            ]
+        }
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_manage_extended_community_list.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_manage_extended_community_list.json
@@ -1,0 +1,84 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for test_manage_extended_community_list.py.",
+        "Keys follow test_manage_extended_community_list_NNNNN[a|b|c]."
+    ],
+    "test_manage_extended_community_list_00030a": {
+        "TEST_NOTES": ["query_all happy path"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists",
+        "MESSAGE": "OK",
+        "DATA": {
+            "extendedCommunityLists": [
+                {
+                    "name": "ECL1",
+                    "type": "standard",
+                    "entries": [
+                        {
+                            "sequenceNumber": 10,
+                            "action": "permit",
+                            "routeTargetCollection": ["65000:100"]
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "test_manage_extended_community_list_00100a": {
+        "TEST_NOTES": ["create_bulk happy path"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {
+                    "name": "ECL1",
+                    "status": "success",
+                    "message": "Successfully created extended community list ECL1"
+                }
+            ]
+        }
+    },
+    "test_manage_extended_community_list_00110a": {
+        "TEST_NOTES": ["create_bulk per-item failure"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {
+                    "name": "ECL1",
+                    "status": "failed",
+                    "message": "duplicate name"
+                }
+            ]
+        }
+    },
+    "test_manage_extended_community_list_00200a": {
+        "TEST_NOTES": ["update happy path"],
+        "RETURN_CODE": 204,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists/ECL1",
+        "MESSAGE": "No Content",
+        "DATA": {}
+    },
+    "test_manage_extended_community_list_00300a": {
+        "TEST_NOTES": ["delete_bulk happy path"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/extendedCommunityListActions/remove",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {
+                    "name": "ECL1",
+                    "status": "success",
+                    "message": "Successfully deleted extended community list ECL1"
+                }
+            ]
+        }
+    }
+}

--- a/tests/unit/module_utils/models/test_manage_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_community_list.py
@@ -145,3 +145,25 @@ def test_manage_community_list_00070() -> None:
     CommunityListModel.from_config({"name": "C" * 51, "tenant_name": tenant_name})
     with pytest.raises(ValueError, match="tenant-scoped community list API name"):
         CommunityListModel.from_config({"name": "C" * 52, "tenant_name": tenant_name})
+
+
+def test_manage_community_list_00080() -> None:
+    """Verify type-specific validation is config-only and does not reject ND responses."""
+    response = {
+        "name": "CL-EXPANDED",
+        "type": "expanded",
+        "entries": [
+            {
+                "sequenceNumber": 10,
+                "action": "permit",
+                "communityNumberRegex": "100:.*",
+                "noAdvertise": False,
+            }
+        ],
+    }
+
+    instance = CommunityListModel.from_response(response)
+    assert instance.entries[0].no_advertise is False
+
+    with pytest.raises(ValueError, match="no_advertise must not be set"):
+        CommunityListModel.from_config(response)

--- a/tests/unit/module_utils/models/test_manage_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_community_list.py
@@ -40,7 +40,7 @@ def test_manage_community_list_00010() -> None:
     """
     instance = CommunityListModel.from_config({"name": "CL-DELETE"})
 
-    assert CommunityListModel.identifiers == ["name"]
+    assert CommunityListModel.identifiers == ["api_name"]
     assert CommunityListModel.identifier_strategy == "single"
     assert instance.get_identifier_value() == "CL-DELETE"
     assert instance.type is None
@@ -105,3 +105,43 @@ def test_manage_community_list_00040() -> None:
     assert config_options["name"]["required"] is True
     assert "required" not in config_options["type"]
     assert "required" not in config_options["entries"]
+
+
+def test_manage_community_list_00050() -> None:
+    """Verify tenant-scoped names are normalized while API identity stays qualified."""
+    instance = CommunityListModel.from_config(
+        {
+            "name": "tenantA~CL-TENANT",
+            "tenant_name": "tenantA",
+            "type": "standard",
+            "entries": [{"sequence_number": 10, "action": "permit"}],
+        }
+    )
+
+    assert instance.name == "CL-TENANT"
+    assert instance.api_name == "tenantA~CL-TENANT"
+    assert instance.get_identifier_value() == "tenantA~CL-TENANT"
+    assert instance.to_config()["name"] == "CL-TENANT"
+    assert instance.to_payload()["name"] == "tenantA~CL-TENANT"
+
+
+def test_manage_community_list_00060() -> None:
+    """Verify same-name lists in different tenants have distinct identifiers."""
+    first = CommunityListModel.from_config({"name": "CL-SHARED", "tenant_name": "tenantA"})
+    second = CommunityListModel.from_config({"name": "CL-SHARED", "tenant_name": "tenantB"})
+
+    assert first.get_identifier_value() == "tenantA~CL-SHARED"
+    assert second.get_identifier_value() == "tenantB~CL-SHARED"
+    assert first.get_identifier_value() != second.get_identifier_value()
+
+
+def test_manage_community_list_00070() -> None:
+    """Verify default and tenant-qualified API name length limits."""
+    CommunityListModel.from_config({"name": "C" * 63})
+    with pytest.raises(ValueError, match="default-tenant community list name"):
+        CommunityListModel.from_config({"name": "C" * 64})
+
+    tenant_name = "T" * 63
+    CommunityListModel.from_config({"name": "C" * 51, "tenant_name": tenant_name})
+    with pytest.raises(ValueError, match="tenant-scoped community list API name"):
+        CommunityListModel.from_config({"name": "C" * 52, "tenant_name": tenant_name})

--- a/tests/unit/module_utils/models/test_manage_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_community_list.py
@@ -6,9 +6,7 @@
 
 """Unit tests for models/manage_community_list/manage_community_list.py."""
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_community_list.manage_community_list import CommunityListModel

--- a/tests/unit/module_utils/models/test_manage_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_community_list.py
@@ -103,6 +103,7 @@ def test_manage_community_list_00040() -> None:
     config_options = spec["config"]["options"]
 
     assert config_options["name"]["required"] is True
+    assert spec["cluster_name"]["type"] == "str"
     assert "required" not in config_options["type"]
     assert "required" not in config_options["entries"]
 

--- a/tests/unit/module_utils/models/test_manage_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_community_list.py
@@ -167,3 +167,25 @@ def test_manage_community_list_00080() -> None:
 
     with pytest.raises(ValueError, match="no_advertise must not be set"):
         CommunityListModel.from_config(response)
+
+
+def test_manage_community_list_00090() -> None:
+    """Verify type and entries are required only for write-state config."""
+    for state in ("merged", "replaced", "overridden"):
+        with pytest.raises(ValueError, match=f"required for state '{state}'"):
+            CommunityListModel.from_config({"name": "CL1"}, context={"state": state})
+
+    deleted = CommunityListModel.from_config({"name": "CL1"}, context={"state": "deleted"})
+    without_state = CommunityListModel.from_config({"name": "CL1"})
+    complete = CommunityListModel.from_config(
+        {
+            "name": "CL1",
+            "type": "standard",
+            "entries": [{"sequence_number": 10, "action": "permit"}],
+        },
+        context={"state": "merged"},
+    )
+
+    assert deleted.type is None
+    assert without_state.entries is None
+    assert complete.type == "standard"

--- a/tests/unit/module_utils/models/test_manage_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_community_list.py
@@ -115,7 +115,7 @@ def test_manage_community_list_00050() -> None:
             "name": "tenantA~CL-TENANT",
             "tenant_name": "tenantA",
             "type": "standard",
-            "entries": [{"sequence_number": 10, "action": "permit"}],
+            "entries": [{"sequence_number": 10, "action": "permit", "internet": True}],
         }
     )
 
@@ -182,7 +182,7 @@ def test_manage_community_list_00090() -> None:
         {
             "name": "CL1",
             "type": "standard",
-            "entries": [{"sequence_number": 10, "action": "permit"}],
+            "entries": [{"sequence_number": 10, "action": "permit", "internet": True}],
         },
         context={"state": "merged"},
     )
@@ -244,15 +244,104 @@ def test_manage_community_list_00110() -> None:
         {
             "name": "CL1",
             "type": "standard",
-            "entries": [{"sequenceNumber": 10, "action": "permit", "noExport": True}],
+            "entries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "communityNumbers": ["100:200"],
+                    "noExport": True,
+                }
+            ],
         }
     )
     proposed = CommunityListModel.from_config(
         {
             "name": "CL1",
             "type": "standard",
-            "entries": [{"sequence_number": 10, "action": "permit", "no_export": False}],
+            "entries": [
+                {
+                    "sequence_number": 10,
+                    "action": "permit",
+                    "community_numbers": ["100:200"],
+                    "no_export": False,
+                }
+            ],
         }
     )
 
     assert current.get_diff(proposed, exclude_unset=True) is False
+
+
+@pytest.mark.parametrize(
+    "entry",
+    (
+        {"sequence_number": 10, "action": "permit"},
+        {"sequence_number": 10, "action": "permit", "community_numbers": []},
+        {
+            "sequence_number": 10,
+            "action": "permit",
+            "no_advertise": False,
+            "blackhole": False,
+            "no_export": False,
+            "internet": False,
+            "graceful_shutdown": False,
+            "local_asn": False,
+        },
+    ),
+)
+def test_manage_community_list_00120(entry: dict[str, object]) -> None:
+    """Verify standard config entries require a community number or an enabled flag."""
+    with pytest.raises(ValueError, match="must set at least one community number or enable at least one well-known community flag"):
+        CommunityListModel.from_config(
+            {
+                "name": "CL-STANDARD",
+                "type": "standard",
+                "entries": [entry],
+            },
+            context={"state": "merged"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    (
+        ("community_numbers", ["100:200"]),
+        ("no_advertise", True),
+        ("blackhole", True),
+        ("no_export", True),
+        ("internet", True),
+        ("graceful_shutdown", True),
+        ("local_asn", True),
+    ),
+)
+def test_manage_community_list_00130(field_name: str, field_value: object) -> None:
+    """Verify every supported standard-entry match selector satisfies validation."""
+    entry = {
+        "sequence_number": 10,
+        "action": "permit",
+        field_name: field_value,
+    }
+
+    instance = CommunityListModel.from_config(
+        {
+            "name": "CL-STANDARD",
+            "type": "standard",
+            "entries": [entry],
+        },
+        context={"state": "merged"},
+    )
+
+    assert getattr(instance.entries[0], field_name) == field_value
+
+
+def test_manage_community_list_00140() -> None:
+    """Verify flagless standard entries remain parseable as controller responses."""
+    instance = CommunityListModel.from_response(
+        {
+            "name": "CL-STANDARD",
+            "type": "standard",
+            "entries": [{"sequenceNumber": 10, "action": "permit"}],
+        }
+    )
+
+    assert instance.entries[0].sequence_number == 10

--- a/tests/unit/module_utils/models/test_manage_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_community_list.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for models/manage_community_list/manage_community_list.py."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_community_list.manage_community_list import CommunityListModel
+
+STANDARD_API_RESPONSE = {
+    "name": "CL-STANDARD",
+    "type": "standard",
+    "tenantName": "tenantA",
+    "lastUpdateTimestamp": "2026-01-01T00:00:00Z",
+    "entries": [
+        {
+            "sequenceNumber": 10,
+            "action": "permit",
+            "communityNumbers": ["100:200"],
+            "noAdvertise": False,
+        }
+    ],
+}
+
+
+def test_manage_community_list_00010() -> None:
+    """
+    # Summary
+
+    Verify identifier configuration and name-only delete model construction.
+
+    ## Classes and Methods
+
+    - CommunityListModel.from_config()
+    - CommunityListModel.get_identifier_value()
+    """
+    instance = CommunityListModel.from_config({"name": "CL-DELETE"})
+
+    assert CommunityListModel.identifiers == ["name"]
+    assert CommunityListModel.identifier_strategy == "single"
+    assert instance.get_identifier_value() == "CL-DELETE"
+    assert instance.type is None
+    assert instance.entries is None
+
+
+def test_manage_community_list_00020() -> None:
+    """
+    # Summary
+
+    Verify API alias loading and payload serialization.
+
+    ## Classes and Methods
+
+    - CommunityListModel.from_response()
+    - CommunityListModel.to_payload()
+    """
+    instance = CommunityListModel.from_response(STANDARD_API_RESPONSE)
+    payload = instance.to_payload()
+
+    assert instance.name == "CL-STANDARD"
+    assert instance.tenant_name == "tenantA"
+    assert "lastUpdateTimestamp" not in payload
+    assert payload["tenantName"] == "tenantA"
+    assert payload["entries"][0]["sequenceNumber"] == 10
+    assert payload["entries"][0]["communityNumbers"] == ["100:200"]
+
+
+def test_manage_community_list_00030() -> None:
+    """
+    # Summary
+
+    Verify type-specific validation for expanded community lists.
+
+    ## Classes and Methods
+
+    - CommunityListModel.from_config()
+    """
+    with pytest.raises(ValueError, match="community_number_regex is required"):
+        CommunityListModel.from_config(
+            {
+                "name": "CL-EXPANDED",
+                "type": "expanded",
+                "entries": [{"sequence_number": 10, "action": "permit"}],
+            }
+        )
+
+
+def test_manage_community_list_00040() -> None:
+    """
+    # Summary
+
+    Verify the argument spec allows name-only config for state=deleted.
+
+    ## Classes and Methods
+
+    - CommunityListModel.get_argument_spec()
+    """
+    spec = CommunityListModel.get_argument_spec()
+    config_options = spec["config"]["options"]
+
+    assert config_options["name"]["required"] is True
+    assert "required" not in config_options["type"]
+    assert "required" not in config_options["entries"]

--- a/tests/unit/module_utils/models/test_manage_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_community_list.py
@@ -189,3 +189,69 @@ def test_manage_community_list_00090() -> None:
     assert deleted.type is None
     assert without_state.entries is None
     assert complete.type == "standard"
+
+
+def test_manage_community_list_00100() -> None:
+    """Verify ND-added false defaults do not break merged-state idempotency."""
+    current = CommunityListModel.from_response(
+        {
+            "name": "CL1",
+            "type": "standard",
+            "entries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "communityNumbers": ["100:200"],
+                    "noAdvertise": False,
+                    "blackhole": False,
+                    "noExport": False,
+                    "internet": False,
+                    "gracefulShutdown": False,
+                    "localAsn": False,
+                },
+                {
+                    "sequenceNumber": 20,
+                    "action": "deny",
+                    "communityNumbers": [],
+                    "noAdvertise": False,
+                    "blackhole": False,
+                    "noExport": True,
+                    "internet": False,
+                    "gracefulShutdown": False,
+                    "localAsn": False,
+                },
+            ],
+        }
+    )
+    proposed = CommunityListModel.from_config(
+        {
+            "name": "CL1",
+            "type": "standard",
+            "entries": [
+                {"sequence_number": 10, "action": "permit", "community_numbers": ["100:200"]},
+                {"sequence_number": 20, "action": "deny", "no_export": True},
+            ],
+        }
+    )
+
+    assert current.get_diff(proposed, exclude_unset=True) is True
+
+
+def test_manage_community_list_00110() -> None:
+    """Verify explicitly clearing a true well-known flag still produces a diff."""
+    current = CommunityListModel.from_response(
+        {
+            "name": "CL1",
+            "type": "standard",
+            "entries": [{"sequenceNumber": 10, "action": "permit", "noExport": True}],
+        }
+    )
+    proposed = CommunityListModel.from_config(
+        {
+            "name": "CL1",
+            "type": "standard",
+            "entries": [{"sequence_number": 10, "action": "permit", "no_export": False}],
+        }
+    )
+
+    assert current.get_diff(proposed, exclude_unset=True) is False

--- a/tests/unit/module_utils/models/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_extended_community_list.py
@@ -105,6 +105,7 @@ def test_manage_extended_community_list_00040() -> None:
     config_options = spec["config"]["options"]
 
     assert config_options["name"]["required"] is True
+    assert spec["cluster_name"]["type"] == "str"
     assert "required" not in config_options["type"]
     assert "required" not in config_options["entries"]
 

--- a/tests/unit/module_utils/models/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_extended_community_list.py
@@ -42,7 +42,7 @@ def test_manage_extended_community_list_00010() -> None:
     """
     instance = ExtendedCommunityListModel.from_config({"name": "ECL-DELETE"})
 
-    assert ExtendedCommunityListModel.identifiers == ["name"]
+    assert ExtendedCommunityListModel.identifiers == ["api_name"]
     assert ExtendedCommunityListModel.identifier_strategy == "single"
     assert instance.get_identifier_value() == "ECL-DELETE"
     assert instance.type is None
@@ -107,3 +107,43 @@ def test_manage_extended_community_list_00040() -> None:
     assert config_options["name"]["required"] is True
     assert "required" not in config_options["type"]
     assert "required" not in config_options["entries"]
+
+
+def test_manage_extended_community_list_00050() -> None:
+    """Verify tenant-scoped names are normalized while API identity stays qualified."""
+    instance = ExtendedCommunityListModel.from_config(
+        {
+            "name": "tenantA~ECL-TENANT",
+            "tenant_name": "tenantA",
+            "type": "standard",
+            "entries": [{"sequence_number": 10, "action": "permit"}],
+        }
+    )
+
+    assert instance.name == "ECL-TENANT"
+    assert instance.api_name == "tenantA~ECL-TENANT"
+    assert instance.get_identifier_value() == "tenantA~ECL-TENANT"
+    assert instance.to_config()["name"] == "ECL-TENANT"
+    assert instance.to_payload()["name"] == "tenantA~ECL-TENANT"
+
+
+def test_manage_extended_community_list_00060() -> None:
+    """Verify same-name lists in different tenants have distinct identifiers."""
+    first = ExtendedCommunityListModel.from_config({"name": "ECL-SHARED", "tenant_name": "tenantA"})
+    second = ExtendedCommunityListModel.from_config({"name": "ECL-SHARED", "tenant_name": "tenantB"})
+
+    assert first.get_identifier_value() == "tenantA~ECL-SHARED"
+    assert second.get_identifier_value() == "tenantB~ECL-SHARED"
+    assert first.get_identifier_value() != second.get_identifier_value()
+
+
+def test_manage_extended_community_list_00070() -> None:
+    """Verify default and tenant-qualified API name length limits."""
+    ExtendedCommunityListModel.from_config({"name": "E" * 63})
+    with pytest.raises(ValueError, match="default-tenant extended community list name"):
+        ExtendedCommunityListModel.from_config({"name": "E" * 64})
+
+    tenant_name = "T" * 63
+    ExtendedCommunityListModel.from_config({"name": "E" * 51, "tenant_name": tenant_name})
+    with pytest.raises(ValueError, match="tenant-scoped extended community list API name"):
+        ExtendedCommunityListModel.from_config({"name": "E" * 52, "tenant_name": tenant_name})

--- a/tests/unit/module_utils/models/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_extended_community_list.py
@@ -169,3 +169,25 @@ def test_manage_extended_community_list_00080() -> None:
 
     with pytest.raises(ValueError, match="route_target_collection must not be set"):
         ExtendedCommunityListModel.from_config(response)
+
+
+def test_manage_extended_community_list_00090() -> None:
+    """Verify type and entries are required only for write-state config."""
+    for state in ("merged", "replaced", "overridden"):
+        with pytest.raises(ValueError, match=f"required for state '{state}'"):
+            ExtendedCommunityListModel.from_config({"name": "ECL1"}, context={"state": state})
+
+    deleted = ExtendedCommunityListModel.from_config({"name": "ECL1"}, context={"state": "deleted"})
+    without_state = ExtendedCommunityListModel.from_config({"name": "ECL1"})
+    complete = ExtendedCommunityListModel.from_config(
+        {
+            "name": "ECL1",
+            "type": "standard",
+            "entries": [{"sequence_number": 10, "action": "permit"}],
+        },
+        context={"state": "merged"},
+    )
+
+    assert deleted.type is None
+    assert without_state.entries is None
+    assert complete.type == "standard"

--- a/tests/unit/module_utils/models/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_extended_community_list.py
@@ -117,7 +117,7 @@ def test_manage_extended_community_list_00050() -> None:
             "name": "tenantA~ECL-TENANT",
             "tenant_name": "tenantA",
             "type": "standard",
-            "entries": [{"sequence_number": 10, "action": "permit"}],
+            "entries": [{"sequence_number": 10, "action": "permit", "route_target_collection": ["65000:100"]}],
         }
     )
 
@@ -184,7 +184,7 @@ def test_manage_extended_community_list_00090() -> None:
         {
             "name": "ECL1",
             "type": "standard",
-            "entries": [{"sequence_number": 10, "action": "permit"}],
+            "entries": [{"sequence_number": 10, "action": "permit", "route_target_collection": ["65000:100"]}],
         },
         context={"state": "merged"},
     )
@@ -321,3 +321,66 @@ def test_manage_extended_community_list_00140(route_targets: list[str]) -> None:
                 ],
             }
         )
+
+
+@pytest.mark.parametrize(
+    "entry",
+    (
+        {"sequence_number": 10, "action": "permit"},
+        {
+            "sequence_number": 10,
+            "action": "permit",
+            "router_mac_collection": [],
+            "route_target_collection": [],
+            "site_of_origin_collection": [],
+            "transitive_generic_extended_collection": [],
+            "non_transitive_generic_extended_collection": [],
+        },
+    ),
+)
+def test_manage_extended_community_list_00150(entry: dict) -> None:
+    """Verify standard entries require at least one non-empty selector collection."""
+    with pytest.raises(ValueError, match="at least one standard selector collection"):
+        ExtendedCommunityListModel.from_config(
+            {
+                "name": "ECL-FLAGLESS",
+                "type": "standard",
+                "entries": [entry],
+            }
+        )
+
+
+def test_manage_extended_community_list_00160() -> None:
+    """Verify sparse standard entries returned by ND remain readable."""
+    instance = ExtendedCommunityListModel.from_response(
+        {
+            "name": "ECL-RESPONSE",
+            "type": "standard",
+            "entries": [{"sequenceNumber": 10, "action": "permit"}],
+        }
+    )
+
+    assert instance.entries[0].route_target_collection is None
+
+
+@pytest.mark.parametrize(
+    ("selector", "value"),
+    (
+        ("router_mac_collection", "d478.1111.57b8"),
+        ("route_target_collection", "65000:100"),
+        ("site_of_origin_collection", "64512:300"),
+        ("transitive_generic_extended_collection", "65000:123"),
+        ("non_transitive_generic_extended_collection", "64512:789"),
+    ),
+)
+def test_manage_extended_community_list_00170(selector: str, value: str) -> None:
+    """Verify each standard selector collection independently satisfies the requirement."""
+    instance = ExtendedCommunityListModel.from_config(
+        {
+            "name": "ECL-SELECTOR",
+            "type": "standard",
+            "entries": [{"sequence_number": 10, "action": "permit", selector: [value]}],
+        }
+    )
+
+    assert getattr(instance.entries[0], selector) == [value]

--- a/tests/unit/module_utils/models/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_extended_community_list.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for models/manage_extended_community_list/manage_extended_community_list.py."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_community_list.manage_extended_community_list import (
+    ExtendedCommunityListModel,
+)
+
+STANDARD_API_RESPONSE = {
+    "name": "ECL-STANDARD",
+    "type": "standard",
+    "tenantName": "tenantA",
+    "lastUpdateTimestamp": "2026-01-01T00:00:00Z",
+    "entries": [
+        {
+            "sequenceNumber": 10,
+            "action": "permit",
+            "routeTargetCollection": ["65000:100"],
+            "routerMacCollection": ["d478.1111.57b8"],
+        }
+    ],
+}
+
+
+def test_manage_extended_community_list_00010() -> None:
+    """
+    # Summary
+
+    Verify identifier configuration and name-only delete model construction.
+
+    ## Classes and Methods
+
+    - ExtendedCommunityListModel.from_config()
+    - ExtendedCommunityListModel.get_identifier_value()
+    """
+    instance = ExtendedCommunityListModel.from_config({"name": "ECL-DELETE"})
+
+    assert ExtendedCommunityListModel.identifiers == ["name"]
+    assert ExtendedCommunityListModel.identifier_strategy == "single"
+    assert instance.get_identifier_value() == "ECL-DELETE"
+    assert instance.type is None
+    assert instance.entries is None
+
+
+def test_manage_extended_community_list_00020() -> None:
+    """
+    # Summary
+
+    Verify API alias loading and payload serialization.
+
+    ## Classes and Methods
+
+    - ExtendedCommunityListModel.from_response()
+    - ExtendedCommunityListModel.to_payload()
+    """
+    instance = ExtendedCommunityListModel.from_response(STANDARD_API_RESPONSE)
+    payload = instance.to_payload()
+
+    assert instance.name == "ECL-STANDARD"
+    assert instance.tenant_name == "tenantA"
+    assert "lastUpdateTimestamp" not in payload
+    assert payload["tenantName"] == "tenantA"
+    assert payload["entries"][0]["sequenceNumber"] == 10
+    assert payload["entries"][0]["routeTargetCollection"] == ["65000:100"]
+
+
+def test_manage_extended_community_list_00030() -> None:
+    """
+    # Summary
+
+    Verify type-specific validation for expanded extended community lists.
+
+    ## Classes and Methods
+
+    - ExtendedCommunityListModel.from_config()
+    """
+    with pytest.raises(ValueError, match="community_number_regex is required"):
+        ExtendedCommunityListModel.from_config(
+            {
+                "name": "ECL-EXPANDED",
+                "type": "expanded",
+                "entries": [{"sequence_number": 10, "action": "permit"}],
+            }
+        )
+
+
+def test_manage_extended_community_list_00040() -> None:
+    """
+    # Summary
+
+    Verify the argument spec allows name-only config for state=deleted.
+
+    ## Classes and Methods
+
+    - ExtendedCommunityListModel.get_argument_spec()
+    """
+    spec = ExtendedCommunityListModel.get_argument_spec()
+    config_options = spec["config"]["options"]
+
+    assert config_options["name"]["required"] is True
+    assert "required" not in config_options["type"]
+    assert "required" not in config_options["entries"]

--- a/tests/unit/module_utils/models/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_extended_community_list.py
@@ -6,9 +6,7 @@
 
 """Unit tests for models/manage_extended_community_list/manage_extended_community_list.py."""
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_community_list.manage_extended_community_list import (

--- a/tests/unit/module_utils/models/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_extended_community_list.py
@@ -222,3 +222,102 @@ def test_manage_extended_community_list_00100() -> None:
     )
 
     assert current.get_diff(proposed, exclude_unset=True) is True
+
+
+def test_manage_extended_community_list_00110() -> None:
+    """Verify packed route-target config is normalized and serialized canonically."""
+    instance = ExtendedCommunityListModel.from_config(
+        {
+            "name": "ECL-PACKED",
+            "type": "standard",
+            "entries": [
+                {
+                    "sequence_number": 10,
+                    "action": "permit",
+                    "route_target_collection": ["65000:100,65000:200", "192.0.2.1:300"],
+                }
+            ],
+        }
+    )
+
+    expected = ["65000:100", "65000:200", "192.0.2.1:300"]
+    assert instance.entries[0].route_target_collection == expected
+    assert instance.to_payload()["entries"][0]["routeTargetCollection"] == expected
+
+
+def test_manage_extended_community_list_00120() -> None:
+    """Verify packed route targets returned by ND are normalized before reconciliation."""
+    instance = ExtendedCommunityListModel.from_response(
+        {
+            "name": "ECL-PACKED",
+            "type": "standard",
+            "entries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "routeTargetCollection": ["65000:100,65000:200"],
+                }
+            ],
+        }
+    )
+
+    assert instance.entries[0].route_target_collection == ["65000:100", "65000:200"]
+
+
+def test_manage_extended_community_list_00130() -> None:
+    """Verify packed response data is idempotent with equivalent unpacked config."""
+    current = ExtendedCommunityListModel.from_response(
+        {
+            "name": "ECL-PACKED",
+            "type": "standard",
+            "entries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "routeTargetCollection": ["65000:100,65000:200"],
+                }
+            ],
+        }
+    )
+    proposed = ExtendedCommunityListModel.from_config(
+        {
+            "name": "ECL-PACKED",
+            "type": "standard",
+            "entries": [
+                {
+                    "sequence_number": 10,
+                    "action": "permit",
+                    "route_target_collection": ["65000:100", "65000:200"],
+                }
+            ],
+        }
+    )
+
+    assert current.get_diff(proposed, exclude_unset=True) is True
+
+
+@pytest.mark.parametrize(
+    "route_targets",
+    (
+        ["65000:100,"],
+        [",65000:100"],
+        ["65000:100,invalid"],
+        ["65000:100, 65000:200"],
+    ),
+)
+def test_manage_extended_community_list_00140(route_targets: list[str]) -> None:
+    """Verify malformed packed route-target items remain invalid."""
+    with pytest.raises(ValueError, match="route_target_collection entry"):
+        ExtendedCommunityListModel.from_config(
+            {
+                "name": "ECL-INVALID",
+                "type": "standard",
+                "entries": [
+                    {
+                        "sequence_number": 10,
+                        "action": "permit",
+                        "route_target_collection": route_targets,
+                    }
+                ],
+            }
+        )

--- a/tests/unit/module_utils/models/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_extended_community_list.py
@@ -147,3 +147,25 @@ def test_manage_extended_community_list_00070() -> None:
     ExtendedCommunityListModel.from_config({"name": "E" * 51, "tenant_name": tenant_name})
     with pytest.raises(ValueError, match="tenant-scoped extended community list API name"):
         ExtendedCommunityListModel.from_config({"name": "E" * 52, "tenant_name": tenant_name})
+
+
+def test_manage_extended_community_list_00080() -> None:
+    """Verify type-specific validation is config-only and does not reject ND responses."""
+    response = {
+        "name": "ECL-EXPANDED",
+        "type": "expanded",
+        "entries": [
+            {
+                "sequenceNumber": 10,
+                "action": "permit",
+                "communityNumberRegex": "65000:.*",
+                "routeTargetCollection": [],
+            }
+        ],
+    }
+
+    instance = ExtendedCommunityListModel.from_response(response)
+    assert instance.entries[0].route_target_collection == []
+
+    with pytest.raises(ValueError, match="route_target_collection must not be set"):
+        ExtendedCommunityListModel.from_config(response)

--- a/tests/unit/module_utils/models/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/models/test_manage_extended_community_list.py
@@ -191,3 +191,33 @@ def test_manage_extended_community_list_00090() -> None:
     assert deleted.type is None
     assert without_state.entries is None
     assert complete.type == "standard"
+
+
+def test_manage_extended_community_list_00100() -> None:
+    """Verify ND-added empty collection defaults do not break merged-state idempotency."""
+    current = ExtendedCommunityListModel.from_response(
+        {
+            "name": "ECL1",
+            "type": "standard",
+            "entries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "routeTargetCollection": ["65000:100"],
+                    "routerMacCollection": [],
+                    "siteOfOriginCollection": [],
+                    "transitiveGenericExtendedCollection": [],
+                    "nonTransitiveGenericExtendedCollection": [],
+                }
+            ],
+        }
+    )
+    proposed = ExtendedCommunityListModel.from_config(
+        {
+            "name": "ECL1",
+            "type": "standard",
+            "entries": [{"sequence_number": 10, "action": "permit", "route_target_collection": ["65000:100"]}],
+        }
+    )
+
+    assert current.get_diff(proposed, exclude_unset=True) is True

--- a/tests/unit/module_utils/orchestrators/test_manage_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_community_list.py
@@ -51,7 +51,7 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
 
 
 class _FakeFabricContext:
-    """Minimal `FabricContext` stand-in for query preflight."""
+    """Minimal `FabricContext` stand-in for mutation preflight."""
 
     def __init__(self) -> None:
         self.validated = False
@@ -112,12 +112,11 @@ def test_manage_community_list_00030() -> None:
     """
     # Summary
 
-    Verify query_all validates fabric prerequisites and extracts the response wrapper.
+    Verify query_all reads inventory without running mutation preflight.
 
     ## Classes and Methods
 
     - ManageCommunityListOrchestrator.query_all()
-    - ManageCommunityListOrchestrator.validate_prerequisites()
     """
     method_name = inspect.stack()[0][3]
 
@@ -129,8 +128,23 @@ def test_manage_community_list_00030() -> None:
 
     result = instance.query_all()
 
-    assert fabric_context.validated is True
+    assert fabric_context.validated is False
     assert result[0]["name"] == "CL1"
+
+
+def test_manage_community_list_00020() -> None:
+    """Verify mutation preflight delegates to FabricContext only when config exists."""
+
+    def responses():
+        yield {}
+
+    unused_rest_send, instance, fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+
+    instance.preflight([])
+    assert fabric_context.validated is False
+    instance.preflight([_model()])
+    assert fabric_context.validated is True
 
 
 def test_manage_community_list_00100() -> None:

--- a/tests/unit/module_utils/orchestrators/test_manage_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_community_list.py
@@ -28,7 +28,7 @@ def responses_manage_community_list(key: str):
     return load_fixture("test_manage_community_list")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1", cluster_name: str | None = None) -> RestSend:
     """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
@@ -39,7 +39,10 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    params = {"check_mode": False, "fabric_name": fabric_name}
+    if cluster_name is not None:
+        params["cluster_name"] = cluster_name
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -294,3 +297,60 @@ def test_manage_community_list_00320(monkeypatch: pytest.MonkeyPatch) -> None:
     instance.delete_bulk([model])
 
     assert operation_types == [OperationType.CREATE, OperationType.UPDATE, OperationType.DELETE]
+
+
+def test_manage_community_list_00400(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify query_all walks and de-duplicates Lucene pages."""
+    pages = [
+        {"communityLists": [{"name": "CL1"}, {"name": "CL2"}]},
+        {"communityLists": [{"name": "CL2"}, {"name": "CL3"}]},
+        {"communityLists": []},
+    ]
+    paths = []
+
+    def fake_request(*args, **kwargs):
+        paths.append(kwargs["path"])
+        return pages.pop(0)
+
+    def responses():
+        yield {}
+
+    unused_rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+    assert unused_fabric_context is not None
+    monkeypatch.setattr(ManageCommunityListOrchestrator, "query_all_page_size", 2)
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all()
+
+    assert [item["name"] for item in result] == ["CL1", "CL2", "CL3"]
+    assert paths == [
+        "/api/v1/manage/fabrics/fabric_1/communityLists?max=2&offset=0",
+        "/api/v1/manage/fabrics/fabric_1/communityLists?max=2&offset=2",
+        "/api/v1/manage/fabrics/fabric_1/communityLists?max=2&offset=4",
+    ]
+
+
+def test_manage_community_list_00410(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify cluster_name is forwarded to collection and item reads."""
+    paths = []
+
+    def fake_request(*args, **kwargs):
+        paths.append(kwargs["path"])
+        return {"communityLists": []}
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()), cluster_name="cluster-1")
+    instance = ManageCommunityListOrchestrator(rest_send=rest_send)
+    instance._fabric_context = _FakeFabricContext()
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    instance.query_all()
+    instance.query_one(_model())
+
+    assert paths == [
+        "/api/v1/manage/fabrics/fabric_1/communityLists?clusterName=cluster-1&max=100&offset=0",
+        "/api/v1/manage/fabrics/fabric_1/communityLists/CL1?clusterName=cluster-1",
+    ]

--- a/tests/unit/module_utils/orchestrators/test_manage_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_community_list.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import inspect
 
 import pytest
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_community_list.manage_community_list import CommunityListModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_community_list import ManageCommunityListOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
@@ -270,3 +270,27 @@ def test_manage_community_list_00310() -> None:
 
     instance.delete_bulk([CommunityListModel.from_config({"name": "CL1", "tenant_name": "tenantA"})])
     assert rest_send.committed_payload == {"communityListNames": ["tenantA~CL1"]}
+
+
+def test_manage_community_list_00320(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify custom mutation paths record create, update, and delete operation types."""
+    operation_types = []
+
+    def fake_request(*args, **kwargs):
+        operation_types.append(kwargs.get("operation_type"))
+        return {"results": []}
+
+    def responses():
+        yield {}
+
+    unused_rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+    assert unused_fabric_context is not None
+    monkeypatch.setattr(instance, "_request", fake_request)
+    model = _model()
+
+    instance.create_bulk([model])
+    instance.update(model)
+    instance.delete_bulk([model])
+
+    assert operation_types == [OperationType.CREATE, OperationType.UPDATE, OperationType.DELETE]

--- a/tests/unit/module_utils/orchestrators/test_manage_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_community_list.py
@@ -67,15 +67,16 @@ def _instance(gen_responses: ResponseGenerator) -> tuple[RestSend, ManageCommuni
     return rest_send, instance, fabric_context
 
 
-def _model(name: str = "CL1") -> CommunityListModel:
+def _model(name: str = "CL1", tenant_name: str | None = None) -> CommunityListModel:
     """Build a standard community list model."""
-    return CommunityListModel.from_config(
-        {
-            "name": name,
-            "type": "standard",
-            "entries": [{"sequence_number": 10, "action": "permit", "community_numbers": ["100:200"]}],
-        }
-    )
+    config = {
+        "name": name,
+        "type": "standard",
+        "entries": [{"sequence_number": 10, "action": "permit", "community_numbers": ["100:200"]}],
+    }
+    if tenant_name is not None:
+        config["tenant_name"] = tenant_name
+    return CommunityListModel.from_config(config)
 
 
 def test_manage_community_list_00010() -> None:
@@ -250,3 +251,22 @@ def test_manage_community_list_00300() -> None:
     assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/communityListActions/remove"
     assert rest_send.verb == HttpVerbEnum.POST.value
     assert rest_send.committed_payload == {"communityListNames": ["CL1"]}
+
+
+def test_manage_community_list_00310() -> None:
+    """Verify tenant-scoped update paths and delete payloads use API names."""
+    update_model = _model("CL1", tenant_name="tenantA")
+
+    def responses():
+        yield responses_manage_community_list("test_manage_community_list_00200a")
+        yield responses_manage_community_list("test_manage_community_list_00300a")
+
+    rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_fabric_context is not None
+
+    instance.update(update_model)
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/communityLists/tenantA~CL1"
+    assert rest_send.committed_payload["name"] == "tenantA~CL1"
+
+    instance.delete_bulk([CommunityListModel.from_config({"name": "CL1", "tenant_name": "tenantA"})])
+    assert rest_send.committed_payload == {"communityListNames": ["tenantA~CL1"]}

--- a/tests/unit/module_utils/orchestrators/test_manage_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_community_list.py
@@ -6,9 +6,7 @@
 
 """Unit tests for ManageCommunityListOrchestrator."""
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import inspect
 

--- a/tests/unit/module_utils/orchestrators/test_manage_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_community_list.py
@@ -197,6 +197,20 @@ def test_manage_community_list_00110() -> None:
         instance.create_bulk([_model()])
 
 
+def test_manage_community_list_00115() -> None:
+    """Verify non-failure and missing 207 status tokens are tolerated."""
+    result = {
+        "results": [
+            {"name": "CL1", "status": "accepted", "message": "queued"},
+            {"name": "CL2", "status": "", "message": "no status"},
+            {"name": "CL3", "message": "status omitted"},
+        ]
+    }
+
+    with does_not_raise():
+        ManageCommunityListOrchestrator._raise_on_207_action_errors(result)
+
+
 def test_manage_community_list_00120() -> None:
     """
     # Summary

--- a/tests/unit/module_utils/orchestrators/test_manage_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_community_list.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for ManageCommunityListOrchestrator."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+import inspect
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_community_list.manage_community_list import CommunityListModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_community_list import ManageCommunityListOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_manage_community_list(key: str):
+    """Load fixture data for manage community list orchestrator tests."""
+    return load_fixture("test_manage_community_list")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+    """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+class _FakeFabricContext:
+    """Minimal `FabricContext` stand-in for query preflight."""
+
+    def __init__(self) -> None:
+        self.validated = False
+
+    def validate_for_mutation(self) -> None:
+        """Record that preflight validation was invoked."""
+        self.validated = True
+
+
+def _instance(gen_responses: ResponseGenerator) -> tuple[RestSend, ManageCommunityListOrchestrator, _FakeFabricContext]:
+    """Build a `RestSend` and orchestrator with fake fabric preflight."""
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManageCommunityListOrchestrator(rest_send=rest_send)
+    fabric_context = _FakeFabricContext()
+    instance._fabric_context = fabric_context
+    return rest_send, instance, fabric_context
+
+
+def _model(name: str = "CL1") -> CommunityListModel:
+    """Build a standard community list model."""
+    return CommunityListModel.from_config(
+        {
+            "name": name,
+            "type": "standard",
+            "entries": [{"sequence_number": 10, "action": "permit", "community_numbers": ["100:200"]}],
+        }
+    )
+
+
+def test_manage_community_list_00010() -> None:
+    """
+    # Summary
+
+    Verify orchestrator initialization and fabric_name lookup from RestSend params.
+
+    ## Classes and Methods
+
+    - ManageCommunityListOrchestrator.__init__()
+    - ManageCommunityListOrchestrator.fabric_name
+    """
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()), fabric_name="SITE1")
+
+    with does_not_raise():
+        instance = ManageCommunityListOrchestrator(rest_send=rest_send)
+
+    assert instance.model_class is CommunityListModel
+    assert instance.supports_bulk_create is True
+    assert instance.supports_bulk_delete is True
+    assert instance.fabric_name == "SITE1"
+
+
+def test_manage_community_list_00030() -> None:
+    """
+    # Summary
+
+    Verify query_all validates fabric prerequisites and extracts the response wrapper.
+
+    ## Classes and Methods
+
+    - ManageCommunityListOrchestrator.query_all()
+    - ManageCommunityListOrchestrator.validate_prerequisites()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_community_list(f"{method_name}a")
+
+    unused_rest_send, instance, fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+
+    result = instance.query_all()
+
+    assert fabric_context.validated is True
+    assert result[0]["name"] == "CL1"
+
+
+def test_manage_community_list_00100() -> None:
+    """
+    # Summary
+
+    Verify create_bulk sends the wrapped payload and accepts all-success 207 results.
+
+    ## Classes and Methods
+
+    - ManageCommunityListOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_community_list(f"{method_name}a")
+
+    rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_fabric_context is not None
+
+    with does_not_raise():
+        instance.create_bulk([_model()])
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/communityLists"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert rest_send.committed_payload["communityLists"][0]["name"] == "CL1"
+
+
+def test_manage_community_list_00110() -> None:
+    """
+    # Summary
+
+    Verify create_bulk raises when a 207 result item reports failure.
+
+    ## Classes and Methods
+
+    - ManageCommunityListOrchestrator.create_bulk()
+    - ManageCommunityListOrchestrator._raise_on_207_action_errors()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_community_list(f"{method_name}a")
+
+    unused_rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+    assert unused_fabric_context is not None
+
+    with pytest.raises(RuntimeError, match="duplicate name"):
+        instance.create_bulk([_model()])
+
+
+def test_manage_community_list_00120() -> None:
+    """
+    # Summary
+
+    Verify writes reject name-only models while still allowing them for delete models.
+
+    ## Classes and Methods
+
+    - ManageCommunityListOrchestrator.create()
+    - ManageCommunityListOrchestrator._validate_write_model()
+    """
+
+    def responses():
+        yield {}
+
+    unused_rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+    assert unused_fabric_context is not None
+
+    with pytest.raises(RuntimeError, match="requires type, entries"):
+        instance.create(CommunityListModel.from_config({"name": "CL1"}))
+
+
+def test_manage_community_list_00200() -> None:
+    """
+    # Summary
+
+    Verify update sends a per-item PUT payload.
+
+    ## Classes and Methods
+
+    - ManageCommunityListOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_community_list(f"{method_name}a")
+
+    rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_fabric_context is not None
+
+    instance.update(_model())
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/communityLists/CL1"
+    assert rest_send.verb == HttpVerbEnum.PUT.value
+    assert rest_send.committed_payload["entries"][0]["communityNumbers"] == ["100:200"]
+
+
+def test_manage_community_list_00300() -> None:
+    """
+    # Summary
+
+    Verify delete_bulk only needs names and uses the action endpoint.
+
+    ## Classes and Methods
+
+    - ManageCommunityListOrchestrator.delete_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_community_list(f"{method_name}a")
+
+    rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_fabric_context is not None
+
+    instance.delete_bulk([CommunityListModel.from_config({"name": "CL1"})])
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/communityListActions/remove"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert rest_send.committed_payload == {"communityListNames": ["CL1"]}

--- a/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for ManageExtendedCommunityListOrchestrator."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+import inspect
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_community_list.manage_extended_community_list import (
+    ExtendedCommunityListModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_extended_community_list import (
+    ManageExtendedCommunityListOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_manage_extended_community_list(key: str):
+    """Load fixture data for manage extended community list orchestrator tests."""
+    return load_fixture("test_manage_extended_community_list")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+    """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+class _FakeFabricContext:
+    """Minimal `FabricContext` stand-in for query preflight."""
+
+    def __init__(self) -> None:
+        self.validated = False
+
+    def validate_for_mutation(self) -> None:
+        """Record that preflight validation was invoked."""
+        self.validated = True
+
+
+def _instance(gen_responses: ResponseGenerator) -> tuple[RestSend, ManageExtendedCommunityListOrchestrator, _FakeFabricContext]:
+    """Build a `RestSend` and orchestrator with fake fabric preflight."""
+    rest_send = _build_rest_send(gen_responses)
+    instance = ManageExtendedCommunityListOrchestrator(rest_send=rest_send)
+    fabric_context = _FakeFabricContext()
+    instance._fabric_context = fabric_context
+    return rest_send, instance, fabric_context
+
+
+def _model(name: str = "ECL1") -> ExtendedCommunityListModel:
+    """Build a standard extended community list model."""
+    return ExtendedCommunityListModel.from_config(
+        {
+            "name": name,
+            "type": "standard",
+            "entries": [{"sequence_number": 10, "action": "permit", "route_target_collection": ["65000:100"]}],
+        }
+    )
+
+
+def test_manage_extended_community_list_00010() -> None:
+    """
+    # Summary
+
+    Verify orchestrator initialization and fabric_name lookup from RestSend params.
+
+    ## Classes and Methods
+
+    - ManageExtendedCommunityListOrchestrator.__init__()
+    - ManageExtendedCommunityListOrchestrator.fabric_name
+    """
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()), fabric_name="SITE1")
+
+    with does_not_raise():
+        instance = ManageExtendedCommunityListOrchestrator(rest_send=rest_send)
+
+    assert instance.model_class is ExtendedCommunityListModel
+    assert instance.supports_bulk_create is True
+    assert instance.supports_bulk_delete is True
+    assert instance.fabric_name == "SITE1"
+
+
+def test_manage_extended_community_list_00030() -> None:
+    """
+    # Summary
+
+    Verify query_all validates fabric prerequisites and extracts the response wrapper.
+
+    ## Classes and Methods
+
+    - ManageExtendedCommunityListOrchestrator.query_all()
+    - ManageExtendedCommunityListOrchestrator.validate_prerequisites()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_extended_community_list(f"{method_name}a")
+
+    unused_rest_send, instance, fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+
+    result = instance.query_all()
+
+    assert fabric_context.validated is True
+    assert result[0]["name"] == "ECL1"
+
+
+def test_manage_extended_community_list_00100() -> None:
+    """
+    # Summary
+
+    Verify create_bulk sends the wrapped payload and accepts all-success 207 results.
+
+    ## Classes and Methods
+
+    - ManageExtendedCommunityListOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_extended_community_list(f"{method_name}a")
+
+    rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_fabric_context is not None
+
+    with does_not_raise():
+        instance.create_bulk([_model()])
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert rest_send.committed_payload["extendedCommunityLists"][0]["name"] == "ECL1"
+
+
+def test_manage_extended_community_list_00110() -> None:
+    """
+    # Summary
+
+    Verify create_bulk raises when a 207 result item reports failure.
+
+    ## Classes and Methods
+
+    - ManageExtendedCommunityListOrchestrator.create_bulk()
+    - ManageExtendedCommunityListOrchestrator._raise_on_207_action_errors()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_extended_community_list(f"{method_name}a")
+
+    unused_rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+    assert unused_fabric_context is not None
+
+    with pytest.raises(RuntimeError, match="duplicate name"):
+        instance.create_bulk([_model()])
+
+
+def test_manage_extended_community_list_00120() -> None:
+    """
+    # Summary
+
+    Verify writes reject name-only models while still allowing them for delete models.
+
+    ## Classes and Methods
+
+    - ManageExtendedCommunityListOrchestrator.create()
+    - ManageExtendedCommunityListOrchestrator._validate_write_model()
+    """
+
+    def responses():
+        yield {}
+
+    unused_rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+    assert unused_fabric_context is not None
+
+    with pytest.raises(RuntimeError, match="requires type, entries"):
+        instance.create(ExtendedCommunityListModel.from_config({"name": "ECL1"}))
+
+
+def test_manage_extended_community_list_00200() -> None:
+    """
+    # Summary
+
+    Verify update sends a per-item PUT payload.
+
+    ## Classes and Methods
+
+    - ManageExtendedCommunityListOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_extended_community_list(f"{method_name}a")
+
+    rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_fabric_context is not None
+
+    instance.update(_model())
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists/ECL1"
+    assert rest_send.verb == HttpVerbEnum.PUT.value
+    assert rest_send.committed_payload["entries"][0]["routeTargetCollection"] == ["65000:100"]
+
+
+def test_manage_extended_community_list_00300() -> None:
+    """
+    # Summary
+
+    Verify delete_bulk only needs names and uses the action endpoint.
+
+    ## Classes and Methods
+
+    - ManageExtendedCommunityListOrchestrator.delete_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_manage_extended_community_list(f"{method_name}a")
+
+    rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_fabric_context is not None
+
+    instance.delete_bulk([ExtendedCommunityListModel.from_config({"name": "ECL1"})])
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/extendedCommunityListActions/remove"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert rest_send.committed_payload == {"extendedCommunityListNames": ["ECL1"]}

--- a/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
@@ -71,15 +71,16 @@ def _instance(gen_responses: ResponseGenerator) -> tuple[RestSend, ManageExtende
     return rest_send, instance, fabric_context
 
 
-def _model(name: str = "ECL1") -> ExtendedCommunityListModel:
+def _model(name: str = "ECL1", tenant_name: str | None = None) -> ExtendedCommunityListModel:
     """Build a standard extended community list model."""
-    return ExtendedCommunityListModel.from_config(
-        {
-            "name": name,
-            "type": "standard",
-            "entries": [{"sequence_number": 10, "action": "permit", "route_target_collection": ["65000:100"]}],
-        }
-    )
+    config = {
+        "name": name,
+        "type": "standard",
+        "entries": [{"sequence_number": 10, "action": "permit", "route_target_collection": ["65000:100"]}],
+    }
+    if tenant_name is not None:
+        config["tenant_name"] = tenant_name
+    return ExtendedCommunityListModel.from_config(config)
 
 
 def test_manage_extended_community_list_00010() -> None:
@@ -254,3 +255,22 @@ def test_manage_extended_community_list_00300() -> None:
     assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/extendedCommunityListActions/remove"
     assert rest_send.verb == HttpVerbEnum.POST.value
     assert rest_send.committed_payload == {"extendedCommunityListNames": ["ECL1"]}
+
+
+def test_manage_extended_community_list_00310() -> None:
+    """Verify tenant-scoped update paths and delete payloads use API names."""
+    update_model = _model("ECL1", tenant_name="tenantA")
+
+    def responses():
+        yield responses_manage_extended_community_list("test_manage_extended_community_list_00200a")
+        yield responses_manage_extended_community_list("test_manage_extended_community_list_00300a")
+
+    rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_fabric_context is not None
+
+    instance.update(update_model)
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists/tenantA~ECL1"
+    assert rest_send.committed_payload["name"] == "tenantA~ECL1"
+
+    instance.delete_bulk([ExtendedCommunityListModel.from_config({"name": "ECL1", "tenant_name": "tenantA"})])
+    assert rest_send.committed_payload == {"extendedCommunityListNames": ["tenantA~ECL1"]}

--- a/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
@@ -32,7 +32,7 @@ def responses_manage_extended_community_list(key: str):
     return load_fixture("test_manage_extended_community_list")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1", cluster_name: str | None = None) -> RestSend:
     """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
@@ -43,7 +43,10 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    params = {"check_mode": False, "fabric_name": fabric_name}
+    if cluster_name is not None:
+        params["cluster_name"] = cluster_name
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -298,3 +301,60 @@ def test_manage_extended_community_list_00320(monkeypatch: pytest.MonkeyPatch) -
     instance.delete_bulk([model])
 
     assert operation_types == [OperationType.CREATE, OperationType.UPDATE, OperationType.DELETE]
+
+
+def test_manage_extended_community_list_00400(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify query_all walks and de-duplicates Lucene pages."""
+    pages = [
+        {"extendedCommunityLists": [{"name": "ECL1"}, {"name": "ECL2"}]},
+        {"extendedCommunityLists": [{"name": "ECL2"}, {"name": "ECL3"}]},
+        {"extendedCommunityLists": []},
+    ]
+    paths = []
+
+    def fake_request(*args, **kwargs):
+        paths.append(kwargs["path"])
+        return pages.pop(0)
+
+    def responses():
+        yield {}
+
+    unused_rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+    assert unused_fabric_context is not None
+    monkeypatch.setattr(ManageExtendedCommunityListOrchestrator, "query_all_page_size", 2)
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all()
+
+    assert [item["name"] for item in result] == ["ECL1", "ECL2", "ECL3"]
+    assert paths == [
+        "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists?max=2&offset=0",
+        "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists?max=2&offset=2",
+        "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists?max=2&offset=4",
+    ]
+
+
+def test_manage_extended_community_list_00410(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify cluster_name is forwarded to collection and item reads."""
+    paths = []
+
+    def fake_request(*args, **kwargs):
+        paths.append(kwargs["path"])
+        return {"extendedCommunityLists": []}
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()), cluster_name="cluster-1")
+    instance = ManageExtendedCommunityListOrchestrator(rest_send=rest_send)
+    instance._fabric_context = _FakeFabricContext()
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    instance.query_all()
+    instance.query_one(_model())
+
+    assert paths == [
+        "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists?clusterName=cluster-1&max=100&offset=0",
+        "/api/v1/manage/fabrics/fabric_1/extendedCommunityLists/ECL1?clusterName=cluster-1",
+    ]

--- a/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
@@ -55,7 +55,7 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
 
 
 class _FakeFabricContext:
-    """Minimal `FabricContext` stand-in for query preflight."""
+    """Minimal `FabricContext` stand-in for mutation preflight."""
 
     def __init__(self) -> None:
         self.validated = False
@@ -116,12 +116,11 @@ def test_manage_extended_community_list_00030() -> None:
     """
     # Summary
 
-    Verify query_all validates fabric prerequisites and extracts the response wrapper.
+    Verify query_all reads inventory without running mutation preflight.
 
     ## Classes and Methods
 
     - ManageExtendedCommunityListOrchestrator.query_all()
-    - ManageExtendedCommunityListOrchestrator.validate_prerequisites()
     """
     method_name = inspect.stack()[0][3]
 
@@ -133,8 +132,23 @@ def test_manage_extended_community_list_00030() -> None:
 
     result = instance.query_all()
 
-    assert fabric_context.validated is True
+    assert fabric_context.validated is False
     assert result[0]["name"] == "ECL1"
+
+
+def test_manage_extended_community_list_00020() -> None:
+    """Verify mutation preflight delegates to FabricContext only when config exists."""
+
+    def responses():
+        yield {}
+
+    unused_rest_send, instance, fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+
+    instance.preflight([])
+    assert fabric_context.validated is False
+    instance.preflight([_model()])
+    assert fabric_context.validated is True
 
 
 def test_manage_extended_community_list_00100() -> None:

--- a/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
@@ -201,6 +201,20 @@ def test_manage_extended_community_list_00110() -> None:
         instance.create_bulk([_model()])
 
 
+def test_manage_extended_community_list_00115() -> None:
+    """Verify non-failure and missing 207 status tokens are tolerated."""
+    result = {
+        "results": [
+            {"name": "ECL1", "status": "accepted", "message": "queued"},
+            {"name": "ECL2", "status": "", "message": "no status"},
+            {"name": "ECL3", "message": "status omitted"},
+        ]
+    }
+
+    with does_not_raise():
+        ManageExtendedCommunityListOrchestrator._raise_on_207_action_errors(result)
+
+
 def test_manage_extended_community_list_00120() -> None:
     """
     # Summary

--- a/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import inspect
 
 import pytest
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_extended_community_list.manage_extended_community_list import (
     ExtendedCommunityListModel,
 )
@@ -274,3 +274,27 @@ def test_manage_extended_community_list_00310() -> None:
 
     instance.delete_bulk([ExtendedCommunityListModel.from_config({"name": "ECL1", "tenant_name": "tenantA"})])
     assert rest_send.committed_payload == {"extendedCommunityListNames": ["tenantA~ECL1"]}
+
+
+def test_manage_extended_community_list_00320(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify custom mutation paths record create, update, and delete operation types."""
+    operation_types = []
+
+    def fake_request(*args, **kwargs):
+        operation_types.append(kwargs.get("operation_type"))
+        return {"results": []}
+
+    def responses():
+        yield {}
+
+    unused_rest_send, instance, unused_fabric_context = _instance(ResponseGenerator(responses()))
+    assert unused_rest_send is not None
+    assert unused_fabric_context is not None
+    monkeypatch.setattr(instance, "_request", fake_request)
+    model = _model()
+
+    instance.create_bulk([model])
+    instance.update(model)
+    instance.delete_bulk([model])
+
+    assert operation_types == [OperationType.CREATE, OperationType.UPDATE, OperationType.DELETE]

--- a/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_extended_community_list.py
@@ -6,9 +6,7 @@
 
 """Unit tests for ManageExtendedCommunityListOrchestrator."""
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import inspect
 

--- a/tests/unit/modules/test_nd_manage_community_list.py
+++ b/tests/unit/modules/test_nd_manage_community_list.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from ansible_collections.cisco.nd.plugins.modules import nd_manage_community_list
+
+
+def test_nd_manage_community_list_documents_standard_entry_match_requirement() -> None:
+    """Verify module documentation does not advertise controller-rejected match-all entries."""
+    documentation = nd_manage_community_list.DOCUMENTATION
+
+    assert "must set at least one explicit community number or enable at least one well-known community flag" in documentation
+    assert "valid (match all communities)" not in documentation

--- a/tests/unit/modules/test_nd_manage_extended_community_list.py
+++ b/tests/unit/modules/test_nd_manage_extended_community_list.py
@@ -8,3 +8,10 @@ def test_nd_manage_extended_community_list_documents_packed_route_target_normali
     documentation = nd_manage_extended_community_list.DOCUMENTATION
 
     assert "Comma-separated route targets in one list item are accepted and normalized to separate values" in documentation
+
+
+def test_nd_manage_extended_community_list_documents_standard_selector_requirement() -> None:
+    """Verify module documentation describes the standard-entry selector requirement."""
+    documentation = nd_manage_extended_community_list.DOCUMENTATION
+
+    assert "Standard entries require at least one non-empty selector collection" in documentation

--- a/tests/unit/modules/test_nd_manage_extended_community_list.py
+++ b/tests/unit/modules/test_nd_manage_extended_community_list.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from ansible_collections.cisco.nd.plugins.modules import nd_manage_extended_community_list
+
+
+def test_nd_manage_extended_community_list_documents_packed_route_target_normalization() -> None:
+    """Verify module documentation describes the canonical route-target representation."""
+    documentation = nd_manage_extended_community_list.DOCUMENTATION
+
+    assert "Comma-separated route targets in one list item are accepted and normalized to separate values" in documentation


### PR DESCRIPTION
## Related Issue(s)

Fixes #241
Fixes #242

## Proposed Changes

- Add `nd_manage_community_list` for ND 4.2+ Routing Policies Community Lists.
- Add `nd_manage_extended_community_list` for ND 4.2+ Routing Policies Extended Community Lists.
- Implement Manage API endpoints, models, enums, and orchestrators using the current Orchestrators framework and `NDStateMachine`.
- Support `merged`, `replaced`, `overridden`, and `deleted` states.
- Add module documentation, examples, return data, and check mode support.
- Add unit coverage for endpoints, models, and orchestrators.
- Add integration test targets for both modules.

## Test Notes

- Ran focused unit tests for the new endpoint, model, and orchestrator coverage: `30 passed`.

## Cisco Nexus Dashboard Version

Developed against Cisco Nexus Dashboard 4.2.1 / ND 4.2+.

## Related ND API Resource Category

* [ ] analyze
* [ ] infa
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
