### PR TITLE
[ND 4.2+] Add module for Routing Policies Route Maps (NDA-29)

### DIFF
--- a/plugins/module_utils/endpoints/mixins.py
+++ b/plugins/module_utils/endpoints/mixins.py
@@ -120,6 +120,12 @@ class UpdateGroupNameMixin(BaseModel):
     update_group_name: str | None = Field(default=None, min_length=1, description="Update group name")
 
 
+class RouteMapNameMixin(BaseModel):
+    """Mixin for endpoints that require route_map_name parameter."""
+
+    route_map_name: str | None = Field(default=None, min_length=1, max_length=115, description="Route map name")
+
+
 class VrfNameMixin(BaseModel):
     """Mixin for endpoints that require vrf_name parameter."""
 

--- a/plugins/module_utils/endpoints/v1/manage/manage_route_maps.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_route_maps.py
@@ -1,0 +1,479 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+ND Manage Route Maps endpoint models.
+
+This module contains endpoint definitions for route-map-related operations
+in the ND Manage API.
+
+## Endpoints
+
+- `EpManageRouteMapsGet` - Get a specific route map by name
+  (GET /api/v1/manage/fabrics/{fabricName}/routeMaps/{routeMapName})
+- `EpManageRouteMapsListGet` - List all route maps for a fabric
+  (GET /api/v1/manage/fabrics/{fabricName}/routeMaps)
+- `EpManageRouteMapsPost` - Bulk-create route maps for a fabric
+  (POST /api/v1/manage/fabrics/{fabricName}/routeMaps)
+- `EpManageRouteMapsPut` - Update a specific route map
+  (PUT /api/v1/manage/fabrics/{fabricName}/routeMaps/{routeMapName})
+- `EpManageRouteMapsDelete` - Delete a specific route map
+  (DELETE /api/v1/manage/fabrics/{fabricName}/routeMaps/{routeMapName})
+- `EpManageRouteMapsBulkDelete` - Bulk-delete route maps by name
+  (POST /api/v1/manage/fabrics/{fabricName}/routeMapActions/remove)
+"""
+
+from __future__ import annotations
+
+__metaclass__ = type
+
+from typing import ClassVar, Literal, Optional
+from urllib.parse import quote
+
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin, RouteMapNameMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
+
+
+class RouteMapsEndpointParams(EndpointQueryParams):
+    """
+    # Summary
+
+    Query parameters shared by single-item route map endpoints.
+
+    ## Parameters
+
+    - cluster_name: Name of the target Nexus Dashboard cluster (multi-cluster deployments)
+
+    ## Usage
+
+    ```python
+    params = RouteMapsEndpointParams(cluster_name="cluster1")
+    query_string = params.to_query_string()
+    # Returns: "clusterName=cluster1"
+    ```
+    """
+
+    cluster_name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
+    )
+
+
+class RouteMapsListEndpointParams(EndpointQueryParams):
+    """
+    # Summary
+
+    Query parameters for the GET /fabrics/{fabricName}/routeMaps list endpoint.
+
+    ## Parameters
+
+    - cluster_name: Name of the target Nexus Dashboard cluster (multi-cluster deployments)
+    - filter: Lucene-format filter string
+    - max: Maximum number of records to return
+    - offset: Number of records to skip for pagination
+    - sort: Sort field with optional ``:desc`` suffix
+
+    ## Usage
+
+    ```python
+    params = RouteMapsListEndpointParams(max=10, offset=0)
+    query_string = params.to_query_string()
+    # Returns: "max=10&offset=0"
+    ```
+    """
+
+    cluster_name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
+    )
+
+    filter: Optional[str] = Field(
+        default=None,
+        description="Lucene format filter - Filter the response based on this filter field",
+    )
+
+    max: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Number of records to return",
+    )
+
+    offset: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Number of records to skip for pagination",
+    )
+
+    sort: Optional[str] = Field(
+        default=None,
+        description="Sort the records by the declared fields in either ascending (default) or descending (:desc) order",
+    )
+
+
+class _EpManageRouteMapsBase(RouteMapNameMixin, FabricNameMixin, NDEndpointBaseModel):
+    """
+    Base class for ND Manage Route Maps endpoints.
+
+    Provides common functionality for all HTTP methods on the
+    /api/v1/manage/fabrics/{fabricName}/routeMaps endpoint.
+
+    Subclasses may override:
+    - ``_require_fabric_name``: set to ``False`` if fabric name is not required.
+    - ``_require_route_map_name``: set to ``False`` for collection-level endpoints
+      (list, bulk-create) that do not include a route map name in the path.
+    """
+
+    _require_fabric_name: ClassVar[bool] = True
+    _require_route_map_name: ClassVar[bool] = True
+
+    endpoint_params: EndpointQueryParams = Field(default_factory=EndpointQueryParams, description="Endpoint-specific query parameters")
+
+    def set_identifiers(self, identifier: IdentifierKey = None) -> None:
+        """Set the route_map_name from the identifier value."""
+        self.route_map_name = identifier
+
+    @property
+    def path(self) -> str:
+        """
+        # Summary
+
+        Build the endpoint path for route maps.
+
+        ## Returns
+
+        - Complete endpoint path string including fabric name, optional route map name,
+          and query string.
+
+        ## Raises
+
+        - ``ValueError`` if ``fabric_name`` is required but not set.
+        - ``ValueError`` if ``route_map_name`` is required but not set.
+        """
+        if self._require_fabric_name and self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        if self._require_route_map_name and self.route_map_name is None:
+            raise ValueError(f"{type(self).__name__}.path: route_map_name must be set before accessing path.")
+
+        segments = ["fabrics"]
+        if self.fabric_name is not None:
+            segments.append(quote(self.fabric_name, safe=""))
+        segments.append("routeMaps")
+        if self.route_map_name is not None:
+            segments.append(quote(self.route_map_name, safe=""))
+
+        base_path = BasePath.path(*segments)
+        query_string = self.endpoint_params.to_query_string()
+        if query_string:
+            return f"{base_path}?{query_string}"
+        return base_path
+
+
+class EpManageRouteMapsGet(_EpManageRouteMapsBase):
+    """
+    # Summary
+
+    ND Manage Route Maps GET Endpoint
+
+    ## Description
+
+    Endpoint to retrieve a specific route map by name from a fabric.
+    Both ``fabric_name`` and ``route_map_name`` are required path parameters.
+
+    ## Path
+
+    - ``/api/v1/manage/fabrics/{fabricName}/routeMaps/{routeMapName}``
+    - ``/api/v1/manage/fabrics/{fabricName}/routeMaps/{routeMapName}?clusterName=cluster1``
+
+    ## Verb
+
+    - GET
+
+    ## Raises
+
+    - ``ValueError`` if ``fabric_name`` or ``route_map_name`` is not set when accessing ``path``
+
+    ## Usage
+
+    ```python
+    ep = EpManageRouteMapsGet()
+    ep.fabric_name = "my-fabric"
+    ep.route_map_name = "my-route-map"
+    path = ep.path
+    verb = ep.verb
+    ```
+    """
+
+    class_name: Literal["EpManageRouteMapsGet"] = Field(default="EpManageRouteMapsGet", description="Class name for backward compatibility")
+
+    endpoint_params: RouteMapsEndpointParams = Field(default_factory=RouteMapsEndpointParams, description="Endpoint-specific query parameters")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.GET
+
+
+class EpManageRouteMapsListGet(_EpManageRouteMapsBase):
+    """
+    # Summary
+
+    ND Manage Route Maps List GET Endpoint
+
+    ## Description
+
+    Endpoint to list all route maps for a given fabric.
+    Supports optional query parameters for filtering, pagination, and sorting.
+
+    ## Path
+
+    - ``/api/v1/manage/fabrics/{fabricName}/routeMaps``
+    - ``/api/v1/manage/fabrics/{fabricName}/routeMaps?max=10&offset=0``
+
+    ## Verb
+
+    - GET
+
+    ## Raises
+
+    - ``ValueError`` if ``fabric_name`` is not set when accessing ``path``
+
+    ## Usage
+
+    ```python
+    ep = EpManageRouteMapsListGet()
+    ep.fabric_name = "my-fabric"
+    path = ep.path
+    verb = ep.verb
+    ```
+    """
+
+    _require_route_map_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageRouteMapsListGet"] = Field(default="EpManageRouteMapsListGet", description="Class name for backward compatibility")
+
+    endpoint_params: RouteMapsListEndpointParams = Field(default_factory=RouteMapsListEndpointParams, description="Endpoint-specific query parameters")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.GET
+
+
+class EpManageRouteMapsPost(_EpManageRouteMapsBase):
+    """
+    # Summary
+
+    ND Manage Route Maps POST Endpoint
+
+    ## Description
+
+    Endpoint to bulk-create route maps for a given fabric.
+    The request body must conform to the ``CreateRouteMapsRequest`` schema:
+    ``{"routeMaps": [{"name": ..., "entries": [...]}, ...]}``.
+
+    ## Path
+
+    - ``/api/v1/manage/fabrics/{fabricName}/routeMaps``
+
+    ## Verb
+
+    - POST
+
+    ## Request Body
+
+    ``CreateRouteMapsRequest`` schema -- ``{"routeMaps": [RouteMap, ...]}``.
+
+    ## Raises
+
+    - ``ValueError`` if ``fabric_name`` is not set when accessing ``path``
+
+    ## Usage
+
+    ```python
+    ep = EpManageRouteMapsPost()
+    ep.fabric_name = "my-fabric"
+    rest_send.path = ep.path
+    rest_send.verb = ep.verb
+    rest_send.payload = {"routeMaps": [{"name": "rm1", "entries": [...]}]}
+    ```
+    """
+
+    _require_route_map_name: ClassVar[bool] = False
+
+    class_name: Literal["EpManageRouteMapsPost"] = Field(default="EpManageRouteMapsPost", description="Class name for backward compatibility")
+
+    endpoint_params: RouteMapsEndpointParams = Field(default_factory=RouteMapsEndpointParams, description="Endpoint-specific query parameters")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.POST
+
+
+class EpManageRouteMapsPut(_EpManageRouteMapsBase):
+    """
+    # Summary
+
+    ND Manage Route Maps PUT Endpoint
+
+    ## Description
+
+    Endpoint to update a specific route map in a fabric.
+    Both ``fabric_name`` and ``route_map_name`` are required path parameters.
+    The request body must conform to the ``RouteMap`` schema.
+
+    ## Path
+
+    - ``/api/v1/manage/fabrics/{fabricName}/routeMaps/{routeMapName}``
+
+    ## Verb
+
+    - PUT
+
+    ## Request Body
+
+    ``RouteMap`` schema -- ``{"name": ..., "entries": [...]}``.
+
+    ## Raises
+
+    - ``ValueError`` if ``fabric_name`` or ``route_map_name`` is not set when accessing ``path``
+
+    ## Usage
+
+    ```python
+    ep = EpManageRouteMapsPut()
+    ep.fabric_name = "my-fabric"
+    ep.route_map_name = "my-route-map"
+    rest_send.path = ep.path
+    rest_send.verb = ep.verb
+    rest_send.payload = {"name": "my-route-map", "entries": [...]}
+    ```
+    """
+
+    class_name: Literal["EpManageRouteMapsPut"] = Field(default="EpManageRouteMapsPut", description="Class name for backward compatibility")
+
+    endpoint_params: RouteMapsEndpointParams = Field(default_factory=RouteMapsEndpointParams, description="Endpoint-specific query parameters")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.PUT
+
+
+class EpManageRouteMapsDelete(_EpManageRouteMapsBase):
+    """
+    # Summary
+
+    ND Manage Route Maps DELETE Endpoint
+
+    ## Description
+
+    Endpoint to delete a specific route map from a fabric.
+    Both ``fabric_name`` and ``route_map_name`` are required path parameters.
+
+    ## Path
+
+    - ``/api/v1/manage/fabrics/{fabricName}/routeMaps/{routeMapName}``
+
+    ## Verb
+
+    - DELETE
+
+    ## Raises
+
+    - ``ValueError`` if ``fabric_name`` or ``route_map_name`` is not set when accessing ``path``
+
+    ## Usage
+
+    ```python
+    ep = EpManageRouteMapsDelete()
+    ep.fabric_name = "my-fabric"
+    ep.route_map_name = "my-route-map"
+    rest_send.path = ep.path
+    rest_send.verb = ep.verb
+    ```
+    """
+
+    class_name: Literal["EpManageRouteMapsDelete"] = Field(default="EpManageRouteMapsDelete", description="Class name for backward compatibility")
+
+    endpoint_params: RouteMapsEndpointParams = Field(default_factory=RouteMapsEndpointParams, description="Endpoint-specific query parameters")
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.DELETE
+
+
+class EpManageRouteMapsBulkDelete(FabricNameMixin, NDEndpointBaseModel):
+    """
+    # Summary
+
+    ND Manage Route Maps Bulk DELETE Endpoint
+
+    ## Description
+
+    Endpoint to bulk-delete multiple route maps from a fabric using the
+    ``routeMapActions/remove`` sub-resource.  The request body must conform to
+    the ``RouteMapDeleteRequest`` schema:
+    ``{"routeMapNames": ["rm1", "rm2", ...]}``.
+
+    ## Path
+
+    - ``/api/v1/manage/fabrics/{fabricName}/routeMapActions/remove``
+
+    ## Verb
+
+    - POST
+
+    ## Request Body
+
+    ``RouteMapDeleteRequest`` schema -- ``{"routeMapNames": [str, ...]}``.
+
+    ## Raises
+
+    - ``ValueError`` if ``fabric_name`` is not set when accessing ``path``
+
+    ## Usage
+
+    ```python
+    ep = EpManageRouteMapsBulkDelete()
+    ep.fabric_name = "my-fabric"
+    rest_send.path = ep.path
+    rest_send.verb = ep.verb
+    rest_send.payload = {"routeMapNames": ["MY-BGP-ROUTEMAP-1", "MY-BGP-ROUTEMAP-2"]}
+    ```
+    """
+
+    class_name: Literal["EpManageRouteMapsBulkDelete"] = Field(default="EpManageRouteMapsBulkDelete", description="Class name for backward compatibility")
+    endpoint_params: RouteMapsEndpointParams = Field(default_factory=RouteMapsEndpointParams, description="Endpoint-specific query parameters")
+
+    @property
+    def path(self) -> str:
+        """
+        Build the bulk-delete endpoint path.
+
+        ## Raises
+
+        - ``ValueError`` if ``fabric_name`` is not set.
+        """
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        base_path = BasePath.path("fabrics", quote(self.fabric_name, safe=""), "routeMapActions", "remove")
+        query_string = self.endpoint_params.to_query_string()
+        if query_string:
+            return f"{base_path}?{query_string}"
+        return base_path
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return the HTTP verb for this endpoint."""
+        return HttpVerbEnum.POST

--- a/plugins/module_utils/endpoints/v1/manage/manage_route_maps.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_route_maps.py
@@ -27,8 +27,6 @@ in the ND Manage API.
 
 from __future__ import annotations
 
-__metaclass__ = type
-
 from typing import ClassVar, Literal, Optional
 from urllib.parse import quote
 

--- a/plugins/module_utils/endpoints/v1/manage/manage_route_maps.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_route_maps.py
@@ -34,8 +34,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin, RouteMapNameMixin
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import CompositeQueryParams, EndpointQueryParams, LuceneQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ConfigDict, Field
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
 
@@ -58,6 +58,8 @@ class RouteMapsEndpointParams(EndpointQueryParams):
     ```
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     cluster_name: str | None = Field(
         default=None,
         min_length=1,
@@ -74,46 +76,25 @@ class RouteMapsListEndpointParams(EndpointQueryParams):
     ## Parameters
 
     - cluster_name: Name of the target Nexus Dashboard cluster (multi-cluster deployments)
-    - filter: Lucene-format filter string
-    - max: Maximum number of records to return
-    - offset: Number of records to skip for pagination
-    - sort: Sort field with optional ``:desc`` suffix
+
+    Lucene filtering, pagination, and sorting are handled by the list endpoint's
+    separate ``lucene_params`` field.
 
     ## Usage
 
     ```python
-    params = RouteMapsListEndpointParams(max=10, offset=0)
+    params = RouteMapsListEndpointParams(cluster_name="cluster1")
     query_string = params.to_query_string()
-    # Returns: "max=10&offset=0"
+    # Returns: "clusterName=cluster1"
     ```
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     cluster_name: str | None = Field(
         default=None,
         min_length=1,
         description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
-    )
-
-    filter: str | None = Field(
-        default=None,
-        description="Lucene format filter - Filter the response based on this filter field",
-    )
-
-    max: int | None = Field(
-        default=None,
-        ge=1,
-        description="Number of records to return",
-    )
-
-    offset: int | None = Field(
-        default=None,
-        ge=0,
-        description="Number of records to skip for pagination",
-    )
-
-    sort: str | None = Field(
-        default=None,
-        description="Sort the records by the declared fields in either ascending (default) or descending (:desc) order",
     )
 
 
@@ -138,6 +119,10 @@ class _EpManageRouteMapsBase(RouteMapNameMixin, FabricNameMixin, NDEndpointBaseM
     def set_identifiers(self, identifier: IdentifierKey = None) -> None:
         """Set the route_map_name from the identifier value."""
         self.route_map_name = identifier
+
+    def _query_string(self) -> str:
+        """Return endpoint-specific query parameters."""
+        return self.endpoint_params.to_query_string()
 
     @property
     def path(self) -> str:
@@ -169,7 +154,7 @@ class _EpManageRouteMapsBase(RouteMapNameMixin, FabricNameMixin, NDEndpointBaseM
             segments.append(quote(self.route_map_name, safe=""))
 
         base_path = BasePath.path(*segments)
-        query_string = self.endpoint_params.to_query_string()
+        query_string = self._query_string()
         if query_string:
             return f"{base_path}?{query_string}"
         return base_path
@@ -259,6 +244,11 @@ class EpManageRouteMapsListGet(_EpManageRouteMapsBase):
     class_name: Literal["EpManageRouteMapsListGet"] = Field(default="EpManageRouteMapsListGet", description="Class name for backward compatibility")
 
     endpoint_params: RouteMapsListEndpointParams = Field(default_factory=RouteMapsListEndpointParams, description="Endpoint-specific query parameters")
+    lucene_params: LuceneQueryParams = Field(default_factory=LuceneQueryParams, description="Lucene-style filtering parameters")
+
+    def _query_string(self) -> str:
+        """Return composed endpoint and Lucene query parameters."""
+        return CompositeQueryParams().add(self.endpoint_params).add(self.lucene_params).to_query_string()
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_route_maps.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_route_maps.py
@@ -27,7 +27,7 @@ in the ND Manage API.
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal, Optional
+from typing import ClassVar, Literal
 from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
@@ -58,7 +58,7 @@ class RouteMapsEndpointParams(EndpointQueryParams):
     ```
     """
 
-    cluster_name: Optional[str] = Field(
+    cluster_name: str | None = Field(
         default=None,
         min_length=1,
         description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
@@ -88,30 +88,30 @@ class RouteMapsListEndpointParams(EndpointQueryParams):
     ```
     """
 
-    cluster_name: Optional[str] = Field(
+    cluster_name: str | None = Field(
         default=None,
         min_length=1,
         description="Name of the target Nexus Dashboard cluster to execute this API, in a multi-cluster deployment",
     )
 
-    filter: Optional[str] = Field(
+    filter: str | None = Field(
         default=None,
         description="Lucene format filter - Filter the response based on this filter field",
     )
 
-    max: Optional[int] = Field(
+    max: int | None = Field(
         default=None,
         ge=1,
         description="Number of records to return",
     )
 
-    offset: Optional[int] = Field(
+    offset: int | None = Field(
         default=None,
         ge=0,
         description="Number of records to skip for pagination",
     )
 
-    sort: Optional[str] = Field(
+    sort: str | None = Field(
         default=None,
         description="Sort the records by the declared fields in either ascending (default) or descending (:desc) order",
     )

--- a/plugins/module_utils/models/manage_route_map/enums.py
+++ b/plugins/module_utils/models/manage_route_map/enums.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+Enumerations for Route Map management.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from enum import Enum
+
+
+class ActionEnum(str, Enum):
+    """Action values for a route map entry."""
+
+    PERMIT = "permit"
+    DENY = "deny"
+
+
+class RuleTypeEnum(str, Enum):
+    """Rule type discriminator values for route map rule entries."""
+
+    MATCH_IPV4_ACL = "matchIpv4Acl"
+    MATCH_IPV6_ACL = "matchIpv6Acl"
+    MATCH_IPV4_PREFIX_LIST = "matchIpv4PrefixList"
+    MATCH_IPV6_PREFIX_LIST = "matchIpv6PrefixList"
+    MATCH_COMMUNITY = "matchCommunity"
+    MATCH_EXTENDED_COMMUNITY = "matchExtendedCommunity"
+    MATCH_TAG = "matchTag"
+    SET_COMMUNITY = "setCommunity"
+    SET_EXTENDED_COMMUNITY_LIST = "setExtendedCommunityList"
+    SET_LOCAL_PREFERENCE = "setLocalPreference"
+    SET_IPV4_NEXT_HOP = "setIpv4NextHop"
+    SET_IPV6_NEXT_HOP = "setIpv6NextHop"

--- a/plugins/module_utils/models/manage_route_map/enums.py
+++ b/plugins/module_utils/models/manage_route_map/enums.py
@@ -7,8 +7,6 @@
 Enumerations for Route Map management.
 """
 
-from __future__ import absolute_import, division, print_function
-
 from enum import Enum
 
 

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -428,7 +428,8 @@ class RouteMapModel(NDBaseModel):
 
     ## Identifier
 
-    ``name`` (single) - the route map name within its fabric.
+    ``api_name`` (single) - the API route map name within its fabric.
+    For tenant-specific route maps this is ``tenant_name~name``.
 
     ## Serialization Notes
 
@@ -440,7 +441,7 @@ class RouteMapModel(NDBaseModel):
 
     # --- Identifier Configuration ---
 
-    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifiers: ClassVar[Optional[List[str]]] = ["api_name"]
     identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "single"
 
     # --- Serialization Configuration ---
@@ -475,6 +476,22 @@ class RouteMapModel(NDBaseModel):
         alias="entries",
         description="List of route map entries (sequence + action + rule conditions).",
     )
+
+    @property
+    def api_name(self) -> str:
+        """Return the route-map name used in API paths and delete payloads."""
+        if self.tenant_name and not self.name.startswith(f"{self.tenant_name}~"):
+            return f"{self.tenant_name}~{self.name}"
+        return self.name
+
+    @model_validator(mode="after")
+    def normalize_tenant_scoped_name(self) -> "RouteMapModel":
+        """Store tenant-scoped route maps with a bare name and tenant context."""
+        if self.tenant_name:
+            prefix = f"{self.tenant_name}~"
+            if self.name.startswith(prefix):
+                self.name = self.name[len(prefix) :]
+        return self
 
     # --- Argument Spec ---
 

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -42,15 +42,78 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Set
+import ipaddress
+from typing import Annotated, Any, ClassVar, Dict, List, Literal, Optional, Set
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field, model_validator
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.enums import ActionEnum, RuleTypeEnum
 
 # Rule type choices list (used in argument_spec)
 RULE_TYPE_CHOICES = [e.value for e in RuleTypeEnum]
+Uint32 = Annotated[int, Field(ge=0, le=4294967295)]
+
+_REQUIRED_RULE_FIELDS: Dict[str, Set[str]] = {
+    RuleTypeEnum.MATCH_IPV4_ACL.value: {"access_control_list_name"},
+    RuleTypeEnum.MATCH_IPV6_ACL.value: {"access_control_list_name"},
+    RuleTypeEnum.MATCH_IPV4_PREFIX_LIST.value: {"prefix_list_names"},
+    RuleTypeEnum.MATCH_IPV6_PREFIX_LIST.value: {"prefix_list_names"},
+    RuleTypeEnum.MATCH_COMMUNITY.value: {"community_list_names"},
+    RuleTypeEnum.MATCH_EXTENDED_COMMUNITY.value: {"extended_community_list_names"},
+    RuleTypeEnum.MATCH_TAG.value: {"tags"},
+    RuleTypeEnum.SET_COMMUNITY.value: {"community_numbers"},
+    RuleTypeEnum.SET_EXTENDED_COMMUNITY_LIST.value: {"extended_community_list_name"},
+    RuleTypeEnum.SET_LOCAL_PREFERENCE.value: {"value"},
+}
+
+_ALLOWED_RULE_FIELDS: Dict[str, Set[str]] = {
+    RuleTypeEnum.MATCH_IPV4_ACL.value: {"access_control_list_name"},
+    RuleTypeEnum.MATCH_IPV6_ACL.value: {"access_control_list_name"},
+    RuleTypeEnum.MATCH_IPV4_PREFIX_LIST.value: {"prefix_list_names"},
+    RuleTypeEnum.MATCH_IPV6_PREFIX_LIST.value: {"prefix_list_names"},
+    RuleTypeEnum.MATCH_COMMUNITY.value: {"community_list_names", "exact_match"},
+    RuleTypeEnum.MATCH_EXTENDED_COMMUNITY.value: {"extended_community_list_names", "exact_match"},
+    RuleTypeEnum.MATCH_TAG.value: {"tags"},
+    RuleTypeEnum.SET_COMMUNITY.value: {
+        "additive",
+        "community_numbers",
+        "graceful_restart_shutdown_community",
+        "internet_community",
+        "local_as_community",
+        "no_advertise_community",
+        "no_export_community",
+    },
+    RuleTypeEnum.SET_EXTENDED_COMMUNITY_LIST.value: {"extended_community_list_name"},
+    RuleTypeEnum.SET_LOCAL_PREFERENCE.value: {"value"},
+    RuleTypeEnum.SET_IPV4_NEXT_HOP.value: {
+        "drop_on_fail",
+        "enforce_order",
+        "load_share",
+        "next_hop_ip_collection",
+        "redistribute_unchanged",
+        "track_id",
+        "unchanged",
+        "use_peer_address",
+        "verify_availability",
+    },
+    RuleTypeEnum.SET_IPV6_NEXT_HOP.value: {
+        "drop_on_fail",
+        "enforce_order",
+        "load_share",
+        "next_hop_ip_collection",
+        "redistribute_unchanged",
+        "track_id",
+        "unchanged",
+        "use_peer_address",
+        "verify_availability",
+    },
+}
+
+_NEXT_HOP_RULE_TYPES = {
+    RuleTypeEnum.SET_IPV4_NEXT_HOP.value,
+    RuleTypeEnum.SET_IPV6_NEXT_HOP.value,
+}
 
 
 class RouteMapRuleEntryModel(NDNestedModel):
@@ -83,7 +146,8 @@ class RouteMapRuleEntryModel(NDNestedModel):
                                    ``loadShare``, ``enforceOrder``,
                                    ``verifyAvailability``, ``usePeerAddress``,
                                    ``redistributeUnchanged``, ``unchanged``,
-                                   ``trackId``
+                                   ``trackId``. Exactly one next-hop mode is
+                                   required.
     - ``setIpv6NextHop``         - same optional fields as ``setIpv4NextHop``
     """
 
@@ -133,7 +197,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- matchTag ---
 
-    tags: Optional[List[int]] = Field(
+    tags: Optional[List[Uint32]] = Field(
         default=None,
         alias="tags",
         description="List of integer tags to match (0-4294967295).",
@@ -193,7 +257,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- setLocalPreference ---
 
-    value: Optional[int] = Field(
+    value: Optional[Uint32] = Field(
         default=None,
         alias="value",
         description="Local preference value (0-4294967295).",
@@ -252,8 +316,79 @@ class RouteMapRuleEntryModel(NDNestedModel):
     track_id: Optional[int] = Field(
         default=None,
         alias="trackId",
+        ge=1,
+        le=512,
         description="Tracking subsystem object ID (1-512).",
     )
+
+    # --- Validators ---
+
+    @model_validator(mode="after")
+    def validate_rule_type_fields(self) -> "RouteMapRuleEntryModel":
+        """
+        Validate discriminator-specific rule fields.
+
+        The OpenAPI schema represents each rule type as a separate object, while
+        this Ansible model intentionally keeps a flat field surface. This
+        validator restores the per-rule required/allowed-field contract.
+        """
+        self._validate_rule_type()
+        self._validate_required_fields()
+        self._validate_allowed_fields()
+        self._validate_next_hop()
+        return self
+
+    @staticmethod
+    def _is_missing(value: Any) -> bool:
+        """Return True when a value should be treated as absent for rule validation."""
+        return value is None or value == "" or value == []
+
+    def _validate_rule_type(self) -> None:
+        """Validate the rule_type discriminator before applying its field matrix."""
+        if self.rule_type not in _ALLOWED_RULE_FIELDS:
+            raise ValueError(f"rule_type '{self.rule_type}' must be one of: {', '.join(RULE_TYPE_CHOICES)}")
+
+    def _validate_required_fields(self) -> None:
+        """Validate fields required by the active rule_type."""
+        required_fields = _REQUIRED_RULE_FIELDS.get(self.rule_type, set())
+        missing = [field for field in sorted(required_fields) if self._is_missing(getattr(self, field))]
+        if missing:
+            raise ValueError(f"rule_type '{self.rule_type}' requires: {', '.join(missing)}")
+
+    def _validate_allowed_fields(self) -> None:
+        """Validate that populated fields are allowed by the active rule_type."""
+        allowed_fields = _ALLOWED_RULE_FIELDS.get(self.rule_type, set())
+        provided_fields = {field for field in self.model_fields_set if field != "rule_type" and not self._is_missing(getattr(self, field))}
+        unexpected = sorted(provided_fields - allowed_fields)
+        if unexpected:
+            raise ValueError(f"rule_type '{self.rule_type}' does not allow: {', '.join(unexpected)}")
+
+    def _validate_next_hop(self) -> None:
+        """Validate next-hop rule mode and address-family combinations."""
+        if self.rule_type not in _NEXT_HOP_RULE_TYPES:
+            return
+
+        selected_modes = [
+            bool(self.next_hop_ip_collection),
+            self.use_peer_address is True,
+            self.unchanged is True,
+            self.redistribute_unchanged is True,
+        ]
+        if sum(selected_modes) != 1:
+            raise ValueError(
+                f"rule_type '{self.rule_type}' requires exactly one next-hop mode: "
+                "next_hop_ip_collection, use_peer_address, unchanged, or redistribute_unchanged."
+            )
+
+        if self.next_hop_ip_collection:
+            expected_version = 4 if self.rule_type == RuleTypeEnum.SET_IPV4_NEXT_HOP.value else 6
+            for address in self.next_hop_ip_collection:
+                parsed_address = ipaddress.ip_address(address)
+                if parsed_address.version != expected_version:
+                    raise ValueError(f"rule_type '{self.rule_type}' expects IPv{expected_version} next-hop addresses.")
+
+        if self.track_id is not None and self._is_missing(self.next_hop_ip_collection):
+            raise ValueError("track_id requires next_hop_ip_collection.")
 
 
 class RouteMapEntryModel(NDNestedModel):

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -438,8 +438,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
         ordering_flags = self._enabled_next_hop_fields(_NEXT_HOP_ORDERING_FLAG_FIELDS)
         if restricted_modes and ordering_flags:
             raise ValueError(
-                "Cannot mix use_peer_address, redistribute_unchanged, or unchanged with "
-                "drop_on_fail, load_share, or enforce_order next-hop configurations."
+                "Cannot mix use_peer_address, redistribute_unchanged, or unchanged with " "drop_on_fail, load_share, or enforce_order next-hop configurations."
             )
 
         use_peer_conflicts = self._enabled_next_hop_fields(_USE_PEER_ADDRESS_COMPANION_DENY_FIELDS)

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -528,6 +528,9 @@ class RouteMapModel(NDBaseModel):
                 type="str",
                 required=True,
             ),
+            cluster_name=dict(
+                type="str",
+            ),
             config=dict(
                 type="list",
                 elements="dict",

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -38,9 +38,7 @@ payload = rm.to_payload()
 ```
 """
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 import ipaddress
 from typing import Annotated, Any, ClassVar, Dict, List, Literal, Optional, Set

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -41,7 +41,7 @@ payload = rm.to_payload()
 from __future__ import annotations
 
 import ipaddress
-from typing import Annotated, Any, ClassVar, Dict, List, Literal, Optional, Set
+from typing import Annotated, Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field, model_validator
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
@@ -52,7 +52,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.e
 RULE_TYPE_CHOICES = [e.value for e in RuleTypeEnum]
 Uint32 = Annotated[int, Field(ge=0, le=4294967295)]
 
-_REQUIRED_RULE_FIELDS: Dict[str, Set[str]] = {
+_REQUIRED_RULE_FIELDS: dict[str, set[str]] = {
     RuleTypeEnum.MATCH_IPV4_ACL.value: {"access_control_list_name"},
     RuleTypeEnum.MATCH_IPV6_ACL.value: {"access_control_list_name"},
     RuleTypeEnum.MATCH_IPV4_PREFIX_LIST.value: {"prefix_list_names"},
@@ -65,7 +65,7 @@ _REQUIRED_RULE_FIELDS: Dict[str, Set[str]] = {
     RuleTypeEnum.SET_LOCAL_PREFERENCE.value: {"value"},
 }
 
-_ALLOWED_RULE_FIELDS: Dict[str, Set[str]] = {
+_ALLOWED_RULE_FIELDS: dict[str, set[str]] = {
     RuleTypeEnum.MATCH_IPV4_ACL.value: {"access_control_list_name"},
     RuleTypeEnum.MATCH_IPV6_ACL.value: {"access_control_list_name"},
     RuleTypeEnum.MATCH_IPV4_PREFIX_LIST.value: {"prefix_list_names"},
@@ -164,7 +164,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- matchIpv4Acl / matchIpv6Acl ---
 
-    access_control_list_name: Optional[str] = Field(
+    access_control_list_name: str | None = Field(
         default=None,
         alias="accessControlListName",
         description="Name of the access control list to match.",
@@ -172,7 +172,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- matchIpv4PrefixList / matchIpv6PrefixList ---
 
-    prefix_list_names: Optional[List[str]] = Field(
+    prefix_list_names: list[str] | None = Field(
         default=None,
         alias="prefixListNames",
         description="Names of the prefix lists to match.",
@@ -180,7 +180,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- matchCommunity ---
 
-    community_list_names: Optional[List[str]] = Field(
+    community_list_names: list[str] | None = Field(
         default=None,
         alias="communityListNames",
         description="Names of the community lists to match.",
@@ -188,7 +188,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- matchExtendedCommunity ---
 
-    extended_community_list_names: Optional[List[str]] = Field(
+    extended_community_list_names: list[str] | None = Field(
         default=None,
         alias="extendedCommunityListNames",
         description="Names of the extended community lists to match.",
@@ -196,7 +196,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- matchCommunity / matchExtendedCommunity ---
 
-    exact_match: Optional[bool] = Field(
+    exact_match: bool | None = Field(
         default=None,
         alias="exactMatch",
         description="Require an exact match for the (extended) community lists.",
@@ -204,7 +204,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- matchTag ---
 
-    tags: Optional[List[Uint32]] = Field(
+    tags: list[Uint32] | None = Field(
         default=None,
         alias="tags",
         description="List of integer tags to match (0-4294967295).",
@@ -212,43 +212,43 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- setCommunity ---
 
-    community_numbers: Optional[List[str]] = Field(
+    community_numbers: list[str] | None = Field(
         default=None,
         alias="communityNumbers",
         description="Community numbers in ASN2:NN format (e.g. '65000:100').",
     )
 
-    additive: Optional[bool] = Field(
+    additive: bool | None = Field(
         default=None,
         alias="additive",
         description="Add communities without replacing existing ones.",
     )
 
-    graceful_restart_shutdown_community: Optional[bool] = Field(
+    graceful_restart_shutdown_community: bool | None = Field(
         default=None,
         alias="gracefulRestartShutdownCommunity",
         description="Set the graceful-restart shutdown community.",
     )
 
-    no_advertise_community: Optional[bool] = Field(
+    no_advertise_community: bool | None = Field(
         default=None,
         alias="noAdvertiseCommunity",
         description="Set the no-advertise community.",
     )
 
-    no_export_community: Optional[bool] = Field(
+    no_export_community: bool | None = Field(
         default=None,
         alias="noExportCommunity",
         description="Set the no-export community.",
     )
 
-    local_as_community: Optional[bool] = Field(
+    local_as_community: bool | None = Field(
         default=None,
         alias="localAsCommunity",
         description="Set the local-AS community.",
     )
 
-    internet_community: Optional[bool] = Field(
+    internet_community: bool | None = Field(
         default=None,
         alias="internetCommunity",
         description="Set the internet community.",
@@ -256,7 +256,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- setExtendedCommunityList ---
 
-    extended_community_list_name: Optional[str] = Field(
+    extended_community_list_name: str | None = Field(
         default=None,
         alias="extendedCommunityListName",
         description="Name of the extended community list to set.",
@@ -264,7 +264,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- setLocalPreference ---
 
-    value: Optional[Uint32] = Field(
+    value: Uint32 | None = Field(
         default=None,
         alias="value",
         description="Local preference value (0-4294967295).",
@@ -272,55 +272,55 @@ class RouteMapRuleEntryModel(NDNestedModel):
 
     # --- setIpv4NextHop / setIpv6NextHop ---
 
-    next_hop_ip_collection: Optional[List[str]] = Field(
+    next_hop_ip_collection: list[str] | None = Field(
         default=None,
         alias="nextHopIpCollection",
         description="List of next-hop IP addresses.",
     )
 
-    drop_on_fail: Optional[bool] = Field(
+    drop_on_fail: bool | None = Field(
         default=None,
         alias="dropOnFail",
         description="Drop the packet if the next hop is unavailable.",
     )
 
-    load_share: Optional[bool] = Field(
+    load_share: bool | None = Field(
         default=None,
         alias="loadShare",
         description="Enable load sharing across multiple next hops.",
     )
 
-    enforce_order: Optional[bool] = Field(
+    enforce_order: bool | None = Field(
         default=None,
         alias="enforceOrder",
         description="Enforce the order of next-hop IPs.",
     )
 
-    verify_availability: Optional[bool] = Field(
+    verify_availability: bool | None = Field(
         default=None,
         alias="verifyAvailability",
         description="Ensure the next hop is reachable before using it.",
     )
 
-    use_peer_address: Optional[bool] = Field(
+    use_peer_address: bool | None = Field(
         default=None,
         alias="usePeerAddress",
         description="Use the peer address as the next hop.",
     )
 
-    redistribute_unchanged: Optional[bool] = Field(
+    redistribute_unchanged: bool | None = Field(
         default=None,
         alias="redistributeUnchanged",
         description="Redistribute routes without changing the next hop.",
     )
 
-    unchanged: Optional[bool] = Field(
+    unchanged: bool | None = Field(
         default=None,
         alias="unchanged",
         description="Keep the next hop unchanged.",
     )
 
-    track_id: Optional[int] = Field(
+    track_id: int | None = Field(
         default=None,
         alias="trackId",
         ge=1,
@@ -421,7 +421,7 @@ class RouteMapEntryModel(NDNestedModel):
         description="Action for this entry: permit or deny.",
     )
 
-    rule_entries: List[RouteMapRuleEntryModel] = Field(
+    rule_entries: list[RouteMapRuleEntryModel] = Field(
         alias="ruleEntries",
         description="List of match or set rule conditions.",
     )
@@ -448,14 +448,14 @@ class RouteMapModel(NDBaseModel):
 
     # --- Identifier Configuration ---
 
-    identifiers: ClassVar[Optional[List[str]]] = ["api_name"]
-    identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "single"
+    identifiers: ClassVar[list[str] | None] = ["api_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
 
     # --- Serialization Configuration ---
 
-    exclude_from_diff: ClassVar[Set[str]] = {"last_update_timestamp"}
-    payload_exclude_fields: ClassVar[Set[str]] = {"last_update_timestamp"}
-    unwanted_keys: ClassVar[List] = []
+    exclude_from_diff: ClassVar[set[str]] = {"last_update_timestamp"}
+    payload_exclude_fields: ClassVar[set[str]] = {"last_update_timestamp"}
+    unwanted_keys: ClassVar[list] = []
 
     # --- Fields ---
 
@@ -466,19 +466,19 @@ class RouteMapModel(NDBaseModel):
         description="Name of the route map (pattern: ^[a-zA-Z0-9~_-]+$).",
     )
 
-    last_update_timestamp: Optional[str] = Field(
+    last_update_timestamp: str | None = Field(
         default=None,
         alias="lastUpdateTimestamp",
         description="Timestamp of the last update (read-only, set by ND).",
     )
 
-    tenant_name: Optional[str] = Field(
+    tenant_name: str | None = Field(
         default=None,
         alias="tenantName",
         description="Tenant name for tenant-specific route maps.",
     )
 
-    entries: Optional[List[RouteMapEntryModel]] = Field(
+    entries: list[RouteMapEntryModel] | None = Field(
         default=None,
         alias="entries",
         description="List of route map entries (sequence + action + rule conditions).",
@@ -500,7 +500,7 @@ class RouteMapModel(NDBaseModel):
                 self.name = self.name[len(prefix) :]
         return self
 
-    def to_diff_dict(self, **kwargs) -> Dict[str, Any]:
+    def to_diff_dict(self, **kwargs) -> dict[str, Any]:
         """Export for diff comparison, normalizing ND next-hop false defaults."""
         data = super().to_diff_dict(**kwargs)
         for entry in data.get("entries") or []:
@@ -515,7 +515,7 @@ class RouteMapModel(NDBaseModel):
     # --- Argument Spec ---
 
     @classmethod
-    def get_argument_spec(cls) -> Dict[str, Any]:
+    def get_argument_spec(cls) -> dict[str, Any]:
         return dict(
             fabric_name=dict(
                 type="str",

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -114,6 +114,15 @@ _NEXT_HOP_RULE_TYPES = {
     RuleTypeEnum.SET_IPV4_NEXT_HOP.value,
     RuleTypeEnum.SET_IPV6_NEXT_HOP.value,
 }
+_NEXT_HOP_FALSE_DEFAULT_FIELDS = (
+    "dropOnFail",
+    "enforceOrder",
+    "loadShare",
+    "redistributeUnchanged",
+    "unchanged",
+    "usePeerAddress",
+    "verifyAvailability",
+)
 
 
 class RouteMapRuleEntryModel(NDNestedModel):
@@ -492,6 +501,18 @@ class RouteMapModel(NDBaseModel):
             if self.name.startswith(prefix):
                 self.name = self.name[len(prefix) :]
         return self
+
+    def to_diff_dict(self, **kwargs) -> Dict[str, Any]:
+        """Export for diff comparison, normalizing ND next-hop false defaults."""
+        data = super().to_diff_dict(**kwargs)
+        for entry in data.get("entries") or []:
+            for rule_entry in entry.get("ruleEntries") or []:
+                if rule_entry.get("ruleType") not in _NEXT_HOP_RULE_TYPES:
+                    continue
+                for field_name in _NEXT_HOP_FALSE_DEFAULT_FIELDS:
+                    if rule_entry.get(field_name) is False:
+                        rule_entry.pop(field_name)
+        return data
 
     # --- Argument Spec ---
 

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -51,6 +51,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.e
 # Rule type choices list (used in argument_spec)
 RULE_TYPE_CHOICES = [e.value for e in RuleTypeEnum]
 Uint32 = Annotated[int, Field(ge=0, le=4294967295)]
+DEFAULT_TENANT_ROUTE_MAP_NAME_MAX_LENGTH = 63
+TENANT_ROUTE_MAP_API_NAME_MAX_LENGTH = 115
 
 _REQUIRED_RULE_FIELDS: dict[str, set[str]] = {
     RuleTypeEnum.MATCH_IPV4_ACL.value: {"access_control_list_name"},
@@ -462,7 +464,8 @@ class RouteMapModel(NDBaseModel):
     name: str = Field(
         alias="name",
         min_length=1,
-        max_length=115,
+        max_length=TENANT_ROUTE_MAP_API_NAME_MAX_LENGTH,
+        pattern=r"^[a-zA-Z0-9~_-]+$",
         description="Name of the route map (pattern: ^[a-zA-Z0-9~_-]+$).",
     )
 
@@ -475,6 +478,9 @@ class RouteMapModel(NDBaseModel):
     tenant_name: str | None = Field(
         default=None,
         alias="tenantName",
+        min_length=1,
+        max_length=DEFAULT_TENANT_ROUTE_MAP_NAME_MAX_LENGTH,
+        pattern=r"^[A-Za-z0-9_-]+$",
         description="Tenant name for tenant-specific route maps.",
     )
 
@@ -499,12 +505,16 @@ class RouteMapModel(NDBaseModel):
         return data
 
     @model_validator(mode="after")
-    def normalize_tenant_scoped_name(self) -> "RouteMapModel":
-        """Store tenant-scoped route maps with a bare name and tenant context."""
+    def normalize_and_validate_route_map_name(self) -> "RouteMapModel":
+        """Store tenant route maps with a bare config name and enforce API name limits."""
         if self.tenant_name:
             prefix = f"{self.tenant_name}~"
             if self.name.startswith(prefix):
                 self.name = self.name[len(prefix) :]
+            if len(self.api_name) > TENANT_ROUTE_MAP_API_NAME_MAX_LENGTH:
+                raise ValueError(f"tenant-scoped route map API name '{self.api_name}' must be " f"{TENANT_ROUTE_MAP_API_NAME_MAX_LENGTH} characters or fewer.")
+        elif len(self.name) > DEFAULT_TENANT_ROUTE_MAP_NAME_MAX_LENGTH:
+            raise ValueError(f"default-tenant route map name '{self.name}' must be {DEFAULT_TENANT_ROUTE_MAP_NAME_MAX_LENGTH} characters or fewer.")
         return self
 
     def to_diff_dict(self, **kwargs) -> dict[str, Any]:

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -491,6 +491,13 @@ class RouteMapModel(NDBaseModel):
             return f"{self.tenant_name}~{self.name}"
         return self.name
 
+    def to_payload(self, **kwargs) -> dict[str, Any]:
+        """Export API payload, using the fully qualified API name for tenant-scoped route maps."""
+        data = super().to_payload(**kwargs)
+        if self.tenant_name:
+            data["name"] = self.api_name
+        return data
+
     @model_validator(mode="after")
     def normalize_tenant_scoped_name(self) -> "RouteMapModel":
         """Store tenant-scoped route maps with a bare name and tenant context."""

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -114,6 +114,24 @@ _NEXT_HOP_RULE_TYPES = {
     RuleTypeEnum.SET_IPV4_NEXT_HOP.value,
     RuleTypeEnum.SET_IPV6_NEXT_HOP.value,
 }
+_NEXT_HOP_BOOLEAN_OPTION_FIELDS = (
+    "drop_on_fail",
+    "enforce_order",
+    "load_share",
+    "redistribute_unchanged",
+    "unchanged",
+    "use_peer_address",
+    "verify_availability",
+)
+_NEXT_HOP_RESTRICTED_MODE_FIELDS = ("use_peer_address", "redistribute_unchanged", "unchanged")
+_NEXT_HOP_ORDERING_FLAG_FIELDS = ("drop_on_fail", "enforce_order", "load_share")
+_USE_PEER_ADDRESS_COMPANION_DENY_FIELDS = (
+    "drop_on_fail",
+    "enforce_order",
+    "load_share",
+    "redistribute_unchanged",
+    "unchanged",
+)
 _NEXT_HOP_FALSE_DEFAULT_FIELDS = (
     "dropOnFail",
     "enforceOrder",
@@ -155,8 +173,8 @@ class RouteMapRuleEntryModel(NDNestedModel):
                                    ``loadShare``, ``enforceOrder``,
                                    ``verifyAvailability``, ``usePeerAddress``,
                                    ``redistributeUnchanged``, ``unchanged``,
-                                   ``trackId``. Exactly one next-hop mode is
-                                   required.
+                                   ``trackId``. UI/controller next-hop option
+                                   rules are enforced locally.
     - ``setIpv6NextHop``         - same optional fields as ``setIpv4NextHop``
     """
 
@@ -373,22 +391,17 @@ class RouteMapRuleEntryModel(NDNestedModel):
             raise ValueError(f"rule_type '{self.rule_type}' does not allow: {', '.join(unexpected)}")
 
     def _validate_next_hop(self) -> None:
-        """Validate next-hop rule mode and address-family combinations."""
+        """Validate next-hop address family and UI/controller option combinations."""
         if self.rule_type not in _NEXT_HOP_RULE_TYPES:
             return
 
-        selected_modes = [
-            bool(self.next_hop_ip_collection),
-            self.use_peer_address is True,
-            self.unchanged is True,
-            self.redistribute_unchanged is True,
-        ]
-        if sum(selected_modes) != 1:
-            raise ValueError(
-                f"rule_type '{self.rule_type}' requires exactly one next-hop mode: "
-                "next_hop_ip_collection, use_peer_address, unchanged, or redistribute_unchanged."
-            )
+        self._validate_next_hop_address_family()
+        self._validate_next_hop_dependencies()
+        self._validate_next_hop_option_presence()
+        self._validate_next_hop_option_compatibility()
 
+    def _validate_next_hop_address_family(self) -> None:
+        """Validate that next-hop addresses match the IPv4/IPv6 rule type."""
         if self.next_hop_ip_collection:
             expected_version = 4 if self.rule_type == RuleTypeEnum.SET_IPV4_NEXT_HOP.value else 6
             for address in self.next_hop_ip_collection:
@@ -396,8 +409,44 @@ class RouteMapRuleEntryModel(NDNestedModel):
                 if parsed_address.version != expected_version:
                     raise ValueError(f"rule_type '{self.rule_type}' expects IPv{expected_version} next-hop addresses.")
 
-        if self.track_id is not None and self._is_missing(self.next_hop_ip_collection):
-            raise ValueError("track_id requires next_hop_ip_collection.")
+    def _validate_next_hop_dependencies(self) -> None:
+        """Validate next-hop dependencies confirmed through ND UI/controller behavior."""
+        if self.verify_availability is True and self._is_missing(self.next_hop_ip_collection):
+            raise ValueError("verify_availability requires next_hop_ip_collection.")
+
+        if self.track_id is not None and (self._is_missing(self.next_hop_ip_collection) or self.verify_availability is not True):
+            raise ValueError("track_id requires next_hop_ip_collection and verify_availability.")
+
+    def _validate_next_hop_option_presence(self) -> None:
+        """Validate that each next-hop rule selects at least one IP next-hop option."""
+        has_next_hop_addresses = not self._is_missing(self.next_hop_ip_collection)
+        has_boolean_option = bool(self._enabled_next_hop_fields(_NEXT_HOP_BOOLEAN_OPTION_FIELDS))
+        if not has_next_hop_addresses and not has_boolean_option:
+            raise ValueError(f"rule_type '{self.rule_type}' requires at least one next-hop IP option.")
+
+    def _validate_next_hop_option_compatibility(self) -> None:
+        """
+        Validate UI/controller-only next-hop option combinations.
+
+        OpenAPI defines the available next-hop fields, but it does not fully
+        encode the controller compatibility matrix for these flat Ansible
+        fields. These checks mirror verified UI behavior for IPv4 and IPv6.
+        """
+        restricted_modes = self._enabled_next_hop_fields(_NEXT_HOP_RESTRICTED_MODE_FIELDS)
+        ordering_flags = self._enabled_next_hop_fields(_NEXT_HOP_ORDERING_FLAG_FIELDS)
+        if restricted_modes and ordering_flags:
+            raise ValueError(
+                "Cannot mix use_peer_address, redistribute_unchanged, or unchanged with "
+                "drop_on_fail, load_share, or enforce_order next-hop configurations."
+            )
+
+        use_peer_conflicts = self._enabled_next_hop_fields(_USE_PEER_ADDRESS_COMPANION_DENY_FIELDS)
+        if self.use_peer_address is True and use_peer_conflicts:
+            raise ValueError(f"use_peer_address cannot be mixed with: {', '.join(use_peer_conflicts)}.")
+
+    def _enabled_next_hop_fields(self, field_names: tuple[str, ...]) -> list[str]:
+        """Return next-hop boolean field names explicitly enabled by the rule."""
+        return [field_name for field_name in field_names if getattr(self, field_name) is True]
 
 
 class RouteMapEntryModel(NDNestedModel):

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -1,0 +1,503 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+Pydantic models for Route Map management via Nexus Dashboard.
+
+This module provides Pydantic models for creating, updating, and deleting
+route maps through the Nexus Dashboard Fabric Controller (NDFC) Manage API.
+
+## Models Overview
+
+- ``RouteMapRuleEntryModel`` - Flat model for all rule entry types
+  (match/set conditions discriminated by ``ruleType``)
+- ``RouteMapEntryModel``     - A single route map entry (sequence + action + rules)
+- ``RouteMapModel``          - Complete route map (name + entries list)
+
+## Usage
+
+```python
+# Create a route map model from Ansible config
+rm = RouteMapModel.from_config({
+    "name": "MY-BGP-ROUTEMAP-1",
+    "entries": [
+        {
+            "sequence_number": 10,
+            "action": "permit",
+            "rule_entries": [
+                {"rule_type": "matchIpv4PrefixList", "prefix_list_names": ["PL-1"]},
+            ],
+        }
+    ],
+})
+payload = rm.to_payload()
+# {"name": "MY-BGP-ROUTEMAP-1", "entries": [{"sequenceNumber": 10, "action": "permit",
+#   "ruleEntries": [{"ruleType": "matchIpv4PrefixList", "prefixListNames": ["PL-1"]}]}]}
+```
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Set
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.enums import ActionEnum, RuleTypeEnum
+
+# Rule type choices list (used in argument_spec)
+RULE_TYPE_CHOICES = [e.value for e in RuleTypeEnum]
+
+
+class RouteMapRuleEntryModel(NDNestedModel):
+    """
+    # Summary
+
+    Flat Pydantic model for a single route map rule entry.
+
+    A rule entry is a match or set condition identified by ``ruleType``.
+    All variant-specific fields are Optional; only the fields relevant to the
+    active ``ruleType`` are serialised into the API payload
+    (``exclude_none=True`` in ``to_payload``).
+
+    ## Supported ruleType values
+
+    - ``matchIpv4Acl``           - ``accessControlListName`` (required)
+    - ``matchIpv6Acl``           - ``accessControlListName`` (required)
+    - ``matchIpv4PrefixList``    - ``prefixListNames`` (required)
+    - ``matchIpv6PrefixList``    - ``prefixListNames`` (required)
+    - ``matchCommunity``         - ``communityListNames`` (required), ``exactMatch``
+    - ``matchExtendedCommunity`` - ``extendedCommunityListNames`` (required), ``exactMatch``
+    - ``matchTag``               - ``tags`` (required)
+    - ``setCommunity``           - ``communityNumbers`` (required), ``additive``,
+                                   ``gracefulRestartShutdownCommunity``,
+                                   ``noAdvertiseCommunity``, ``noExportCommunity``,
+                                   ``localAsCommunity``, ``internetCommunity``
+    - ``setExtendedCommunityList`` - ``extendedCommunityListName`` (required)
+    - ``setLocalPreference``     - ``value`` (required)
+    - ``setIpv4NextHop``         - ``nextHopIpCollection``, ``dropOnFail``,
+                                   ``loadShare``, ``enforceOrder``,
+                                   ``verifyAvailability``, ``usePeerAddress``,
+                                   ``redistributeUnchanged``, ``unchanged``,
+                                   ``trackId``
+    - ``setIpv6NextHop``         - same optional fields as ``setIpv4NextHop``
+    """
+
+    # --- Discriminator (required for every rule entry) ---
+
+    rule_type: str = Field(alias="ruleType", description="Rule type discriminator.")
+
+    # --- matchIpv4Acl / matchIpv6Acl ---
+
+    access_control_list_name: Optional[str] = Field(
+        default=None,
+        alias="accessControlListName",
+        description="Name of the access control list to match.",
+    )
+
+    # --- matchIpv4PrefixList / matchIpv6PrefixList ---
+
+    prefix_list_names: Optional[List[str]] = Field(
+        default=None,
+        alias="prefixListNames",
+        description="Names of the prefix lists to match.",
+    )
+
+    # --- matchCommunity ---
+
+    community_list_names: Optional[List[str]] = Field(
+        default=None,
+        alias="communityListNames",
+        description="Names of the community lists to match.",
+    )
+
+    # --- matchExtendedCommunity ---
+
+    extended_community_list_names: Optional[List[str]] = Field(
+        default=None,
+        alias="extendedCommunityListNames",
+        description="Names of the extended community lists to match.",
+    )
+
+    # --- matchCommunity / matchExtendedCommunity ---
+
+    exact_match: Optional[bool] = Field(
+        default=None,
+        alias="exactMatch",
+        description="Require an exact match for the (extended) community lists.",
+    )
+
+    # --- matchTag ---
+
+    tags: Optional[List[int]] = Field(
+        default=None,
+        alias="tags",
+        description="List of integer tags to match (0-4294967295).",
+    )
+
+    # --- setCommunity ---
+
+    community_numbers: Optional[List[str]] = Field(
+        default=None,
+        alias="communityNumbers",
+        description="Community numbers in ASN2:NN format (e.g. '65000:100').",
+    )
+
+    additive: Optional[bool] = Field(
+        default=None,
+        alias="additive",
+        description="Add communities without replacing existing ones.",
+    )
+
+    graceful_restart_shutdown_community: Optional[bool] = Field(
+        default=None,
+        alias="gracefulRestartShutdownCommunity",
+        description="Set the graceful-restart shutdown community.",
+    )
+
+    no_advertise_community: Optional[bool] = Field(
+        default=None,
+        alias="noAdvertiseCommunity",
+        description="Set the no-advertise community.",
+    )
+
+    no_export_community: Optional[bool] = Field(
+        default=None,
+        alias="noExportCommunity",
+        description="Set the no-export community.",
+    )
+
+    local_as_community: Optional[bool] = Field(
+        default=None,
+        alias="localAsCommunity",
+        description="Set the local-AS community.",
+    )
+
+    internet_community: Optional[bool] = Field(
+        default=None,
+        alias="internetCommunity",
+        description="Set the internet community.",
+    )
+
+    # --- setExtendedCommunityList ---
+
+    extended_community_list_name: Optional[str] = Field(
+        default=None,
+        alias="extendedCommunityListName",
+        description="Name of the extended community list to set.",
+    )
+
+    # --- setLocalPreference ---
+
+    value: Optional[int] = Field(
+        default=None,
+        alias="value",
+        description="Local preference value (0-4294967295).",
+    )
+
+    # --- setIpv4NextHop / setIpv6NextHop ---
+
+    next_hop_ip_collection: Optional[List[str]] = Field(
+        default=None,
+        alias="nextHopIpCollection",
+        description="List of next-hop IP addresses.",
+    )
+
+    drop_on_fail: Optional[bool] = Field(
+        default=None,
+        alias="dropOnFail",
+        description="Drop the packet if the next hop is unavailable.",
+    )
+
+    load_share: Optional[bool] = Field(
+        default=None,
+        alias="loadShare",
+        description="Enable load sharing across multiple next hops.",
+    )
+
+    enforce_order: Optional[bool] = Field(
+        default=None,
+        alias="enforceOrder",
+        description="Enforce the order of next-hop IPs.",
+    )
+
+    verify_availability: Optional[bool] = Field(
+        default=None,
+        alias="verifyAvailability",
+        description="Ensure the next hop is reachable before using it.",
+    )
+
+    use_peer_address: Optional[bool] = Field(
+        default=None,
+        alias="usePeerAddress",
+        description="Use the peer address as the next hop.",
+    )
+
+    redistribute_unchanged: Optional[bool] = Field(
+        default=None,
+        alias="redistributeUnchanged",
+        description="Redistribute routes without changing the next hop.",
+    )
+
+    unchanged: Optional[bool] = Field(
+        default=None,
+        alias="unchanged",
+        description="Keep the next hop unchanged.",
+    )
+
+    track_id: Optional[int] = Field(
+        default=None,
+        alias="trackId",
+        description="Tracking subsystem object ID (1-512).",
+    )
+
+
+class RouteMapEntryModel(NDNestedModel):
+    """
+    # Summary
+
+    A single route map entry (one sequence block).
+
+    Each entry consists of a sequence number, a permit/deny action, and a list
+    of rule entries (match/set conditions).
+    """
+
+    sequence_number: int = Field(
+        alias="sequenceNumber",
+        ge=0,
+        le=65535,
+        description="Route map sequence number (0-65535).",
+    )
+
+    action: ActionEnum = Field(
+        default=ActionEnum.PERMIT,
+        alias="action",
+        description="Action for this entry: permit or deny.",
+    )
+
+    rule_entries: List[RouteMapRuleEntryModel] = Field(
+        alias="ruleEntries",
+        description="List of match or set rule conditions.",
+    )
+
+
+class RouteMapModel(NDBaseModel):
+    """
+    # Summary
+
+    Route map configuration for a Nexus Dashboard fabric.
+
+    ## Identifier
+
+    ``name`` (single) - the route map name within its fabric.
+
+    ## Serialization Notes
+
+    - ``last_update_timestamp`` is a read-only field returned by the API.
+      It is excluded from payload output and diff comparisons.
+    - ``fabric_name`` is managed at the orchestrator level and is NOT part of
+      this model; path construction is handled by the endpoint classes.
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "single"
+
+    # --- Serialization Configuration ---
+
+    exclude_from_diff: ClassVar[Set[str]] = {"last_update_timestamp"}
+    payload_exclude_fields: ClassVar[Set[str]] = {"last_update_timestamp"}
+    unwanted_keys: ClassVar[List] = []
+
+    # --- Fields ---
+
+    name: str = Field(
+        alias="name",
+        min_length=1,
+        max_length=115,
+        description="Name of the route map (pattern: ^[a-zA-Z0-9~_-]+$).",
+    )
+
+    last_update_timestamp: Optional[str] = Field(
+        default=None,
+        alias="lastUpdateTimestamp",
+        description="Timestamp of the last update (read-only, set by ND).",
+    )
+
+    tenant_name: Optional[str] = Field(
+        default=None,
+        alias="tenantName",
+        description="Tenant name for tenant-specific route maps.",
+    )
+
+    entries: Optional[List[RouteMapEntryModel]] = Field(
+        default=None,
+        alias="entries",
+        description="List of route map entries (sequence + action + rule conditions).",
+    )
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> Dict[str, Any]:
+        return dict(
+            fabric_name=dict(
+                type="str",
+                required=True,
+            ),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    name=dict(
+                        type="str",
+                        required=True,
+                    ),
+                    entries=dict(
+                        type="list",
+                        elements="dict",
+                        options=dict(
+                            sequence_number=dict(
+                                type="int",
+                                default=10,
+                            ),
+                            action=dict(
+                                type="str",
+                                default="permit",
+                                choices=["permit", "deny"],
+                            ),
+                            rule_entries=dict(
+                                type="list",
+                                elements="dict",
+                                required=True,
+                                options=dict(
+                                    rule_type=dict(
+                                        type="str",
+                                        required=True,
+                                        choices=RULE_TYPE_CHOICES,
+                                        aliases=["ruleType"],
+                                    ),
+                                    # matchIpv4Acl / matchIpv6Acl
+                                    access_control_list_name=dict(
+                                        type="str",
+                                        aliases=["accessControlListName"],
+                                    ),
+                                    # matchIpv4PrefixList / matchIpv6PrefixList
+                                    prefix_list_names=dict(
+                                        type="list",
+                                        elements="str",
+                                        aliases=["prefixListNames"],
+                                    ),
+                                    # matchCommunity
+                                    community_list_names=dict(
+                                        type="list",
+                                        elements="str",
+                                        aliases=["communityListNames"],
+                                    ),
+                                    # matchExtendedCommunity
+                                    extended_community_list_names=dict(
+                                        type="list",
+                                        elements="str",
+                                        aliases=["extendedCommunityListNames"],
+                                    ),
+                                    # matchCommunity / matchExtendedCommunity
+                                    exact_match=dict(
+                                        type="bool",
+                                        aliases=["exactMatch"],
+                                    ),
+                                    # matchTag
+                                    tags=dict(
+                                        type="list",
+                                        elements="int",
+                                    ),
+                                    # setCommunity
+                                    community_numbers=dict(
+                                        type="list",
+                                        elements="str",
+                                        aliases=["communityNumbers"],
+                                    ),
+                                    additive=dict(type="bool"),
+                                    graceful_restart_shutdown_community=dict(
+                                        type="bool",
+                                        aliases=["gracefulRestartShutdownCommunity"],
+                                    ),
+                                    no_advertise_community=dict(
+                                        type="bool",
+                                        aliases=["noAdvertiseCommunity"],
+                                    ),
+                                    no_export_community=dict(
+                                        type="bool",
+                                        aliases=["noExportCommunity"],
+                                    ),
+                                    local_as_community=dict(
+                                        type="bool",
+                                        aliases=["localAsCommunity"],
+                                    ),
+                                    internet_community=dict(
+                                        type="bool",
+                                        aliases=["internetCommunity"],
+                                    ),
+                                    # setExtendedCommunityList
+                                    extended_community_list_name=dict(
+                                        type="str",
+                                        aliases=["extendedCommunityListName"],
+                                    ),
+                                    # setLocalPreference
+                                    value=dict(type="int"),
+                                    # setIpv4NextHop / setIpv6NextHop
+                                    next_hop_ip_collection=dict(
+                                        type="list",
+                                        elements="str",
+                                        aliases=["nextHopIpCollection"],
+                                    ),
+                                    drop_on_fail=dict(
+                                        type="bool",
+                                        aliases=["dropOnFail"],
+                                    ),
+                                    load_share=dict(
+                                        type="bool",
+                                        aliases=["loadShare"],
+                                    ),
+                                    enforce_order=dict(
+                                        type="bool",
+                                        aliases=["enforceOrder"],
+                                    ),
+                                    verify_availability=dict(
+                                        type="bool",
+                                        aliases=["verifyAvailability"],
+                                    ),
+                                    use_peer_address=dict(
+                                        type="bool",
+                                        aliases=["usePeerAddress"],
+                                    ),
+                                    redistribute_unchanged=dict(
+                                        type="bool",
+                                        aliases=["redistributeUnchanged"],
+                                    ),
+                                    unchanged=dict(type="bool"),
+                                    track_id=dict(
+                                        type="int",
+                                        aliases=["trackId"],
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    tenant_name=dict(
+                        type="str",
+                        aliases=["tenantName"],
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -132,6 +132,8 @@ _USE_PEER_ADDRESS_COMPANION_DENY_FIELDS = (
     "redistribute_unchanged",
     "unchanged",
 )
+# TODO(4.2.1) TBD: ND echoes these next-hop booleans as false on GET even when
+# the module never sent them, so diff normalization treats false as absent.
 _NEXT_HOP_FALSE_DEFAULT_FIELDS = (
     "dropOnFail",
     "enforceOrder",
@@ -573,6 +575,8 @@ class RouteMapModel(NDBaseModel):
             for rule_entry in entry.get("ruleEntries") or []:
                 if rule_entry.get("ruleType") not in _NEXT_HOP_RULE_TYPES:
                     continue
+                # TODO(4.2.1) TBD: Strip false values that ND adds on read for
+                # unsent next-hop booleans so create/read diffs stay idempotent.
                 for field_name in _NEXT_HOP_FALSE_DEFAULT_FIELDS:
                     if rule_entry.get(field_name) is False:
                         rule_entry.pop(field_name)

--- a/plugins/module_utils/models/manage_route_map/manage_route_map.py
+++ b/plugins/module_utils/models/manage_route_map/manage_route_map.py
@@ -438,7 +438,7 @@ class RouteMapRuleEntryModel(NDNestedModel):
         ordering_flags = self._enabled_next_hop_fields(_NEXT_HOP_ORDERING_FLAG_FIELDS)
         if restricted_modes and ordering_flags:
             raise ValueError(
-                "Cannot mix use_peer_address, redistribute_unchanged, or unchanged with " "drop_on_fail, load_share, or enforce_order next-hop configurations."
+                "Cannot mix use_peer_address, redistribute_unchanged, or unchanged with drop_on_fail, load_share, or enforce_order next-hop configurations."
             )
 
         use_peer_conflicts = self._enabled_next_hop_fields(_USE_PEER_ADDRESS_COMPANION_DENY_FIELDS)

--- a/plugins/module_utils/orchestrators/manage_route_map.py
+++ b/plugins/module_utils/orchestrators/manage_route_map.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, List, Type
+from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_route_maps import (
@@ -41,21 +41,21 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
     ``fabric_name`` via ``rest_send.params``.
     """
 
-    model_class: ClassVar[Type[NDBaseModel]] = RouteMapModel
+    model_class: ClassVar[type[NDBaseModel]] = RouteMapModel
 
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
 
     # Standard endpoint references (single-item operations)
-    create_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsPost
-    update_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsPut
-    delete_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsDelete
-    query_one_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsGet
-    query_all_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsListGet
+    create_endpoint: type[NDEndpointBaseModel] = EpManageRouteMapsPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageRouteMapsPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageRouteMapsDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageRouteMapsGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageRouteMapsListGet
 
     # Bulk endpoint references
-    create_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsPost
-    delete_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsBulkDelete
+    create_bulk_endpoint: type[NDEndpointBaseModel] = EpManageRouteMapsPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] = EpManageRouteMapsBulkDelete
 
     _fabric_context: FabricContext | None = None
 
@@ -163,7 +163,7 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
     # Write operations -- bulk
     # -------------------------------------------------------------------------
 
-    def create_bulk(self, model_instances: List[RouteMapModel], **kwargs) -> ResponseType:
+    def create_bulk(self, model_instances: list[RouteMapModel], **kwargs) -> ResponseType:
         """
         Bulk-create route maps.
 
@@ -179,7 +179,7 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
         except Exception as e:
             raise Exception(f"Bulk create failed: {e}") from e
 
-    def delete_bulk(self, model_instances: List[RouteMapModel], **kwargs) -> ResponseType:
+    def delete_bulk(self, model_instances: list[RouteMapModel], **kwargs) -> ResponseType:
         """
         Bulk-delete route maps.
 

--- a/plugins/module_utils/orchestrators/manage_route_map.py
+++ b/plugins/module_utils/orchestrators/manage_route_map.py
@@ -65,6 +65,11 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
         return self.rest_send.params.get("fabric_name")
 
     @property
+    def cluster_name(self) -> str | None:
+        """Return the optional target cluster name from module params."""
+        return self.rest_send.params.get("cluster_name")
+
+    @property
     def fabric_context(self) -> FabricContext:
         """Return a lazily-created fabric context for pre-flight checks."""
         if self._fabric_context is None:
@@ -72,8 +77,11 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
         return self._fabric_context
 
     def _configure_endpoint(self, api_endpoint):
-        """Set fabric_name on a route-map endpoint before path generation."""
+        """Set module-scoped endpoint values before path generation."""
         api_endpoint.fabric_name = self.fabric_name
+        params = getattr(api_endpoint, "endpoint_params", None)
+        if self.cluster_name and params is not None and hasattr(params, "cluster_name"):
+            params.cluster_name = self.cluster_name
         return api_endpoint
 
     def preflight(self, model_instances: list[RouteMapModel]) -> None:

--- a/plugins/module_utils/orchestrators/manage_route_map.py
+++ b/plugins/module_utils/orchestrators/manage_route_map.py
@@ -190,7 +190,7 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
         """
         try:
             api_endpoint = self._configure_endpoint(self.delete_bulk_endpoint())
-            route_map_names = [item.name for item in model_instances]
+            route_map_names = [item.get_identifier_value() for item in model_instances]
             payload = {"routeMapNames": route_map_names}
             result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload, operation_type=OperationType.DELETE)
             self._raise_on_bulk_errors(result, "delete")

--- a/plugins/module_utils/orchestrators/manage_route_map.py
+++ b/plugins/module_utils/orchestrators/manage_route_map.py
@@ -24,6 +24,11 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.m
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
+# Per-item ``status`` values in a 207 Multi-Status body that count as a failure. Anything else --
+# ``success``, missing, empty, or future progress tokens -- is tolerated so informational rows do
+# not surface as spurious errors. Mirrors the ACL orchestrator's denylist approach.
+_FAILURE_STATUSES = frozenset({"failed", "failure", "error"})
+
 
 class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
     """
@@ -94,7 +99,13 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
         """Raise when a 207 bulk response contains failed per-item results."""
         if not isinstance(result, dict):
             return
-        failures = [item for item in result.get("results", []) if isinstance(item, dict) and item.get("status") not in (None, "", "success")]
+        failures = []
+        for item in result.get("results", []):
+            if not isinstance(item, dict):
+                continue
+            status = str(item.get("status") or "").lower()
+            if status in _FAILURE_STATUSES:
+                failures.append(item)
         if not failures:
             return
         details = []

--- a/plugins/module_utils/orchestrators/manage_route_map.py
+++ b/plugins/module_utils/orchestrators/manage_route_map.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+from typing import ClassVar, List, Type
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_route_maps import (
+    EpManageRouteMapsDelete,
+    EpManageRouteMapsBulkDelete,
+    EpManageRouteMapsGet,
+    EpManageRouteMapsListGet,
+    EpManageRouteMapsPost,
+    EpManageRouteMapsPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import OperationType
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.manage_route_map import RouteMapModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
+    """
+    Orchestrator for Route Map CRUD operations.
+
+    This orchestrator manages route maps for a single fabric identified by
+    ``fabric_name``.  Because the API only supports bulk-create
+    (``POST /routeMaps`` with ``{"routeMaps": [...]}``) and bulk-delete
+    (``POST /routeMapActions/remove`` with ``{"routeMapNames": [...]}``)
+    those two operations are implemented as custom ``create_bulk`` /
+    ``delete_bulk`` methods.  Individual updates are performed via the
+    standard ``PUT /routeMaps/{routeMapName}`` endpoint.
+
+    The fabric scope is read from the top-level module parameter
+    ``fabric_name`` via ``rest_send.params``.
+    """
+
+    model_class: ClassVar[Type[NDBaseModel]] = RouteMapModel
+
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+
+    # Standard endpoint references (single-item operations)
+    create_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsPost
+    update_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsPut
+    delete_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsDelete
+    query_one_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsGet
+    query_all_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsListGet
+
+    # Bulk endpoint references
+    create_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsPost
+    delete_bulk_endpoint: Type[NDEndpointBaseModel] = EpManageRouteMapsBulkDelete
+
+    _fabric_context: FabricContext | None = None
+
+    @property
+    def fabric_name(self) -> str:
+        """Return the fabric name from module params."""
+        return self.rest_send.params.get("fabric_name")
+
+    @property
+    def fabric_context(self) -> FabricContext:
+        """Return a lazily-created fabric context for pre-flight checks."""
+        if self._fabric_context is None:
+            self._fabric_context = FabricContext(rest_send=self.rest_send, fabric_name=self.fabric_name)
+        return self._fabric_context
+
+    def _configure_endpoint(self, api_endpoint):
+        """Set fabric_name on a route-map endpoint before path generation."""
+        api_endpoint.fabric_name = self.fabric_name
+        return api_endpoint
+
+    def preflight(self, model_instances: list[RouteMapModel]) -> None:
+        """Validate that the target fabric can be mutated before writes."""
+        if model_instances:
+            self.fabric_context.validate_for_mutation()
+
+    @staticmethod
+    def _raise_on_bulk_errors(result: ResponseType, action: str) -> None:
+        """Raise when a 207 bulk response contains failed per-item results."""
+        if not isinstance(result, dict):
+            return
+        failures = [item for item in result.get("results", []) if isinstance(item, dict) and item.get("status") not in (None, "", "success")]
+        if not failures:
+            return
+        details = []
+        for item in failures:
+            name = item.get("name") or "<unknown>"
+            status = item.get("status") or "<unknown>"
+            message = item.get("message") or "no message"
+            details.append(f"{name}: {status}: {message}")
+        raise RuntimeError(f"Route map bulk {action} failed for {', '.join(details)}")
+
+    # -------------------------------------------------------------------------
+    # Query helpers
+    # -------------------------------------------------------------------------
+
+    def query_all(self) -> ResponseType:
+        """
+        List all route maps for the configured fabric.
+
+        The API response is wrapped under the ``"routeMaps"`` key; this method
+        extracts and returns the list directly.
+        """
+        try:
+            api_endpoint = self._configure_endpoint(self.query_all_endpoint())
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            return result.get("routeMaps", []) or []
+        except Exception as e:
+            raise Exception(f"Query all failed: {e}") from e
+
+    def query_one(self, model_instance: RouteMapModel, **kwargs) -> ResponseType:
+        """Retrieve a single route map by name."""
+        try:
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint())
+            api_endpoint.set_identifiers(model_instance.get_identifier_value())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise Exception(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    # -------------------------------------------------------------------------
+    # Write operations -- single item
+    # -------------------------------------------------------------------------
+
+    def create(self, model_instance: RouteMapModel, **kwargs) -> ResponseType:
+        """
+        Create a single route map via the bulk-create endpoint.
+
+        Wraps the single model payload in ``{"routeMaps": [...]}``.
+        """
+        try:
+            return self.create_bulk([model_instance])
+        except Exception as e:
+            raise Exception(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: RouteMapModel, **kwargs) -> ResponseType:
+        """Update an existing route map via the PUT endpoint."""
+        try:
+            api_endpoint = self._configure_endpoint(self.update_endpoint())
+            api_endpoint.set_identifiers(model_instance.get_identifier_value())
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload(), operation_type=OperationType.UPDATE)
+        except Exception as e:
+            raise Exception(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: RouteMapModel, **kwargs) -> ResponseType:
+        """
+        Delete a single route map via the bulk-delete endpoint.
+
+        Wraps the single name in ``{"routeMapNames": [...]}``.
+        """
+        try:
+            return self.delete_bulk([model_instance])
+        except Exception as e:
+            raise Exception(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    # -------------------------------------------------------------------------
+    # Write operations -- bulk
+    # -------------------------------------------------------------------------
+
+    def create_bulk(self, model_instances: List[RouteMapModel], **kwargs) -> ResponseType:
+        """
+        Bulk-create route maps.
+
+        Sends ``POST /fabrics/{fabricName}/routeMaps`` with body:
+        ``{"routeMaps": [<RouteMap payload>, ...]}``.
+        """
+        try:
+            api_endpoint = self._configure_endpoint(self.create_bulk_endpoint())
+            payload = {"routeMaps": [item.to_payload() for item in model_instances]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload, operation_type=OperationType.CREATE)
+            self._raise_on_bulk_errors(result, "create")
+            return result
+        except Exception as e:
+            raise Exception(f"Bulk create failed: {e}") from e
+
+    def delete_bulk(self, model_instances: List[RouteMapModel], **kwargs) -> ResponseType:
+        """
+        Bulk-delete route maps.
+
+        Sends ``POST /fabrics/{fabricName}/routeMapActions/remove`` with body:
+        ``{"routeMapNames": ["name1", "name2", ...]}``.
+        """
+        try:
+            api_endpoint = self._configure_endpoint(self.delete_bulk_endpoint())
+            route_map_names = [item.name for item in model_instances]
+            payload = {"routeMapNames": route_map_names}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload, operation_type=OperationType.DELETE)
+            self._raise_on_bulk_errors(result, "delete")
+            return result
+        except Exception as e:
+            raise Exception(f"Bulk delete failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_route_map.py
+++ b/plugins/module_utils/orchestrators/manage_route_map.py
@@ -4,9 +4,7 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type
+from __future__ import annotations
 
 from typing import ClassVar, List, Type
 

--- a/plugins/module_utils/orchestrators/manage_route_map.py
+++ b/plugins/module_utils/orchestrators/manage_route_map.py
@@ -29,6 +29,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types impor
 # not surface as spurious errors. Mirrors the ACL orchestrator's denylist approach.
 _FAILURE_STATUSES = frozenset({"failed", "failure", "error"})
 
+# camelCase wrapper key used in route-map list responses and bulk-create request bodies.
+_LIST_KEY = "routeMaps"
+
 
 class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
     """
@@ -50,6 +53,8 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
 
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
+    query_all_page_size: ClassVar[int] = 100
+    query_all_max_pages: ClassVar[int] = 10000
 
     # Standard endpoint references (single-item operations)
     create_endpoint: type[NDEndpointBaseModel] = EpManageRouteMapsPost
@@ -124,13 +129,42 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
         """
         List all route maps for the configured fabric.
 
-        The API response is wrapped under the ``"routeMaps"`` key; this method
-        extracts and returns the list directly.
+        The list endpoint paginates, so this walks the collection with
+        ``max``/``offset`` until a page arrives short or empty. A ``seen`` set
+        de-duplicates by route-map name so an ignored offset cannot loop
+        forever, and ``query_all_max_pages`` bounds the walk as a final safety
+        net.
         """
         try:
-            api_endpoint = self._configure_endpoint(self.query_all_endpoint())
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-            return result.get("routeMaps", []) or []
+            page_size = self.query_all_page_size
+            collected: list[dict] = []
+            seen: set[str] = set()
+            offset = 0
+            pages_fetched = 0
+            while pages_fetched < self.query_all_max_pages:
+                pages_fetched += 1
+                api_endpoint = self._configure_endpoint(self.query_all_endpoint())
+                api_endpoint.lucene_params.max = page_size
+                api_endpoint.lucene_params.offset = offset
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                page = result.get(_LIST_KEY, []) or [] if isinstance(result, dict) else (result or [])
+                if not page:
+                    break
+
+                new_rows = 0
+                for row in page:
+                    name = row.get("name") if isinstance(row, dict) else None
+                    if name is not None:
+                        if name in seen:
+                            continue
+                        seen.add(name)
+                    collected.append(row)
+                    new_rows += 1
+
+                if len(page) < page_size or new_rows == 0:
+                    break
+                offset += page_size
+            return collected
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
 
@@ -191,7 +225,7 @@ class ManageRouteMapOrchestrator(NDBaseOrchestrator[RouteMapModel]):
         """
         try:
             api_endpoint = self._configure_endpoint(self.create_bulk_endpoint())
-            payload = {"routeMaps": [item.to_payload() for item in model_instances]}
+            payload = {_LIST_KEY: [item.to_payload() for item in model_instances]}
             result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload, operation_type=OperationType.CREATE)
             self._raise_on_bulk_errors(result, "create")
             return result

--- a/plugins/modules/nd_manage_route_map.py
+++ b/plugins/modules/nd_manage_route_map.py
@@ -1,0 +1,427 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_manage_route_map
+version_added: "1.6.0"
+short_description: Manage route maps on Cisco Nexus Dashboard fabrics
+description:
+- Manage route maps on a Cisco Nexus Dashboard (ND) fabric.
+- It supports creating, updating, and deleting route maps.
+- Route maps are created and deleted in bulk via dedicated bulk-API endpoints.
+- Each route map contains one or more entries, each entry containing
+  a sequence number, a permit/deny action, and a list of match/set rule conditions.
+author:
+- Gaspard Micol (@gmicol)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric that owns the route maps.
+    - This is a required parameter for all operations.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of route maps to configure.
+    type: list
+    elements: dict
+    required: True
+    suboptions:
+      name:
+        description:
+        - The name of the route map.
+        - Allowed characters are C([a-zA-Z0-9~_-]).
+        - Maximum length is 115 characters (63 for the default tenant).
+        type: str
+        required: true
+      tenant_name:
+        description:
+        - Optional tenant name for tenant-specific route maps.
+        - Tenant-specific route maps are identified by their full O(config.name), typically in C(tenant~route_map) form.
+        type: str
+        aliases: [ tenantName ]
+      entries:
+        description:
+        - The list of route map entries.
+        - Each entry defines a sequence block with a permit/deny action
+          and one or more match/set rule conditions.
+        - Required when O(state=merged), O(state=replaced), or O(state=overridden).
+        - Not required when O(state=deleted); the route map name is enough to delete an existing route map.
+        type: list
+        elements: dict
+        suboptions:
+          sequence_number:
+            description:
+            - The sequence number of the route map entry (0-65535).
+            - Lower sequence numbers are evaluated first.
+            type: int
+            default: 10
+          action:
+            description:
+            - The action to take when the entry matches.
+            type: str
+            default: permit
+            choices: [ permit, deny ]
+          rule_entries:
+            description:
+            - The list of match or set rule conditions for this entry.
+            - Each rule is discriminated by O(config.entries.rule_entries.rule_type).
+            type: list
+            elements: dict
+            required: true
+            suboptions:
+              rule_type:
+                description:
+                - The type of the rule entry.
+                - Determines which additional fields are required.
+                type: str
+                required: true
+                choices:
+                - matchIpv4Acl
+                - matchIpv6Acl
+                - matchIpv4PrefixList
+                - matchIpv6PrefixList
+                - matchCommunity
+                - matchExtendedCommunity
+                - matchTag
+                - setCommunity
+                - setExtendedCommunityList
+                - setLocalPreference
+                - setIpv4NextHop
+                - setIpv6NextHop
+                aliases: [ ruleType ]
+              access_control_list_name:
+                description:
+                - Name of the access control list to match.
+                - Required when O(config.entries.rule_entries.rule_type=matchIpv4Acl)
+                  or O(config.entries.rule_entries.rule_type=matchIpv6Acl).
+                type: str
+                aliases: [ accessControlListName ]
+              prefix_list_names:
+                description:
+                - Names of the prefix lists to match.
+                - Required when O(config.entries.rule_entries.rule_type=matchIpv4PrefixList)
+                  or O(config.entries.rule_entries.rule_type=matchIpv6PrefixList).
+                type: list
+                elements: str
+                aliases: [ prefixListNames ]
+              community_list_names:
+                description:
+                - Names of the community lists to match.
+                - Required when O(config.entries.rule_entries.rule_type=matchCommunity).
+                type: list
+                elements: str
+                aliases: [ communityListNames ]
+              extended_community_list_names:
+                description:
+                - Names of the extended community lists to match.
+                - Required when O(config.entries.rule_entries.rule_type=matchExtendedCommunity).
+                type: list
+                elements: str
+                aliases: [ extendedCommunityListNames ]
+              exact_match:
+                description:
+                - Require an exact match for (extended) community list comparisons.
+                - Used with C(matchCommunity) and C(matchExtendedCommunity).
+                type: bool
+                aliases: [ exactMatch ]
+              tags:
+                description:
+                - List of integer tags to match (0-4294967295).
+                - Required when O(config.entries.rule_entries.rule_type=matchTag).
+                type: list
+                elements: int
+              community_numbers:
+                description:
+                - Community numbers to set, each in ASN2:NN format (e.g. C(65000:100)).
+                - Required when O(config.entries.rule_entries.rule_type=setCommunity).
+                type: list
+                elements: str
+                aliases: [ communityNumbers ]
+              additive:
+                description:
+                - Add communities without replacing existing ones.
+                - Used with C(setCommunity).
+                type: bool
+              graceful_restart_shutdown_community:
+                description:
+                - Set the graceful-restart shutdown community.
+                - Used with C(setCommunity).
+                type: bool
+                aliases: [ gracefulRestartShutdownCommunity ]
+              no_advertise_community:
+                description:
+                - Set the no-advertise community.
+                - Used with C(setCommunity).
+                type: bool
+                aliases: [ noAdvertiseCommunity ]
+              no_export_community:
+                description:
+                - Set the no-export community.
+                - Used with C(setCommunity).
+                type: bool
+                aliases: [ noExportCommunity ]
+              local_as_community:
+                description:
+                - Set the local-AS community.
+                - Used with C(setCommunity).
+                type: bool
+                aliases: [ localAsCommunity ]
+              internet_community:
+                description:
+                - Set the internet community.
+                - Used with C(setCommunity).
+                type: bool
+                aliases: [ internetCommunity ]
+              extended_community_list_name:
+                description:
+                - Name of the extended community list to set.
+                - Required when O(config.entries.rule_entries.rule_type=setExtendedCommunityList).
+                type: str
+                aliases: [ extendedCommunityListName ]
+              value:
+                description:
+                - Local preference value (0-4294967295).
+                - Required when O(config.entries.rule_entries.rule_type=setLocalPreference).
+                type: int
+              next_hop_ip_collection:
+                description:
+                - List of next-hop IP addresses to set.
+                - Used with C(setIpv4NextHop) and C(setIpv6NextHop).
+                type: list
+                elements: str
+                aliases: [ nextHopIpCollection ]
+              drop_on_fail:
+                description:
+                - Drop the packet if the next hop is unavailable.
+                - Used with C(setIpv4NextHop) and C(setIpv6NextHop).
+                type: bool
+                aliases: [ dropOnFail ]
+              load_share:
+                description:
+                - Enable load sharing across multiple next hops.
+                - Used with C(setIpv4NextHop) and C(setIpv6NextHop).
+                type: bool
+                aliases: [ loadShare ]
+              enforce_order:
+                description:
+                - Enforce the order of next-hop IPs.
+                - Used with C(setIpv4NextHop) and C(setIpv6NextHop).
+                type: bool
+                aliases: [ enforceOrder ]
+              verify_availability:
+                description:
+                - Ensure the next hop is reachable before using it.
+                - Used with C(setIpv4NextHop) and C(setIpv6NextHop).
+                type: bool
+                aliases: [ verifyAvailability ]
+              use_peer_address:
+                description:
+                - Use the peer address as the next hop.
+                - Used with C(setIpv4NextHop) and C(setIpv6NextHop).
+                type: bool
+                aliases: [ usePeerAddress ]
+              redistribute_unchanged:
+                description:
+                - Redistribute routes without changing the next hop.
+                - Used with C(setIpv4NextHop) and C(setIpv6NextHop).
+                type: bool
+                aliases: [ redistributeUnchanged ]
+              unchanged:
+                description:
+                - Keep the next hop unchanged.
+                - Used with C(setIpv4NextHop) and C(setIpv6NextHop).
+                type: bool
+              track_id:
+                description:
+                - Tracking subsystem object ID (1-512).
+                - Used with C(setIpv4NextHop) and C(setIpv6NextHop).
+                type: int
+                aliases: [ trackId ]
+  state:
+    description:
+    - The desired state of the route map resources on Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new route maps and update existing ones
+      as defined in your configuration.
+      Route maps on ND that are not specified in the configuration are left unchanged.
+    - Use O(state=replaced) to replace the route maps specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      Route maps on ND that are not in the configuration will be deleted. Use with caution.
+    - Use O(state=deleted) to remove the route maps specified in the configuration
+      from Cisco Nexus Dashboard.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard having version 4.2.1 or higher.
+- Route maps are created and deleted in bulk via the API.
+  When O(state=overridden) is used, all route maps not present in the configuration
+  will be deleted in a single bulk-delete API call.
+"""
+
+EXAMPLES = r"""
+- name: Create route maps with prefix-list and community match rules
+  cisco.nd.nd_manage_route_map:
+    fabric_name: my-fabric
+    config:
+      - name: MY-BGP-ROUTEMAP-1
+        entries:
+          - sequence_number: 10
+            action: permit
+            rule_entries:
+              - rule_type: matchIpv4PrefixList
+                prefix_list_names:
+                  - PL-IPV4-1
+                  - PL-IPV4-2
+          - sequence_number: 20
+            action: deny
+            rule_entries:
+              - rule_type: matchCommunity
+                community_list_names:
+                  - COMM-LIST-1
+                exact_match: true
+      - name: MY-BGP-ROUTEMAP-2
+        entries:
+          - sequence_number: 10
+            action: permit
+            rule_entries:
+              - rule_type: setLocalPreference
+                value: 200
+    state: merged
+
+- name: Create route map with next-hop set rule
+  cisco.nd.nd_manage_route_map:
+    fabric_name: my-fabric
+    config:
+      - name: MY-BGP-ROUTEMAP-3
+        entries:
+          - sequence_number: 10
+            action: permit
+            rule_entries:
+              - rule_type: setIpv4NextHop
+                next_hop_ip_collection:
+                  - 192.168.1.1
+                  - 192.168.1.2
+                drop_on_fail: true
+                load_share: true
+    state: merged
+
+- name: Update a route map (replace its entries)
+  cisco.nd.nd_manage_route_map:
+    fabric_name: my-fabric
+    config:
+      - name: MY-BGP-ROUTEMAP-1
+        entries:
+          - sequence_number: 10
+            action: permit
+            rule_entries:
+              - rule_type: matchIpv6PrefixList
+                prefix_list_names:
+                  - PL-IPV6-1
+    state: replaced
+
+- name: Delete specific route maps
+  cisco.nd.nd_manage_route_map:
+    fabric_name: my-fabric
+    config:
+      - name: MY-BGP-ROUTEMAP-1
+      - name: MY-BGP-ROUTEMAP-2
+    state: deleted
+
+- name: Override -- enforce exact set of route maps (delete all others)
+  cisco.nd.nd_manage_route_map:
+    fabric_name: my-fabric
+    config:
+      - name: MY-BGP-ROUTEMAP-FINAL
+        entries:
+          - sequence_number: 10
+            action: permit
+            rule_entries:
+              - rule_type: setLocalPreference
+                value: 100
+    state: overridden
+"""
+
+RETURN = r"""
+"""
+
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.manage_route_map import RouteMapModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_route_map import ManageRouteMapOrchestrator
+
+
+def _validate_route_map_config(module: AnsibleModule) -> None:
+    """Reject write-state config entries that cannot produce a RouteMap payload."""
+    if module.params.get("state") == "deleted":
+        return
+    for item in module.params.get("config") or []:
+        if not isinstance(item, dict):
+            continue
+        if not item.get("entries"):
+            module.fail_json(msg=f"route map '{item.get('name')}': entries must contain at least one entry for state '{module.params.get('state')}'.")
+
+
+def main():
+    argument_spec = nd_argument_spec()
+    argument_spec.update(RouteMapModel.get_argument_spec())
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    _validate_route_map_config(module)
+    module_log = logging.getLogger("nd.nd_manage_route_map")
+
+    nd_state_machine = None
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=ManageRouteMapOrchestrator,
+        )
+
+        module_log.debug("manage_state begin state=%s check_mode=%s", module.params.get("state"), module.check_mode)
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine is not None else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+    except Exception as e:
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine is not None else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_manage_route_map.py
+++ b/plugins/modules/nd_manage_route_map.py
@@ -47,6 +47,7 @@ options:
       tenant_name:
         description:
         - Optional tenant name for tenant-specific route maps.
+        - Maximum length is 63 characters. Allowed characters are C([A-Za-z0-9_-]).
         - When set, O(config.name) may be either the bare route map name or the fully qualified C(tenant~route_map) API name.
         - The module normalizes tenant-scoped route maps to a bare O(config.name) and uses C(tenant~route_map) for API lookups and deletes.
         type: str

--- a/plugins/modules/nd_manage_route_map.py
+++ b/plugins/modules/nd_manage_route_map.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_manage_route_map
-version_added: "1.6.0"
+version_added: "2.0.0"
 short_description: Manage route maps on Cisco Nexus Dashboard fabrics
 description:
 - Manage route maps on a Cisco Nexus Dashboard (ND) fabric.
@@ -355,6 +355,90 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The route map configuration before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no route map configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - name: RM_EXPORT
+    tenant_name: tenantSales
+    entries:
+    - sequence_number: 10
+      action: permit
+      rule_entries:
+      - rule_type: matchIpv4PrefixList
+        prefix_list_names:
+        - tenantSales~PL_EXPORT
+after:
+  description:
+  - The route map configuration after the module ran, structured the same as the O(config) parameter.
+  - This reflects the module's predicted post-write state; it is not re-read from the controller after writes.
+  - In check mode, this is the configuration that would result if the module ran outside check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - name: RM_EXPORT
+    tenant_name: tenantSales
+    entries:
+    - sequence_number: 10
+      action: permit
+      rule_entries:
+      - rule_type: setLocalPreference
+        value: 200
+diff:
+  description: The per-route-map difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - name: RM_EXPORT
+    tenant_name: tenantSales
+    entries:
+    - sequence_number: 10
+      action: permit
+      rule_entries:
+      - rule_type: setLocalPreference
+        value: 200
+proposed:
+  description: The route map configuration the module proposed to apply before reconciliation with existing state.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - name: RM_EXPORT
+    tenant_name: tenantSales
+    entries:
+    - sequence_number: 10
+      action: permit
+      rule_entries:
+      - rule_type: setLocalPreference
+        value: 200
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "manage_state begin state=merged check_mode=False"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "route map 'RM_EXPORT': entries must contain at least one entry for state 'merged'."
 """
 
 import logging

--- a/plugins/modules/nd_manage_route_map.py
+++ b/plugins/modules/nd_manage_route_map.py
@@ -26,6 +26,10 @@ options:
     - This is a required parameter for all operations.
     type: str
     required: true
+  cluster_name:
+    description:
+    - Target cluster name in a multi-cluster deployment.
+    type: str
   config:
     description:
     - The list of route maps to configure.

--- a/plugins/modules/nd_manage_route_map.py
+++ b/plugins/modules/nd_manage_route_map.py
@@ -4,8 +4,6 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-
 ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
 
 DOCUMENTATION = r"""

--- a/plugins/modules/nd_manage_route_map.py
+++ b/plugins/modules/nd_manage_route_map.py
@@ -45,7 +45,8 @@ options:
       tenant_name:
         description:
         - Optional tenant name for tenant-specific route maps.
-        - Tenant-specific route maps are identified by their full O(config.name), typically in C(tenant~route_map) form.
+        - When set, O(config.name) may be either the bare route map name or the fully qualified C(tenant~route_map) API name.
+        - The module normalizes tenant-scoped route maps to a bare O(config.name) and uses C(tenant~route_map) for API lookups and deletes.
         type: str
         aliases: [ tenantName ]
       entries:

--- a/tests/integration/targets/nd_manage_route_map/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_manage_route_map/tasks/deleted.yaml
@@ -1,0 +1,32 @@
+---
+# Deleted state tests for nd_manage_route_map.
+
+- name: "DELETED: Delete primary route map (check mode)"
+  cisco.nd.nd_manage_route_map: &delete_primary
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ test_route_map_primary_name }}"
+    state: deleted
+  check_mode: true
+  register: cm_deleted_primary
+
+- name: "DELETED: Delete primary route map (normal mode)"
+  cisco.nd.nd_manage_route_map: *delete_primary
+  register: nm_deleted_primary
+
+- name: "DELETED: Verify primary route map removed"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_primary is changed
+      - nm_deleted_primary is changed
+      - nm_deleted_primary.after | selectattr('name', 'equalto', test_route_map_primary_name) | list | length == 0
+
+- name: "DELETED IDEMPOTENT: Delete primary route map again"
+  cisco.nd.nd_manage_route_map: *delete_primary
+  register: nm_deleted_idem_primary
+
+- name: "DELETED IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_idem_primary is not changed

--- a/tests/integration/targets/nd_manage_route_map/tasks/main.yaml
+++ b/tests/integration/targets/nd_manage_route_map/tasks/main.yaml
@@ -1,0 +1,42 @@
+---
+# Test code for the nd_manage_route_map module.
+#
+# --- Usage ---
+#
+#   ansible-test integration nd_manage_route_map
+#
+# The overridden-state test is skipped by default because route-map override is fabric-wide and
+# deletes route maps not present in the supplied config. Enable only on a disposable fabric:
+#
+#   ansible-test integration nd_manage_route_map -e nd_test_route_map_enable_overridden=true
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ nd_output_level | default("debug") }}'
+
+- name: Run nd_manage_route_map state tests
+  block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+      when: nd_test_route_map_enable_overridden | default(false) | bool
+
+    - name: Run deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  module_defaults:
+    cisco.nd.nd_manage_route_map:
+      timeout: 300

--- a/tests/integration/targets/nd_manage_route_map/tasks/merged.yaml
+++ b/tests/integration/targets/nd_manage_route_map/tasks/merged.yaml
@@ -1,0 +1,61 @@
+---
+# Merged state tests for nd_manage_route_map.
+
+- name: "MERGED CREATE: Create primary route map (check mode)"
+  cisco.nd.nd_manage_route_map: &merge_primary
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ route_map_primary }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_primary
+
+- name: "MERGED CREATE: Create primary route map (normal mode)"
+  cisco.nd.nd_manage_route_map: *merge_primary
+  register: nm_merged_create_primary
+
+- name: "MERGED CREATE: Verify primary route map creation"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_primary is changed
+      - nm_merged_create_primary is changed
+      - nm_merged_create_primary.after | selectattr('name', 'equalto', test_route_map_primary_name) | list | length == 1
+
+- name: "MERGED IDEMPOTENT: Re-apply primary route map (check mode)"
+  cisco.nd.nd_manage_route_map: *merge_primary
+  check_mode: true
+  register: cm_merged_idem_primary
+
+- name: "MERGED IDEMPOTENT: Re-apply primary route map (normal mode)"
+  cisco.nd.nd_manage_route_map: *merge_primary
+  register: nm_merged_idem_primary
+
+- name: "MERGED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem_primary is not changed
+      - nm_merged_idem_primary is not changed
+
+- name: "MERGED UPDATE: Update primary route map local preference (check mode)"
+  cisco.nd.nd_manage_route_map: &merge_primary_updated
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ route_map_primary_updated }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_update_primary
+
+- name: "MERGED UPDATE: Update primary route map local preference (normal mode)"
+  cisco.nd.nd_manage_route_map: *merge_primary_updated
+  register: nm_merged_update_primary
+
+- name: "MERGED UPDATE: Verify primary route map updated"
+  vars:
+    primary_after: "{{ nm_merged_update_primary.after | selectattr('name', 'equalto', test_route_map_primary_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_update_primary is changed
+      - nm_merged_update_primary is changed
+      - primary_after.entries[0].rule_entries[0].value == 200

--- a/tests/integration/targets/nd_manage_route_map/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_manage_route_map/tasks/overridden.yaml
@@ -1,0 +1,31 @@
+---
+# Overridden state tests for nd_manage_route_map.
+#
+# WARNING: O(state=overridden) is fabric-wide for route maps. This file is only included when
+# nd_test_route_map_enable_overridden=true.
+
+- name: "OVERRIDDEN PRE: Add secondary and tertiary route maps via merged"
+  cisco.nd.nd_manage_route_map:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ route_map_secondary }}"
+      - "{{ route_map_tertiary }}"
+    state: merged
+
+- name: "OVERRIDDEN: Keep only primary route map"
+  cisco.nd.nd_manage_route_map:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ route_map_primary_replaced }}"
+    state: overridden
+  register: nm_overridden_primary
+
+- name: "OVERRIDDEN: Verify secondary and tertiary route maps were removed"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_primary is changed
+      - nm_overridden_primary.after | selectattr('name', 'equalto', test_route_map_primary_name) | list | length == 1
+      - nm_overridden_primary.after | selectattr('name', 'equalto', test_route_map_secondary_name) | list | length == 0
+      - nm_overridden_primary.after | selectattr('name', 'equalto', test_route_map_tertiary_name) | list | length == 0

--- a/tests/integration/targets/nd_manage_route_map/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_manage_route_map/tasks/replaced.yaml
@@ -1,0 +1,37 @@
+---
+# Replaced state tests for nd_manage_route_map.
+
+- name: "REPLACED: Replace primary route map with matchTag entry (check mode)"
+  cisco.nd.nd_manage_route_map: &replace_primary
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ route_map_primary_replaced }}"
+    state: replaced
+  check_mode: true
+  register: cm_replaced_primary
+
+- name: "REPLACED: Replace primary route map with matchTag entry (normal mode)"
+  cisco.nd.nd_manage_route_map: *replace_primary
+  register: nm_replaced_primary
+
+- name: "REPLACED: Verify primary route map replacement"
+  vars:
+    primary_after: "{{ nm_replaced_primary.after | selectattr('name', 'equalto', test_route_map_primary_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - cm_replaced_primary is changed
+      - nm_replaced_primary is changed
+      - primary_after.entries[0].sequence_number == 20
+      - primary_after.entries[0].action == "deny"
+      - primary_after.entries[0].rule_entries[0].rule_type == "matchTag"
+      - primary_after.entries[0].rule_entries[0].tags == [65000]
+
+- name: "REPLACED IDEMPOTENT: Re-apply replacement"
+  cisco.nd.nd_manage_route_map: *replace_primary
+  register: nm_replaced_idem_primary
+
+- name: "REPLACED IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_idem_primary is not changed

--- a/tests/integration/targets/nd_manage_route_map/tasks/setup.yaml
+++ b/tests/integration/targets/nd_manage_route_map/tasks/setup.yaml
@@ -1,0 +1,14 @@
+---
+# Pre-test cleanup: delete route maps left over from prior failed runs.
+
+- name: "SETUP: Remove test route maps if present"
+  cisco.nd.nd_manage_route_map:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - name: "{{ test_route_map_primary_name }}"
+      - name: "{{ test_route_map_secondary_name }}"
+      - name: "{{ test_route_map_tertiary_name }}"
+    state: deleted
+  failed_when: false
+  tags: always

--- a/tests/integration/targets/nd_manage_route_map/vars/main.yaml
+++ b/tests/integration/targets/nd_manage_route_map/vars/main.yaml
@@ -1,0 +1,64 @@
+---
+# Variables for nd_manage_route_map integration tests.
+#
+# Override the following in tests/integration/inventory.networking [nd:vars] or extra-vars:
+#   nd_test_fabric_name              - fabric in which to create route maps
+#   nd_test_route_map_primary_name   - primary disposable route map name
+#   nd_test_route_map_secondary_name - secondary disposable route map name
+#   nd_test_route_map_tertiary_name  - tertiary disposable route map name
+#   nd_test_route_map_enable_overridden=true to run the destructive overridden-state test
+
+test_fabric_name: "{{ nd_test_fabric_name | default('SITE1') }}"
+test_route_map_primary_name: "{{ nd_test_route_map_primary_name | default('ANSIBLE_RM_PRIMARY') }}"
+test_route_map_secondary_name: "{{ nd_test_route_map_secondary_name | default('ANSIBLE_RM_SECONDARY') }}"
+test_route_map_tertiary_name: "{{ nd_test_route_map_tertiary_name | default('ANSIBLE_RM_TERTIARY') }}"
+
+route_map_primary:
+  name: "{{ test_route_map_primary_name }}"
+  entries:
+    - sequence_number: 10
+      action: permit
+      rule_entries:
+        - rule_type: setLocalPreference
+          value: 100
+
+route_map_primary_updated:
+  name: "{{ test_route_map_primary_name }}"
+  entries:
+    - sequence_number: 10
+      action: permit
+      rule_entries:
+        - rule_type: setLocalPreference
+          value: 200
+
+route_map_primary_replaced:
+  name: "{{ test_route_map_primary_name }}"
+  entries:
+    - sequence_number: 20
+      action: deny
+      rule_entries:
+        - rule_type: matchTag
+          tags:
+            - 65000
+
+route_map_secondary:
+  name: "{{ test_route_map_secondary_name }}"
+  entries:
+    - sequence_number: 10
+      action: permit
+      rule_entries:
+        - rule_type: setCommunity
+          community_numbers:
+            - "65000:100"
+          additive: true
+
+route_map_tertiary:
+  name: "{{ test_route_map_tertiary_name }}"
+  entries:
+    - sequence_number: 10
+      action: permit
+      rule_entries:
+        - rule_type: setIpv4NextHop
+          next_hop_ip_collection:
+            - 192.0.2.10
+          drop_on_fail: true

--- a/tests/unit/module_utils/endpoints/test_manage_route_maps.py
+++ b/tests/unit/module_utils/endpoints/test_manage_route_maps.py
@@ -24,6 +24,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     RouteMapsEndpointParams,
     RouteMapsListEndpointParams,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
 
@@ -105,10 +106,33 @@ def test_manage_route_maps_endpoint_00050() -> None:
     - RouteMapsListEndpointParams.to_query_string()
     - EpManageRouteMapsListGet.path
     """
-    instance = EpManageRouteMapsListGet(endpoint_params=RouteMapsListEndpointParams(cluster_name="cluster1", max=50, offset=10, sort="name:desc"))
+    instance = EpManageRouteMapsListGet(
+        endpoint_params=RouteMapsListEndpointParams(cluster_name="cluster1"),
+        lucene_params=LuceneQueryParams(max=50, offset=10, sort="name:desc"),
+    )
     instance.fabric_name = "SITE1"
 
-    assert instance.path == "/api/v1/manage/fabrics/SITE1/routeMaps?clusterName=cluster1&max=50&offset=10&sort=name:desc"
+    assert instance.path == "/api/v1/manage/fabrics/SITE1/routeMaps?clusterName=cluster1&max=50&offset=10&sort=name%3Adesc"
+
+
+def test_manage_route_maps_endpoint_00060() -> None:
+    """
+    # Summary
+
+    Verify Lucene filters are composed separately from endpoint query params.
+
+    ## Classes and Methods
+
+    - LuceneQueryParams.to_query_string()
+    - EpManageRouteMapsListGet.path
+    """
+    instance = EpManageRouteMapsListGet(
+        endpoint_params=RouteMapsListEndpointParams(cluster_name="cluster1"),
+        lucene_params=LuceneQueryParams(filter="name:RM SALES", max=100),
+    )
+    instance.fabric_name = "SITE1"
+
+    assert instance.path == "/api/v1/manage/fabrics/SITE1/routeMaps?clusterName=cluster1&filter=name:RM%20SALES&max=100"
 
 
 def test_manage_route_maps_endpoint_00100() -> None:

--- a/tests/unit/module_utils/endpoints/test_manage_route_maps.py
+++ b/tests/unit/module_utils/endpoints/test_manage_route_maps.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for endpoints/v1/manage/manage_route_maps.py.
+
+Tests route-map endpoint path construction, required path parameters, query parameters, and
+percent-encoding of dynamic fabric / route-map path segments.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_route_maps import (
+    EpManageRouteMapsBulkDelete,
+    EpManageRouteMapsDelete,
+    EpManageRouteMapsGet,
+    EpManageRouteMapsListGet,
+    EpManageRouteMapsPost,
+    EpManageRouteMapsPut,
+    RouteMapsEndpointParams,
+    RouteMapsListEndpointParams,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+
+
+def test_manage_route_maps_endpoint_00010() -> None:
+    """
+    # Summary
+
+    Verify the collection list endpoint instantiates and exposes GET.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsListGet.__init__()
+    - EpManageRouteMapsListGet.verb
+    """
+    with does_not_raise():
+        instance = EpManageRouteMapsListGet()
+
+    assert instance.verb == HttpVerbEnum.GET
+    assert instance.fabric_name is None
+
+
+def test_manage_route_maps_endpoint_00020() -> None:
+    """
+    # Summary
+
+    Verify collection-level endpoints require fabric_name before path generation.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsListGet.path
+    """
+    instance = EpManageRouteMapsListGet()
+
+    with pytest.raises(ValueError, match="fabric_name must be set"):
+        result = instance.path  # pylint: disable=unused-variable
+
+
+def test_manage_route_maps_endpoint_00030() -> None:
+    """
+    # Summary
+
+    Verify the list endpoint returns the routeMaps collection URL.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsListGet.path
+    """
+    instance = EpManageRouteMapsListGet()
+    instance.fabric_name = "SITE1"
+
+    assert instance.path == "/api/v1/manage/fabrics/SITE1/routeMaps"
+
+
+def test_manage_route_maps_endpoint_00040() -> None:
+    """
+    # Summary
+
+    Verify fabric_name is percent-encoded in collection paths.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsListGet.path
+    """
+    instance = EpManageRouteMapsListGet()
+    instance.fabric_name = "fab/odd"
+
+    assert instance.path == "/api/v1/manage/fabrics/fab%2Fodd/routeMaps"
+
+
+def test_manage_route_maps_endpoint_00050() -> None:
+    """
+    # Summary
+
+    Verify list query params are appended to the collection URL.
+
+    ## Classes and Methods
+
+    - RouteMapsListEndpointParams.to_query_string()
+    - EpManageRouteMapsListGet.path
+    """
+    instance = EpManageRouteMapsListGet(endpoint_params=RouteMapsListEndpointParams(cluster_name="cluster1", max=50, offset=10, sort="name:desc"))
+    instance.fabric_name = "SITE1"
+
+    assert instance.path == "/api/v1/manage/fabrics/SITE1/routeMaps?clusterName=cluster1&max=50&offset=10&sort=name:desc"
+
+
+def test_manage_route_maps_endpoint_00100() -> None:
+    """
+    # Summary
+
+    Verify per-name endpoints require route_map_name before path generation.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsGet.path
+    """
+    instance = EpManageRouteMapsGet()
+    instance.fabric_name = "SITE1"
+
+    with pytest.raises(ValueError, match="route_map_name must be set"):
+        result = instance.path  # pylint: disable=unused-variable
+
+
+def test_manage_route_maps_endpoint_00110() -> None:
+    """
+    # Summary
+
+    Verify the per-name GET path and identifier setter.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsGet.set_identifiers()
+    - EpManageRouteMapsGet.path
+    """
+    instance = EpManageRouteMapsGet()
+    instance.fabric_name = "SITE1"
+    instance.set_identifiers("RM1")
+
+    assert instance.path == "/api/v1/manage/fabrics/SITE1/routeMaps/RM1"
+
+
+def test_manage_route_maps_endpoint_00120() -> None:
+    """
+    # Summary
+
+    Verify fabric_name and route_map_name are percent-encoded in per-name paths.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsGet.path
+    """
+    instance = EpManageRouteMapsGet()
+    instance.fabric_name = "fab/odd"
+    instance.set_identifiers("tenant~rm/one")
+
+    assert instance.path == "/api/v1/manage/fabrics/fab%2Fodd/routeMaps/tenant~rm%2Fone"
+
+
+def test_manage_route_maps_endpoint_00200() -> None:
+    """
+    # Summary
+
+    Verify POST uses the collection path and POST verb.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsPost.path
+    - EpManageRouteMapsPost.verb
+    """
+    instance = EpManageRouteMapsPost()
+    instance.fabric_name = "SITE1"
+
+    assert instance.verb == HttpVerbEnum.POST
+    assert instance.path == "/api/v1/manage/fabrics/SITE1/routeMaps"
+
+
+def test_manage_route_maps_endpoint_00210() -> None:
+    """
+    # Summary
+
+    Verify PUT and DELETE paths use the encoded per-name route map URL.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsPut.path
+    - EpManageRouteMapsDelete.path
+    """
+    for endpoint_class, expected_verb in ((EpManageRouteMapsPut, HttpVerbEnum.PUT), (EpManageRouteMapsDelete, HttpVerbEnum.DELETE)):
+        instance = endpoint_class()
+        instance.fabric_name = "fab/odd"
+        instance.set_identifiers("rm/one")
+
+        assert instance.verb == expected_verb
+        assert instance.path == "/api/v1/manage/fabrics/fab%2Fodd/routeMaps/rm%2Fone"
+
+
+def test_manage_route_maps_endpoint_00300() -> None:
+    """
+    # Summary
+
+    Verify the bulk-delete action endpoint path, verb, encoding, and query params.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsBulkDelete.path
+    - RouteMapsEndpointParams.to_query_string()
+    """
+    instance = EpManageRouteMapsBulkDelete(endpoint_params=RouteMapsEndpointParams(cluster_name="cluster1"))
+    instance.fabric_name = "fab/odd"
+
+    assert instance.verb == HttpVerbEnum.POST
+    assert instance.path == "/api/v1/manage/fabrics/fab%2Fodd/routeMapActions/remove?clusterName=cluster1"
+
+
+def test_manage_route_maps_endpoint_00310() -> None:
+    """
+    # Summary
+
+    Verify the bulk-delete action endpoint requires fabric_name.
+
+    ## Classes and Methods
+
+    - EpManageRouteMapsBulkDelete.path
+    """
+    instance = EpManageRouteMapsBulkDelete()
+
+    with pytest.raises(ValueError, match="fabric_name must be set"):
+        result = instance.path  # pylint: disable=unused-variable

--- a/tests/unit/module_utils/endpoints/test_manage_route_maps.py
+++ b/tests/unit/module_utils/endpoints/test_manage_route_maps.py
@@ -11,9 +11,7 @@ Tests route-map endpoint path construction, required path parameters, query para
 percent-encoding of dynamic fabric / route-map path segments.
 """
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type  # pylint: disable=invalid-name
+from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_route_maps import (

--- a/tests/unit/module_utils/endpoints/test_manage_route_maps.py
+++ b/tests/unit/module_utils/endpoints/test_manage_route_maps.py
@@ -135,6 +135,29 @@ def test_manage_route_maps_endpoint_00060() -> None:
     assert instance.path == "/api/v1/manage/fabrics/SITE1/routeMaps?clusterName=cluster1&filter=name:RM%20SALES&max=100"
 
 
+@pytest.mark.parametrize(
+    "lucene_config, error",
+    [
+        ({"max": 10001}, "10000"),
+        ({"sort": "name:sideways"}, "Sort direction"),
+    ],
+    ids=["max-upper-bound", "sort-direction"],
+)
+def test_manage_route_maps_endpoint_00070(lucene_config: dict, error: str) -> None:
+    """
+    # Summary
+
+    Verify list endpoints use shared Lucene query parameter validation.
+
+    ## Classes and Methods
+
+    - LuceneQueryParams.model_validate()
+    - EpManageRouteMapsListGet.__init__()
+    """
+    with pytest.raises(ValueError, match=error):
+        EpManageRouteMapsListGet(lucene_params=LuceneQueryParams(**lucene_config))
+
+
 def test_manage_route_maps_endpoint_00100() -> None:
     """
     # Summary

--- a/tests/unit/module_utils/models/test_manage_route_map.py
+++ b/tests/unit/module_utils/models/test_manage_route_map.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type  # pylint: disable=invalid-name
 
+import pytest
+
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.manage_route_map import (
     RULE_TYPE_CHOICES,
     RouteMapEntryModel,
@@ -101,6 +103,178 @@ def test_manage_route_map_model_00020() -> None:
 
     assert instance.action == "permit"
     assert instance.sequence_number == 20
+
+
+@pytest.mark.parametrize(
+    "rule_config",
+    [
+        {"rule_type": "matchIpv4Acl", "access_control_list_name": "ACL_IPV4"},
+        {"rule_type": "matchIpv6Acl", "access_control_list_name": "ACL_IPV6"},
+        {"rule_type": "matchIpv4PrefixList", "prefix_list_names": ["PL_IPV4"]},
+        {"rule_type": "matchIpv6PrefixList", "prefix_list_names": ["PL_IPV6"]},
+        {"rule_type": "matchCommunity", "community_list_names": ["COMMUNITY_LIST"], "exact_match": True},
+        {"rule_type": "matchExtendedCommunity", "extended_community_list_names": ["EXT_COMMUNITY_LIST"], "exact_match": False},
+        {"rule_type": "matchTag", "tags": [0, 4294967295]},
+        {"rule_type": "setCommunity", "community_numbers": ["65000:100"], "additive": True},
+        {"rule_type": "setExtendedCommunityList", "extended_community_list_name": "EXT_COMMUNITY_LIST"},
+        {"rule_type": "setLocalPreference", "value": 0},
+    ],
+    ids=[
+        "match-ipv4-acl",
+        "match-ipv6-acl",
+        "match-ipv4-prefix-list",
+        "match-ipv6-prefix-list",
+        "match-community",
+        "match-extended-community",
+        "match-tag",
+        "set-community",
+        "set-extended-community-list",
+        "set-local-preference",
+    ],
+)
+def test_manage_route_map_model_00030(rule_config: dict) -> None:
+    """
+    # Summary
+
+    Verify rule-type companion fields accept the valid minimal permutations.
+
+    ## Classes and Methods
+
+    - RouteMapRuleEntryModel.model_validate()
+    """
+    with does_not_raise():
+        instance = RouteMapRuleEntryModel.model_validate(rule_config, by_name=True)
+
+    assert instance.rule_type == rule_config["rule_type"]
+
+
+@pytest.mark.parametrize(
+    "rule_config, error",
+    [
+        ({"rule_type": "matchIpv4Acl"}, "access_control_list_name"),
+        ({"rule_type": "matchIpv6Acl"}, "access_control_list_name"),
+        ({"rule_type": "matchIpv4PrefixList"}, "prefix_list_names"),
+        ({"rule_type": "matchIpv6PrefixList"}, "prefix_list_names"),
+        ({"rule_type": "matchCommunity"}, "community_list_names"),
+        ({"rule_type": "matchExtendedCommunity"}, "extended_community_list_names"),
+        ({"rule_type": "matchTag"}, "tags"),
+        ({"rule_type": "setCommunity"}, "community_numbers"),
+        ({"rule_type": "setExtendedCommunityList"}, "extended_community_list_name"),
+        ({"rule_type": "setLocalPreference"}, "value"),
+        ({"rule_type": "notSupported"}, "rule_type"),
+    ],
+    ids=[
+        "match-ipv4-acl",
+        "match-ipv6-acl",
+        "match-ipv4-prefix-list",
+        "match-ipv6-prefix-list",
+        "match-community",
+        "match-extended-community",
+        "match-tag",
+        "set-community",
+        "set-extended-community-list",
+        "set-local-preference",
+        "unsupported-rule-type",
+    ],
+)
+def test_manage_route_map_model_00040(rule_config: dict, error: str) -> None:
+    """
+    # Summary
+
+    Verify missing required companion fields and unsupported rule types fail validation.
+
+    ## Classes and Methods
+
+    - RouteMapRuleEntryModel.model_validate()
+    """
+    with pytest.raises(ValueError, match=error):
+        RouteMapRuleEntryModel.model_validate(rule_config, by_name=True)
+
+
+def test_manage_route_map_model_00050() -> None:
+    """
+    # Summary
+
+    Verify populated fields from another rule type fail validation.
+
+    ## Classes and Methods
+
+    - RouteMapRuleEntryModel.model_validate()
+    """
+    with pytest.raises(ValueError, match="does not allow"):
+        RouteMapRuleEntryModel.model_validate({"rule_type": "matchTag", "tags": [100], "value": 200}, by_name=True)
+
+
+@pytest.mark.parametrize(
+    "rule_config",
+    [
+        {"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["192.0.2.10"], "drop_on_fail": False, "verify_availability": True, "track_id": 10},
+        {"rule_type": "setIpv4NextHop", "use_peer_address": True},
+        {"rule_type": "setIpv4NextHop", "use_peer_address": True, "verify_availability": True},
+        {"rule_type": "setIpv4NextHop", "unchanged": True},
+        {"rule_type": "setIpv4NextHop", "redistribute_unchanged": True},
+        {"rule_type": "setIpv6NextHop", "next_hop_ip_collection": ["2001:db8::10"]},
+    ],
+    ids=[
+        "ipv4-addresses",
+        "use-peer-address",
+        "use-peer-address-with-verify",
+        "unchanged",
+        "redistribute-unchanged",
+        "ipv6-addresses",
+    ],
+)
+def test_manage_route_map_model_00060(rule_config: dict) -> None:
+    """
+    # Summary
+
+    Verify next-hop rules accept one explicit next-hop mode.
+
+    ## Classes and Methods
+
+    - RouteMapRuleEntryModel.model_validate()
+    """
+    with does_not_raise():
+        instance = RouteMapRuleEntryModel.model_validate(rule_config, by_name=True)
+
+    assert instance.rule_type == rule_config["rule_type"]
+
+
+@pytest.mark.parametrize(
+    "rule_config, error",
+    [
+        ({"rule_type": "setIpv4NextHop"}, "exactly one next-hop mode"),
+        ({"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["192.0.2.10"], "use_peer_address": True}, "exactly one next-hop mode"),
+        ({"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["2001:db8::10"]}, "expects IPv4"),
+        ({"rule_type": "setIpv6NextHop", "next_hop_ip_collection": ["192.0.2.10"]}, "expects IPv6"),
+        ({"rule_type": "setIpv4NextHop", "use_peer_address": True, "track_id": 10}, "track_id requires next_hop_ip_collection"),
+        ({"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["192.0.2.10"], "track_id": 0}, "track_id"),
+        ({"rule_type": "matchTag", "tags": [-1]}, "tags"),
+        ({"rule_type": "setLocalPreference", "value": 4294967296}, "value"),
+    ],
+    ids=[
+        "missing-mode",
+        "multiple-modes",
+        "ipv4-rule-ipv6-address",
+        "ipv6-rule-ipv4-address",
+        "track-id-with-peer-mode",
+        "track-id-out-of-range",
+        "tag-out-of-range",
+        "local-preference-out-of-range",
+    ],
+)
+def test_manage_route_map_model_00070(rule_config: dict, error: str) -> None:
+    """
+    # Summary
+
+    Verify invalid next-hop and numeric boundary permutations fail validation.
+
+    ## Classes and Methods
+
+    - RouteMapRuleEntryModel.model_validate()
+    """
+    with pytest.raises(ValueError, match=error):
+        RouteMapRuleEntryModel.model_validate(rule_config, by_name=True)
 
 
 def test_manage_route_map_model_00100() -> None:

--- a/tests/unit/module_utils/models/test_manage_route_map.py
+++ b/tests/unit/module_utils/models/test_manage_route_map.py
@@ -26,7 +26,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.m
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
 
 SAMPLE_ANSIBLE_CONFIG = {
-    "name": "tenantSales~RM_EXPORT",
+    "name": "RM_EXPORT",
     "tenant_name": "tenantSales",
     "entries": [
         {
@@ -292,9 +292,11 @@ def test_manage_route_map_model_00100() -> None:
         instance = RouteMapModel.from_config(SAMPLE_ANSIBLE_CONFIG)
 
     assert instance.get_identifier_value() == "tenantSales~RM_EXPORT"
+    assert instance.api_name == "tenantSales~RM_EXPORT"
+    assert instance.name == "RM_EXPORT"
     assert instance.tenant_name == "tenantSales"
     assert instance.to_payload() == {
-        "name": "tenantSales~RM_EXPORT",
+        "name": "RM_EXPORT",
         "tenantName": "tenantSales",
         "entries": [
             {
@@ -329,12 +331,35 @@ def test_manage_route_map_model_00110() -> None:
     with does_not_raise():
         instance = RouteMapModel.from_response(SAMPLE_WIRE_RESPONSE)
 
-    assert instance.name == "tenantSales~RM_EXPORT"
+    assert instance.name == "RM_EXPORT"
+    assert instance.get_identifier_value() == "tenantSales~RM_EXPORT"
     assert instance.tenant_name == "tenantSales"
     assert instance.last_update_timestamp == "2026-01-01T00:00:00Z"
     payload = instance.to_payload()
     assert "lastUpdateTimestamp" not in payload
+    assert payload["name"] == "RM_EXPORT"
     assert payload["tenantName"] == "tenantSales"
+
+
+def test_manage_route_map_model_00115() -> None:
+    """
+    # Summary
+
+    Verify tenant-scoped route maps normalize full API names to bare config names.
+
+    ## Classes and Methods
+
+    - RouteMapModel.from_config()
+    - RouteMapModel.get_identifier_value()
+    - RouteMapModel.to_payload()
+    """
+    with does_not_raise():
+        instance = RouteMapModel.from_config({"name": "tenantSales~RM_EXPORT", "tenant_name": "tenantSales"})
+
+    assert instance.name == "RM_EXPORT"
+    assert instance.api_name == "tenantSales~RM_EXPORT"
+    assert instance.get_identifier_value() == "tenantSales~RM_EXPORT"
+    assert instance.to_payload() == {"name": "RM_EXPORT", "tenantName": "tenantSales"}
 
 
 def test_manage_route_map_model_00120() -> None:

--- a/tests/unit/module_utils/models/test_manage_route_map.py
+++ b/tests/unit/module_utils/models/test_manage_route_map.py
@@ -11,9 +11,7 @@ Tests route-map model identifiers, alias conversion, payload serialization, read
 exclusion, tenantName round-trip, delete-by-name construction, and argspec shape.
 """
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type  # pylint: disable=invalid-name
+from __future__ import annotations
 
 import pytest
 

--- a/tests/unit/module_utils/models/test_manage_route_map.py
+++ b/tests/unit/module_utils/models/test_manage_route_map.py
@@ -206,27 +206,53 @@ def test_manage_route_map_model_00050() -> None:
 @pytest.mark.parametrize(
     "rule_config",
     [
-        {"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["192.0.2.10"], "drop_on_fail": False, "verify_availability": True, "track_id": 10},
+        {
+            "rule_type": "setIpv4NextHop",
+            "next_hop_ip_collection": ["192.0.2.10"],
+            "drop_on_fail": False,
+            "verify_availability": True,
+            "track_id": 10,
+        },
         {"rule_type": "setIpv4NextHop", "use_peer_address": True},
-        {"rule_type": "setIpv4NextHop", "use_peer_address": True, "verify_availability": True},
+        {"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["192.0.2.10"], "use_peer_address": True},
+        {
+            "rule_type": "setIpv4NextHop",
+            "next_hop_ip_collection": ["192.0.2.10"],
+            "use_peer_address": True,
+            "verify_availability": True,
+            "track_id": 10,
+        },
+        {"rule_type": "setIpv4NextHop", "drop_on_fail": True, "load_share": True, "enforce_order": True},
+        {"rule_type": "setIpv4NextHop", "redistribute_unchanged": True, "unchanged": True},
         {"rule_type": "setIpv4NextHop", "unchanged": True},
         {"rule_type": "setIpv4NextHop", "redistribute_unchanged": True},
         {"rule_type": "setIpv6NextHop", "next_hop_ip_collection": ["2001:db8::10"]},
+        {
+            "rule_type": "setIpv6NextHop",
+            "next_hop_ip_collection": ["2001:db8::10"],
+            "use_peer_address": True,
+            "verify_availability": True,
+            "track_id": 10,
+        },
     ],
     ids=[
         "ipv4-addresses",
         "use-peer-address",
-        "use-peer-address-with-verify",
+        "ipv4-addresses-with-use-peer",
+        "ipv4-addresses-with-use-peer-verify-track",
+        "drop-load-enforce",
+        "redistribute-and-unchanged",
         "unchanged",
         "redistribute-unchanged",
         "ipv6-addresses",
+        "ipv6-addresses-with-use-peer-verify-track",
     ],
 )
 def test_manage_route_map_model_00060(rule_config: dict) -> None:
     """
     # Summary
 
-    Verify next-hop rules accept one explicit next-hop mode.
+    Verify next-hop rules accept UI-compatible option combinations.
 
     ## Classes and Methods
 
@@ -241,21 +267,49 @@ def test_manage_route_map_model_00060(rule_config: dict) -> None:
 @pytest.mark.parametrize(
     "rule_config, error",
     [
-        ({"rule_type": "setIpv4NextHop"}, "exactly one next-hop mode"),
-        ({"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["192.0.2.10"], "use_peer_address": True}, "exactly one next-hop mode"),
+        ({"rule_type": "setIpv4NextHop"}, "at least one next-hop IP option"),
+        ({"rule_type": "setIpv4NextHop", "verify_availability": True}, "verify_availability requires next_hop_ip_collection"),
+        (
+            {"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["192.0.2.10"], "track_id": 10},
+            "track_id requires next_hop_ip_collection and verify_availability",
+        ),
         ({"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["2001:db8::10"]}, "expects IPv4"),
         ({"rule_type": "setIpv6NextHop", "next_hop_ip_collection": ["192.0.2.10"]}, "expects IPv6"),
-        ({"rule_type": "setIpv4NextHop", "use_peer_address": True, "track_id": 10}, "track_id requires next_hop_ip_collection"),
+        (
+            {"rule_type": "setIpv4NextHop", "use_peer_address": True, "track_id": 10},
+            "track_id requires next_hop_ip_collection and verify_availability",
+        ),
+        (
+            {"rule_type": "setIpv4NextHop", "use_peer_address": True, "redistribute_unchanged": True},
+            "use_peer_address cannot be mixed",
+        ),
+        (
+            {"rule_type": "setIpv4NextHop", "use_peer_address": True, "drop_on_fail": True},
+            "Cannot mix use_peer_address, redistribute_unchanged, or unchanged",
+        ),
+        (
+            {"rule_type": "setIpv4NextHop", "redistribute_unchanged": True, "load_share": True},
+            "Cannot mix use_peer_address, redistribute_unchanged, or unchanged",
+        ),
+        (
+            {"rule_type": "setIpv6NextHop", "unchanged": True, "enforce_order": True},
+            "Cannot mix use_peer_address, redistribute_unchanged, or unchanged",
+        ),
         ({"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["192.0.2.10"], "track_id": 0}, "track_id"),
         ({"rule_type": "matchTag", "tags": [-1]}, "tags"),
         ({"rule_type": "setLocalPreference", "value": 4294967296}, "value"),
     ],
     ids=[
-        "missing-mode",
-        "multiple-modes",
+        "missing-option",
+        "verify-without-addresses",
+        "track-without-verify",
         "ipv4-rule-ipv6-address",
         "ipv6-rule-ipv4-address",
         "track-id-with-peer-mode",
+        "use-peer-with-redistribute",
+        "use-peer-with-drop",
+        "redistribute-with-load-share",
+        "ipv6-unchanged-with-enforce-order",
         "track-id-out-of-range",
         "tag-out-of-range",
         "local-preference-out-of-range",

--- a/tests/unit/module_utils/models/test_manage_route_map.py
+++ b/tests/unit/module_utils/models/test_manage_route_map.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for manage_route_map.py models.
+
+Tests route-map model identifiers, alias conversion, payload serialization, read-only field
+exclusion, tenantName round-trip, delete-by-name construction, and argspec shape.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.manage_route_map import (
+    RULE_TYPE_CHOICES,
+    RouteMapEntryModel,
+    RouteMapModel,
+    RouteMapRuleEntryModel,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "name": "tenantSales~RM_EXPORT",
+    "tenant_name": "tenantSales",
+    "entries": [
+        {
+            "sequence_number": 10,
+            "action": "permit",
+            "rule_entries": [
+                {
+                    "rule_type": "matchIpv4PrefixList",
+                    "prefix_list_names": ["tenantSales~PL_EXPORT"],
+                },
+                {
+                    "rule_type": "setLocalPreference",
+                    "value": 200,
+                },
+            ],
+        }
+    ],
+}
+
+SAMPLE_WIRE_RESPONSE = {
+    "name": "tenantSales~RM_EXPORT",
+    "tenantName": "tenantSales",
+    "lastUpdateTimestamp": "2026-01-01T00:00:00Z",
+    "entries": [
+        {
+            "sequenceNumber": 10,
+            "action": "permit",
+            "ruleEntries": [
+                {
+                    "ruleType": "matchIpv4PrefixList",
+                    "prefixListNames": ["tenantSales~PL_EXPORT"],
+                }
+            ],
+        }
+    ],
+}
+
+
+def test_manage_route_map_model_00010() -> None:
+    """
+    # Summary
+
+    Verify RouteMapRuleEntryModel parses wire aliases.
+
+    ## Classes and Methods
+
+    - RouteMapRuleEntryModel.model_validate()
+    """
+    with does_not_raise():
+        instance = RouteMapRuleEntryModel.model_validate({"ruleType": "setLocalPreference", "value": 150}, by_alias=True)
+
+    assert instance.rule_type == "setLocalPreference"
+    assert instance.value == 150
+
+
+def test_manage_route_map_model_00020() -> None:
+    """
+    # Summary
+
+    Verify RouteMapEntryModel defaults action to permit.
+
+    ## Classes and Methods
+
+    - RouteMapEntryModel.model_validate()
+    """
+    with does_not_raise():
+        instance = RouteMapEntryModel.model_validate(
+            {
+                "sequence_number": 20,
+                "rule_entries": [{"rule_type": "matchTag", "tags": [100]}],
+            },
+            by_name=True,
+        )
+
+    assert instance.action == "permit"
+    assert instance.sequence_number == 20
+
+
+def test_manage_route_map_model_00100() -> None:
+    """
+    # Summary
+
+    Verify RouteMapModel converts Ansible config to the expected API payload.
+
+    ## Classes and Methods
+
+    - RouteMapModel.from_config()
+    - RouteMapModel.to_payload()
+    """
+    with does_not_raise():
+        instance = RouteMapModel.from_config(SAMPLE_ANSIBLE_CONFIG)
+
+    assert instance.get_identifier_value() == "tenantSales~RM_EXPORT"
+    assert instance.tenant_name == "tenantSales"
+    assert instance.to_payload() == {
+        "name": "tenantSales~RM_EXPORT",
+        "tenantName": "tenantSales",
+        "entries": [
+            {
+                "sequenceNumber": 10,
+                "action": "permit",
+                "ruleEntries": [
+                    {
+                        "ruleType": "matchIpv4PrefixList",
+                        "prefixListNames": ["tenantSales~PL_EXPORT"],
+                    },
+                    {
+                        "ruleType": "setLocalPreference",
+                        "value": 200,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def test_manage_route_map_model_00110() -> None:
+    """
+    # Summary
+
+    Verify RouteMapModel parses wire aliases and excludes read-only timestamp from payload.
+
+    ## Classes and Methods
+
+    - RouteMapModel.from_response()
+    - RouteMapModel.to_payload()
+    """
+    with does_not_raise():
+        instance = RouteMapModel.from_response(SAMPLE_WIRE_RESPONSE)
+
+    assert instance.name == "tenantSales~RM_EXPORT"
+    assert instance.tenant_name == "tenantSales"
+    assert instance.last_update_timestamp == "2026-01-01T00:00:00Z"
+    payload = instance.to_payload()
+    assert "lastUpdateTimestamp" not in payload
+    assert payload["tenantName"] == "tenantSales"
+
+
+def test_manage_route_map_model_00120() -> None:
+    """
+    # Summary
+
+    Verify delete-state route map config can be represented by name only.
+
+    ## Classes and Methods
+
+    - RouteMapModel.from_config()
+    - RouteMapModel.get_identifier_value()
+    """
+    with does_not_raise():
+        instance = RouteMapModel.from_config({"name": "RM_DELETE_ME"})
+
+    assert instance.get_identifier_value() == "RM_DELETE_ME"
+    assert instance.entries is None
+
+
+def test_manage_route_map_model_00200() -> None:
+    """
+    # Summary
+
+    Verify the argspec exposes route-map rule choices and does not require entries at argspec level.
+
+    ## Classes and Methods
+
+    - RouteMapModel.get_argument_spec()
+    """
+    spec = RouteMapModel.get_argument_spec()
+    config_options = spec["config"]["options"]
+    rule_options = config_options["entries"]["options"]["rule_entries"]["options"]
+
+    assert config_options["name"]["required"] is True
+    assert config_options["entries"].get("required") is not True
+    assert config_options["tenant_name"]["aliases"] == ["tenantName"]
+    assert set(rule_options["rule_type"]["choices"]) == set(RULE_TYPE_CHOICES)

--- a/tests/unit/module_utils/models/test_manage_route_map.py
+++ b/tests/unit/module_utils/models/test_manage_route_map.py
@@ -485,6 +485,45 @@ def test_manage_route_map_model_00120() -> None:
     assert instance.entries is None
 
 
+def test_manage_route_map_model_00130() -> None:
+    """
+    # Summary
+
+    Verify default-tenant route map names are limited to 63 characters.
+
+    ## Classes and Methods
+
+    - RouteMapModel.from_config()
+    """
+    with does_not_raise():
+        RouteMapModel.from_config({"name": "R" * 63})
+
+    with pytest.raises(ValueError, match="default-tenant route map name"):
+        RouteMapModel.from_config({"name": "R" * 64})
+
+
+def test_manage_route_map_model_00140() -> None:
+    """
+    # Summary
+
+    Verify tenant-scoped route map API names are limited to 115 characters.
+
+    ## Classes and Methods
+
+    - RouteMapModel.from_config()
+    - RouteMapModel.get_identifier_value()
+    """
+    tenant_name = "T" * 63
+
+    with does_not_raise():
+        instance = RouteMapModel.from_config({"name": "R" * 51, "tenant_name": tenant_name})
+
+    assert instance.get_identifier_value() == f"{tenant_name}~{'R' * 51}"
+
+    with pytest.raises(ValueError, match="tenant-scoped route map API name"):
+        RouteMapModel.from_config({"name": "R" * 52, "tenant_name": tenant_name})
+
+
 def test_manage_route_map_model_00200() -> None:
     """
     # Summary

--- a/tests/unit/module_utils/models/test_manage_route_map.py
+++ b/tests/unit/module_utils/models/test_manage_route_map.py
@@ -293,8 +293,9 @@ def test_manage_route_map_model_00100() -> None:
     assert instance.api_name == "tenantSales~RM_EXPORT"
     assert instance.name == "RM_EXPORT"
     assert instance.tenant_name == "tenantSales"
+    assert instance.to_config()["name"] == "RM_EXPORT"
     assert instance.to_payload() == {
-        "name": "RM_EXPORT",
+        "name": "tenantSales~RM_EXPORT",
         "tenantName": "tenantSales",
         "entries": [
             {
@@ -335,8 +336,9 @@ def test_manage_route_map_model_00110() -> None:
     assert instance.last_update_timestamp == "2026-01-01T00:00:00Z"
     payload = instance.to_payload()
     assert "lastUpdateTimestamp" not in payload
-    assert payload["name"] == "RM_EXPORT"
+    assert payload["name"] == "tenantSales~RM_EXPORT"
     assert payload["tenantName"] == "tenantSales"
+    assert instance.to_config()["name"] == "RM_EXPORT"
 
 
 def test_manage_route_map_model_00115() -> None:
@@ -357,7 +359,8 @@ def test_manage_route_map_model_00115() -> None:
     assert instance.name == "RM_EXPORT"
     assert instance.api_name == "tenantSales~RM_EXPORT"
     assert instance.get_identifier_value() == "tenantSales~RM_EXPORT"
-    assert instance.to_payload() == {"name": "RM_EXPORT", "tenantName": "tenantSales"}
+    assert instance.to_payload() == {"name": "tenantSales~RM_EXPORT", "tenantName": "tenantSales"}
+    assert instance.to_config() == {"name": "RM_EXPORT", "tenant_name": "tenantSales"}
 
 
 def test_manage_route_map_model_00116() -> None:

--- a/tests/unit/module_utils/models/test_manage_route_map.py
+++ b/tests/unit/module_utils/models/test_manage_route_map.py
@@ -362,6 +362,110 @@ def test_manage_route_map_model_00115() -> None:
     assert instance.to_payload() == {"name": "RM_EXPORT", "tenantName": "tenantSales"}
 
 
+def test_manage_route_map_model_00116() -> None:
+    """
+    # Summary
+
+    Verify ND-returned false next-hop defaults do not trigger a route-map diff.
+
+    ## Classes and Methods
+
+    - RouteMapModel.from_response()
+    - RouteMapModel.from_config()
+    - RouteMapModel.get_diff()
+    """
+    existing = RouteMapModel.from_response(
+        {
+            "name": "RM_NH",
+            "entries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "ruleEntries": [
+                        {
+                            "ruleType": "setIpv4NextHop",
+                            "nextHopIpCollection": ["192.0.2.10"],
+                            "dropOnFail": False,
+                            "enforceOrder": False,
+                            "loadShare": False,
+                            "redistributeUnchanged": False,
+                            "unchanged": False,
+                            "usePeerAddress": False,
+                            "verifyAvailability": False,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    proposed = RouteMapModel.from_config(
+        {
+            "name": "RM_NH",
+            "entries": [
+                {
+                    "sequence_number": 10,
+                    "action": "permit",
+                    "rule_entries": [{"rule_type": "setIpv4NextHop", "next_hop_ip_collection": ["192.0.2.10"]}],
+                }
+            ],
+        }
+    )
+
+    assert existing.get_diff(proposed, exclude_unset=True) is True
+
+
+def test_manage_route_map_model_00117() -> None:
+    """
+    # Summary
+
+    Verify true next-hop flags still trigger a diff when the proposed rule disables them.
+
+    ## Classes and Methods
+
+    - RouteMapModel.from_response()
+    - RouteMapModel.from_config()
+    - RouteMapModel.get_diff()
+    """
+    existing = RouteMapModel.from_response(
+        {
+            "name": "RM_NH",
+            "entries": [
+                {
+                    "sequenceNumber": 10,
+                    "action": "permit",
+                    "ruleEntries": [
+                        {
+                            "ruleType": "setIpv4NextHop",
+                            "nextHopIpCollection": ["192.0.2.10"],
+                            "verifyAvailability": True,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    proposed = RouteMapModel.from_config(
+        {
+            "name": "RM_NH",
+            "entries": [
+                {
+                    "sequence_number": 10,
+                    "action": "permit",
+                    "rule_entries": [
+                        {
+                            "rule_type": "setIpv4NextHop",
+                            "next_hop_ip_collection": ["192.0.2.10"],
+                            "verify_availability": False,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert existing.get_diff(proposed, exclude_unset=True) is False
+
+
 def test_manage_route_map_model_00120() -> None:
     """
     # Summary

--- a/tests/unit/module_utils/models/test_manage_route_map.py
+++ b/tests/unit/module_utils/models/test_manage_route_map.py
@@ -499,6 +499,7 @@ def test_manage_route_map_model_00200() -> None:
     config_options = spec["config"]["options"]
     rule_options = config_options["entries"]["options"]["rule_entries"]["options"]
 
+    assert spec["cluster_name"]["type"] == "str"
     assert config_options["name"]["required"] is True
     assert config_options["entries"].get("required") is not True
     assert config_options["tenant_name"]["aliases"] == ["tenantName"]

--- a/tests/unit/module_utils/orchestrators/test_manage_route_map.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_route_map.py
@@ -284,7 +284,7 @@ def test_manage_route_map_orchestrator_00310() -> None:
     """
     # Summary
 
-    Verify tenant-scoped updates use the fully qualified API path with a bare-name payload.
+    Verify tenant-scoped updates use the fully qualified API path and payload name.
 
     ## Classes and Methods
 
@@ -304,7 +304,7 @@ def test_manage_route_map_orchestrator_00310() -> None:
     assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps/tenantSales~RM_UPDATE"
     assert rest_send.verb == HttpVerbEnum.PUT
     assert rest_send.committed_payload == model.to_payload()
-    assert rest_send.committed_payload["name"] == "RM_UPDATE"
+    assert rest_send.committed_payload["name"] == "tenantSales~RM_UPDATE"
     assert rest_send.committed_payload["tenantName"] == "tenantSales"
 
 

--- a/tests/unit/module_utils/orchestrators/test_manage_route_map.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_route_map.py
@@ -49,25 +49,26 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "SITE1
     return rest_send
 
 
-def _route_map_model(name: str = "RM1", value: int = 100) -> RouteMapModel:
+def _route_map_model(name: str = "RM1", value: int = 100, tenant_name: str | None = None) -> RouteMapModel:
     """Build a minimal route map model."""
-    return RouteMapModel.from_config(
-        {
-            "name": name,
-            "entries": [
-                {
-                    "sequence_number": 10,
-                    "action": "permit",
-                    "rule_entries": [
-                        {
-                            "rule_type": "setLocalPreference",
-                            "value": value,
-                        }
-                    ],
-                }
-            ],
-        }
-    )
+    config = {
+        "name": name,
+        "entries": [
+            {
+                "sequence_number": 10,
+                "action": "permit",
+                "rule_entries": [
+                    {
+                        "rule_type": "setLocalPreference",
+                        "value": value,
+                    }
+                ],
+            }
+        ],
+    }
+    if tenant_name is not None:
+        config["tenant_name"] = tenant_name
+    return RouteMapModel.from_config(config)
 
 
 class _FakeFabricContext:
@@ -281,6 +282,34 @@ def test_manage_route_map_orchestrator_00300() -> None:
     assert rest_send.committed_payload == model.to_payload()
 
 
+def test_manage_route_map_orchestrator_00310() -> None:
+    """
+    # Summary
+
+    Verify tenant-scoped updates use the fully qualified API path with a bare-name payload.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.update()
+    """
+    model = _route_map_model("RM_UPDATE", value=250, tenant_name="tenantSales")
+
+    def responses():
+        yield _response(return_code=204, message="No Content")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps/tenantSales~RM_UPDATE"
+    assert rest_send.verb == HttpVerbEnum.PUT
+    assert rest_send.committed_payload == model.to_payload()
+    assert rest_send.committed_payload["name"] == "RM_UPDATE"
+    assert rest_send.committed_payload["tenantName"] == "tenantSales"
+
+
 def test_manage_route_map_orchestrator_00400() -> None:
     """
     # Summary
@@ -305,6 +334,32 @@ def test_manage_route_map_orchestrator_00400() -> None:
     assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMapActions/remove"
     assert rest_send.verb == HttpVerbEnum.POST
     assert rest_send.committed_payload == {"routeMapNames": ["RM_DELETE"]}
+
+
+def test_manage_route_map_orchestrator_00405() -> None:
+    """
+    # Summary
+
+    Verify tenant-scoped delete payloads use fully qualified API names.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.delete_bulk()
+    """
+    model = RouteMapModel.from_config({"name": "RM_DELETE", "tenant_name": "tenantSales"})
+
+    def responses():
+        yield _response({"results": [{"name": "tenantSales~RM_DELETE", "status": "success", "message": "removed"}]}, return_code=207, message="Multi-Status")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.delete_bulk([model])
+
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMapActions/remove"
+    assert rest_send.verb == HttpVerbEnum.POST
+    assert rest_send.committed_payload == {"routeMapNames": ["tenantSales~RM_DELETE"]}
 
 
 def test_manage_route_map_orchestrator_00410() -> None:

--- a/tests/unit/module_utils/orchestrators/test_manage_route_map.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_route_map.py
@@ -33,13 +33,16 @@ def _response(data: dict | None = None, return_code: int = 200, message: str = "
     }
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "SITE1") -> RestSend:
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "SITE1", cluster_name: str | None = None) -> RestSend:
     """Build a RestSend wired to file-style sender responses."""
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name, "state": "merged"})
+    params = {"check_mode": False, "fabric_name": fabric_name, "state": "merged"}
+    if cluster_name is not None:
+        params["cluster_name"] = cluster_name
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = ResponseHandler()
     rest_send.unit_test = True
@@ -102,6 +105,7 @@ def test_manage_route_map_orchestrator_00010() -> None:
     assert instance.supports_bulk_create is True
     assert instance.supports_bulk_delete is True
     assert instance.fabric_name == "SITE1"
+    assert instance.cluster_name is None
 
 
 def test_manage_route_map_orchestrator_00020() -> None:
@@ -177,6 +181,33 @@ def test_manage_route_map_orchestrator_00110() -> None:
     assert result == model.to_payload()
     assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps/RM_ONE"
     assert rest_send.verb == HttpVerbEnum.GET
+
+
+def test_manage_route_map_orchestrator_00120() -> None:
+    """
+    # Summary
+
+    Verify cluster_name is forwarded to route-map read endpoints.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.query_all()
+    - ManageRouteMapOrchestrator.query_one()
+    """
+    model = _route_map_model("RM_ONE")
+
+    def responses():
+        yield _response({"routeMaps": []})
+        yield _response(model.to_payload())
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()), cluster_name="CLUSTER-1")
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    instance.query_all()
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps?clusterName=CLUSTER-1"
+
+    instance.query_one(model)
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps/RM_ONE?clusterName=CLUSTER-1"
 
 
 def test_manage_route_map_orchestrator_00200() -> None:
@@ -405,3 +436,35 @@ def test_manage_route_map_orchestrator_00420() -> None:
 
     with pytest.raises(Exception, match=r"Bulk delete failed: Route map bulk delete failed for RM_MISSING: failed: Route map not found\."):
         instance.delete_bulk([model])
+
+
+def test_manage_route_map_orchestrator_00500() -> None:
+    """
+    # Summary
+
+    Verify cluster_name is forwarded to route-map mutation endpoints.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.create_bulk()
+    - ManageRouteMapOrchestrator.update()
+    - ManageRouteMapOrchestrator.delete_bulk()
+    """
+    model = _route_map_model("RM_CLUSTER")
+
+    def responses():
+        yield _response({"results": [{"name": "RM_CLUSTER", "status": "success", "message": "created"}]}, return_code=207, message="Multi-Status")
+        yield _response(return_code=204, message="No Content")
+        yield _response({"results": [{"name": "RM_CLUSTER", "status": "success", "message": "removed"}]}, return_code=207, message="Multi-Status")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()), cluster_name="CLUSTER-1")
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    instance.create_bulk([model])
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps?clusterName=CLUSTER-1"
+
+    instance.update(model)
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps/RM_CLUSTER?clusterName=CLUSTER-1"
+
+    instance.delete_bulk([model])
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMapActions/remove?clusterName=CLUSTER-1"

--- a/tests/unit/module_utils/orchestrators/test_manage_route_map.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_route_map.py
@@ -260,6 +260,39 @@ def test_manage_route_map_orchestrator_00210() -> None:
     assert rest_send.committed_payload == {"routeMaps": [model.to_payload()]}
 
 
+def test_manage_route_map_orchestrator_00215() -> None:
+    """
+    # Summary
+
+    Verify create_bulk tolerates non-failure per-item 207 statuses.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.create_bulk()
+    - ManageRouteMapOrchestrator._raise_on_bulk_errors()
+    """
+    model = _route_map_model("RM_CREATE_ONE")
+
+    def responses():
+        yield _response(
+            {
+                "results": [
+                    {"name": "RM_CREATE_ONE", "status": "accepted", "message": "queued"},
+                    {"name": "RM_CREATE_TWO", "status": "", "message": "no status"},
+                    {"name": "RM_CREATE_THREE", "message": "status omitted"},
+                ]
+            },
+            return_code=207,
+            message="Multi-Status",
+        )
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.create_bulk([model])
+
+
 def test_manage_route_map_orchestrator_00220() -> None:
     """
     # Summary

--- a/tests/unit/module_utils/orchestrators/test_manage_route_map.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_route_map.py
@@ -153,7 +153,38 @@ def test_manage_route_map_orchestrator_00100() -> None:
         result = instance.query_all()
 
     assert result == [_route_map_model().to_payload()]
-    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps"
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps?max=100&offset=0"
+    assert rest_send.verb == HttpVerbEnum.GET
+
+
+def test_manage_route_map_orchestrator_00105(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    # Summary
+
+    Verify query_all walks paginated route-map list responses.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.query_all()
+    """
+    route_map_1 = _route_map_model("RM_PAGE_1").to_payload()
+    route_map_2 = _route_map_model("RM_PAGE_2").to_payload()
+    route_map_3 = _route_map_model("RM_PAGE_3").to_payload()
+
+    def responses():
+        yield _response({"routeMaps": [route_map_1, route_map_2]})
+        yield _response({"routeMaps": [route_map_2, route_map_3]})
+        yield _response({"routeMaps": []})
+
+    monkeypatch.setattr(ManageRouteMapOrchestrator, "query_all_page_size", 2)
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    assert result == [route_map_1, route_map_2, route_map_3]
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps?max=2&offset=4"
     assert rest_send.verb == HttpVerbEnum.GET
 
 
@@ -204,7 +235,7 @@ def test_manage_route_map_orchestrator_00120() -> None:
     instance = ManageRouteMapOrchestrator(rest_send=rest_send)
 
     instance.query_all()
-    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps?clusterName=CLUSTER-1"
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps?clusterName=CLUSTER-1&max=100&offset=0"
 
     instance.query_one(model)
     assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps/RM_ONE?clusterName=CLUSTER-1"

--- a/tests/unit/module_utils/orchestrators/test_manage_route_map.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_route_map.py
@@ -1,0 +1,354 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for ManageRouteMapOrchestrator.
+
+Verifies that route-map CRUD methods configure fabric-scoped endpoints, unwrap list responses,
+wrap create/delete bulk payloads, and fail on per-item 207 bulk errors.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_route_map.manage_route_map import RouteMapModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_route_map import ManageRouteMapOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def _response(data: dict | None = None, return_code: int = 200, message: str = "OK") -> dict:
+    return {
+        "RETURN_CODE": return_code,
+        "MESSAGE": message,
+        "DATA": data or {},
+    }
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "SITE1") -> RestSend:
+    """Build a RestSend wired to file-style sender responses."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name, "state": "merged"})
+    rest_send.sender = sender
+    rest_send.response_handler = ResponseHandler()
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _route_map_model(name: str = "RM1", value: int = 100) -> RouteMapModel:
+    """Build a minimal route map model."""
+    return RouteMapModel.from_config(
+        {
+            "name": name,
+            "entries": [
+                {
+                    "sequence_number": 10,
+                    "action": "permit",
+                    "rule_entries": [
+                        {
+                            "rule_type": "setLocalPreference",
+                            "value": value,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+class _FakeFabricContext:
+    """FabricContext stand-in that records mutation validation."""
+
+    def __init__(self) -> None:
+        self.called = False
+
+    def validate_for_mutation(self) -> None:
+        self.called = True
+
+
+def test_manage_route_map_orchestrator_00010() -> None:
+    """
+    # Summary
+
+    Verify the orchestrator instantiates with current framework defaults.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.__init__()
+    """
+
+    def responses():
+        yield _response()
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+
+    with does_not_raise():
+        instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    assert instance.model_class is RouteMapModel
+    assert instance.supports_bulk_create is True
+    assert instance.supports_bulk_delete is True
+    assert instance.fabric_name == "SITE1"
+
+
+def test_manage_route_map_orchestrator_00020() -> None:
+    """
+    # Summary
+
+    Verify preflight delegates to FabricContext validation when proposed config exists.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.preflight()
+    """
+
+    def responses():
+        yield _response()
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+    fake_context = _FakeFabricContext()
+    instance._fabric_context = fake_context
+
+    instance.preflight([_route_map_model()])
+
+    assert fake_context.called is True
+
+
+def test_manage_route_map_orchestrator_00100() -> None:
+    """
+    # Summary
+
+    Verify query_all unwraps the routeMaps response list.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.query_all()
+    """
+
+    def responses():
+        yield _response({"routeMaps": [_route_map_model().to_payload()]})
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all()
+
+    assert result == [_route_map_model().to_payload()]
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps"
+    assert rest_send.verb == HttpVerbEnum.GET
+
+
+def test_manage_route_map_orchestrator_00110() -> None:
+    """
+    # Summary
+
+    Verify query_one sets the route map identifier in the endpoint path.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.query_one()
+    """
+    model = _route_map_model("RM_ONE")
+
+    def responses():
+        yield _response(model.to_payload())
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_one(model)
+
+    assert result == model.to_payload()
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps/RM_ONE"
+    assert rest_send.verb == HttpVerbEnum.GET
+
+
+def test_manage_route_map_orchestrator_00200() -> None:
+    """
+    # Summary
+
+    Verify create_bulk wraps route maps under the routeMaps payload key.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.create_bulk()
+    """
+    model = _route_map_model("RM_CREATE")
+
+    def responses():
+        yield _response({"results": [{"name": "RM_CREATE", "status": "success", "message": "created"}]}, return_code=207, message="Multi-Status")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.create_bulk([model])
+
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps"
+    assert rest_send.verb == HttpVerbEnum.POST
+    assert rest_send.committed_payload == {"routeMaps": [model.to_payload()]}
+
+
+def test_manage_route_map_orchestrator_00210() -> None:
+    """
+    # Summary
+
+    Verify create delegates to create_bulk for single route maps.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.create()
+    """
+    model = _route_map_model("RM_CREATE_ONE")
+
+    def responses():
+        yield _response({"results": [{"name": "RM_CREATE_ONE", "status": "success", "message": "created"}]}, return_code=207, message="Multi-Status")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.create(model)
+
+    assert rest_send.committed_payload == {"routeMaps": [model.to_payload()]}
+
+
+def test_manage_route_map_orchestrator_00220() -> None:
+    """
+    # Summary
+
+    Verify create_bulk raises on failed per-item 207 results.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.create_bulk()
+    - ManageRouteMapOrchestrator._raise_on_bulk_errors()
+    """
+    model = _route_map_model("RM_EXISTS")
+
+    def responses():
+        yield _response(
+            {"results": [{"name": "RM_EXISTS", "status": "failed", "message": "Route map already exists."}]}, return_code=207, message="Multi-Status"
+        )
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with pytest.raises(Exception, match=r"Bulk create failed: Route map bulk create failed for RM_EXISTS: failed: Route map already exists\."):
+        instance.create_bulk([model])
+
+
+def test_manage_route_map_orchestrator_00300() -> None:
+    """
+    # Summary
+
+    Verify update sends a per-route-map PUT with the model payload.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.update()
+    """
+    model = _route_map_model("RM_UPDATE", value=250)
+
+    def responses():
+        yield _response(return_code=204, message="No Content")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMaps/RM_UPDATE"
+    assert rest_send.verb == HttpVerbEnum.PUT
+    assert rest_send.committed_payload == model.to_payload()
+
+
+def test_manage_route_map_orchestrator_00400() -> None:
+    """
+    # Summary
+
+    Verify delete_bulk wraps route map identifiers under routeMapNames.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.delete_bulk()
+    """
+    model = RouteMapModel.from_config({"name": "RM_DELETE"})
+
+    def responses():
+        yield _response({"results": [{"name": "RM_DELETE", "status": "success", "message": "removed"}]}, return_code=207, message="Multi-Status")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.delete_bulk([model])
+
+    assert rest_send.path == "/api/v1/manage/fabrics/SITE1/routeMapActions/remove"
+    assert rest_send.verb == HttpVerbEnum.POST
+    assert rest_send.committed_payload == {"routeMapNames": ["RM_DELETE"]}
+
+
+def test_manage_route_map_orchestrator_00410() -> None:
+    """
+    # Summary
+
+    Verify delete delegates to delete_bulk for single route maps.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.delete()
+    """
+    model = RouteMapModel.from_config({"name": "RM_DELETE_ONE"})
+
+    def responses():
+        yield _response({"results": [{"name": "RM_DELETE_ONE", "status": "success", "message": "removed"}]}, return_code=207, message="Multi-Status")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.delete(model)
+
+    assert rest_send.committed_payload == {"routeMapNames": ["RM_DELETE_ONE"]}
+
+
+def test_manage_route_map_orchestrator_00420() -> None:
+    """
+    # Summary
+
+    Verify delete_bulk raises on failed per-item 207 results.
+
+    ## Classes and Methods
+
+    - ManageRouteMapOrchestrator.delete_bulk()
+    - ManageRouteMapOrchestrator._raise_on_bulk_errors()
+    """
+    model = RouteMapModel.from_config({"name": "RM_MISSING"})
+
+    def responses():
+        yield _response({"results": [{"name": "RM_MISSING", "status": "failed", "message": "Route map not found."}]}, return_code=207, message="Multi-Status")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = ManageRouteMapOrchestrator(rest_send=rest_send)
+
+    with pytest.raises(Exception, match=r"Bulk delete failed: Route map bulk delete failed for RM_MISSING: failed: Route map not found\."):
+        instance.delete_bulk([model])

--- a/tests/unit/module_utils/orchestrators/test_manage_route_map.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_route_map.py
@@ -11,9 +11,7 @@ Verifies that route-map CRUD methods configure fabric-scoped endpoints, unwrap l
 wrap create/delete bulk payloads, and fail on per-item 207 bulk errors.
 """
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type  # pylint: disable=invalid-name
+from __future__ import annotations
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum


### PR DESCRIPTION
## Related Issue(s)

- Resolves CiscoDevNet/ansible-nd#238

## Proposed Changes

- Add initial `nd_manage_route_map` support for Cisco Nexus Dashboard 4.2+ Route Maps.
- Add route-map endpoint models for:
  - list/get route maps
  - bulk create route maps
  - replace route map
  - delete route map
  - bulk remove route maps
- Add Pydantic models and enums for route maps, entries, and supported match/set rule entries.
- Add a fabric-scoped route-map orchestrator using the current Orchestrators framework and `NDStateMachine`.
- Support `merged`, `replaced`, `overridden`, and `deleted` states.
- Support tenant-specific route maps through full route-map names and optional `tenant_name`.
- Add module documentation, examples, and route-map integration target files.
- Add unit coverage for endpoint, model, and orchestrator behavior.

## Test Notes

- Focused unit tests:
  - `python -m pytest tests/unit/module_utils/endpoints/test_manage_route_maps.py tests/unit/module_utils/models/test_manage_route_map.py tests/unit/module_utils/orchestrators/test_manage_route_map.py -q`
  - Result: `29 passed`

## Cisco Nexus Dashboard Version

- Developed against Cisco Nexus Dashboard 4.2.1 / ND 4.2+

## Related ND API Resource Category

* [ ] analyze
* [ ] infa
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
