### PR TITLE
nd_interface_subinterface_managed

### DIFF
--- a/plugins/module_utils/models/interfaces/enums.py
+++ b/plugins/module_utils/models/interfaces/enums.py
@@ -153,3 +153,13 @@ class SviPolicyTypeEnum(str, Enum):
     """
 
     SVI = "svi"
+
+
+class SubinterfaceManagedPolicyTypeEnum(str, Enum):
+    """
+    # Summary
+
+    Policy type for managed L3 subinterfaces.
+    """
+
+    SUBINTERFACE = "subinterface"

--- a/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
+++ b/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
@@ -1,0 +1,304 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Managed L3 subinterface Pydantic models for Nexus Dashboard.
+
+This module defines nested Pydantic models that mirror the ND Manage Interfaces API payload structure for L3
+subinterfaces (`interfaceType: "subInterface"`, `policyType: "subinterface"`, `mode: "managed"`). The playbook config
+uses the same nesting so that `to_payload()` and `from_response()` work via standard Pydantic serialization with no
+custom wrapping or flattening.
+
+## Parents
+
+A subinterface is created on a physical Ethernet parent (e.g. `Ethernet1/3.2`) or on a Port-channel parent
+(e.g. `Port-channel10.5`). The parent type is encoded only in the `interface_name` string; the ND API does not require
+a separate parent reference. The `.<sub>` portion encodes the 802.1Q dot1q sub-id.
+
+## Model Hierarchy
+
+- `SubinterfaceManagedInterfaceModel` (top-level, `NDBaseModel`)
+    - `interface_name` (identifier, e.g. `Ethernet1/3.2`)
+    - `interface_type` (hardcoded: "subInterface")
+    - `config_data` -> `SubinterfaceManagedConfigDataModel`
+        - `mode` (hardcoded: "managed")
+        - `network_os` -> `SubinterfaceManagedNetworkOSModel`
+            - `network_os_type` (hardcoded: "nx-os")
+            - `policy` -> `SubinterfaceManagedPolicyModel`
+                - `policy_type` (hardcoded: SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE), `vlan_id`, L3 fields, PIM, Netflow
+
+## Field set
+
+Fields in `SubinterfaceManagedPolicyModel` mirror the `policyType: "subinterface"` schema in the ND Manage API
+(createInterfaceSubInterfaceNexusType) as observed on ND 4.2.1, covering vlan_id, VRF binding, IPv4/IPv6 addressing,
+routing tag, MTU, PIM, ip-redirects, admin-state, and netflow. The "unmanaged" subinterface variant
+(`policyType: "monitorSubinterface"`) is handled by a separate module.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    field_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceManagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+
+
+class SubinterfaceManagedPolicyModel(NDNestedModel):
+    """
+    # Summary
+
+    Policy fields for a managed L3 subinterface. Maps directly to the `configData.networkOS.policy` object in the
+    ND API.
+
+    `policy_type` is required by the API as a discriminator on both POST and PUT, so it carries a default of
+    `SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE` and is always serialized.
+
+    ## Raises
+
+    None
+    """
+
+    policy_type: SubinterfaceManagedPolicyTypeEnum = Field(
+        default=SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE,
+        alias="policyType",
+        frozen=True,
+        description="Interface policy type (hardcoded for this module)",
+    )
+    admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the subinterface")
+    description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Subinterface description")
+    extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the subinterface")
+    mtu: int | None = Field(default=None, alias="mtu", ge=576, le=9216, description="Subinterface MTU")
+    vlan_id: int | None = Field(default=None, alias="vlanId", ge=2, le=4094, description="802.1Q VLAN tag for the subinterface")
+    vrf_interface: str | None = Field(
+        default=None, alias="vrfInterface", min_length=1, max_length=32, description="Interface VRF name; use `default` for default VRF"
+    )
+    ip: str | None = Field(default=None, alias="ip", description="IPv4 address of the subinterface")
+    prefix: int | None = Field(default=None, alias="prefix", ge=8, le=31, description="IPv4 netmask length used with `ip`")
+    ipv6: str | None = Field(default=None, alias="ipv6", description="IPv6 address of the subinterface")
+    ipv6_prefix: int | None = Field(default=None, alias="ipv6Prefix", ge=1, le=127, description="IPv6 netmask length used with `ipv6`")
+    routing_tag: str | None = Field(default=None, alias="routingTag", description="Routing tag associated with the subinterface IP address")
+    ip_redirects: bool | None = Field(default=None, alias="ipRedirects", description="Disable both IPv4/IPv6 redirects on the interface")
+    pim_sparse: bool | None = Field(default=None, alias="pimSparse", description="Enable PIM sparse-mode on the subinterface")
+    pim_dr_priority: int | None = Field(
+        default=None, alias="pimDrPriority", ge=1, le=4294967295, description="Priority for PIM DR election on the subinterface"
+    )
+    netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the subinterface")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 3 Netflow monitor name (required when `netflow=true`)")
+    netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name (applicable to N7K only)")
+
+    # TODO(4.2.1) ND returns routingTag as int on GET despite OpenAPI declaring it string. Coerce so round-trip
+    # comparisons work. Lab-confirmed against the subinterface HAR; same wire quirk as nd_interface_svi.
+    @field_validator("routing_tag", mode="before")
+    @classmethod
+    def coerce_routing_tag_to_string(cls, value):
+        """
+        # Summary
+
+        Accept `routing_tag` as either string or integer. ND 4.2's API accepts string form on POST/PUT, but GET
+        responses return the value as an integer. Coerce ints to their decimal string form so round-trips and
+        idempotency comparisons work uniformly.
+
+        ## Raises
+
+        None
+        """
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+        return value
+
+
+class SubinterfaceManagedNetworkOSModel(NDNestedModel):
+    """
+    # Summary
+
+    Network OS container for a managed subinterface. Maps to `configData.networkOS` in the ND API.
+
+    ## Raises
+
+    None
+    """
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: SubinterfaceManagedPolicyModel | None = Field(default=None, alias="policy")
+
+
+class SubinterfaceManagedConfigDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Config data container for a managed subinterface. Maps to `configData` in the ND API. `mode` is always `"managed"`
+    for this module and is required by the API as a discriminator.
+
+    ## Raises
+
+    None
+    """
+
+    mode: Literal["managed"] = Field(default="managed", alias="mode", frozen=True)
+    network_os: SubinterfaceManagedNetworkOSModel = Field(alias="networkOS")
+
+
+class SubinterfaceManagedOperDataModel(NDNestedModel):
+    """
+    # Summary
+
+    Operational state container returned by GET on a managed subinterface. Server-populated and read-only. Excluded
+    from payloads via `SubinterfaceManagedInterfaceModel.payload_exclude_fields`.
+
+    ## Raises
+
+    None
+    """
+
+    admin_status: str | None = Field(default=None, alias="adminStatus")
+    operational_description: str | None = Field(default=None, alias="operationalDescription")
+    operational_status: str | None = Field(default=None, alias="operationalStatus")
+    switch_name: str | None = Field(default=None, alias="switchName")
+
+
+class SubinterfaceManagedInterfaceModel(NDBaseModel):
+    """
+    # Summary
+
+    Managed L3 subinterface configuration for Nexus Dashboard.
+
+    Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
+    Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
+
+    `interface_type` is sent on POST but NOT on PUT (the API rejects it on PUT). The orchestrator's `update()` method
+    is responsible for popping it from the payload before sending.
+
+    ## Raises
+
+    None
+    """
+
+    # --- Identifier Configuration ---
+
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+
+    # --- Serialization Configuration ---
+
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip", "oper_data"}
+
+    # --- Fields ---
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["subInterface"] = Field(default="subInterface", alias="interfaceType", frozen=True)
+    config_data: SubinterfaceManagedConfigDataModel | None = Field(default=None, alias="configData")
+    oper_data: SubinterfaceManagedOperDataModel | None = Field(default=None, alias="operData")
+
+    @field_validator("interface_name", mode="before")
+    @classmethod
+    def normalize_interface_name(cls, value):
+        """
+        # Summary
+
+        Validate that `interface_name` is a dotted subinterface form on either an Ethernet or Port-channel parent
+        (e.g. `Ethernet1/3.2`, `Port-channel10.5`). The parent kind is inferred from the prefix; no separate
+        `parent_interface` argument is needed. The sub-id portion (`.<n>`) is required.
+
+        Accepts any case for the parent prefix and normalizes to canonical capitalization (`Ethernet...`,
+        `Port-channel...`) so user input, POST payloads, and GET responses all compare equal.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `value` is a string without a `.<sub>` segment.
+        - If `value` does not start with `Ethernet` or `Port-channel` (case-insensitive).
+        """
+        if not isinstance(value, str) or not value:
+            return value
+        stripped = value.strip()
+        if "." not in stripped:
+            raise ValueError(f"interface_name must include a dot-separated subinterface id (e.g. 'Ethernet1/3.2'); got {value!r}")
+        parent, sub = stripped.rsplit(".", 1)
+        parent_lower = parent.lower()
+        # TODO(4.2.1) ND accepts canonical-case parents on POST (`Ethernet1/3.2`) but returns the same name lowercased
+        # on GET (`ethernet1/3.2`, `port-channel10.5`). Normalize both inputs to canonical case so idempotency
+        # comparisons work without re-implementing case-insensitive equality everywhere.
+        if parent_lower.startswith("ethernet"):
+            canonical_parent = "Ethernet" + parent[len("ethernet") :]
+        elif parent_lower.startswith("port-channel"):
+            canonical_parent = "Port-channel" + parent[len("port-channel") :]
+        else:
+            raise ValueError(f"interface_name parent must be 'Ethernet...' or 'Port-channel...'; got parent={parent!r}")
+        return f"{canonical_parent}.{sub}"
+
+    # --- Argument Spec ---
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        """
+        # Summary
+
+        Return the Ansible argument spec for the `nd_interface_subinterface_managed` module.
+
+        Each config item targets a single managed L3 subinterface identified by `interface_name`
+        (e.g. `Ethernet1/3.2`). To configure multiple subinterfaces in one task, list multiple config items.
+        Per-subinterface L3 settings (vlan_id, ip, vrf_interface, ...) live under `config_data.network_os.policy`
+        and apply to that one subinterface only.
+
+        ## Raises
+
+        None
+        """
+        return dict(
+            fabric_name=dict(type="str", required=True),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=True,
+                options=dict(
+                    switch_ip=dict(type="str", required=True),
+                    interface_name=dict(type="str", required=True),
+                    config_data=dict(
+                        type="dict",
+                        options=dict(
+                            network_os=dict(
+                                type="dict",
+                                options=dict(
+                                    policy=dict(
+                                        type="dict",
+                                        options=dict(
+                                            admin_state=dict(type="bool"),
+                                            description=dict(type="str"),
+                                            extra_config=dict(type="str"),
+                                            mtu=dict(type="int"),
+                                            vlan_id=dict(type="int"),
+                                            vrf_interface=dict(type="str"),
+                                            ip=dict(type="str"),
+                                            prefix=dict(type="int"),
+                                            ipv6=dict(type="str"),
+                                            ipv6_prefix=dict(type="int"),
+                                            routing_tag=dict(type="str"),
+                                            ip_redirects=dict(type="bool"),
+                                            pim_sparse=dict(type="bool"),
+                                            pim_dr_priority=dict(type="int"),
+                                            netflow=dict(type="bool"),
+                                            netflow_monitor=dict(type="str"),
+                                            netflow_sampler=dict(type="str"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            state=dict(
+                type="str",
+                default="merged",
+                choices=["merged", "replaced", "overridden", "deleted"],
+            ),
+        )

--- a/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
+++ b/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
@@ -43,6 +43,7 @@ from typing import ClassVar, Literal
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
     field_validator,
+    model_validator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceManagedPolicyTypeEnum
@@ -112,6 +113,47 @@ class SubinterfaceManagedPolicyModel(NDNestedModel):
         if isinstance(value, int) and not isinstance(value, bool):
             return str(value)
         return value
+
+    @model_validator(mode="after")
+    def _validate_netflow_monitor_present(self) -> SubinterfaceManagedPolicyModel:
+        """
+        # Summary
+
+        Reject enabling `netflow` without supplying a `netflow_monitor`.
+
+        The DOCUMENTATION and field description state that `netflow_monitor` is required when `netflow` is true. Enforcing it at the model layer
+        fails an incomplete policy early with a clear error instead of pushing a netflow config with no monitor and deferring the outcome to ND.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `netflow` is true and `netflow_monitor` is missing or empty.
+        """
+        if self.netflow is True and not self.netflow_monitor:
+            raise ValueError("netflow_monitor must be provided when netflow is true.")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_ip_prefix_paired(self) -> SubinterfaceManagedPolicyModel:
+        """
+        # Summary
+
+        Reject supplying only one half of an address/mask pair. `ip` requires `prefix` (and `ipv6` requires `ipv6_prefix`) and vice versa, so a
+        partial address is never serialized into a payload that ND would reject or apply ambiguously.
+
+        ## Raises
+
+        ### ValueError
+
+        - If exactly one of `ip` / `prefix` is set.
+        - If exactly one of `ipv6` / `ipv6_prefix` is set.
+        """
+        if (self.ip is None) != (self.prefix is None):
+            raise ValueError("ip and prefix are required together; set both or neither.")
+        if (self.ipv6 is None) != (self.ipv6_prefix is None):
+            raise ValueError("ipv6 and ipv6_prefix are required together; set both or neither.")
+        return self
 
 
 class SubinterfaceManagedNetworkOSModel(NDNestedModel):

--- a/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
+++ b/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
@@ -172,8 +172,9 @@ class SubinterfaceManagedInterfaceModel(NDBaseModel):
     Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
     Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
 
-    `interface_type` is sent on POST but NOT on PUT (the API rejects it on PUT). The orchestrator's `update()` method
-    is responsible for popping it from the payload before sending.
+    `interface_type` is required by the ND API on both POST and PUT. The per-interface PUT (`updateInterface`) uses
+    `interfaceType` as the request-body discriminator (mapping `subInterface` -> `interfaceSubInterface`) and lists it
+    in `required`, so `to_payload()` always serializes it for both verbs (verified against the ND 4.2.1 OpenAPI spec).
 
     ## Raises
 

--- a/plugins/module_utils/orchestrators/subinterface_managed_interface.py
+++ b/plugins/module_utils/orchestrators/subinterface_managed_interface.py
@@ -1,0 +1,291 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Managed L3 subinterface orchestrator for Nexus Dashboard.
+
+This module provides `SubinterfaceManagedInterfaceOrchestrator`, which implements CRUD operations for managed L3
+subinterfaces (`interfaceType: "subInterface"`, `policyType: "subinterface"`, `mode: "managed"`) via the ND Manage
+Interfaces API. Supports configuring subinterfaces across multiple switches in a single task.
+
+Each mutation operation (create, update, delete) is followed by a deploy call to persist changes to the switch.
+Deploy and remove operations are batched per-switch and executed in bulk after all mutations are complete.
+
+Subinterfaces are logical and support both `interfaceActions/remove` (bulk delete) and `interfaceActions/deploy`
+(bulk deploy), so `state: deleted` queues both and lets the standard `remove_pending` + `deploy_pending` flow
+handle the work (the same pattern used by `nd_interface_svi`, unlike physical ethernet which must use normalize).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+    EpManageInterfacesRemove,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceManagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import SubinterfaceManagedInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class SubinterfaceManagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[SubinterfaceManagedInterfaceModel]):
+    """
+    # Summary
+
+    Orchestrator for managed L3 subinterface CRUD operations on Nexus Dashboard.
+
+    Supports configuring subinterfaces across multiple switches in a single task. Each config item includes a
+    `switch_ip` that is resolved to a `switchId` via `FabricContext`.
+
+    Mutation methods (`create`, `update`) queue deploys instead of executing them immediately. Call `deploy_pending`
+    after all mutations are complete to deploy all changes in a single API call. `delete` queues subinterfaces for
+    bulk removal via `remove_pending`.
+
+    For `state: overridden`, `query_all` queries ALL switches in the fabric to enable fabric-wide convergence.
+
+    Uses `FabricContext` for pre-flight validation and switch resolution.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
+    - Via `create` if the create API request fails.
+    - Via `update` if the update API request fails.
+    - Via `remove_pending` if the bulk remove API request fails.
+    - Via `deploy_pending` if the bulk deploy API request fails.
+    - Via `query_one` if the query API request fails.
+    - Via `query_all` if the query API request fails.
+    """
+
+    model_class: ClassVar[type[NDBaseModel]] = SubinterfaceManagedInterfaceModel
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+
+    # TODO ND returns HTTP 207 Multi-Status on subinterface POST with per-item `status: "failed"` when the parent
+    # interface is not in routed mode (or other policy validation fails). Our RestSend response_handler treats 207 as
+    # success and returns the body without raising, so without this check the orchestrator would silently report
+    # "changed" when nothing was actually created. Remove this workaround once CiscoDevNet/ansible-nd#295 lands the
+    # 207-aware response handling at the RestSend layer.
+    @staticmethod
+    def _raise_on_multi_status_failures(response: ResponseType) -> None:
+        """
+        # Summary
+
+        Inspect a 207 Multi-Status body and raise if any item carries `status: "failed"` or `status: "error"`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If `response["results"]` contains any item with `status` in `("failed", "error")`.
+        """
+        if not isinstance(response, dict):
+            return
+        results = response.get("results") or []
+        failed = [r for r in results if isinstance(r, dict) and r.get("status") in ("failed", "error")]
+        if failed:
+            summary = "; ".join(f"{r.get('name')}: {r.get('message')}" for r in failed)
+            raise RuntimeError(f"ND rejected {len(failed)} interface(s): {summary}")
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = NDEndpointBaseModel  # unused; delete() uses bulk remove
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesRemove
+
+    def create(self, model_instance: SubinterfaceManagedInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create a managed L3 subinterface. Resolves `switch_ip` from the model instance, injects `switchId`, and wraps
+        the payload in an `interfaces` array. Queues a deploy for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            request_body = {"interfaces": [payload]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+            self._raise_on_multi_status_failures(result)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: SubinterfaceManagedInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update a managed L3 subinterface. Resolves `switch_ip` from the model instance, injects `switchId` into the
+        payload. Queues a deploy for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: SubinterfaceManagedInterfaceModel, **kwargs) -> None:
+        """
+        # Summary
+
+        Queue a managed L3 subinterface for deferred bulk removal via `remove_pending` and bulk deploy via
+        `deploy_pending`. The remove deletes the subinterface from ND's config; the subsequent deploy pushes that
+        removal to the switch.
+
+        No API calls are made until `remove_pending` and `deploy_pending` are called after all mutations are complete.
+
+        ## Raises
+
+        None
+        """
+        switch_id = self._resolve_switch_id(model_instance.switch_ip)
+        self._queue_remove(model_instance.interface_name, switch_id)
+        self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def create_bulk(self, model_instances: list[SubinterfaceManagedInterfaceModel], **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create multiple managed L3 subinterfaces in bulk. Groups subinterfaces by switch and sends one POST per
+        switch with all subinterfaces in the `interfaces` array, reducing API calls from N to one-per-switch. Queues
+        deploys for all created subinterfaces for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create API request fails.
+        """
+        try:
+            groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+            for model_instance in model_instances:
+                switch_id = self._resolve_switch_id(model_instance.switch_ip)
+                payload = model_instance.to_payload()
+                payload["switchId"] = switch_id
+                groups[switch_id].append((model_instance.interface_name, payload))
+
+            results = []
+            for switch_id, items in groups.items():
+                api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
+                request_body = {"interfaces": [payload for interface_name, payload in items]}
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+                self._raise_on_multi_status_failures(result)
+                results.append(result)
+                for interface_name, payload in items:
+                    self._queue_deploy(interface_name, switch_id)
+            return results
+        except Exception as e:
+            raise RuntimeError(f"Bulk create failed: {e}") from e
+
+    def delete_bulk(self, model_instances: list[SubinterfaceManagedInterfaceModel], **kwargs) -> None:
+        """
+        # Summary
+
+        Queue multiple managed L3 subinterfaces for deferred bulk removal and deployment. No API calls are made until
+        `remove_pending` and `deploy_pending` are called after `manage_state` completes.
+
+        ## Raises
+
+        None
+        """
+        for model_instance in model_instances:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            self._queue_remove(model_instance.interface_name, switch_id)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+
+    def query_one(self, model_instance: SubinterfaceManagedInterfaceModel, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Query a single managed L3 subinterface by name on a specific switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
+        subinterfaces with `interfaceType: "subInterface"` and `policyType: "subinterface"` (managed variant). The
+        unmanaged variant (`monitorSubinterface`) is managed by a separate orchestrator and is excluded here.
+
+        Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning
+        any data.
+
+        Each returned interface dict is enriched with a `switch_ip` field so that
+        `SubinterfaceManagedInterfaceModel` can be constructed with the composite identifier
+        `(switch_ip, interface_name)`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist on the target ND node.
+        - If the fabric is in deployment-freeze mode.
+        - If the query API request fails.
+        """
+        managed_policy_types = {e.value for e in SubinterfaceManagedPolicyTypeEnum}
+        try:
+            self.validate_prerequisites()
+            all_subifs = []
+            for switch_ip, switch_id in self.fabric_context.switch_map.items():
+                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                if not result:
+                    continue
+                interfaces = result.get("interfaces", []) or []
+                subifs = [iface for iface in interfaces if iface.get("interfaceType") == "subInterface"]
+                managed = [
+                    iface for iface in subifs if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_policy_types
+                ]
+                for iface in managed:
+                    iface["switchIp"] = switch_ip
+                all_subifs.extend(managed)
+            return all_subifs
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/subinterface_managed_interface.py
+++ b/plugins/module_utils/orchestrators/subinterface_managed_interface.py
@@ -72,7 +72,7 @@ class SubinterfaceManagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[Subin
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
 
-    # TODO ND returns HTTP 207 Multi-Status on subinterface POST with per-item `status: "failed"` when the parent
+    # TODO(4.2.1) ND returns HTTP 207 Multi-Status on subinterface POST with per-item `status: "failed"` when the parent
     # interface is not in routed mode (or other policy validation fails). Our RestSend response_handler treats 207 as
     # success and returns the body without raising, so without this check the orchestrator would silently report
     # "changed" when nothing was actually created. Remove this workaround once CiscoDevNet/ansible-nd#295 lands the
@@ -276,7 +276,7 @@ class SubinterfaceManagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[Subin
             for switch_ip, switch_id in self.fabric_context.switch_map.items():
                 api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
                 result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                if not result:
+                if not isinstance(result, dict):
                     continue
                 interfaces = result.get("interfaces", []) or []
                 subifs = [iface for iface in interfaces if iface.get("interfaceType") == "subInterface"]

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -17,7 +17,7 @@ description:
   O(config[].interface_name) value (e.g. C(Ethernet1/3.2) or C(Port-channel10.5)).
 - This module manages the managed variant only (C(policyType) C(subinterface)).
   The unmanaged variant (C(policyType) C(monitorSubinterface)) is handled by C(nd_interface_subinterface_unmanaged).
-- It supports creating, updating, querying, and deleting subinterface configurations on switches within a fabric.
+- It supports creating, updating, and deleting subinterface configurations on switches within a fabric.
 - Each config item targets a single subinterface identified by O(config[].interface_name).
 - Configure multiple subinterfaces in one task by listing multiple config items.
 author:

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -236,6 +236,40 @@ EXAMPLES = r"""
               prefix: 24
     state: merged
 
+- name: Replace the configuration of a specific subinterface
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 2
+              ip: 10.20.30.40
+              prefix: 24
+              description: Reprovisioned subinterface Ethernet1/3.2
+    state: replaced
+
+# state=overridden is fabric-wide: every managed subinterface in the fabric that is managed by this module and is
+# NOT listed below is deleted. An empty config list deletes ALL such subinterfaces in the fabric. Use with caution.
+- name: Enforce subinterfaces fabric-wide, deleting all others managed by this module
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 2
+              ip: 10.10.10.1
+              prefix: 24
+              description: Subinterface to keep; all other managed subinterfaces deleted
+    state: overridden
+
 - name: Delete a subinterface
   cisco.nd.nd_interface_subinterface_managed:
     fabric_name: my_fabric

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -9,7 +9,7 @@ ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported
 DOCUMENTATION = r"""
 ---
 module: nd_interface_subinterface_managed
-version_added: "1.6.0"
+version_added: "2.0.0"
 short_description: Manage L3 (managed) subinterfaces on Cisco Nexus Dashboard
 description:
 - Manage L3 subinterfaces (managed variant) on Cisco Nexus Dashboard.

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -297,6 +297,88 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
+  - An empty list when no matching interface configuration existed.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.2
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          vlan_id: 2
+          vrf_interface: VRF1
+          ip: 192.168.50.50
+          prefix: 24
+after:
+  description:
+  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.2
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          vlan_id: 2
+          vrf_interface: VRF1
+          ip: 192.168.50.60
+          prefix: 24
+diff:
+  description: The per-interface difference between C(before) and C(after).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.2
+    config_data:
+      network_os:
+        policy:
+          ip: 192.168.50.60
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/3.2
+    config_data:
+      network_os:
+        policy:
+          ip: 192.168.50.60
+logs:
+  description: Internal diagnostic log messages collected during the run.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample:
+  - "Querying existing subinterface configuration"
+msg:
+  description: A human-readable error message, present only when the module fails.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
 """
 
 import logging

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -1,0 +1,342 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_interface_subinterface_managed
+version_added: "1.6.0"
+short_description: Manage L3 (managed) subinterfaces on Cisco Nexus Dashboard
+description:
+- Manage L3 subinterfaces (managed variant) on Cisco Nexus Dashboard.
+- A subinterface is created on an Ethernet or Port-channel parent interface; the parent type is encoded in the
+  O(config[].interface_name) value (e.g. C(Ethernet1/3.2) or C(Port-channel10.5)).
+- This module manages the managed variant only (C(policyType) C(subinterface)).
+  The unmanaged variant (C(policyType) C(monitorSubinterface)) is handled by C(nd_interface_subinterface_unmanaged).
+- It supports creating, updating, querying, and deleting subinterface configurations on switches within a fabric.
+- Each config item targets a single subinterface identified by O(config[].interface_name).
+- Configure multiple subinterfaces in one task by listing multiple config items.
+author:
+- Allen Robel (@allenrobel)
+options:
+  fabric_name:
+    description:
+    - The name of the fabric containing the target switches.
+    type: str
+    required: true
+  config:
+    description:
+    - The list of L3 subinterfaces to configure.
+    - Each item specifies the target switch, the subinterface name, and the policy configuration.
+    - Multiple subinterfaces and multiple switches can be configured in a single task by listing additional items.
+    - The structure mirrors the ND Manage Interfaces API payload.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      switch_ip:
+        description:
+        - The management IP address of the switch on which to manage the subinterface.
+        - This is resolved to the switch serial number (switchId) internally.
+        type: str
+        required: true
+      interface_name:
+        description:
+        - The full subinterface name, including the dot-separated sub-id (e.g. C(Ethernet1/3.2), C(Port-channel10.5)).
+        - The parent kind is inferred from the prefix; only Ethernet and Port-channel parents are supported.
+        type: str
+        required: true
+      config_data:
+        description:
+        - The configuration data for this subinterface, following the ND API structure.
+        type: dict
+        suboptions:
+          network_os:
+            description:
+            - Network OS specific configuration.
+            type: dict
+            suboptions:
+              policy:
+                description:
+                - The policy configuration for the subinterface.
+                type: dict
+                suboptions:
+                  admin_state:
+                    description:
+                    - The administrative state of the subinterface.
+                    - Defaults to V(true) when unset during creation.
+                    type: bool
+                  description:
+                    description:
+                    - Subinterface description.
+                    - Maximum 254 characters.
+                    type: str
+                  extra_config:
+                    description:
+                    - Additional CLI configuration commands to apply to the subinterface.
+                    type: str
+                  mtu:
+                    description:
+                    - Subinterface MTU.
+                    - Valid range is 576-9216.
+                    type: int
+                  vlan_id:
+                    description:
+                    - 802.1Q VLAN tag for the subinterface.
+                    - Valid range is 2-4094.
+                    type: int
+                  vrf_interface:
+                    description:
+                    - VRF the subinterface is bound to.
+                    - Use V(default) for the default VRF.
+                    type: str
+                  ip:
+                    description:
+                    - IPv4 address of the subinterface.
+                    type: str
+                  prefix:
+                    description:
+                    - IPv4 netmask length used with O(config[].config_data.network_os.policy.ip).
+                    - Valid range is 8-31.
+                    type: int
+                  ipv6:
+                    description:
+                    - IPv6 address of the subinterface.
+                    type: str
+                  ipv6_prefix:
+                    description:
+                    - IPv6 netmask length used with O(config[].config_data.network_os.policy.ipv6).
+                    - Valid range is 1-127.
+                    type: int
+                  routing_tag:
+                    description:
+                    - Routing tag associated with the subinterface IP address.
+                    type: str
+                  ip_redirects:
+                    description:
+                    - Disable both IPv4/IPv6 redirects on the subinterface.
+                    type: bool
+                  pim_sparse:
+                    description:
+                    - Enable PIM sparse-mode on the subinterface.
+                    type: bool
+                  pim_dr_priority:
+                    description:
+                    - Priority for PIM DR election on the subinterface.
+                    - Valid range is 1-4294967295.
+                    type: int
+                  netflow:
+                    description:
+                    - Whether netflow is enabled on the subinterface.
+                    type: bool
+                  netflow_monitor:
+                    description:
+                    - Layer 3 Netflow monitor name.
+                    - Required when O(config[].config_data.network_os.policy.netflow=true).
+                    type: str
+                  netflow_sampler:
+                    description:
+                    - Netflow sampler name (applicable to N7K only).
+                    type: str
+  deploy:
+    description:
+    - Whether to deploy interface changes after mutations are complete.
+    - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module execution
+      via the C(interfaceActions/deploy) API. Only the subinterfaces modified by this task are deployed.
+    - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+    - Setting O(deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+    type: bool
+    default: true
+  state:
+    description:
+    - The desired state of the network resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the resources specified in the configuration.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      The resources on ND will be modified to exactly match the configuration.
+      Any managed subinterface managed by this module that exists on ND but is not present in the configuration will be deleted.
+      Use with extra caution.
+    - Use O(state=deleted) to remove the specified subinterfaces via the C(interfaceActions/remove) API followed by a deploy.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard.
+- This module manages NX-OS L3 subinterfaces only (interface_type C(subInterface), mode C(managed),
+  network_os_type C(nx-os), policy_type C(subinterface)). These values are hardcoded by the module and are not user-configurable.
+- The unmanaged variant (C(policyType) C(monitorSubinterface)) is handled by C(nd_interface_subinterface_unmanaged).
+- The parent interface must be in routed (L3) mode before a subinterface can be created on it.
+  ND rejects subinterface POST against L2 access/trunk parents with the message
+  "Sub-interface can be created only on routed physical or port-channel interfaces (discovered mode is not routed)".
+  In practice this blocks subinterfaces on typical vPC port-channels and peer-link port-channels, which are L2.
+  Change the parent's policy to a routed type (e.g. routedHost for Ethernet, l3PortChannel for Port-channel) before
+  using this module; the module does not auto-normalize the parent.
+"""
+
+EXAMPLES = r"""
+- name: Create a managed L3 subinterface on an Ethernet parent
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: "Tenant subinterface vlan 2"
+              vlan_id: 2
+              vrf_interface: VRF1
+              ip: 192.168.50.50
+              prefix: 24
+              ipv6: "2001:192:168:50::50"
+              ipv6_prefix: 64
+              routing_tag: "12345"
+              mtu: 9216
+              ip_redirects: true
+              pim_sparse: true
+              pim_dr_priority: 1
+              netflow: false
+    state: merged
+
+- name: Create multiple subinterfaces on different parents in one task
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.10
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 10
+              ip: 10.10.10.1
+              prefix: 24
+      - switch_ip: 192.168.1.1
+        interface_name: Port-channel10.20
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 20
+              ip: 10.10.20.1
+              prefix: 24
+    state: merged
+
+- name: Delete a subinterface
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+    state: deleted
+
+- name: Stage changes without deploying
+  cisco.nd.nd_interface_subinterface_managed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/3.2
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: 2
+              ip: 192.168.50.50
+              prefix: 24
+    deploy: false
+    state: merged
+"""
+
+RETURN = r"""
+"""
+
+import logging
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import SubinterfaceManagedInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_managed_interface import SubinterfaceManagedInterfaceOrchestrator
+
+
+def main():
+    """
+    # Summary
+
+    Entry point for the `nd_interface_subinterface_managed` Ansible module. Initializes the `NDStateMachine` with
+    `SubinterfaceManagedInterfaceOrchestrator` and executes the requested state operation.
+
+    ## Raises
+
+    None (catches all exceptions and calls `module.fail_json`).
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(SubinterfaceManagedInterfaceModel.get_argument_spec())
+    argument_spec.update(
+        deploy=dict(type="bool", default=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+    setup_logging(module)
+    module_log = logging.getLogger("nd.nd_interface_subinterface_managed")
+    module_log.debug(
+        "config items=%d switches=%d",
+        len(module.params["config"]),
+        len({item.get("switch_ip") for item in module.params["config"]}),
+    )
+
+    nd_state_machine = None
+
+    try:
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=SubinterfaceManagedInterfaceOrchestrator,
+        )
+        if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
+            raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
+        nd_state_machine.model_orchestrator.deploy = module.params["deploy"]
+
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s deploy=%s",
+            module.params.get("state"),
+            module.check_mode,
+            module.params["deploy"],
+        )
+        nd_state_machine.manage_state()
+        module_log.debug("manage_state end")
+
+        if not module.check_mode:
+            nd_state_machine.model_orchestrator.remove_pending()
+            nd_state_machine.model_orchestrator.deploy_pending()
+
+        module.exit_json(**nd_state_machine.output.format())
+
+    except NDStateMachineError as e:
+        module_log.exception("NDStateMachineError during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module execution failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -142,15 +142,20 @@ options:
                     description:
                     - Netflow sampler name (applicable to N7K only).
                     type: str
-  deploy:
+  config_actions:
     description:
-    - Whether to deploy interface changes after mutations are complete.
-    - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module execution
-      via the C(interfaceActions/deploy) API. Only the subinterfaces modified by this task are deployed.
-    - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
-    - Setting O(deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
-    type: bool
-    default: true
+    - Controls deploy behavior after interface mutations are complete.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether to deploy interface changes after mutations are complete.
+        - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
+          execution via the C(interfaceActions/deploy) API. Only the subinterfaces modified by this task are deployed.
+        - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        type: bool
+        default: true
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -252,7 +257,8 @@ EXAMPLES = r"""
               vlan_id: 2
               ip: 192.168.50.50
               prefix: 24
-    deploy: false
+    config_actions:
+      deploy: false
     state: merged
 """
 
@@ -287,7 +293,12 @@ def main():
     argument_spec = nd_argument_spec()
     argument_spec.update(SubinterfaceManagedInterfaceModel.get_argument_spec())
     argument_spec.update(
-        deploy=dict(type="bool", default=True),
+        config_actions={
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
     )
 
     module = AnsibleModule(
@@ -312,13 +323,15 @@ def main():
         )
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
-        nd_state_machine.model_orchestrator.deploy = module.params["deploy"]
+        config_actions = module.params.get("config_actions") or {}
+        deploy = config_actions.get("deploy", True)
+        nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(
             "manage_state begin state=%s check_mode=%s deploy=%s",
             module.params.get("state"),
             module.check_mode,
-            module.params["deploy"],
+            deploy,
         )
         nd_state_machine.manage_state()
         module_log.debug("manage_state end")

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/deleted.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/deleted.yaml
@@ -1,0 +1,62 @@
+---
+# Deleted state tests for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# At this point Eth.2 and PC.5 exist (from overridden reduce). Delete actually
+# removes the subinterfaces from ND via interfaceActions/remove + deploy.
+
+- name: "DELETED: Delete Eth.2 (check mode)"
+  cisco.nd.nd_interface_subinterface_managed: &delete_eth_2
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: "{{ ethernet_parent }}.2"
+    state: deleted
+  check_mode: true
+  register: cm_deleted_eth_2
+
+- name: "DELETED: Delete Eth.2 (normal mode)"
+  cisco.nd.nd_interface_subinterface_managed: *delete_eth_2
+  register: nm_deleted_eth_2
+
+- name: "DELETED: Verify Eth.2 was removed"
+  vars:
+    eth_2_name: "{{ ethernet_parent }}.2"
+    eth_2_after: "{{ nm_deleted_eth_2.after | selectattr('interface_name', 'equalto', eth_2_name) | list }}"
+  ansible.builtin.assert:
+    that:
+      - cm_deleted_eth_2 is changed
+      - nm_deleted_eth_2 is changed
+      - eth_2_after | length == 0
+
+- name: "DELETED IDEMPOTENT: Delete Eth.2 again"
+  cisco.nd.nd_interface_subinterface_managed: *delete_eth_2
+  register: nm_deleted_eth_2_idem
+
+- name: "DELETED IDEMPOTENT: Verify no change when subinterface already gone"
+  ansible.builtin.assert:
+    that:
+      - nm_deleted_eth_2_idem is not changed
+
+# --- DELETED: BULK CLEANUP (FINAL TEARDOWN) ---
+
+- name: "DELETED CLEANUP: Remove any remaining test subinterfaces"
+  cisco.nd.nd_interface_subinterface_managed:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config: "{{ cleanup_config }}"
+    state: deleted
+  register: nm_deleted_cleanup
+
+- name: "DELETED CLEANUP: Verify all test subinterfaces are gone"
+  vars:
+    remaining: >-
+      {{ nm_deleted_cleanup.after
+         | selectattr('interface_name', 'in', cleanup_config | map(attribute='interface_name') | list)
+         | list }}
+  ansible.builtin.assert:
+    that:
+      - remaining | length == 0

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/main.yaml
@@ -1,0 +1,49 @@
+---
+# Test code for the nd_interface_subinterface_managed module
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# --- Usage ---
+#
+# Run the test suite with ansible-test:
+#   ansible-test network-integration nd_interface_subinterface_managed
+#
+# --- Optional test variables ---
+#
+# Set the variables below in the [nd:vars] section of tests/integration/inventory.networking
+#
+# nd_logging_config (str, default: "")
+#   Path to a JSON file conforming to logging.config.dictConfig (see
+#   plugins/module_utils/common/log.py for an example). When set, the path is
+#   forwarded to the module subprocess via the ND_LOGGING_CONFIG environment
+#   variable.
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+- name: Run nd_interface_subinterface_managed state tests with optional logging env
+  block:
+    - name: Pre-test cleanup
+      ansible.builtin.include_tasks: setup.yaml
+
+    - name: Run merged state tests
+      ansible.builtin.include_tasks: merged.yaml
+
+    - name: Run replaced state tests
+      ansible.builtin.include_tasks: replaced.yaml
+
+    - name: Run overridden state tests
+      ansible.builtin.include_tasks: overridden.yaml
+
+    - name: Run deleted state tests
+      ansible.builtin.include_tasks: deleted.yaml
+  environment:
+    ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/merged.yaml
@@ -1,0 +1,122 @@
+---
+# Merged state tests for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- MERGED CREATE: SINGLE SUBINTERFACE (ETHERNET PARENT) ---
+
+- name: "MERGED CREATE: Create Eth.2 subinterface (check mode)"
+  cisco.nd.nd_interface_subinterface_managed: &merge_eth_2
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_2 }}"
+    state: merged
+  check_mode: true
+  register: cm_merged_create_eth_2
+
+- name: "MERGED CREATE: Create Eth.2 subinterface (normal mode)"
+  cisco.nd.nd_interface_subinterface_managed: *merge_eth_2
+  register: nm_merged_create_eth_2
+
+- name: "MERGED CREATE: Verify Eth.2 creation"
+  vars:
+    expected_name: "{{ ethernet_parent }}.2"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_create_eth_2 is changed
+      - nm_merged_create_eth_2 is changed
+      - nm_merged_create_eth_2.after | selectattr('switch_ip', 'equalto', test_switch_ip) | selectattr('interface_name', 'equalto', expected_name) | list | length == 1
+
+# --- MERGED CREATE: MULTIPLE SUBINTERFACES IN ONE TASK ---
+
+- name: "MERGED CREATE: Create Eth.3 and Eth.4 in one task"
+  cisco.nd.nd_interface_subinterface_managed: &merge_eth_3_4
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_3 }}"
+      - "{{ subif_eth_4 }}"
+    state: merged
+  register: nm_merged_create_eth_3_4
+
+- name: "MERGED CREATE: Verify Eth.3 and Eth.4 creation"
+  vars:
+    eth_3_name: "{{ ethernet_parent }}.3"
+    eth_4_name: "{{ ethernet_parent }}.4"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_create_eth_3_4 is changed
+      - nm_merged_create_eth_3_4.after | selectattr('interface_name', 'equalto', eth_3_name) | list | length == 1
+      - nm_merged_create_eth_3_4.after | selectattr('interface_name', 'equalto', eth_4_name) | list | length == 1
+
+# --- MERGED CREATE: SUBINTERFACE ON PORT-CHANNEL PARENT ---
+
+- name: "MERGED CREATE: Create subinterface on Port-channel parent"
+  cisco.nd.nd_interface_subinterface_managed:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_pc_5 }}"
+    state: merged
+  register: nm_merged_create_pc_5
+
+- name: "MERGED CREATE: Verify Port-channel subinterface creation"
+  vars:
+    pc_5_name: "{{ port_channel_parent }}.5"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_create_pc_5 is changed
+      - nm_merged_create_pc_5.after | selectattr('interface_name', 'equalto', pc_5_name) | list | length == 1
+
+# --- MERGED IDEMPOTENCY ---
+
+- name: "MERGED IDEMPOTENT: Re-apply Eth.2 (check mode)"
+  cisco.nd.nd_interface_subinterface_managed: *merge_eth_2
+  check_mode: true
+  register: cm_merged_idem_eth_2
+
+- name: "MERGED IDEMPOTENT: Re-apply Eth.2 (normal mode)"
+  cisco.nd.nd_interface_subinterface_managed: *merge_eth_2
+  register: nm_merged_idem_eth_2
+
+- name: "MERGED IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - cm_merged_idem_eth_2 is not changed
+      - nm_merged_idem_eth_2 is not changed
+
+# --- MERGED UPDATE ---
+
+- name: "MERGED UPDATE: Change description, ip, pim_sparse, pim_dr_priority on Eth.2"
+  cisco.nd.nd_interface_subinterface_managed: &merge_eth_2_updated
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ subif_eth_2_updated }}"
+    state: merged
+  register: nm_merged_update_eth_2
+
+- name: "MERGED UPDATE: Verify Eth.2 was updated"
+  vars:
+    eth_2_name: "{{ ethernet_parent }}.2"
+    eth_2_after: "{{ nm_merged_update_eth_2.after | selectattr('interface_name', 'equalto', eth_2_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_eth_2 is changed
+      - eth_2_after.config_data.network_os.policy.description == "Updated subif Eth.2"
+      - eth_2_after.config_data.network_os.policy.ip == "192.168.50.51"
+      - eth_2_after.config_data.network_os.policy.ip_redirects == false
+      - eth_2_after.config_data.network_os.policy.pim_sparse == true
+      - eth_2_after.config_data.network_os.policy.pim_dr_priority == 50
+      - eth_2_after.config_data.network_os.policy.routing_tag == "12345"
+
+- name: "MERGED UPDATE: Re-apply update for idempotency"
+  cisco.nd.nd_interface_subinterface_managed: *merge_eth_2_updated
+  register: nm_merged_update_eth_2_idem
+
+- name: "MERGED UPDATE: Verify idempotency after update"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_update_eth_2_idem is not changed

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/overridden.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/overridden.yaml
@@ -1,0 +1,60 @@
+---
+# Overridden state tests for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# At this point Eth.2, Eth.3, Eth.4, and PC.5 exist on the fabric. Override
+# reduces the set to only what is specified; any managed subinterface managed by
+# this module that is not in the config is removed.
+
+- name: "OVERRIDDEN: Reduce to only Eth.2 and PC.5"
+  cisco.nd.nd_interface_subinterface_managed: &override_eth_2_pc_5
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: "{{ ethernet_parent }}.2"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: "Overridden Eth.2"
+              vlan_id: 2
+              vrf_interface: default
+              ip: 10.99.200.1
+              prefix: 24
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: "{{ port_channel_parent }}.5"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: "Overridden PC.5"
+              vlan_id: 5
+              vrf_interface: default
+              ip: 10.99.205.1
+              prefix: 24
+    state: overridden
+  register: nm_overridden_reduce
+
+- name: "OVERRIDDEN: Verify reduce changed and removed entries are gone"
+  vars:
+    eth_3_name: "{{ ethernet_parent }}.3"
+    eth_4_name: "{{ ethernet_parent }}.4"
+    eth_3_after: "{{ nm_overridden_reduce.after | selectattr('interface_name', 'equalto', eth_3_name) | list }}"
+    eth_4_after: "{{ nm_overridden_reduce.after | selectattr('interface_name', 'equalto', eth_4_name) | list }}"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_reduce is changed
+      - eth_3_after | length == 0
+      - eth_4_after | length == 0
+
+- name: "OVERRIDDEN IDEMPOTENT: Re-apply"
+  cisco.nd.nd_interface_subinterface_managed: *override_eth_2_pc_5
+  register: nm_overridden_idem
+
+- name: "OVERRIDDEN IDEMPOTENT: Verify no change"
+  ansible.builtin.assert:
+    that:
+      - nm_overridden_idem is not changed

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/replaced.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/replaced.yaml
@@ -1,0 +1,45 @@
+---
+# Replaced state tests for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# At this point Eth.2 (updated), Eth.3, Eth.4, and PC.5 exist from merged.yaml.
+
+- name: "REPLACED: Replace Eth.3 with a stripped-down config"
+  cisco.nd.nd_interface_subinterface_managed: &replace_eth_3
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: "{{ ethernet_parent }}.3"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: "Replaced Eth.3"
+              vlan_id: 3
+              vrf_interface: default
+              ip: 10.99.3.1
+              prefix: 24
+    state: replaced
+  register: nm_replaced_eth_3
+
+- name: "REPLACED: Verify Eth.3 was replaced"
+  vars:
+    eth_3_name: "{{ ethernet_parent }}.3"
+    eth_3_after: "{{ nm_replaced_eth_3.after | selectattr('interface_name', 'equalto', eth_3_name) | first }}"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_eth_3 is changed
+      - eth_3_after.config_data.network_os.policy.description == "Replaced Eth.3"
+      - eth_3_after.config_data.network_os.policy.ip == "10.99.3.1"
+
+- name: "REPLACED IDEMPOTENT: Re-apply replace for Eth.3"
+  cisco.nd.nd_interface_subinterface_managed: *replace_eth_3
+  register: nm_replaced_eth_3_idem
+
+- name: "REPLACED IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_replaced_eth_3_idem is not changed

--- a/tests/integration/targets/nd_interface_subinterface_managed/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/tasks/setup.yaml
@@ -1,0 +1,23 @@
+---
+# Pre-test cleanup for nd_interface_subinterface_managed
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Called from main.yaml before the merged/replaced/overridden/deleted state
+# blocks. Ensures no test subinterfaces exist on the target switch before the
+# state tests run.
+
+- name: "SETUP: Remove test subinterfaces before state tests"
+  cisco.nd.nd_interface_subinterface_managed:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config: "{{ cleanup_config }}"
+    state: deleted
+  register: setup_cleanup
+  tags: always
+
+- name: "DEBUG: Show cleanup result"
+  ansible.builtin.debug:
+    var: setup_cleanup
+  tags: always

--- a/tests/integration/targets/nd_interface_subinterface_managed/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_subinterface_managed/vars/main.yaml
@@ -1,0 +1,106 @@
+---
+# Variables for nd_interface_subinterface_managed integration tests.
+#
+# Override fabric_name, switch_ip, ethernet_parent and port_channel_parent in your
+# inventory or extra-vars to match a real ND 4.2 testbed.
+#
+# The parent interfaces must exist and (for Ethernet parents) must be free of any
+# L2 mode conflicts before subinterfaces can be created on them.
+
+test_fabric_name: "{{ nd_test_fabric_name | default('test_fabric') }}"
+test_switch_ip: "{{ nd_test_switch_ip | default('192.168.1.1') }}"
+ethernet_parent: "{{ nd_test_ethernet_parent | default('Ethernet1/3') }}"
+port_channel_parent: "{{ nd_test_port_channel_parent | default('Port-channel10') }}"
+
+# --- Base configs ---
+
+subif_eth_2:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.2"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Ansible integration test subif Eth.2"
+        vlan_id: 2
+        vrf_interface: default
+        ip: 192.168.50.50
+        prefix: 24
+        ipv6: "2001:192:168:50::50"
+        ipv6_prefix: 64
+        mtu: 9216
+        ip_redirects: true
+        pim_sparse: false
+        pim_dr_priority: 1
+        netflow: false
+
+subif_eth_3:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.3"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Ansible integration test subif Eth.3"
+        vlan_id: 3
+        vrf_interface: default
+        ip: 192.168.51.50
+        prefix: 24
+
+subif_eth_4:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.4"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Ansible integration test subif Eth.4"
+        vlan_id: 4
+        vrf_interface: default
+        ip: 192.168.52.50
+        prefix: 24
+
+subif_pc_5:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ port_channel_parent }}.5"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Ansible integration test subif PC.5"
+        vlan_id: 5
+        vrf_interface: default
+        ip: 192.168.55.1
+        prefix: 24
+
+# --- Updated configs for merge/replace tests ---
+
+subif_eth_2_updated:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_name: "{{ ethernet_parent }}.2"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        description: "Updated subif Eth.2"
+        vlan_id: 2
+        vrf_interface: default
+        ip: 192.168.50.51
+        prefix: 24
+        ip_redirects: false
+        pim_sparse: true
+        pim_dr_priority: 50
+        routing_tag: "12345"
+        netflow: false
+
+# --- Cleanup helper: all test subinterfaces to remove before tests run ---
+
+cleanup_config:
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.2"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.3"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ ethernet_parent }}.4"
+  - switch_ip: "{{ test_switch_ip }}"
+    interface_name: "{{ port_channel_parent }}.5"

--- a/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_managed_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_managed_interface.json
@@ -1,0 +1,260 @@
+{
+    "TEST_NOTES": [
+        "Fixture data for tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py",
+        "Each key matches a test function + suffix (a/b/c/...) per CLAUDE.md unit-test conventions.",
+        "Simulates ND responses for:",
+        "  - GET /api/v1/manage/fabrics/{fabric}/summary  (fabric_summary)",
+        "  - GET /api/v1/manage/fabrics/{fabric}/switches (switch_map)",
+        "  - GET /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces (list)",
+        "  - GET /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces/{name} (one)",
+        "  - POST /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces (create)",
+        "  - PUT  /api/v1/manage/fabrics/{fabric}/switches/{sn}/interfaces/{name} (update)",
+        "  - POST /api/v1/manage/fabrics/{fabric}/interfaceActions/remove",
+        "  - POST /api/v1/manage/fabrics/{fabric}/interfaceActions/deploy"
+    ],
+    "test_query_all_happy_path_00400a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_happy_path_00400b": {
+        "TEST_NOTES": ["Switch list: two switches"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400c": {
+        "TEST_NOTES": [
+            "Switch FDO11111AAA: one managed subinterface (kept), one ethernet (filtered out by interfaceType), one subinterface with unmanaged monitorSubinterface policy (filtered out by policyType)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Ethernet1/3.2",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "subinterface", "description": "kept"}}
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "accessHost"}}
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3.9",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "unmanaged",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "monitorSubinterface"}}
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_happy_path_00400d": {
+        "TEST_NOTES": ["Switch FDO22222BBB: one managed subinterface on a Port-channel parent"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Port-channel10.5",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "subinterface", "description": "switch-2"}}
+                    }
+                }
+            ]
+        }
+    },
+    "test_query_all_fabric_not_found_00420a": {
+        "TEST_NOTES": ["Fabric summary 404 — drives validate_for_mutation to raise"],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_query_one_happy_path_00500a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_query_one_happy_path_00500b": {
+        "TEST_NOTES": ["GET /interfaces/Ethernet1/3.2 — returns single managed subinterface"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/Ethernet1/3.2",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaceName": "Ethernet1/3.2",
+            "interfaceType": "subInterface",
+            "switchId": "FDO11111AAA",
+            "configData": {
+                "mode": "managed",
+                "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "subinterface", "description": "exists"}}
+            }
+        }
+    },
+    "test_create_happy_path_00600a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_happy_path_00600b": {
+        "TEST_NOTES": ["POST /interfaces — create response (all items success)"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.2", "status": "success", "message": "Interface added successfully"}
+            ]
+        }
+    },
+    "test_create_multi_status_failure_00610a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_multi_status_failure_00610b": {
+        "TEST_NOTES": ["POST /interfaces — 207 Multi-Status body with a per-item failure (parent not in routed mode)"],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.2", "status": "failed", "message": "parent not in routed mode"}
+            ]
+        }
+    },
+    "test_update_happy_path_00700a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_update_happy_path_00700b": {
+        "TEST_NOTES": ["PUT /interfaces/Ethernet1/3.2 — update response"],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/Ethernet1/3.2",
+        "MESSAGE": "OK",
+        "DATA": {}
+    },
+    "test_delete_happy_path_00800a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_remove_pending_happy_path_00810a": {
+        "TEST_NOTES": ["POST /interfaceActions/remove — bulk remove response"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/remove",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"interfaceName": "Ethernet1/3.2", "status": "success", "message": "Interface removed", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_deploy_pending_happy_path_00820a": {
+        "TEST_NOTES": ["POST /interfaceActions/deploy — bulk deploy response"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/deploy",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"interfaceName": "Ethernet1/3.2", "status": "success", "message": "Interface deployed", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_bulk_happy_path_00900a": {
+        "TEST_NOTES": ["Switch list for switch_id resolution (switch_map cached after first call)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_create_bulk_happy_path_00900b": {
+        "TEST_NOTES": ["POST /interfaces with two subinterfaces in the array"],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "results": [
+                {"name": "Ethernet1/3.2", "status": "success"},
+                {"name": "Ethernet1/3.3", "status": "success"}
+            ]
+        }
+    }
+}

--- a/tests/unit/module_utils/models/test_subinterface_managed_interface.py
+++ b/tests/unit/module_utils/models/test_subinterface_managed_interface.py
@@ -309,12 +309,19 @@ def test_subinterface_managed_interface_00220(field, value, should_raise):
 
     - SubinterfaceManagedPolicyModel.__init__()
     """
+    # `prefix`/`ipv6_prefix` are required-together with `ip`/`ipv6` (see `_validate_ip_prefix_paired`), so supply
+    # the paired address when range-testing the mask length in isolation.
+    kwargs = {field: value}
+    if field == "prefix":
+        kwargs.setdefault("ip", "10.1.1.1")
+    elif field == "ipv6_prefix":
+        kwargs.setdefault("ipv6", "2001:db8::1")
     if should_raise:
         with pytest.raises(ValidationError):
-            SubinterfaceManagedPolicyModel(**{field: value})
+            SubinterfaceManagedPolicyModel(**kwargs)
     else:
         with does_not_raise():
-            instance = SubinterfaceManagedPolicyModel(**{field: value})
+            instance = SubinterfaceManagedPolicyModel(**kwargs)
         assert getattr(instance, field) == value
 
 
@@ -361,6 +368,60 @@ def test_subinterface_managed_interface_00240():
         SubinterfaceManagedPolicyModel(vrf_interface="")
     with pytest.raises(ValidationError):
         SubinterfaceManagedPolicyModel(vrf_interface="a" * 33)
+
+
+def test_subinterface_managed_interface_00250():
+    """
+    # Summary
+
+    Verify `_validate_netflow_monitor_present`: `netflow_monitor` is required when `netflow` is true.
+
+    ## Test
+
+    - `netflow=True` without `netflow_monitor` is rejected
+    - `netflow=True` with `netflow_monitor` is accepted
+    - `netflow=False` (or unset) without `netflow_monitor` is accepted
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel._validate_netflow_monitor_present()
+    """
+    with pytest.raises(ValidationError, match="netflow_monitor must be provided when netflow is true"):
+        SubinterfaceManagedPolicyModel(netflow=True)
+    with does_not_raise():
+        SubinterfaceManagedPolicyModel(netflow=True, netflow_monitor="MONITOR-1")
+        SubinterfaceManagedPolicyModel(netflow=False)
+        SubinterfaceManagedPolicyModel()
+
+
+def test_subinterface_managed_interface_00260():
+    """
+    # Summary
+
+    Verify `_validate_ip_prefix_paired`: `ip`/`prefix` (and `ipv6`/`ipv6_prefix`) are required together.
+
+    ## Test
+
+    - `ip` without `prefix` is rejected; `prefix` without `ip` is rejected
+    - `ipv6` without `ipv6_prefix` is rejected; `ipv6_prefix` without `ipv6` is rejected
+    - Both halves of a pair, or neither, is accepted
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel._validate_ip_prefix_paired()
+    """
+    with pytest.raises(ValidationError, match="ip and prefix are required together"):
+        SubinterfaceManagedPolicyModel(ip="10.1.1.1")
+    with pytest.raises(ValidationError, match="ip and prefix are required together"):
+        SubinterfaceManagedPolicyModel(prefix=24)
+    with pytest.raises(ValidationError, match="ipv6 and ipv6_prefix are required together"):
+        SubinterfaceManagedPolicyModel(ipv6="2001:db8::1")
+    with pytest.raises(ValidationError, match="ipv6 and ipv6_prefix are required together"):
+        SubinterfaceManagedPolicyModel(ipv6_prefix=64)
+    with does_not_raise():
+        SubinterfaceManagedPolicyModel(ip="10.1.1.1", prefix=24)
+        SubinterfaceManagedPolicyModel(ipv6="2001:db8::1", ipv6_prefix=64)
+        SubinterfaceManagedPolicyModel()
 
 
 # =============================================================================

--- a/tests/unit/module_utils/models/test_subinterface_managed_interface.py
+++ b/tests/unit/module_utils/models/test_subinterface_managed_interface.py
@@ -1,0 +1,934 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for subinterface_managed_interface.py
+
+Tests the managed L3 subinterface Pydantic model classes.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceManagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import (
+    SubinterfaceManagedConfigDataModel,
+    SubinterfaceManagedInterfaceModel,
+    SubinterfaceManagedNetworkOSModel,
+    SubinterfaceManagedOperDataModel,
+    SubinterfaceManagedPolicyModel,
+)
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# =============================================================================
+# Test data constants
+# =============================================================================
+
+SAMPLE_API_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "Ethernet1/3.2",
+    "interfaceType": "subInterface",
+    "switchId": "FDO11111AAA",
+    "configData": {
+        "mode": "managed",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "policyType": "subinterface",
+                "adminState": True,
+                "description": "Sample subinterface",
+                "vlanId": 2,
+                "ip": "10.20.30.40",
+                "ipRedirects": True,
+                "netflow": False,
+                "pimDrPriority": 1,
+                "pimSparse": False,
+                "prefix": 24,
+            },
+        },
+    },
+    "operData": {
+        "adminStatus": "up",
+        "operationalDescription": "subinterface is down",
+        "operationalStatus": "down",
+        "switchName": "LE1",
+    },
+}
+
+SAMPLE_ANSIBLE_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "Ethernet1/3.2",
+    "interface_type": "subInterface",
+    "config_data": {
+        "mode": "managed",
+        "network_os": {
+            "network_os_type": "nx-os",
+            "policy": {
+                "policy_type": "subinterface",
+                "admin_state": True,
+                "description": "Sample subinterface",
+                "vlan_id": 2,
+                "ip": "10.20.30.40",
+                "ip_redirects": True,
+                "netflow": False,
+                "pim_dr_priority": 1,
+                "pim_sparse": False,
+                "prefix": 24,
+            },
+        },
+    },
+}
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — initialization and defaults
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00100():
+    """
+    # Summary
+
+    Verify every policy field defaults to None except `policy_type` which defaults to
+    `SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE`.
+
+    ## Test
+
+    - Instantiate with no arguments
+    - All optional fields are None
+    - policy_type defaults to "subinterface"
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SubinterfaceManagedPolicyModel()
+    assert instance.policy_type == SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE
+    assert instance.policy_type == "subinterface"
+    assert instance.admin_state is None
+    assert instance.description is None
+    assert instance.extra_config is None
+    assert instance.mtu is None
+    assert instance.vlan_id is None
+    assert instance.vrf_interface is None
+    assert instance.ip is None
+    assert instance.prefix is None
+    assert instance.ipv6 is None
+    assert instance.ipv6_prefix is None
+    assert instance.routing_tag is None
+    assert instance.ip_redirects is None
+    assert instance.pim_sparse is None
+    assert instance.pim_dr_priority is None
+    assert instance.netflow is None
+    assert instance.netflow_monitor is None
+    assert instance.netflow_sampler is None
+
+
+def test_subinterface_managed_interface_00110():
+    """
+    # Summary
+
+    Verify construction with snake_case field names.
+
+    ## Test
+
+    - Construct with Python field names
+    - Values accessible
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SubinterfaceManagedPolicyModel(
+            admin_state=True,
+            description="test",
+            vlan_id=10,
+            ip="10.0.0.1",
+            prefix=24,
+            mtu=9216,
+        )
+    assert instance.admin_state is True
+    assert instance.description == "test"
+    assert instance.vlan_id == 10
+    assert instance.ip == "10.0.0.1"
+    assert instance.prefix == 24
+    assert instance.mtu == 9216
+    # Hardcoded model default; user no longer supplies this field.
+    assert instance.policy_type == "subinterface"
+
+
+def test_subinterface_managed_interface_00120():
+    """
+    # Summary
+
+    Verify construction with camelCase aliases.
+
+    ## Test
+
+    - Construct with API alias names
+    - Values accessible by Python names
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        instance = SubinterfaceManagedPolicyModel(
+            adminState=True,
+            ipRedirects=True,
+            pimDrPriority=5,
+            vlanId=20,
+            policyType="subinterface",
+        )
+    assert instance.admin_state is True
+    assert instance.ip_redirects is True
+    assert instance.pim_dr_priority == 5
+    assert instance.vlan_id == 20
+    assert instance.policy_type == "subinterface"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — description ASCII validator
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,should_raise",
+    [
+        ("plain ASCII", False),
+        ("with-hyphen and 123", False),
+        ("", False),
+        (None, False),
+        ("em — dash", True),
+        ("smart “quotes”", True),
+        ("emoji \U0001f600", True),
+        ("latin-1 \xe9", True),
+    ],
+    ids=[
+        "ascii_ok",
+        "ascii_punct_digits",
+        "empty_string",
+        "none_passthrough",
+        "em_dash_rejected",
+        "smart_quotes_rejected",
+        "emoji_rejected",
+        "latin1_rejected",
+    ],
+)
+def test_subinterface_managed_interface_00130(value, should_raise):
+    """
+    # Summary
+
+    Verify `description` (typed `AsciiDescription`) rejects any non-ASCII character.
+
+    Cisco backend pipes interface descriptions through CLI generators that 500 on UTF-8. Catching this client-side
+    gives users a clear error instead of a generic "unexpected error during policy execution" 500.
+
+    ## Test
+
+    - ASCII strings (including empty and None) accepted
+    - Any non-ASCII character (em-dash, smart quotes, emoji, latin-1) raises
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    - models.types.ascii_only()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError, match="description must contain only ASCII"):
+            SubinterfaceManagedPolicyModel(description=value)
+    else:
+        with does_not_raise():
+            instance = SubinterfaceManagedPolicyModel(description=value)
+        assert instance.description == value
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — range validation
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "field,value,should_raise",
+    [
+        ("mtu", 576, False),
+        ("mtu", 9216, False),
+        ("mtu", 575, True),
+        ("mtu", 9217, True),
+        ("vlan_id", 2, False),
+        ("vlan_id", 4094, False),
+        ("vlan_id", 1, True),
+        ("vlan_id", 4095, True),
+        ("prefix", 8, False),
+        ("prefix", 31, False),
+        ("prefix", 7, True),
+        ("prefix", 32, True),
+        ("ipv6_prefix", 1, False),
+        ("ipv6_prefix", 127, False),
+        ("ipv6_prefix", 0, True),
+        ("ipv6_prefix", 128, True),
+        ("pim_dr_priority", 1, False),
+        ("pim_dr_priority", 4294967295, False),
+        ("pim_dr_priority", 0, True),
+        ("pim_dr_priority", 4294967296, True),
+    ],
+    ids=lambda v: str(v) if not isinstance(v, bool) else ("raise" if v else "ok"),
+)
+def test_subinterface_managed_interface_00220(field, value, should_raise):
+    """
+    # Summary
+
+    Verify ge/le constraints on every numeric policy field.
+
+    ## Test
+
+    - At-min and at-max values accepted
+    - Below-min and above-max values rejected with ValidationError
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    if should_raise:
+        with pytest.raises(ValidationError):
+            SubinterfaceManagedPolicyModel(**{field: value})
+    else:
+        with does_not_raise():
+            instance = SubinterfaceManagedPolicyModel(**{field: value})
+        assert getattr(instance, field) == value
+
+
+def test_subinterface_managed_interface_00230():
+    """
+    # Summary
+
+    Verify `description` max_length=254.
+
+    ## Test
+
+    - 254 characters accepted
+    - 255 characters rejected
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        SubinterfaceManagedPolicyModel(description="a" * 254)
+    with pytest.raises(ValidationError):
+        SubinterfaceManagedPolicyModel(description="a" * 255)
+
+
+def test_subinterface_managed_interface_00240():
+    """
+    # Summary
+
+    Verify `vrf_interface` length constraints (min_length=1, max_length=32).
+
+    ## Test
+
+    - 1 and 32 character strings accepted
+    - empty string and 33 character string rejected
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.__init__()
+    """
+    with does_not_raise():
+        SubinterfaceManagedPolicyModel(vrf_interface="a")
+        SubinterfaceManagedPolicyModel(vrf_interface="a" * 32)
+    with pytest.raises(ValidationError):
+        SubinterfaceManagedPolicyModel(vrf_interface="")
+    with pytest.raises(ValidationError):
+        SubinterfaceManagedPolicyModel(vrf_interface="a" * 33)
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — payload / config serialization
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00300():
+    """
+    # Summary
+
+    Verify `to_payload`-style serialization (model_dump with aliases, exclude_none) emits camelCase keys.
+
+    ## Test
+
+    - Construct with snake_case
+    - Dump with by_alias=True
+    - Output uses API camelCase keys
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.model_dump()
+    """
+    instance = SubinterfaceManagedPolicyModel(
+        admin_state=True,
+        description="payload",
+        vlan_id=30,
+        ip_redirects=True,
+        pim_dr_priority=2,
+    )
+    data = instance.model_dump(by_alias=True, exclude_none=True)
+    assert data["adminState"] is True
+    assert data["description"] == "payload"
+    assert data["vlanId"] == 30
+    assert data["ipRedirects"] is True
+    assert data["pimDrPriority"] == 2
+    assert "admin_state" not in data
+    assert "ip_redirects" not in data
+
+
+# =============================================================================
+# Test: SubinterfaceManagedPolicyModel — routing_tag int->str coercion
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("12345", "12345"),
+        (12345, "12345"),
+        (0, "0"),
+        (None, None),
+    ],
+    ids=["string_passthrough", "int_coerced", "zero_int_coerced", "none_passthrough"],
+)
+def test_subinterface_managed_interface_00310(value, expected):
+    """
+    # Summary
+
+    Verify `routing_tag` accepts both strings (Ansible playbook side / POST/PUT request side) and integers (ND
+    GET response side). ND coerces input to int internally and returns int on GET even though OpenAPI declares
+    the field as string; the model normalizes to string for clean round-trips.
+
+    ## Test
+
+    - String values pass through unchanged
+    - Integer values are coerced to their decimal string form
+    - None passes through
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedPolicyModel.coerce_routing_tag_to_string()
+    """
+    instance = SubinterfaceManagedPolicyModel(routing_tag=value)
+    assert instance.routing_tag == expected
+
+
+# =============================================================================
+# Test: SubinterfaceManagedNetworkOSModel
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00400():
+    """
+    # Summary
+
+    Verify default values for SubinterfaceManagedNetworkOSModel.
+
+    ## Test
+
+    - network_os_type defaults to "nx-os"
+    - policy defaults to None
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedNetworkOSModel.__init__()
+    """
+    instance = SubinterfaceManagedNetworkOSModel()
+    assert instance.network_os_type == "nx-os"
+    assert instance.policy is None
+
+
+def test_subinterface_managed_interface_00410():
+    """
+    # Summary
+
+    Verify SubinterfaceManagedNetworkOSModel accepts a SubinterfaceManagedPolicyModel as the `policy` field.
+
+    ## Test
+
+    - Pass a populated policy
+    - Access through the network OS container
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedNetworkOSModel.__init__()
+    """
+    policy = SubinterfaceManagedPolicyModel(admin_state=True, description="net-os")
+    instance = SubinterfaceManagedNetworkOSModel(policy=policy)
+    assert instance.policy is not None
+    assert instance.policy.admin_state is True
+    assert instance.policy.description == "net-os"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedConfigDataModel
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00500():
+    """
+    # Summary
+
+    Verify SubinterfaceManagedConfigDataModel defaults — `mode` is "managed" and `network_os` is required.
+
+    ## Test
+
+    - Construct with only network_os
+    - mode defaults to "managed"
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedConfigDataModel.__init__()
+    """
+    nos = SubinterfaceManagedNetworkOSModel(policy=SubinterfaceManagedPolicyModel(admin_state=True))
+    instance = SubinterfaceManagedConfigDataModel(network_os=nos)
+    assert instance.mode == "managed"
+    assert instance.network_os is not None
+
+
+def test_subinterface_managed_interface_00510():
+    """
+    # Summary
+
+    Verify SubinterfaceManagedConfigDataModel rejects construction without network_os.
+
+    ## Test
+
+    - Construct with no network_os
+    - ValidationError raised
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedConfigDataModel.__init__()
+    """
+    with pytest.raises(ValidationError):
+        SubinterfaceManagedConfigDataModel()  # network_os is required
+
+
+# =============================================================================
+# Test: SubinterfaceManagedOperDataModel — read-only operational data
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00600():
+    """
+    # Summary
+
+    Verify SubinterfaceManagedOperDataModel parses GET-side aliases.
+
+    ## Test
+
+    - Construct with camelCase aliases
+    - Access by snake_case fields
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedOperDataModel.__init__()
+    """
+    instance = SubinterfaceManagedOperDataModel(
+        adminStatus="up",
+        operationalDescription="subinterface is down",
+        operationalStatus="down",
+        switchName="LE1",
+    )
+    assert instance.admin_status == "up"
+    assert instance.operational_description == "subinterface is down"
+    assert instance.operational_status == "down"
+    assert instance.switch_name == "LE1"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — interface_name normalization
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("Ethernet1/3.2", "Ethernet1/3.2"),
+        ("ethernet1/3.2", "Ethernet1/3.2"),
+        ("ETHERNET1/3.2", "Ethernet1/3.2"),
+        ("eThErNeT1/3.2", "Ethernet1/3.2"),
+        ("Port-channel10.5", "Port-channel10.5"),
+        ("port-channel10.5", "Port-channel10.5"),
+        ("PORT-CHANNEL10.5", "Port-channel10.5"),
+        ("  Ethernet1/3.2  ", "Ethernet1/3.2"),
+    ],
+    ids=[
+        "ethernet_canonical_passthrough",
+        "ethernet_lowercase",
+        "ethernet_uppercase",
+        "ethernet_mixed_case",
+        "portchannel_canonical_passthrough",
+        "portchannel_lowercase",
+        "portchannel_uppercase",
+        "ethernet_padded",
+    ],
+)
+def test_subinterface_managed_interface_00700(value, expected):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` canonicalizes the parent prefix capitalization while preserving the
+    dot-separated sub-id (e.g. `ethernet1/3.2` -> `Ethernet1/3.2`, `port-channel10.5` -> `Port-channel10.5`).
+
+    ## Test
+
+    - Any-cased Ethernet/Port-channel parents normalize to canonical capitalization
+    - Surrounding whitespace is stripped
+    - The `.<sub>` segment is preserved
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.normalize_interface_name()
+    """
+    instance = SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+    assert instance.interface_name == expected
+
+
+def test_subinterface_managed_interface_00710():
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects a name without a dot-separated sub-id.
+
+    ## Test
+
+    - A parent-only name (no `.<sub>`) raises ValidationError mentioning the dot-separated requirement
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match="must include a dot-separated subinterface id"):
+        SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name="Ethernet1/3")
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["Loopback0.1", "Vlan10.2", "mgmt0.3", "Tunnel1.4"],
+    ids=["loopback", "vlan", "mgmt", "tunnel"],
+)
+def test_subinterface_managed_interface_00720(value):
+    """
+    # Summary
+
+    Verify `normalize_interface_name` rejects parents that are neither Ethernet nor Port-channel.
+
+    ## Test
+
+    - A dotted name on a non-Ethernet/Port-channel parent raises ValidationError mentioning the allowed parents
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.normalize_interface_name()
+    """
+    with pytest.raises(ValidationError, match="parent must be 'Ethernet...' or 'Port-channel...'"):
+        SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name=value)
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — composite identifier
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00800():
+    """
+    # Summary
+
+    Verify identifier configuration: composite `(switch_ip, interface_name)`.
+
+    ## Test
+
+    - identifier_strategy is "composite"
+    - identifiers is ["switch_ip", "interface_name"]
+    - get_identifier_value returns the tuple
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel — class attributes
+    - SubinterfaceManagedInterfaceModel.get_identifier_value()
+    """
+    assert SubinterfaceManagedInterfaceModel.identifier_strategy == "composite"
+    assert SubinterfaceManagedInterfaceModel.identifiers == ["switch_ip", "interface_name"]
+    instance = SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name="Ethernet1/3.2")
+    assert instance.get_identifier_value() == ("1.2.3.4", "Ethernet1/3.2")
+
+
+def test_subinterface_managed_interface_00810():
+    """
+    # Summary
+
+    Verify `payload_exclude_fields` excludes `switch_ip` and `oper_data` from `to_payload`.
+
+    ## Test
+
+    - Construct from a full GET response
+    - to_payload omits switchIp and operData
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.to_payload()
+    """
+    instance = SubinterfaceManagedInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+    assert "switchIp" not in payload
+    assert "operData" not in payload
+    # Verify the remaining top-level shape
+    assert payload["interfaceName"] == "Ethernet1/3.2"
+    assert payload["interfaceType"] == "subInterface"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — from_response robustness
+# =============================================================================
+
+
+def test_subinterface_managed_interface_00900():
+    """
+    # Summary
+
+    Verify `from_response` is robust to missing nested structures.
+
+    ## Test
+
+    - Response with no configData
+    - Response with configData but no policy
+    - Both return a valid model without raising
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.from_response()
+    """
+    minimal = {
+        "switchIp": "1.2.3.4",
+        "interfaceName": "Ethernet1/3.2",
+        "switchId": "X",
+    }
+    with does_not_raise():
+        SubinterfaceManagedInterfaceModel.from_response(minimal)
+
+    no_policy = copy.deepcopy(minimal)
+    no_policy["configData"] = {"mode": "managed", "networkOS": {"networkOSType": "nx-os"}}
+    with does_not_raise():
+        SubinterfaceManagedInterfaceModel.from_response(no_policy)
+
+
+def test_subinterface_managed_interface_00910():
+    """
+    # Summary
+
+    Verify a populated policy round-trips through `from_response` -> `to_payload` with all fields preserved.
+
+    ## Test
+
+    - Response includes vlan_id, ip, prefix, PIM, netflow fields
+    - After from_response, every field is reachable on the model
+    - to_payload re-emits every field with API names
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.from_response()
+    - SubinterfaceManagedInterfaceModel.to_payload()
+    """
+    response = copy.deepcopy(SAMPLE_API_RESPONSE)
+    response["configData"]["networkOS"]["policy"].update(
+        {
+            "mtu": 9216,
+            "vrfInterface": "tenant_a",
+            "ipv6": "2001:db8::1",
+            "ipv6Prefix": 64,
+            "routingTag": "12345",
+            "netflow": True,
+            "netflowMonitor": "MON1",
+        }
+    )
+
+    instance = SubinterfaceManagedInterfaceModel.from_response(response)
+    policy = instance.config_data.network_os.policy
+    assert policy.mtu == 9216
+    assert policy.vrf_interface == "tenant_a"
+    assert policy.ipv6 == "2001:db8::1"
+    assert policy.ipv6_prefix == 64
+    assert policy.routing_tag == "12345"
+    assert policy.netflow is True
+    assert policy.netflow_monitor == "MON1"
+
+    payload_policy = instance.to_payload()["configData"]["networkOS"]["policy"]
+    assert payload_policy["mtu"] == 9216
+    assert payload_policy["vrfInterface"] == "tenant_a"
+    assert payload_policy["ipv6"] == "2001:db8::1"
+    assert payload_policy["ipv6Prefix"] == 64
+    assert payload_policy["routingTag"] == "12345"
+    assert payload_policy["netflow"] is True
+    assert payload_policy["netflowMonitor"] == "MON1"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — round-trip from_response -> to_payload
+# =============================================================================
+
+
+def test_subinterface_managed_interface_01000():
+    """
+    # Summary
+
+    Verify a full GET response round-trips through from_response and to_payload, producing the same shape minus
+    excluded fields. All fields present in SAMPLE_API_RESPONSE must round-trip cleanly with their API aliases.
+
+    ## Test
+
+    - Build model from SAMPLE_API_RESPONSE
+    - to_payload result matches expected
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.from_response()
+    - SubinterfaceManagedInterfaceModel.to_payload()
+    """
+    instance = SubinterfaceManagedInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    payload = instance.to_payload()
+
+    expected_policy_keys = set(SAMPLE_API_RESPONSE["configData"]["networkOS"]["policy"].keys())
+    assert set(payload["configData"]["networkOS"]["policy"].keys()) == expected_policy_keys
+    assert payload["interfaceName"] == "Ethernet1/3.2"
+    assert payload["interfaceType"] == "subInterface"
+    assert payload["configData"]["mode"] == "managed"
+    assert payload["configData"]["networkOS"]["networkOSType"] == "nx-os"
+
+
+def test_subinterface_managed_interface_01010():
+    """
+    # Summary
+
+    Verify from_config (Ansible-side snake_case) produces an equivalent model to from_response (API-side camelCase).
+
+    ## Test
+
+    - Build model A from SAMPLE_API_RESPONSE
+    - Build model B from SAMPLE_ANSIBLE_CONFIG
+    - to_payload outputs match
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.from_response()
+    - SubinterfaceManagedInterfaceModel.from_config()
+    """
+    a = SubinterfaceManagedInterfaceModel.from_response(SAMPLE_API_RESPONSE)
+    b = SubinterfaceManagedInterfaceModel.from_config(SAMPLE_ANSIBLE_CONFIG)
+    # b has no oper_data so payloads should match (oper_data excluded from payload anyway)
+    assert a.to_payload() == b.to_payload()
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — get_argument_spec
+# =============================================================================
+
+
+def test_subinterface_managed_interface_01100():
+    """
+    # Summary
+
+    Verify the argument spec exposes the expected top-level keys and required structure.
+
+    ## Test
+
+    - fabric_name is required str
+    - config is required list-of-dict
+    - state is enum with merged/replaced/overridden/deleted
+    - policy options include the writable fields and exclude the hardcoded discriminators
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.get_argument_spec()
+    """
+    spec = SubinterfaceManagedInterfaceModel.get_argument_spec()
+    assert spec["fabric_name"]["type"] == "str"
+    assert spec["fabric_name"]["required"] is True
+    assert spec["config"]["type"] == "list"
+    assert spec["config"]["required"] is True
+    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert spec["state"]["default"] == "merged"
+
+    config_options = spec["config"]["options"]
+    assert config_options["switch_ip"]["required"] is True
+    assert config_options["interface_name"]["type"] == "str"
+    assert config_options["interface_name"]["required"] is True
+    # interface_type, mode, and network_os_type are hardcoded in the Pydantic model
+    # and intentionally absent from the user-facing argument spec.
+    assert "interface_type" not in config_options
+    assert "mode" not in config_options["config_data"]["options"]
+    assert "network_os_type" not in config_options["config_data"]["options"]["network_os"]["options"]
+
+    policy_options = config_options["config_data"]["options"]["network_os"]["options"]["policy"]["options"]
+    expected_policy_fields = {
+        "admin_state",
+        "description",
+        "extra_config",
+        "mtu",
+        "vlan_id",
+        "vrf_interface",
+        "ip",
+        "prefix",
+        "ipv6",
+        "ipv6_prefix",
+        "routing_tag",
+        "ip_redirects",
+        "pim_sparse",
+        "pim_dr_priority",
+        "netflow",
+        "netflow_monitor",
+        "netflow_sampler",
+    }
+    assert set(policy_options.keys()) == expected_policy_fields
+    assert "policy_type" not in policy_options
+    assert policy_options["vlan_id"]["type"] == "int"
+
+
+# =============================================================================
+# Test: SubinterfaceManagedInterfaceModel — interface_type default
+# =============================================================================
+
+
+def test_subinterface_managed_interface_01200():
+    """
+    # Summary
+
+    Verify `interface_type` defaults to "subInterface".
+
+    ## Test
+
+    - Construct without interface_type
+    - Field equals "subInterface"
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.__init__()
+    """
+    instance = SubinterfaceManagedInterfaceModel(switch_ip="1.2.3.4", interface_name="Ethernet1/3.2")
+    assert instance.interface_type == "subInterface"

--- a/tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py
@@ -1,0 +1,589 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for subinterface_managed_interface orchestrator.
+
+Verifies that `SubinterfaceManagedInterfaceOrchestrator` correctly:
+- declares the right `model_class` and bulk-support flags
+- filters `query_all` results down to interfaceType=subInterface + managed policyType=subinterface
+- builds correct POST/PUT payloads on create/update
+- queues remove + deploy on delete (no immediate API call)
+- groups create_bulk by switch
+- raises on 207 Multi-Status bodies that carry per-item failures
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as the `sender` injected into a real
+`RestSend`. Responses are read from
+`tests/unit/module_utils/fixtures/fixture_data/test_subinterface_managed_interface.json`.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import SubinterfaceManagedInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_managed_interface import SubinterfaceManagedInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+
+def responses_subif(key: str):
+    """Load fixture data for the orchestrator's test_subinterface_managed_interface.json file."""
+    return load_fixture("test_subinterface_managed_interface")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> SubinterfaceManagedInterfaceOrchestrator:
+    """Construct an orchestrator with the file-based RestSend injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    return SubinterfaceManagedInterfaceOrchestrator(rest_send=rest_send)
+
+
+def _build_model(switch_ip: str = "192.168.1.1", interface_name: str = "Ethernet1/3.2", **policy_kwargs) -> SubinterfaceManagedInterfaceModel:
+    """Build a SubinterfaceManagedInterfaceModel with optional policy fields populated."""
+    config_data = None
+    if policy_kwargs:
+        config_data = {"mode": "managed", "network_os": {"network_os_type": "nx-os", "policy": policy_kwargs}}
+    return SubinterfaceManagedInterfaceModel.from_config(
+        {"switch_ip": switch_ip, "interface_name": interface_name, "interface_type": "subInterface", "config_data": config_data}
+    )
+
+
+# =============================================================================
+# Test: ClassVar / model_class
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00010() -> None:
+    """
+    # Summary
+
+    Verify `model_class` points to `SubinterfaceManagedInterfaceModel`.
+
+    ## Test
+
+    - model_class is SubinterfaceManagedInterfaceModel
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.model_class
+    """
+    assert SubinterfaceManagedInterfaceOrchestrator.model_class is SubinterfaceManagedInterfaceModel
+
+
+def test_subinterface_managed_orchestrator_00020() -> None:
+    """
+    # Summary
+
+    Verify bulk-support flags are enabled.
+
+    ## Test
+
+    - supports_bulk_create is True
+    - supports_bulk_delete is True
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator
+    """
+    assert SubinterfaceManagedInterfaceOrchestrator.supports_bulk_create is True
+    assert SubinterfaceManagedInterfaceOrchestrator.supports_bulk_delete is True
+
+
+# =============================================================================
+# Test: _raise_on_multi_status_failures — 207 Multi-Status handling
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        "not a dict",
+        {},
+        {"results": []},
+        {"results": [{"name": "Ethernet1/3.2", "status": "success"}]},
+    ],
+    ids=["none", "non_dict", "empty_dict", "empty_results", "all_success"],
+)
+def test_subinterface_managed_orchestrator_00100(response) -> None:
+    """
+    # Summary
+
+    Verify `_raise_on_multi_status_failures` does NOT raise for non-dict bodies, missing/empty results, or
+    all-success results.
+
+    ## Test
+
+    - None / non-dict / empty results / all-success bodies do not raise
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures()
+    """
+    with does_not_raise():
+        SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures(response)
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["failed", "error"],
+    ids=["failed", "error"],
+)
+def test_subinterface_managed_orchestrator_00110(status) -> None:
+    """
+    # Summary
+
+    Verify `_raise_on_multi_status_failures` raises `RuntimeError` when any result item carries
+    `status: "failed"` or `status: "error"`, surfacing the per-item name and message.
+
+    ND returns HTTP 207 Multi-Status on subinterface POST with per-item failures (e.g. parent not in routed mode)
+    that the RestSend layer treats as success; this guard converts those into a hard failure.
+
+    ## Test
+
+    - A results body with one failed item raises RuntimeError mentioning the count and message
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures()
+    """
+    response = {
+        "results": [
+            {"name": "Ethernet1/3.2", "status": "success"},
+            {"name": "Ethernet1/3.3", "status": status, "message": "parent not in routed mode"},
+        ]
+    }
+    with pytest.raises(RuntimeError, match=r"ND rejected 1 interface\(s\).*parent not in routed mode"):
+        SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures(response)
+
+
+# =============================================================================
+# Test: query_all — happy path with filtering
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00400() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=subInterface AND
+    managed policyType=subinterface, and injects `switchIp` onto each kept interface.
+
+    ## Test
+
+    - Fabric summary returns 200
+    - Two switches in the switch list
+    - Switch 1 returns: managed subinterface (kept), ethernet (filtered by interfaceType),
+      unmanaged subinterface with policyType=monitorSubinterface (filtered by policyType)
+    - Switch 2 returns: managed subinterface (kept)
+    - Result contains exactly two subinterfaces with switchIp injected
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_subif("test_query_all_happy_path_00400a")
+        yield responses_subif("test_query_all_happy_path_00400b")
+        yield responses_subif("test_query_all_happy_path_00400c")
+        yield responses_subif("test_query_all_happy_path_00400d")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    by_name = {iface["interfaceName"]: iface for iface in result}
+    assert set(by_name) == {"Ethernet1/3.2", "Port-channel10.5"}
+
+    assert by_name["Ethernet1/3.2"]["switchIp"] == "192.168.1.1"
+    assert by_name["Port-channel10.5"]["switchIp"] == "192.168.1.2"
+
+    # Filtered out: ethernet (interfaceType) and monitorSubinterface (policyType)
+    assert "Ethernet1/1" not in by_name
+    assert "Ethernet1/3.9" not in by_name
+
+
+def test_subinterface_managed_orchestrator_00420() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - query_all raises RuntimeError mentioning the fabric name
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.query_all()
+    - FabricContext.validate_for_mutation()
+    """
+
+    def responses():
+        yield responses_subif("test_query_all_fabric_not_found_00420a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        orchestrator.query_all()
+
+
+# =============================================================================
+# Test: query_one — happy path
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00500() -> None:
+    """
+    # Summary
+
+    Verify `query_one` resolves the switch_ip and issues a GET on the interface.
+
+    ## Test
+
+    - Switch list returns one switch
+    - Interface GET returns the subinterface body
+    - query_one returns the response DATA
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.query_one()
+    """
+
+    def responses():
+        yield responses_subif("test_query_one_happy_path_00500a")
+        yield responses_subif("test_query_one_happy_path_00500b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="Ethernet1/3.2")
+        result = orchestrator.query_one(model)
+
+    assert result["interfaceName"] == "Ethernet1/3.2"
+    assert result["interfaceType"] == "subInterface"
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "subinterface"
+
+
+# =============================================================================
+# Test: create — happy path; payload inspection
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00600() -> None:
+    """
+    # Summary
+
+    Verify `create` resolves switch_ip, issues a POST wrapping the payload in `interfaces[]`, injects `switchId`, and
+    queues a deploy.
+
+    ## Test
+
+    - Switch list returns one switch
+    - POST returns success
+    - After create, the interface is queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.create()
+    """
+
+    def responses():
+        yield responses_subif("test_create_happy_path_00600a")
+        yield responses_subif("test_create_happy_path_00600b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="Ethernet1/3.2", admin_state=True, vlan_id=2, ip="10.20.30.40", prefix=24)
+        orchestrator.create(model)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+def test_subinterface_managed_orchestrator_00610() -> None:
+    """
+    # Summary
+
+    Verify `create` raises `RuntimeError` when the POST returns a 207 Multi-Status body with a per-item failure,
+    rather than silently reporting success and queuing a deploy.
+
+    ## Test
+
+    - Switch list returns one switch
+    - POST returns a results body containing one item with status "failed"
+    - create raises RuntimeError mentioning the create failure
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.create()
+    - SubinterfaceManagedInterfaceOrchestrator._raise_on_multi_status_failures()
+    """
+
+    def responses():
+        yield responses_subif("test_create_multi_status_failure_00610a")
+        yield responses_subif("test_create_multi_status_failure_00610b")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    model = _build_model(interface_name="Ethernet1/3.2", admin_state=True, vlan_id=2, ip="10.20.30.40", prefix=24)
+
+    with pytest.raises(RuntimeError, match=r"Create failed.*parent not in routed mode"):
+        orchestrator.create(model)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") not in orchestrator._pending_deploys
+
+
+# =============================================================================
+# Test: update — happy path
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00700() -> None:
+    """
+    # Summary
+
+    Verify `update` resolves switch_ip, issues a PUT on the interface, and queues a deploy.
+
+    ## Test
+
+    - Switch list returns one switch
+    - PUT returns 200
+    - After update, the interface is queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.update()
+    """
+
+    def responses():
+        yield responses_subif("test_update_happy_path_00700a")
+        yield responses_subif("test_update_happy_path_00700b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="Ethernet1/3.2", description="updated description")
+        orchestrator.update(model)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+# =============================================================================
+# Test: delete — queues remove + deploy, no immediate API call
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00800() -> None:
+    """
+    # Summary
+
+    Verify `delete` queues both a remove and a deploy without making any API call beyond the switch_id resolution.
+    The actual remove/deploy happens later via `remove_pending` / `deploy_pending`.
+
+    ## Test
+
+    - Switch list returns one switch
+    - delete() makes only the switch_map GET (one fixture consumed)
+    - After delete, the interface is queued in both `_pending_removes` and `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.delete()
+    """
+
+    def responses():
+        yield responses_subif("test_delete_happy_path_00800a")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        model = _build_model(interface_name="Ethernet1/3.2")
+        orchestrator.delete(model)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_removes
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+def test_subinterface_managed_orchestrator_00810() -> None:
+    """
+    # Summary
+
+    Verify `remove_pending` issues `interfaceActions/remove` with all queued interfaces and clears the queue.
+
+    ## Test
+
+    - Queue one interface manually (no preceding switch_map GET needed)
+    - Call remove_pending
+    - Queue is empty after success
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.remove_pending()
+    """
+
+    def responses():
+        yield responses_subif("test_remove_pending_happy_path_00810a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    orchestrator._queue_remove("Ethernet1/3.2", "FDO11111AAA")
+
+    with does_not_raise():
+        orchestrator.remove_pending()
+
+    assert orchestrator._pending_removes == []
+
+
+def test_subinterface_managed_orchestrator_00820() -> None:
+    """
+    # Summary
+
+    Verify `deploy_pending` issues `interfaceActions/deploy` with all queued interfaces and clears the queue.
+
+    ## Test
+
+    - Queue one interface manually
+    - Call deploy_pending
+    - Queue is empty after success
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.deploy_pending()
+    """
+
+    def responses():
+        yield responses_subif("test_deploy_pending_happy_path_00820a")
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+    orchestrator._queue_deploy("Ethernet1/3.2", "FDO11111AAA")
+
+    with does_not_raise():
+        orchestrator.deploy_pending()
+
+    assert orchestrator._pending_deploys == []
+
+
+# =============================================================================
+# Test: create_bulk — multiple subinterfaces grouped per switch
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_00900() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` groups interfaces by switch and sends one POST per switch with all subinterfaces in the
+    `interfaces` array. Both interfaces are queued for deploy.
+
+    ## Test
+
+    - Two subinterfaces on the same switch
+    - One POST issued (one switch group)
+    - Both interfaces queued in `_pending_deploys`
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceOrchestrator.create_bulk()
+    """
+
+    def responses():
+        yield responses_subif("test_create_bulk_happy_path_00900a")
+        yield responses_subif("test_create_bulk_happy_path_00900b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses)
+        models = [
+            _build_model(interface_name="Ethernet1/3.2", admin_state=True, vlan_id=2, ip="10.20.30.40", prefix=24),
+            _build_model(interface_name="Ethernet1/3.3", admin_state=True, vlan_id=3, ip="10.20.31.40", prefix=24),
+        ]
+        orchestrator.create_bulk(models)
+
+    assert ("Ethernet1/3.2", "FDO11111AAA") in orchestrator._pending_deploys
+    assert ("Ethernet1/3.3", "FDO11111AAA") in orchestrator._pending_deploys
+
+
+# =============================================================================
+# Test: payload shape — verify the nested PUT body shape
+# =============================================================================
+
+
+def test_subinterface_managed_orchestrator_01000() -> None:
+    """
+    # Summary
+
+    Verify the in-memory payload built by `to_payload` for a subinterface is shaped correctly for the PUT API:
+    nested `configData.networkOS.policy` block, no `switch_ip` or `oper_data` at top level. (Wire dispatch is
+    exercised elsewhere; this asserts the payload shape on a model the orchestrator would send unmodified.)
+
+    ## Test
+
+    - Build a partial-update model (description-only)
+    - to_payload produces the canonical nested shape
+    - switchId injection done by orchestrator is not in to_payload
+
+    ## Classes and Methods
+
+    - SubinterfaceManagedInterfaceModel.to_payload()
+    - SubinterfaceManagedInterfaceOrchestrator.update() — payload assembly
+    """
+    model = _build_model(interface_name="Ethernet1/3.2", description="just description")
+    payload = model.to_payload()
+
+    assert payload["interfaceName"] == "Ethernet1/3.2"
+    assert payload["interfaceType"] == "subInterface"
+    assert "switchIp" not in payload
+    assert "operData" not in payload
+    assert "switchId" not in payload  # injected by orchestrator, not by model
+
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert policy["policyType"] == "subinterface"
+    assert policy["description"] == "just description"


### PR DESCRIPTION
## Related Issue(s)

References CiscoDevNet/ansible-nd#295 (the 207-status:failed silent-success bug in `response_handler_nd.py` is worked around in this module via `_raise_on_multi_status_failures`; remove the workaround when #295 lands).

- CiscoDevNet/ansible-nd#324

### Deferred follow-ups (tracked)

- #348 — interface orchestrator CRUD + policy-type serializer dedup (cross-cutting; sibling source of the unmanaged-variant duplication)
- #349 — query_all per-switch fan-out / no fabric-wide interface endpoint (cross-cutting)

## Proposed Changes

- Add the `nd_interface_subinterface_managed` module to manage L3 subinterfaces (managed variant, `policyType: subinterface`) on Cisco Nexus Dashboard 4.2.
- Add `SubinterfaceManagedInterfaceModel` (Pydantic v2 via the project's `pydantic_compat` shim) and `SubinterfaceManagedInterfaceOrchestrator`, both following the loopback / SVI / ethernet-access patterns.
- Composite identifier `(switch_ip, interface_name)`; bulk POST per switch; partial PUT; bulk remove via `interfaceActions/remove` followed by `interfaceActions/deploy`.
- Add integration test target covering merged (single, multi, Port-channel parent, idempotency, update), replaced, overridden, deleted states.
- Stacked on `nd_interface_svi`; the unmanaged-variant module (`policyType: monitorSubinterface`) follows as a separate PR stacked on this one.

L3 field set: `admin_state`, `description`, `extra_config`, `mtu`, `vlan_id`, `vrf_interface`, `ip`, `prefix`, `ipv6`, `ipv6_prefix`, `routing_tag`, `ip_redirects`, `pim_sparse`, `pim_dr_priority`, `netflow`, `netflow_monitor`, `netflow_sampler`.

## Test Notes

- Integration tests pass on ND 4.2.1 lab SITE1 against routed-mode parents (`Ethernet1/3` and `Port-channel10` on `S1_TOR1`).
- `ansible-test sanity --docker` clean on the touched files.
- Three documented ND 4.2.1 wire workarounds in the model/orchestrator:
  - Parent must be in routed (L3) mode — ND rejects POST against L2 parents with HTTP 207 status:failed; surfaced to the user via the orchestrator's multi-status check and documented in module `notes:`.
  - `routing_tag` is echoed as int on GET despite being string on POST/PUT — model has a `mode='before'` validator coercing int → str. Marked `TODO(4.2.1)`.
  - `interface_name` echoed lowercased on GET — field validator canonicalizes to `Ethernet...` / `Port-channel...` so idempotency comparisons work.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
