### PR TITLE
Fix minimum supported Python version as 3.10 (NDA-32)

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -15,9 +15,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# env:
-#   python_version: '3.11'
-
 jobs:
   pep8-black:
     name: Pep8 Compliance - Black
@@ -57,7 +54,7 @@ jobs:
           - ansible_version: "stable-2.18"
             python_version: "3.11"
 
-          # Ansible 2.17: supports Python 3.7 - 3.12
+          # Ansible 2.17: supports Python 3.10 - 3.12
           - ansible_version: "stable-2.17"
             python_version: "3.12"
           - ansible_version: "stable-2.17"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the [cisco.nd collection index](https://galaxy.ansible.com/ui/repo/published
 ## Requirements
 
 - Ansible v2.16 or newer
-- Python v3.11 or newer
+- Python v3.10 or newer
 
 Follow the [Installing Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) guide for detailed instructions.
 


### PR DESCRIPTION
## Related Issue(s)

Closes #299

## Proposed Changes

Updating documented minimum Python version to 3.10.
