### PR TITLE
nd_interface_vpc_base

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -283,7 +283,7 @@ class EpManageInterfacesDelete(_EpManageInterfacesBase):
     """
     # Summary
 
-    Delete a specific interface configuration.
+    Delete a specific interface via the per-interface endpoint.
 
     - Path: `/api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/interfaces/{interface_name}`
     - Verb: DELETE
@@ -293,6 +293,10 @@ class EpManageInterfacesDelete(_EpManageInterfacesBase):
 
     To reset physical interfaces to their default state, see `EpManageInterfacesNormalize` and set the payload to an
     appropriate default config (for example `module_utils/models/interfaces/interface_default_config.py`).
+
+    Also used by vPC interface orchestrators because the `interfaceActions/remove` bulk endpoint returns
+    `Invalid Interface` for vPC entries on ND 4.2.1 (lab-verified). The per-interface DELETE returns 204
+    on success and a subsequent GET returns 404.
 
     ## Raises
 

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -362,6 +362,6 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
                     existing = interfaces_by_name.get(name)
                     if existing is None or switch_id < existing[0]:
                         interfaces_by_name[name] = (switch_id, iface)
-            return [entry for _, entry in interfaces_by_name.values()]
+            return [entry[1] for entry in interfaces_by_name.values()]
         except Exception as e:
             raise RuntimeError(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -45,6 +45,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import requires_bulk_support
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
@@ -63,9 +64,9 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
     Each create/update reads the `vpcPair` record for the primary switch to obtain the peer serial, which is
     then injected as `peerSwitchId` in the payload. Lookups are cached per orchestrator instance.
 
-    Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` queues vPC interfaces for
-    bulk removal via `interfaceActions/remove` and bulk deploy. Call `remove_pending` and `deploy_pending` after
-    all mutations are complete.
+    Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` issues an immediate
+    per-interface `DELETE /interfaces/{name}` (the bulk `interfaceActions/remove` endpoint rejects vPC interfaces;
+    see the `TODO(4.2.1)` below) and queues a deploy. Call `deploy_pending` after all mutations are complete.
 
     ## Raises
 
@@ -82,7 +83,8 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
     - Via `query_all` if the query API request fails.
     """
 
-    # TODO(4.2.1) The bulk `/api/v1/manage/fabrics/{fabric}/interfaceActions/remove` endpoint returns
+    # TODO(4.2.1) vpc-interface-bulk-delete-silent-fail
+    # The bulk `/api/v1/manage/fabrics/{fabric}/interfaceActions/remove` endpoint returns
     # `{"status":"Failed","message":"Invalid Interface"}` inside a 207 for vPC interfaces (lab-verified). The
     # per-interface `DELETE /interfaces/{name}` endpoint works (returns 204). We therefore disable bulk delete and
     # use the per-interface DELETE via `delete_endpoint`.
@@ -163,16 +165,22 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         """
         # Summary
 
-        Inject `peerSwitchId` into the nested `configData.networkOS.policy` block of an interface payload. The model
-        already nests `peer_switch_id` under `policy`, so this just sets the value if not already present.
+        Inject `peerSwitchId` into the nested `configData.networkOS.policy` block of an interface payload. Every vPC
+        interface requires a peer serial, so a payload without a `policy` block is structurally invalid and is rejected
+        here rather than silently sent to ND as a one-sided vPC.
 
         ## Raises
 
-        None
+        ### RuntimeError
+
+        - If the payload has no `configData.networkOS.policy` block to inject `peerSwitchId` into.
         """
-        policy = payload.get("configData", {}).get("networkOS", {}).get("policy")
-        if policy is not None:
-            policy["peerSwitchId"] = peer_serial
+        policy = (payload.get("configData") or {}).get("networkOS", {}).get("policy")
+        if policy is None:
+            raise RuntimeError(
+                f"vPC interface payload is missing the 'configData.networkOS.policy' block required to inject 'peerSwitchId'; received: {payload!r}"
+            )
+        policy["peerSwitchId"] = peer_serial
         return payload
 
     def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
@@ -257,6 +265,7 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
 
+    @requires_bulk_support("supports_bulk_create")
     def create_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
         """
         # Summary
@@ -315,18 +324,104 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
+    def _switches_to_query(self) -> dict[str, str]:
+        """
+        # Summary
+
+        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
+
+        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
+        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
+        config, so only those switches are returned. This keeps the interface-list request count proportional to
+        config size rather than fabric size (CLAUDE.md performance rule: no per-switch fan-out over the whole fabric).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Via `FabricContext.switch_map` if the switches API query fails.
+        """
+        switch_map = self.fabric_context.switch_map
+        if self.rest_send.params.get("state") == "overridden":
+            return switch_map
+        config_items = self.rest_send.params.get("config") or []
+        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
+        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
+
+    def _configured_switch_ip_by_interface_name(self) -> dict[str, str]:
+        """
+        # Summary
+
+        Map each config `interface_name` to the user-supplied `switch_ip`. A vPC interface spans two peers and ND
+        returns it on both; this lets `query_all` pick the peer whose IP the user actually configured so the existing
+        state's composite identifier `(switch_ip, interface_name)` matches the proposed identifier and the run stays
+        idempotent regardless of which peer the user names.
+
+        ## Raises
+
+        None
+        """
+        mapping: dict[str, str] = {}
+        for item in self.rest_send.params.get("config") or []:
+            name = item.get("interface_name")
+            switch_ip = item.get("switch_ip")
+            if name and switch_ip:
+                mapping[name] = switch_ip
+        return mapping
+
+    @staticmethod
+    def _policy_type(iface: dict) -> str | None:
+        """
+        # Summary
+
+        Return `configData.networkOS.policy.policyType` for an interface dict, tolerating a missing or null value at
+        any level of the nested chain (ND occasionally returns `configData: null`).
+
+        ## Raises
+
+        None
+        """
+        config_data = iface.get("configData") or {}
+        network_os = config_data.get("networkOS") or {}
+        policy = network_os.get("policy") or {}
+        return policy.get("policyType")
+
+    def _managed_vpc_interfaces(self, switch_ip: str, switch_id: str, managed_types: set[str]) -> list[dict]:
+        """
+        # Summary
+
+        Fetch one switch's interface list and return the vPC interfaces whose policy type this orchestrator manages,
+        each enriched with the `switchIp` of the switch it was read from. Tolerates a missing body (`not_found_ok`) and
+        a non-dict body (the `isinstance` guard) without raising.
+
+        ## Raises
+
+        ### Exception
+
+        - If the interface-list request fails (propagated to `query_all`'s wrapper).
+        """
+        api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
+        managed = [iface for iface in interfaces if iface.get("interfaceType") == "vpc" and self._policy_type(iface) in managed_types]
+        for iface in managed:
+            iface["switchIp"] = switch_ip
+        return managed
+
     def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
         """
         # Summary
 
-        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
-        vPC interfaces with policy types managed by this orchestrator (as defined by `_managed_policy_types()`).
+        Validate the fabric context and query interfaces, filtering for vPC interfaces with policy types managed by
+        this orchestrator (as defined by `_managed_policy_types()`).
+
+        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`, and
+        limited to switches named in the user config for all other states.
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
 
-        Each returned interface dict is enriched with a `switch_ip` field so that the model has routing context.
-        vPC interfaces are de-duplicated by `interfaceName` (ND returns each vPC twice — once per peer); the entry
-        with the alphabetically-lower `switchId` is kept as the canonical representative.
+        Each returned interface dict is enriched with a `switchIp` field so that the model can be constructed with the
+        composite identifier `(switch_ip, interface_name)`.
 
         ## Raises
 
@@ -339,29 +434,52 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         managed_types = self._managed_policy_types()
         try:
             self.validate_prerequisites()
-            # TODO(4.2.1) ND returns each vPC interface TWICE — once per peer switch — with identical configData.
-            # Dedupe by interfaceName, keeping the entry whose URL-path `switchId` is alphabetically lower so the
-            # chosen representative is stable across runs. Without this dedupe, `_manage_override_deletions` would
-            # see the peer-side copy as "not in proposed" and queue a spurious delete.
+            configured_ip_by_name = self._configured_switch_ip_by_interface_name()
+            # TODO(4.2.1) vpc-interface-dual-peer-duplicate
+            # ND returns each vPC interface TWICE — once per peer switch — with identical configData. Dedupe by
+            # interfaceName. When the interface is in the user config, keep the peer whose switchIp the user supplied so
+            # idempotency holds regardless of which peer they name; otherwise keep the alphabetically-lower switchId for
+            # a stable representative. Without this dedupe, `_manage_override_deletions` would see the peer-side copy as
+            # "not in proposed" and queue a spurious delete.
             interfaces_by_name: dict[str, tuple[str, dict]] = {}
-            for switch_ip, switch_id in self.fabric_context.switch_map.items():
-                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                if not result:
-                    continue
-                interfaces = result.get("interfaces", []) or []
-                vpc_interfaces = [iface for iface in interfaces if iface.get("interfaceType") == "vpc"]
-                managed = [
-                    iface for iface in vpc_interfaces if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
-                ]
-                for iface in managed:
-                    iface["switchIp"] = switch_ip
+            for switch_ip, switch_id in self._switches_to_query().items():
+                for iface in self._managed_vpc_interfaces(switch_ip, switch_id, managed_types):
                     name = iface.get("interfaceName")
                     if name is None:
                         continue
                     existing = interfaces_by_name.get(name)
-                    if existing is None or switch_id < existing[0]:
+                    if self._prefers_candidate(name, switch_id, switch_ip, existing, configured_ip_by_name):
                         interfaces_by_name[name] = (switch_id, iface)
             return [entry[1] for entry in interfaces_by_name.values()]
         except Exception as e:
             raise RuntimeError(f"Query all failed: {e}") from e
+
+    @staticmethod
+    def _prefers_candidate(
+        name: str,
+        switch_id: str,
+        switch_ip: str,
+        existing: tuple[str, dict] | None,
+        configured_ip_by_name: dict[str, str],
+    ) -> bool:
+        """
+        # Summary
+
+        Decide whether a newly-seen per-peer copy of a vPC interface should replace the one already kept for `name`.
+        Prefer the peer whose `switch_ip` the user configured (idempotency); when neither peer is the configured one
+        (or the interface is not in config, e.g. an `overridden` deletion candidate), prefer the alphabetically-lower
+        `switch_id` for a stable representative.
+
+        ## Raises
+
+        None
+        """
+        if existing is None:
+            return True
+        configured_ip = configured_ip_by_name.get(name)
+        if configured_ip is not None:
+            if switch_ip == configured_ip:
+                return True
+            if existing[1].get("switchIp") == configured_ip:
+                return False
+        return switch_id < existing[0]

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -1,0 +1,367 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# pyright: reportAttributeAccessIssue=false
+# ModelType is NDBaseModel which lacks interface-specific fields (switch_ip,
+# interface_name, config_data). Concrete subclasses always bind ModelType to a
+# model that provides these fields, so the accesses are safe at runtime.
+
+"""
+Base orchestrator for vPC interface modules on Nexus Dashboard.
+
+This module provides `VpcInterfaceBaseOrchestrator`, which implements shared CRUD operations for all vPC interface
+types (`accessVpcHost`, `trunkVpcHost`, etc.) via the ND Manage Interfaces API. Type-specific orchestrators
+inherit from this base and provide their own `model_class` and `_managed_policy_types()`.
+
+Inherits shared interface lifecycle operations (deploy queuing, fabric validation, switch resolution) from
+`NDBaseInterfaceOrchestrator` and adds vPC-specific functionality:
+
+- Peer-serial auto-resolution: each create/update reads the per-switch `vpcPair` endpoint to obtain the peer
+  serial, then injects it as `peerSwitchId` in the payload. Results are cached per orchestrator instance so
+  bulk operations make at most one lookup per primary switch.
+- Standard remove-based deletion (vPC interfaces are virtual and deletable).
+- Fabric-wide `query_all()` filtered by `interfaceType: "vpc"` and per-type policy filtering.
+
+A vPC interface spans two switches in a vPC pair; the user supplies one peer's management IP as `switch_ip`.
+If the supplied switch is not in a vPC pair the orchestrator raises a clear `RuntimeError` instructing the
+user to create the pair first via `nd_manage_vpc_pair`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switches_vpc_pair import (
+    EpVpcPairGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesDelete,
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+ModelType = NDBaseModel
+
+
+class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
+    """
+    # Summary
+
+    Base orchestrator for vPC interface CRUD operations on Nexus Dashboard.
+
+    Provides shared logic for all vPC interface types. Subclasses must set `model_class` and implement
+    `_managed_policy_types()` to define which policy types they manage.
+
+    Each create/update reads the `vpcPair` record for the primary switch to obtain the peer serial, which is
+    then injected as `peerSwitchId` in the payload. Lookups are cached per orchestrator instance.
+
+    Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` queues vPC interfaces for
+    bulk removal via `interfaceActions/remove` and bulk deploy. Call `remove_pending` and `deploy_pending` after
+    all mutations are complete.
+
+    ## Raises
+
+    ### RuntimeError
+
+    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
+    - Via `_resolve_peer_switch_id` if the switch is not in a vPC pair.
+    - Via `create` if the create API request fails.
+    - Via `update` if the update API request fails.
+    - Via `remove_pending` if the bulk remove API request fails.
+    - Via `deploy_pending` if the bulk deploy API request fails.
+    - Via `query_one` if the query API request fails.
+    - Via `query_all` if the query API request fails.
+    """
+
+    # TODO(4.2.1) The bulk `/api/v1/manage/fabrics/{fabric}/interfaceActions/remove` endpoint returns
+    # `{"status":"Failed","message":"Invalid Interface"}` inside a 207 for vPC interfaces (lab-verified). The
+    # per-interface `DELETE /interfaces/{name}` endpoint works (returns 204). We therefore disable bulk delete and
+    # use the per-interface DELETE via `delete_endpoint`.
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = False
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesPost
+    delete_bulk_endpoint: type[NDEndpointBaseModel] | None = None
+
+    def model_post_init(self, __context) -> None:
+        """
+        # Summary
+
+        Initialize mutable private state. Extends `NDBaseInterfaceOrchestrator.model_post_init` with a
+        per-instance peer-serial cache so bulk operations make at most one `vpcPair` GET per primary switch.
+
+        ## Raises
+
+        None
+        """
+        super().model_post_init(__context)
+        self._peer_serial_cache: dict[str, str] = {}
+
+    def _managed_policy_types(self) -> set[str]:
+        """
+        # Summary
+
+        Return the set of API-side policy type values managed by this orchestrator. Subclasses must override this method
+        to return their specific policy types (e.g., `{"accessVpcHost"}` for the access orchestrator).
+
+        ## Raises
+
+        ### NotImplementedError
+
+        - Always, if not overridden by a subclass.
+        """
+        raise NotImplementedError("Subclasses must implement _managed_policy_types()")
+
+    def _resolve_peer_switch_id(self, switch_ip: str, primary_serial: str) -> str:
+        """
+        # Summary
+
+        Resolve the peer switch's serial number for the vPC pair containing `primary_serial`. Reads the per-switch
+        `vpcPair` endpoint. Caches the result per orchestrator instance so bulk operations issue at most one lookup
+        per primary switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the switch is not in a vPC pair (the `vpcPair` GET returns 404 / empty body).
+        - If the `vpcPair` GET returns success but omits `peerSwitchId`.
+        """
+        cached = self._peer_serial_cache.get(primary_serial)
+        if cached:
+            return cached
+        api_endpoint = EpVpcPairGet()
+        api_endpoint.fabric_name = self.fabric_name
+        api_endpoint.switch_id = primary_serial
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        if not result:
+            raise RuntimeError(
+                f"Switch {switch_ip} (serial {primary_serial}) is not in a vPC pair; "
+                f"create the pair via nd_manage_vpc_pair before configuring vPC interfaces."
+            )
+        peer_serial = result.get("peerSwitchId")
+        if not peer_serial:
+            raise RuntimeError(f"vPC pair record for switch {switch_ip} (serial {primary_serial}) is missing 'peerSwitchId'; " f"received: {result!r}")
+        self._peer_serial_cache[primary_serial] = peer_serial
+        return peer_serial
+
+    def _inject_peer_switch_id(self, payload: dict, peer_serial: str) -> dict:
+        """
+        # Summary
+
+        Inject `peerSwitchId` into the nested `configData.networkOS.policy` block of an interface payload. The model
+        already nests `peer_switch_id` under `policy`, so this just sets the value if not already present.
+
+        ## Raises
+
+        None
+        """
+        policy = payload.get("configData", {}).get("networkOS", {}).get("policy")
+        if policy is not None:
+            policy["peerSwitchId"] = peer_serial
+        return payload
+
+    def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create a vPC interface configuration. Resolves `switch_ip` to a primary serial, resolves the peer serial via
+        the vPC pair record, injects both into the payload, and POSTs the wrapped `interfaces` array. Queues a deploy
+        for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the create API request fails.
+        - If the primary switch is not in a vPC pair.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+            api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            self._inject_peer_switch_id(payload, peer_serial)
+            request_body = {"interfaces": [payload]}
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def update(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Update a vPC interface configuration. Resolves `switch_ip` to a primary serial, resolves the peer serial via
+        the vPC pair record, injects both into the payload, and PUTs the updated configuration. Queues a deploy for
+        later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the update API request fails.
+        - If the primary switch is not in a vPC pair.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+            api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            payload = model_instance.to_payload()
+            payload["switchId"] = switch_id
+            self._inject_peer_switch_id(payload, peer_serial)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+            return result
+        except Exception as e:
+            raise RuntimeError(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def delete(self, model_instance: ModelType, **kwargs) -> None:
+        """
+        # Summary
+
+        Delete a vPC interface immediately via the per-interface `DELETE /interfaces/{name}` endpoint, then queue
+        a deploy for later bulk execution via `deploy_pending`. The DELETE returns 204 on success; a subsequent GET
+        returns 404. The deploy pushes the removal to both peers and reverts member interfaces to their fabric
+        default configuration.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the DELETE API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.delete_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            self._queue_deploy(model_instance.interface_name, switch_id)
+        except Exception as e:
+            raise RuntimeError(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def create_bulk(self, model_instances: list[ModelType], **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Create multiple vPC interfaces in bulk. Groups by primary switch, resolves the peer serial once per group, and
+        sends one POST per primary switch with all vPC interfaces in the `interfaces` array. Queues deploys for all
+        created interfaces for later bulk execution via `deploy_pending`.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create API request fails.
+        - If any primary switch is not in a vPC pair.
+        """
+        try:
+            groups: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+            for model_instance in model_instances:
+                switch_id = self._resolve_switch_id(model_instance.switch_ip)
+                peer_serial = self._resolve_peer_switch_id(model_instance.switch_ip, switch_id)
+                payload = model_instance.to_payload()
+                payload["switchId"] = switch_id
+                self._inject_peer_switch_id(payload, peer_serial)
+                groups[switch_id].append((model_instance.interface_name, payload))
+
+            results = []
+            for switch_id, items in groups.items():
+                # Guarded at runtime by @requires_bulk_support("supports_bulk_create")
+                api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
+                request_body = {"interfaces": [payload for interface_name, payload in items]}
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
+                results.append(result)
+                for interface_name, payload in items:
+                    self._queue_deploy(interface_name, switch_id)
+            return results
+        except Exception as e:
+            raise RuntimeError(f"Bulk create failed: {e}") from e
+
+    def query_one(self, model_instance: ModelType, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Query a single vPC interface by name on a specific switch.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the query API request fails.
+        """
+        try:
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            api_endpoint = self._configure_endpoint(self.query_one_endpoint(), switch_sn=switch_id)
+            api_endpoint.set_identifiers(model_instance.interface_name)
+            return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
+        except Exception as e:
+            raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
+        """
+        # Summary
+
+        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
+        vPC interfaces with policy types managed by this orchestrator (as defined by `_managed_policy_types()`).
+
+        Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
+
+        Each returned interface dict is enriched with a `switch_ip` field so that the model has routing context.
+        vPC interfaces are de-duplicated by `interfaceName` (ND returns each vPC twice — once per peer); the entry
+        with the alphabetically-lower `switchId` is kept as the canonical representative.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist on the target ND node.
+        - If the fabric is in deployment-freeze mode.
+        - If the query API request fails.
+        """
+        managed_types = self._managed_policy_types()
+        try:
+            self.validate_prerequisites()
+            # TODO(4.2.1) ND returns each vPC interface TWICE — once per peer switch — with identical configData.
+            # Dedupe by interfaceName, keeping the entry whose URL-path `switchId` is alphabetically lower so the
+            # chosen representative is stable across runs. Without this dedupe, `_manage_override_deletions` would
+            # see the peer-side copy as "not in proposed" and queue a spurious delete.
+            interfaces_by_name: dict[str, tuple[str, dict]] = {}
+            for switch_ip, switch_id in self.fabric_context.switch_map.items():
+                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+                if not result:
+                    continue
+                interfaces = result.get("interfaces", []) or []
+                vpc_interfaces = [iface for iface in interfaces if iface.get("interfaceType") == "vpc"]
+                managed = [
+                    iface for iface in vpc_interfaces if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
+                ]
+                for iface in managed:
+                    iface["switchIp"] = switch_ip
+                    name = iface.get("interfaceName")
+                    if name is None:
+                        continue
+                    existing = interfaces_by_name.get(name)
+                    if existing is None or switch_id < existing[0]:
+                        interfaces_by_name[name] = (switch_id, iface)
+            return [entry for _, entry in interfaces_by_name.values()]
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
@@ -1,0 +1,495 @@
+{
+    "TEST_NOTES": [
+        "Fixtures for tests/unit/module_utils/orchestrators/test_vpc_interface_base.py.",
+        "Exercises the shared VpcInterfaceBaseOrchestrator via the _StubVpcOrchestrator concrete subclass.",
+        "Switch A: fabricManagementIp 192.168.1.1 -> switchId FDO11111AAA (vPC peer FDO22222BBB).",
+        "Switch B: fabricManagementIp 192.168.1.2 -> switchId FDO22222BBB (vPC peer FDO11111AAA).",
+        "Response order per test matches the API call order in the code under test.",
+        "To refresh: capture the corresponding GET/POST/PUT/DELETE responses against a live ND 4.2 fabric with a vPC pair."
+    ],
+
+    "test_vpc_interface_base_00200a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id happy path: vpcPair GET returns the peer serial."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "peerSwitchId": "FDO22222BBB",
+            "vpcDomainId": 1
+        }
+    },
+
+    "test_vpc_interface_base_00210a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id caching: only one vpcPair GET is provided for two calls."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "peerSwitchId": "FDO22222BBB",
+            "vpcDomainId": 1
+        }
+    },
+
+    "test_vpc_interface_base_00220a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id missing pair: vpcPair GET returns 404 (switch not in a vPC pair)."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00230a": {
+        "TEST_NOTES": ["_resolve_peer_switch_id missing peerSwitchId: vpcPair GET succeeds but omits peerSwitchId."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDO11111AAA",
+            "vpcDomainId": 1
+        }
+    },
+
+    "test_vpc_interface_base_00400a": {
+        "TEST_NOTES": ["create happy path: switches list (one switch) for _resolve_switch_id."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00400b": {
+        "TEST_NOTES": ["create happy path: vpcPair GET for _resolve_peer_switch_id."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00400c": {
+        "TEST_NOTES": ["create happy path: POST /interfaces (200)."],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_vpc_interface_base_00410a": {
+        "TEST_NOTES": ["create failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00410b": {
+        "TEST_NOTES": ["create failure: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00410c": {
+        "TEST_NOTES": ["create failure: POST /interfaces returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00420a": {
+        "TEST_NOTES": ["create not-in-pair: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00420b": {
+        "TEST_NOTES": ["create not-in-pair: vpcPair GET returns 404."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00500a": {
+        "TEST_NOTES": ["update happy path: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00500b": {
+        "TEST_NOTES": ["update happy path: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00500c": {
+        "TEST_NOTES": ["update happy path: PUT /interfaces/{name} (200)."],
+        "RETURN_CODE": 200,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_vpc_interface_base_00510a": {
+        "TEST_NOTES": ["update failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00510b": {
+        "TEST_NOTES": ["update failure: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00510c": {
+        "TEST_NOTES": ["update failure: PUT returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "PUT",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00600a": {
+        "TEST_NOTES": ["delete happy path: switches list for _resolve_switch_id."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00600b": {
+        "TEST_NOTES": ["delete happy path: per-interface DELETE returns 204 (no body)."],
+        "RETURN_CODE": 204,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "No Content",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00610a": {
+        "TEST_NOTES": ["delete failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00610b": {
+        "TEST_NOTES": ["delete failure: per-interface DELETE returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "DELETE",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00700a": {
+        "TEST_NOTES": ["create_bulk peer cache: switches list (one switch, fetched once and cached)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00700b": {
+        "TEST_NOTES": ["create_bulk peer cache: a single vpcPair GET serves both interfaces on the same primary switch."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00700c": {
+        "TEST_NOTES": ["create_bulk peer cache: one POST /interfaces carrying both vPC interfaces."],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"status": "ok"}
+    },
+
+    "test_vpc_interface_base_00710a": {
+        "TEST_NOTES": ["create_bulk failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00710b": {
+        "TEST_NOTES": ["create_bulk failure: vpcPair GET."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_00710c": {
+        "TEST_NOTES": ["create_bulk failure: per-switch POST returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00800a": {
+        "TEST_NOTES": ["query_one happy path: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00800b": {
+        "TEST_NOTES": ["query_one happy path: GET /interfaces/{name} returns the vPC interface."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaceName": "vpc501",
+            "interfaceType": "vpc",
+            "configData": {
+                "mode": "access",
+                "networkOS": {
+                    "networkOSType": "nx-os",
+                    "policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO22222BBB"}
+                }
+            }
+        }
+    },
+
+    "test_vpc_interface_base_00810a": {
+        "TEST_NOTES": ["query_one failure: switches list."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00810b": {
+        "TEST_NOTES": ["query_one failure: GET returns 500."],
+        "RETURN_CODE": 500,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {"message": "boom"}
+    },
+
+    "test_vpc_interface_base_00900a": {
+        "TEST_NOTES": ["query_all dedupe: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00900b": {
+        "TEST_NOTES": ["query_all dedupe: switches list (two vPC peers)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00900c": {
+        "TEST_NOTES": [
+            "query_all dedupe: switch A (FDO11111AAA) interfaces.",
+            "Contains the managed accessVpcHost vpc501, an other-policy trunkVpcHost vpc502 (filtered out),",
+            "and a non-vPC ethernet (filtered out). vpc501 also appears on switch B (peer copy)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                },
+                {
+                    "interfaceName": "vpc502",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "trunkVpcHost", "allowedVlans": "1-10"}}}
+                },
+                {
+                    "interfaceName": "Ethernet1/5",
+                    "interfaceType": "ethernet",
+                    "configData": {"networkOS": {"policy": {"policyType": "trunkHost"}}}
+                }
+            ]
+        }
+    },
+    "test_vpc_interface_base_00900d": {
+        "TEST_NOTES": [
+            "query_all dedupe: switch B (FDO22222BBB) interfaces.",
+            "Returns the peer-side copy of vpc501 (same interfaceName) which must be deduped away,",
+            "keeping the alphabetically-lower switchId (FDO11111AAA) representative."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00910a": {
+        "TEST_NOTES": ["query_all no-name skip: fabric summary."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00910b": {
+        "TEST_NOTES": ["query_all no-name skip: switches list (one switch)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00910c": {
+        "TEST_NOTES": [
+            "query_all no-name skip: a managed accessVpcHost vPC interface with no interfaceName.",
+            "It passes the type + policy filters but must be skipped because it has no name to key on."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00930a": {
+        "TEST_NOTES": ["query_all fabric-not-found: summary returns 404; validate_prerequisites raises."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+
+    "test_vpc_interface_base_00940a": {
+        "TEST_NOTES": ["query_all switch-404: fabric summary."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00940b": {
+        "TEST_NOTES": ["query_all switch-404: switches list (one switch)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}
+            ]
+        }
+    },
+    "test_vpc_interface_base_00940c": {
+        "TEST_NOTES": ["query_all switch-404: switch interfaces endpoint returns 404 (no body); switch is skipped."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    }
+}

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
@@ -491,5 +491,147 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
         "MESSAGE": "Not Found",
         "DATA": {}
+    },
+
+    "test_vpc_interface_base_00920a": {
+        "TEST_NOTES": ["query_all config-scoped: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+
+    "test_vpc_interface_base_00920b": {
+        "TEST_NOTES": ["query_all config-scoped: switches list (two switches); only the config switch is queried."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00920c": {
+        "TEST_NOTES": ["query_all config-scoped: config switch (FDO11111AAA) interfaces; switch B is never fetched."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00950a": {
+        "TEST_NOTES": ["query_all peer-preference: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+
+    "test_vpc_interface_base_00950b": {
+        "TEST_NOTES": ["query_all peer-preference: switches list (two vPC peers)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00950c": {
+        "TEST_NOTES": ["query_all peer-preference: switch A (lower switchId) returns vpc501; deduped away in favor of the configured peer."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00950d": {
+        "TEST_NOTES": ["query_all peer-preference: switch B (higher switchId, the configured peer 192.168.1.2) returns vpc501; kept because the user configured it."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc501",
+                    "interfaceType": "vpc",
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                }
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00960a": {
+        "TEST_NOTES": ["query_all malformed-body: fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+
+    "test_vpc_interface_base_00960b": {
+        "TEST_NOTES": ["query_all malformed-body: switches list (two switches)."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00960c": {
+        "TEST_NOTES": ["query_all malformed-body: switch A returns a vPC with configData:null; the null-safe policy-type accessor filters it out."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {"interfaceName": "vpc501", "interfaceType": "vpc", "configData": null}
+            ]
+        }
+    },
+
+    "test_vpc_interface_base_00960d": {
+        "TEST_NOTES": ["query_all malformed-body: switch B returns a bare list as DATA (non-dict); the isinstance guard skips it without AttributeError."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": [{"interfaceName": "junk", "interfaceType": "vpc"}]
     }
 }

--- a/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
@@ -119,8 +119,17 @@ def responses_vpc_base(key: str):
     return load_fixture("test_vpc_interface_base")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
-    """Build a `RestSend` wired to the file-based `Sender` and the real `ResponseHandler`."""
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> RestSend:
+    """Build a `RestSend` wired to the file-based `Sender` and the real `ResponseHandler`.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) and its config-preference dedup can be exercised.
+    """
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
@@ -130,7 +139,13 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -138,9 +153,14 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     return rest_send
 
 
-def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> _StubVpcOrchestrator:
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> _StubVpcOrchestrator:
     """Construct a `_StubVpcOrchestrator` with the file-based `RestSend` injected."""
-    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
     return _StubVpcOrchestrator(rest_send=rest_send)
 
 
@@ -418,12 +438,14 @@ def test_vpc_interface_base_00310() -> None:
     """
     # Summary
 
-    Verify `_inject_peer_switch_id` is a safe no-op when there is no nested policy to inject into.
+    Verify `_inject_peer_switch_id` raises `RuntimeError` when there is no nested `policy` block to inject into. A
+    vPC interface always needs a peer serial, so a policy-less payload is structurally invalid and must fail fast
+    rather than be silently sent to ND as a one-sided vPC.
 
     ## Test
 
-    - Payload with no `policy` key is returned unchanged (no `peerSwitchId` added, no KeyError)
-    - Payload with no `configData` key is returned unchanged
+    - Payload with no `policy` key raises `RuntimeError` matching `missing the 'configData.networkOS.policy' block`
+    - Payload with no `configData` key raises the same `RuntimeError`
 
     ## Classes and Methods
 
@@ -436,11 +458,15 @@ def test_vpc_interface_base_00310() -> None:
     gen_responses = ResponseGenerator(responses())
     instance = _build_orchestrator(gen_responses)
 
+    match = r"missing the 'configData\.networkOS\.policy' block"
+
     no_policy: dict = {"configData": {"networkOS": {}}}
-    assert instance._inject_peer_switch_id(no_policy, "FDO22222BBB") == {"configData": {"networkOS": {}}}
+    with pytest.raises(RuntimeError, match=match):
+        instance._inject_peer_switch_id(no_policy, "FDO22222BBB")
 
     no_config: dict = {"interfaceName": "vpc501"}
-    assert instance._inject_peer_switch_id(no_config, "FDO22222BBB") == {"interfaceName": "vpc501"}
+    with pytest.raises(RuntimeError, match=match):
+        instance._inject_peer_switch_id(no_config, "FDO22222BBB")
 
 
 # =============================================================================
@@ -903,6 +929,8 @@ def test_vpc_interface_base_00900() -> None:
     - The kept entry carries `switchIp` of the lower-`switchId` peer (192.168.1.1 / FDO11111AAA)
     - Request count is exactly 4: summary + switches-list + one interface GET per switch (locks the scan cost)
 
+    `state=overridden` keeps `query_all` fabric-wide so both peers are scanned and the per-peer dedup is exercised.
+
     ## Classes and Methods
 
     - VpcInterfaceBaseOrchestrator.query_all()
@@ -919,7 +947,7 @@ def test_vpc_interface_base_00900() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        instance = _build_orchestrator(gen_responses)
+        instance = _build_orchestrator(gen_responses, state="overridden")
         result = instance.query_all()
 
     assert isinstance(result, list)
@@ -948,6 +976,8 @@ def test_vpc_interface_base_00910() -> None:
     - The single switch returns one managed `accessVpcHost` vPC interface with no `interfaceName`
     - `query_all` returns `[]` (the nameless entry is skipped, not raised on)
 
+    `state=overridden` keeps `query_all` fabric-wide so the switch is scanned.
+
     ## Classes and Methods
 
     - VpcInterfaceBaseOrchestrator.query_all()
@@ -962,7 +992,7 @@ def test_vpc_interface_base_00910() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        instance = _build_orchestrator(gen_responses)
+        instance = _build_orchestrator(gen_responses, state="overridden")
         result = instance.query_all()
 
     assert result == []
@@ -1008,6 +1038,8 @@ def test_vpc_interface_base_00940() -> None:
     - The switch's interfaces endpoint returns 404 (no body)
     - `query_all` returns `[]`
 
+    `state=overridden` keeps `query_all` fabric-wide so the 404 switch is still visited and skipped.
+
     ## Classes and Methods
 
     - VpcInterfaceBaseOrchestrator.query_all()
@@ -1022,7 +1054,123 @@ def test_vpc_interface_base_00940() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        instance = _build_orchestrator(gen_responses)
+        instance = _build_orchestrator(gen_responses, state="overridden")
+        result = instance.query_all()
+
+    assert result == []
+
+
+def test_vpc_interface_base_00920() -> None:
+    """
+    # Summary
+
+    Verify `query_all` scopes its per-switch interface-list fan-out to switches named in the user config when
+    `state` is not `overridden`, rather than querying every switch in the fabric (CLAUDE.md performance rule).
+
+    ## Test
+
+    - Fabric has two switches (192.168.1.1, 192.168.1.2), but config names only 192.168.1.1
+    - state is `merged` (non-overridden), so `_switches_to_query` returns only the config switch
+    - Only the config switch's interfaces are fetched; the second switch is never queried (the response generator
+      yields exactly three responses — summary, switch list, switch-1 interfaces — and would raise if a second
+      per-switch GET were issued)
+    - Result contains only the `accessVpcHost` vPC on the config switch, stamped with the config `switchIp`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._switches_to_query()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "vpc501"}]
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="merged", config=config)
+        result = instance.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc501"
+    assert result[0]["switchIp"] == "192.168.1.1"
+
+
+def test_vpc_interface_base_00950() -> None:
+    """
+    # Summary
+
+    Verify the per-peer dedup keeps the peer whose `switchIp` the user actually configured, so idempotency holds
+    even when the user names the HIGHER-`switchId` peer. A vPC is returned on both peers; without this preference
+    the dedup would canonicalize to the lower-`switchId` peer (192.168.1.1) and the existing-state identifier would
+    never match a config naming 192.168.1.2, churning a spurious delete + recreate under `overridden`.
+
+    ## Test
+
+    - `state=overridden` so both peers are scanned (192.168.1.1 / FDO11111AAA and 192.168.1.2 / FDO22222BBB)
+    - Config names vpc501 on the higher-`switchId` peer 192.168.1.2
+    - The deduped entry carries `switchIp` 192.168.1.2 (the configured peer), not the lower-`switchId` default
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._prefers_candidate()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.2", "interface_name": "vpc501"}]
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden", config=config)
+        result = instance.query_all()
+
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc501"
+    assert result[0]["switchIp"] == "192.168.1.2"
+
+
+def test_vpc_interface_base_00960() -> None:
+    """
+    # Summary
+
+    Verify `query_all` tolerates malformed per-switch bodies without aborting the whole run: a `configData: null`
+    interface is filtered out via the null-safe policy-type accessor, and a non-dict interfaces body is skipped via
+    the `isinstance(result, dict)` guard. Neither raises `AttributeError`.
+
+    ## Test
+
+    - `state=overridden` so both switches are scanned
+    - Switch A returns a vPC interface with `configData: null` (policy type resolves to None → filtered out)
+    - Switch B returns a bare list as its DATA body (non-dict → skipped by the isinstance guard)
+    - `query_all` returns `[]` rather than raising
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._policy_type()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden")
         result = instance.query_all()
 
     assert result == []

--- a/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
@@ -1,0 +1,1028 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for `VpcInterfaceBaseOrchestrator`.
+
+`VpcInterfaceBaseOrchestrator` is an abstract base shared by every vPC interface module (access, trunk-host, ...).
+The concrete per-type orchestrators and models live on the branches stacked above this one, so these tests exercise
+the base directly through `_StubVpcOrchestrator` / `_StubVpcInterfaceModel` -- minimal concrete subclasses that
+bind `model_class` and `_managed_policy_types` without coupling to any per-feature module.
+
+Coverage (per PR #334 review):
+- `_resolve_peer_switch_id`: success, per-instance caching, missing-pair, and missing-`peerSwitchId`.
+- `_inject_peer_switch_id`: injection into `configData.networkOS.policy`, and no-op when no policy is present.
+- `create` / `update`: `switchId` + `peerSwitchId` injection, endpoint path/verb, deploy queuing, error wrapping.
+- `delete`: per-interface DELETE path construction, deploy queuing (no bulk remove), error wrapping.
+- `create_bulk`: per-switch grouping with a single peer lookup per primary switch (cache).
+- `query_one`: per-interface GET path construction and error wrapping.
+- `query_all`: fabric validation, `interfaceType`/`policyType` filtering, `switchIp` enrichment, per-peer dedup,
+  and an explicit request-count lock (2 + one GET per switch) for the fabric-wide scan flagged in review.
+
+Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` injected into a real `RestSend`.
+Responses are read from `tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json`.
+"""
+
+# pylint: disable=disallowed-name
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-few-public-methods
+# pylint: disable=too-many-lines
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+from __future__ import annotations
+
+import inspect
+from typing import ClassVar, Literal, Type
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesDelete,
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import VpcInterfaceBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+
+# =============================================================================
+# Stub model + orchestrator: minimal concrete subclasses of the abstract base
+# =============================================================================
+
+
+class _StubVpcPolicyModel(NDNestedModel):
+    """Minimal vPC policy block mapping to `configData.networkOS.policy`."""
+
+    policy_type: Literal["accessVpcHost"] = Field(default="accessVpcHost", alias="policyType", frozen=True)
+    access_vlan: int | None = Field(default=None, alias="accessVlan")
+    peer_switch_id: str | None = Field(default=None, alias="peerSwitchId")
+
+
+class _StubVpcNetworkOSModel(NDNestedModel):
+    """Minimal networkOS container mapping to `configData.networkOS`."""
+
+    network_os_type: Literal["nx-os"] = Field(default="nx-os", alias="networkOSType", frozen=True)
+    policy: _StubVpcPolicyModel | None = Field(default=None, alias="policy")
+
+
+class _StubVpcConfigDataModel(NDNestedModel):
+    """Minimal config-data container mapping to `configData`."""
+
+    mode: Literal["access"] = Field(default="access", alias="mode", frozen=True)
+    network_os: _StubVpcNetworkOSModel = Field(default_factory=_StubVpcNetworkOSModel, alias="networkOS")
+
+
+class _StubVpcInterfaceModel(NDBaseModel):
+    """Minimal vPC interface model: composite identifier, nested config mirroring the ND wire shape."""
+
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
+
+    switch_ip: str = Field(alias="switchIp")
+    interface_name: str = Field(alias="interfaceName")
+    interface_type: Literal["vpc"] = Field(default="vpc", alias="interfaceType", frozen=True)
+    config_data: _StubVpcConfigDataModel | None = Field(default=None, alias="configData")
+
+
+class _StubVpcOrchestrator(VpcInterfaceBaseOrchestrator):
+    """Concrete subclass binding `model_class` and the managed policy type for the abstract base."""
+
+    model_class: ClassVar[Type[NDBaseModel]] = _StubVpcInterfaceModel
+
+    def _managed_policy_types(self) -> set[str]:
+        return {"accessVpcHost"}
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def responses_vpc_base(key: str):
+    """Load fixture data for the test_vpc_interface_base.json file."""
+    return load_fixture("test_vpc_interface_base")[key]
+
+
+def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
+    """Build a `RestSend` wired to the file-based `Sender` and the real `ResponseHandler`."""
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    response_handler = ResponseHandler()
+    response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+    response_handler.verb = HttpVerbEnum.GET
+    response_handler.commit()
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = response_handler
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    return rest_send
+
+
+def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> _StubVpcOrchestrator:
+    """Construct a `_StubVpcOrchestrator` with the file-based `RestSend` injected."""
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    return _StubVpcOrchestrator(rest_send=rest_send)
+
+
+def _build_model(
+    switch_ip: str = "192.168.1.1",
+    interface_name: str = "vpc501",
+    include_config: bool = True,
+) -> _StubVpcInterfaceModel:
+    """Build a minimal `_StubVpcInterfaceModel` instance for CRUD tests."""
+    kwargs: dict = {"switch_ip": switch_ip, "interface_name": interface_name}
+    if include_config:
+        kwargs["config_data"] = _StubVpcConfigDataModel(
+            network_os=_StubVpcNetworkOSModel(policy=_StubVpcPolicyModel(access_vlan=100)),
+        )
+    return _StubVpcInterfaceModel(**kwargs)
+
+
+# =============================================================================
+# Test: ClassVars / endpoint wiring
+# =============================================================================
+
+
+def test_vpc_interface_base_00010() -> None:
+    """
+    # Summary
+
+    Verify the bulk-support flags: vPC supports bulk create but NOT bulk delete (the `interfaceActions/remove`
+    endpoint returns `Invalid Interface` for vPC entries on ND 4.2.1, so delete goes per-interface).
+
+    ## Test
+
+    - `supports_bulk_create` is True
+    - `supports_bulk_delete` is False
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator
+    """
+    assert VpcInterfaceBaseOrchestrator.supports_bulk_create is True
+    assert VpcInterfaceBaseOrchestrator.supports_bulk_delete is False
+
+
+def test_vpc_interface_base_00020() -> None:
+    """
+    # Summary
+
+    Verify the per-verb endpoint classes are wired to the ND Manage Interfaces endpoints, including the
+    per-interface DELETE endpoint added by this PR.
+
+    The `*_endpoint` attributes are Pydantic instance fields (they hold the endpoint *type*), so they are read
+    off an instance, not the class.
+
+    ## Test
+
+    - create/update/query_one/query_all endpoints point at the expected `EpManageInterfaces*` classes
+    - `delete_endpoint` is the per-interface `EpManageInterfacesDelete`
+    - `delete_bulk_endpoint` is None (bulk delete disabled)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    assert instance.create_endpoint is EpManageInterfacesPost
+    assert instance.update_endpoint is EpManageInterfacesPut
+    assert instance.delete_endpoint is EpManageInterfacesDelete
+    assert instance.query_one_endpoint is EpManageInterfacesGet
+    assert instance.query_all_endpoint is EpManageInterfacesListGet
+    assert instance.delete_bulk_endpoint is None
+
+
+# =============================================================================
+# Test: _managed_policy_types
+# =============================================================================
+
+
+def test_vpc_interface_base_00100() -> None:
+    """
+    # Summary
+
+    Verify the abstract base raises `NotImplementedError` for `_managed_policy_types` and the concrete stub overrides it.
+
+    ## Test
+
+    - Calling `VpcInterfaceBaseOrchestrator._managed_policy_types` (unbound) raises `NotImplementedError`
+    - `_StubVpcOrchestrator._managed_policy_types()` returns `{"accessVpcHost"}`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._managed_policy_types()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    orchestrator = _build_orchestrator(gen_responses)
+
+    with pytest.raises(NotImplementedError, match=r"Subclasses must implement _managed_policy_types"):
+        VpcInterfaceBaseOrchestrator._managed_policy_types(orchestrator)
+
+    assert orchestrator._managed_policy_types() == {"accessVpcHost"}
+
+
+# =============================================================================
+# Test: _resolve_peer_switch_id
+# =============================================================================
+
+
+def test_vpc_interface_base_00200() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` reads the per-switch `vpcPair` endpoint and returns the peer serial.
+
+    ## Test
+
+    - vpcPair GET returns `peerSwitchId: FDO22222BBB`
+    - `_resolve_peer_switch_id` returns `"FDO22222BBB"` and caches it under the primary serial
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        peer = instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert peer == "FDO22222BBB"
+    assert instance._peer_serial_cache == {"FDO11111AAA": "FDO22222BBB"}
+
+
+def test_vpc_interface_base_00210() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` caches per primary serial: a second call for the same switch does NOT
+    issue another `vpcPair` GET (only one response is provided).
+
+    ## Test
+
+    - First call consumes the single vpcPair response and returns the peer
+    - Second call returns the cached peer without consuming another response (generator would be exhausted)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    with does_not_raise():
+        first = instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+        second = instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert first == "FDO22222BBB"
+    assert second == "FDO22222BBB"
+
+
+def test_vpc_interface_base_00220() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises `RuntimeError` when the switch is not in a vPC pair (vpcPair GET 404).
+
+    ## Test
+
+    - vpcPair GET returns 404 (empty body via `not_found_ok`)
+    - `RuntimeError` mentions the switch IP, the serial, and points the user at `nd_manage_vpc_pair`
+    - Nothing is cached
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    match = r"Switch 192\.168\.1\.1 \(serial FDO11111AAA\) is not in a vPC pair.*nd_manage_vpc_pair"
+    with pytest.raises(RuntimeError, match=match):
+        instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert instance._peer_serial_cache == {}
+
+
+def test_vpc_interface_base_00230() -> None:
+    """
+    # Summary
+
+    Verify `_resolve_peer_switch_id` raises `RuntimeError` when the vpcPair record omits `peerSwitchId`.
+
+    ## Test
+
+    - vpcPair GET returns 200 but the body has no `peerSwitchId`
+    - `RuntimeError` matches `missing 'peerSwitchId'`
+    - Nothing is cached
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    match = r"missing 'peerSwitchId'"
+    with pytest.raises(RuntimeError, match=match):
+        instance._resolve_peer_switch_id("192.168.1.1", "FDO11111AAA")
+
+    assert instance._peer_serial_cache == {}
+
+
+# =============================================================================
+# Test: _inject_peer_switch_id
+# =============================================================================
+
+
+def test_vpc_interface_base_00300() -> None:
+    """
+    # Summary
+
+    Verify `_inject_peer_switch_id` sets `peerSwitchId` inside `configData.networkOS.policy`.
+
+    ## Test
+
+    - Payload with a nested policy gets `peerSwitchId` injected
+    - The same dict object is returned (in-place mutation)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._inject_peer_switch_id()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    payload = {"configData": {"networkOS": {"policy": {"policyType": "accessVpcHost"}}}}
+    result = instance._inject_peer_switch_id(payload, "FDO22222BBB")
+
+    assert result is payload
+    assert payload["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+
+
+def test_vpc_interface_base_00310() -> None:
+    """
+    # Summary
+
+    Verify `_inject_peer_switch_id` is a safe no-op when there is no nested policy to inject into.
+
+    ## Test
+
+    - Payload with no `policy` key is returned unchanged (no `peerSwitchId` added, no KeyError)
+    - Payload with no `configData` key is returned unchanged
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator._inject_peer_switch_id()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+
+    no_policy: dict = {"configData": {"networkOS": {}}}
+    assert instance._inject_peer_switch_id(no_policy, "FDO22222BBB") == {"configData": {"networkOS": {}}}
+
+    no_config: dict = {"interfaceName": "vpc501"}
+    assert instance._inject_peer_switch_id(no_config, "FDO22222BBB") == {"interfaceName": "vpc501"}
+
+
+# =============================================================================
+# Test: create
+# =============================================================================
+
+
+def test_vpc_interface_base_00400() -> None:
+    """
+    # Summary
+
+    Verify `create` resolves the switch and peer serials, injects `switchId` and `peerSwitchId`, wraps the payload
+    in `{"interfaces": [...]}`, POSTs to the per-switch interfaces URL, and queues a deploy.
+
+    ## Test
+
+    - POST hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces`
+    - Request body is `{"interfaces": [ {...} ]}` with one element
+    - The element carries `interfaceType: vpc`, `switchId: FDO11111AAA`, no `switchIp`
+    - `configData.networkOS.policy.peerSwitchId` is the resolved peer serial
+    - `_pending_deploys` contains the single `(interface_name, switch_id)` pair
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    - VpcInterfaceBaseOrchestrator._inject_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with does_not_raise():
+        instance.create(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert len(body["interfaces"]) == 1
+    payload_item = body["interfaces"][0]
+    assert payload_item["interfaceName"] == "vpc501"
+    assert payload_item["interfaceType"] == "vpc"
+    assert payload_item["switchId"] == "FDO11111AAA"
+    assert "switchIp" not in payload_item
+    assert payload_item["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+    assert instance._pending_deploys == [("vpc501", "FDO11111AAA")]
+
+
+def test_vpc_interface_base_00410() -> None:
+    """
+    # Summary
+
+    Verify `create` wraps a `_request` failure in `RuntimeError` and queues no deploy.
+
+    ## Test
+
+    - switches-list and vpcPair succeed; POST returns 500
+    - `RuntimeError` matches `Create failed for`
+    - `_pending_deploys` stays empty
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with pytest.raises(RuntimeError, match=r"Create failed for"):
+        instance.create(model)
+
+    assert instance._pending_deploys == []
+
+
+def test_vpc_interface_base_00420() -> None:
+    """
+    # Summary
+
+    Verify `create` surfaces the not-in-a-vPC-pair error (wrapped as `Create failed`) when the primary switch
+    has no vpcPair record.
+
+    ## Test
+
+    - switches-list succeeds; vpcPair GET returns 404
+    - `RuntimeError` matches `Create failed for .*is not in a vPC pair`
+    - No deploy is queued
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with pytest.raises(RuntimeError, match=r"Create failed for .*is not in a vPC pair"):
+        instance.create(model)
+
+    assert instance._pending_deploys == []
+
+
+# =============================================================================
+# Test: update
+# =============================================================================
+
+
+def test_vpc_interface_base_00500() -> None:
+    """
+    # Summary
+
+    Verify `update` issues a PUT to the per-interface URL, injects `switchId` + `peerSwitchId`, and queues a deploy.
+
+    ## Test
+
+    - PUT hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501`
+    - Body carries `switchId`, no `switchIp`, and the injected `peerSwitchId`
+    - `_pending_deploys` contains the `(vpc501, FDO11111AAA)` pair
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with does_not_raise():
+        instance.update(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501"
+    assert rest_send.verb == HttpVerbEnum.PUT.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert body["interfaceName"] == "vpc501"
+    assert body["switchId"] == "FDO11111AAA"
+    assert "switchIp" not in body
+    assert body["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+    assert instance._pending_deploys == [("vpc501", "FDO11111AAA")]
+
+
+def test_vpc_interface_base_00510() -> None:
+    """
+    # Summary
+
+    Verify `update` wraps a `_request` failure in `RuntimeError` and queues no deploy.
+
+    ## Test
+
+    - switches-list and vpcPair succeed; PUT returns 500
+    - `RuntimeError` matches `Update failed for`
+    - `_pending_deploys` stays empty
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.update()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model()
+
+    with pytest.raises(RuntimeError, match=r"Update failed for"):
+        instance.update(model)
+
+    assert instance._pending_deploys == []
+
+
+# =============================================================================
+# Test: delete (per-interface DELETE)
+# =============================================================================
+
+
+def test_vpc_interface_base_00600() -> None:
+    """
+    # Summary
+
+    Verify `delete` issues a per-interface DELETE (not a bulk remove) and queues a deploy.
+
+    ## Test
+
+    - DELETE hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501`
+    - The DELETE returns 204
+    - `_pending_deploys` contains `(vpc501, FDO11111AAA)`; `_pending_removes` stays empty (bulk remove unused)
+    - `delete` returns None
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.delete()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with does_not_raise():
+        result = instance.delete(model)
+
+    assert result is None
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501"
+    assert rest_send.verb == HttpVerbEnum.DELETE.value
+    assert instance._pending_deploys == [("vpc501", "FDO11111AAA")]
+    assert instance._pending_removes == []
+
+
+def test_vpc_interface_base_00610() -> None:
+    """
+    # Summary
+
+    Verify `delete` wraps a DELETE failure in `RuntimeError` and queues no deploy.
+
+    ## Test
+
+    - switches-list succeeds; per-interface DELETE returns 500
+    - `RuntimeError` matches `Delete failed for`
+    - Both queues stay empty
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.delete()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with pytest.raises(RuntimeError, match=r"Delete failed for"):
+        instance.delete(model)
+
+    assert instance._pending_deploys == []
+    assert instance._pending_removes == []
+
+
+# =============================================================================
+# Test: create_bulk (peer lookup cached per primary switch)
+# =============================================================================
+
+
+def test_vpc_interface_base_00700() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` groups interfaces by primary switch and resolves the peer serial only ONCE per primary
+    switch (cache), issuing a single POST carrying both interfaces.
+
+    ## Test
+
+    - Two vPC interfaces on the same primary switch (192.168.1.1)
+    - Only one switches-list, one vpcPair GET, and one POST are consumed (cache prevents a second peer lookup)
+    - Both interfaces carry the injected `peerSwitchId`
+    - Both `(interface_name, switch_id)` pairs are queued for deploy
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create_bulk()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    models = [
+        _build_model(interface_name="vpc501"),
+        _build_model(interface_name="vpc502"),
+    ]
+
+    with does_not_raise():
+        instance.create_bulk(models)
+
+    # A single vpcPair lookup served both interfaces on the same primary switch.
+    assert instance._peer_serial_cache == {"FDO11111AAA": "FDO22222BBB"}
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    body = rest_send.committed_payload
+    assert isinstance(body, dict)
+    assert len(body["interfaces"]) == 2
+    for item in body["interfaces"]:
+        assert item["switchId"] == "FDO11111AAA"
+        assert item["configData"]["networkOS"]["policy"]["peerSwitchId"] == "FDO22222BBB"
+    assert sorted(instance._pending_deploys) == sorted([("vpc501", "FDO11111AAA"), ("vpc502", "FDO11111AAA")])
+
+
+def test_vpc_interface_base_00710() -> None:
+    """
+    # Summary
+
+    Verify `create_bulk` wraps a per-switch `_request` failure in `RuntimeError` matching `Bulk create failed`.
+
+    ## Test
+
+    - switches-list and vpcPair succeed; the per-switch POST returns 500
+    - `RuntimeError` matches `Bulk create failed`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.create_bulk()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    models = [_build_model(interface_name="vpc501")]
+
+    with pytest.raises(RuntimeError, match=r"Bulk create failed"):
+        instance.create_bulk(models)
+
+
+# =============================================================================
+# Test: query_one
+# =============================================================================
+
+
+def test_vpc_interface_base_00800() -> None:
+    """
+    # Summary
+
+    Verify `query_one` issues a GET against the per-interface URL and returns the DATA dict.
+
+    ## Test
+
+    - GET hits `/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501`
+    - Returned dict carries the vPC interface (`interfaceType: vpc`, `policyType: accessVpcHost`)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with does_not_raise():
+        result = instance.query_one(model)
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/vpc501"
+    assert rest_send.verb == HttpVerbEnum.GET.value
+    assert result["interfaceName"] == "vpc501"
+    assert result["interfaceType"] == "vpc"
+    assert result["configData"]["networkOS"]["policy"]["policyType"] == "accessVpcHost"
+
+
+def test_vpc_interface_base_00810() -> None:
+    """
+    # Summary
+
+    Verify `query_one` wraps a `_request` failure in `RuntimeError` mentioning the identifier.
+
+    ## Test
+
+    - switches-list succeeds; GET returns 500
+    - `RuntimeError` matches `Query failed for`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_one()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubVpcOrchestrator(rest_send=rest_send)
+    model = _build_model(include_config=False)
+
+    with pytest.raises(RuntimeError, match=r"Query failed for"):
+        instance.query_one(model)
+
+
+# =============================================================================
+# Test: query_all (fabric-wide scan, filtering, dedup, request count)
+# =============================================================================
+
+
+def test_vpc_interface_base_00900() -> None:
+    """
+    # Summary
+
+    Verify `query_all` validates the fabric, scans every switch, filters to vPC interfaces with managed policy
+    types, injects `switchIp`, de-duplicates the per-peer copies, and -- per PR #334 review -- issues exactly
+    one request per switch plus the fabric summary and switches-list (no N+1 beyond the documented per-switch scan).
+
+    ## Test
+
+    - Switch A returns: managed `accessVpcHost` vpc501, other-policy `trunkVpcHost` vpc502, non-vPC ethernet
+    - Switch B returns: the peer-side copy of vpc501
+    - Result contains exactly vpc501 (vpc502 and the ethernet are filtered out; the peer copy is deduped)
+    - The kept entry carries `switchIp` of the lower-`switchId` peer (192.168.1.1 / FDO11111AAA)
+    - Request count is exactly 4: summary + switches-list + one interface GET per switch (locks the scan cost)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._managed_policy_types()
+    """
+    method_name = inspect.stack()[0][3]
+    calls: list[str] = []
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            calls.append(suffix)
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses)
+        result = instance.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    iface = result[0]
+    assert iface["interfaceName"] == "vpc501"
+    assert iface["switchIp"] == "192.168.1.1"
+
+    by_name = {entry["interfaceName"] for entry in result}
+    assert "vpc502" not in by_name  # other-policy vPC filtered out
+    assert "Ethernet1/5" not in by_name  # non-vPC filtered out
+
+    # Request-count lock: 1 summary (validate) + 1 switches-list + 1 GET per switch (2 switches) = 4.
+    # This pins the fabric-wide scan cost flagged in review so a regression to N+1 fails the test.
+    assert len(calls) == 4
+
+
+def test_vpc_interface_base_00910() -> None:
+    """
+    # Summary
+
+    Verify `query_all` skips a managed vPC interface that has no `interfaceName` (it cannot be keyed for dedup).
+
+    ## Test
+
+    - The single switch returns one managed `accessVpcHost` vPC interface with no `interfaceName`
+    - `query_all` returns `[]` (the nameless entry is skipped, not raised on)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses)
+        result = instance.query_all()
+
+    assert result == []
+
+
+def test_vpc_interface_base_00930() -> None:
+    """
+    # Summary
+
+    Verify `query_all` raises `RuntimeError` (wrapping the validation failure) when the fabric does not exist.
+
+    ## Test
+
+    - Fabric summary returns 404
+    - `query_all` raises `RuntimeError` matching `Query all failed.*missing_fabric`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses, fabric_name="missing_fabric")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
+        instance.query_all()
+
+
+def test_vpc_interface_base_00940() -> None:
+    """
+    # Summary
+
+    Verify `query_all` skips a switch whose interfaces endpoint returns no body (the `not_found_ok` branch) and
+    yields an empty list when no managed vPC interfaces are found.
+
+    ## Test
+
+    - Fabric summary and switches-list succeed (one switch)
+    - The switch's interfaces endpoint returns 404 (no body)
+    - `query_all` returns `[]`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_vpc_base(f"{method_name}a")
+        yield responses_vpc_base(f"{method_name}b")
+        yield responses_vpc_base(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses)
+        result = instance.query_all()
+
+    assert result == []


### PR DESCRIPTION
# Add shared vPC interface infrastructure (VpcInterfaceBaseOrchestrator)

## Related Issue(s)

Unblocks the vPC interface modules (PRs #279 `nd_interface_vpc_access`, #280 `nd_interface_vpc_trunk_host`) after PR #278 (`nd_vpc_pair`) was closed in favor of #197 (`nd_manage_vpc_pair`).

### Deferred follow-ups (tracked)

Code-review findings deferred (not fixed in this PR) with their tracking issues:

- **#348** — `VpcInterfaceBaseOrchestrator` CRUD (`create`/`update`/`query_one`/`create_bulk`) and the new `_switches_to_query` / `_managed_vpc_interfaces` helpers duplicate `PortChannelBaseOrchestrator`; lift into the shared base. Maintenance, not a bug.
- **#349** — `query_all` issues one interface-list GET per switch under `state: overridden` (ND 4.2.1 has no fabric-wide interface-list endpoint). This PR already narrows non-overridden states to config switches via `_switches_to_query()`, so the residual fan-out is overridden-only. (This is the reviewer thread on the fabric-wide scan.)
- **#354** — `delete()` queues a deploy even when the per-interface DELETE was a 404 no-op (a 204 success and a 404 both return a falsy body, so the deploy cannot be cheaply gated without surfacing the return code / lab-verifying the deploy is a no-op for an absent interface).

## Proposed Changes

PR #278 (`nd_vpc_pair`) carried the shared vPC *interface* infrastructure that `nd_interface_vpc_access` and `nd_interface_vpc_trunk_host` depend on. With #278 closed, that infrastructure is re-homed here on a dedicated base branch so the two interface modules can reach `develop` independently:

- **`orchestrators/vpc_interface_base.py`** — `VpcInterfaceBaseOrchestrator`, the shared CRUD base for vPC host-interface modules (`accessVpcHost`, `trunkVpcHost`). Renamed from the original `VpcBaseOrchestrator` to be clearly interface-scoped (parallels `base_interface.py` / `NDBaseInterfaceOrchestrator`), distinct from `develop`'s pair-domain `orchestrators/manage_vpc_pair.py`.
- **`endpoints/v1/manage/manage_interfaces.py`** — adds `EpManageInterfacesDelete` (per-interface DELETE) used for vPC interface removal.
- Peer-serial resolution is **rewired to `develop`'s existing `EpVpcPairGet`** (`manage_fabrics_switches_vpc_pair.py`, from #197) rather than carrying a duplicate vpcPair endpoint — the only genuine overlap with #197 (whose `VpcPairOrchestrator` manages a different resource and cannot serve as a base for interface modules).

## Test Notes

- Unit tests pass on this branch and downstream: `python -m pytest tests/unit/module_utils/orchestrators/ tests/unit/module_utils/endpoints/` (457 passing on this base; 470/483 on the stacked interface branches).
- The downstream interface modules' integration targets (`nd_interface_vpc_access`, `nd_interface_vpc_trunk_host`) pass end-to-end against ND 4.2 / NX-OS 10.6(2) on the SITE1 lab, using `VpcInterfaceBaseOrchestrator` for peer resolution and CRUD.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
