### PR TITLE
Fix pylint ansible-bad-import-from: drop PY3 import from six

### DIFF
--- a/plugins/httpapi/nd.py
+++ b/plugins/httpapi/nd.py
@@ -32,14 +32,15 @@ options:
     - name: ansible_httpapi_login_domain
 """
 
-import os
-import re
 import json
-import pickle
-import traceback
 import mimetypes
+import os
+import pickle
+import re
 import sys
 import tempfile
+import traceback
+
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.connection import ConnectionError
 from ansible.plugins.httpapi import HttpApiBase

--- a/plugins/httpapi/nd.py
+++ b/plugins/httpapi/nd.py
@@ -40,7 +40,6 @@ import traceback
 import mimetypes
 import sys
 import tempfile
-from ansible.module_utils.six import PY3
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.connection import ConnectionError
 from ansible.plugins.httpapi import HttpApiBase
@@ -434,17 +433,15 @@ class HttpApi(HttpApiBase):
         info.update(dict((k.lower(), v) for k, v in response.info().items()))
 
         # Don't be lossy, append header values for duplicate headers
-        # In Py2 there is nothing that needs done, py2 does this for us
-        if PY3:
-            temp_headers = {}
-            for name, value in response.headers.items():
-                # The same as above, lower case keys to match py2 behavior, and create more consistent results
-                name = name.lower()
-                if name in temp_headers:
-                    temp_headers[name] = ", ".join((temp_headers[name], value))
-                else:
-                    temp_headers[name] = value
-            info.update(temp_headers)
+        temp_headers = {}
+        for name, value in response.headers.items():
+            # Lower case keys to create more consistent results
+            name = name.lower()
+            if name in temp_headers:
+                temp_headers[name] = ", ".join((temp_headers[name], value))
+            else:
+                temp_headers[name] = value
+        info.update(temp_headers)
         return info
 
     def get_remote_file_io_stream(self, path, tmpdir, method="GET"):

--- a/plugins/module_utils/nd.py
+++ b/plugins/module_utils/nd.py
@@ -5,17 +5,17 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from functools import reduce
 
-from copy import deepcopy
 import os
 import shutil
 import tempfile
-from ansible.module_utils.basic import json
-from ansible.module_utils.basic import env_fallback
-from ansible.module_utils.six.moves.urllib.parse import urlencode
+from copy import deepcopy
+from functools import reduce
+
 from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.basic import env_fallback, json
 from ansible.module_utils.connection import Connection
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible_collections.cisco.nd.plugins.module_utils.constants import ALLOWED_STATES_TO_APPEND_SENT_AND_PROPOSED
 from ansible_collections.cisco.nd.plugins.module_utils.utils import issubset
 

--- a/plugins/module_utils/nd.py
+++ b/plugins/module_utils/nd.py
@@ -13,7 +13,6 @@ import shutil
 import tempfile
 from ansible.module_utils.basic import json
 from ansible.module_utils.basic import env_fallback
-from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.connection import Connection
@@ -62,10 +61,8 @@ def sanitize(obj_to_sanitize, keys=None, values=None, recursive=True, remove_non
         raise TypeError("object to sanitize can only be of type list or dict. Got {}".format(type(obj_to_sanitize)))
 
 
-if PY3:
-
-    def cmp(a, b):
-        return (a > b) - (a < b)
+def cmp(a, b):
+    return (a > b) - (a < b)
 
 
 def update_qs(params):


### PR DESCRIPTION
## Related Issue(s)

Fixes #341

## Proposed Changes

### pylint `ansible-bad-import-from` (the issue)

The `ansible-test sanity` pylint check reports `ansible-bad-import-from` for importing `PY3` from `ansible.module_utils.six` in two files:

- `plugins/httpapi/nd.py:43`
- `plugins/module_utils/nd.py:16`

The collection requires Python >= 3.10, so the `if PY3:` guards these imports feed are always true. This PR removes the `six` import and the dead Python-2 conditional in both files:

- `plugins/module_utils/nd.py` — unwrap the `cmp()` definition from `if PY3:`.
- `plugins/httpapi/nd.py` — unwrap the duplicate-header handling in `_get_formated_info()` from `if PY3:` and drop the stale py2 comments.

### isort import ordering (bundled cleanup)

Both files were already failing `isort` on `develop` (their imports were never sorted). While in here, this PR also sorts their imports to satisfy the isort configuration in `pyproject.toml`: regroup the stdlib / third-party blocks and collapse the two `ansible.module_utils.basic` imports into a single statement.

No behavioral change on Python 3 from either set of changes.

## Test Notes

- `ansible-test sanity --test pylint plugins/httpapi/nd.py plugins/module_utils/nd.py` passes (exit 0, no `ansible-bad-import-from` errors).
- `isort --check-only` and `black --check` are clean on both files.
- Both files byte-compile cleanly.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [x] infra
* [ ] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
