### PR TITLE
Enforce storm-control percentage/pps mutual exclusivity (#351)

### DIFF
--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -142,8 +142,9 @@ class NDBaseModel(BaseModel, ABC):
 
     @classmethod
     def from_response(cls, response: Dict[str, Any], **kwargs) -> "NDBaseModel":
-        """Create model instance from API response dict."""
-        return cls.model_validate(response, by_alias=True, **kwargs)
+        """Create model instance from API response dict (validation context ``mode=response``)."""
+        context = {"mode": "response", **(kwargs.pop("context", None) or {})}
+        return cls.model_validate(response, by_alias=True, context=context, **kwargs)
 
     @classmethod
     def from_config(cls, ansible_config: Dict[str, Any], **kwargs) -> "NDBaseModel":
@@ -151,10 +152,13 @@ class NDBaseModel(BaseModel, ABC):
 
         Strips None values recursively before validation so that Ansible's
         default None for unspecified options does not override pydantic
-        default_factory values or pollute model_fields_set.
+        default_factory values or pollute model_fields_set. Validation runs with
+        context ``mode=config`` so config-only validators (e.g. the storm-control
+        percentage/pps mutex) fire on config input but not on ND responses.
         """
         cleaned = _strip_none_values(ansible_config)
-        return cls.model_validate(cleaned, by_name=True, **kwargs)
+        context = {"mode": "config", **(kwargs.pop("context", None) or {})}
+        return cls.model_validate(cleaned, by_name=True, context=context, **kwargs)
 
     # --- Identifier Access ---
 

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -5,8 +5,9 @@
 from __future__ import absolute_import, division, print_function
 
 from abc import ABC
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Set, Tuple, Union
+
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict
-from typing import List, Dict, Any, ClassVar, Set, Tuple, Union, Literal, Optional
 from ansible_collections.cisco.nd.plugins.module_utils.utils import issubset
 
 
@@ -228,11 +229,42 @@ class NDBaseModel(BaseModel, ABC):
             exclude_unset: When True, only compare fields explicitly set in
                 ``other`` (via Pydantic's ``exclude_unset``). This prevents
                 default values from triggering false diffs during merge
-                operations.
+                operations. This is the merge-path comparison, so a subset
+                match is additionally cross-checked with ``merge_would_change``
+                to catch merge side effects the one-way subset test cannot see
+                (e.g. mutually exclusive counterpart fields that the merge
+                would clear).
         """
         self_data = self.to_diff_dict()
         other_data = other.to_diff_dict(exclude_unset=exclude_unset)
-        return issubset(other_data, self_data)
+        is_subset = issubset(other_data, self_data)
+        if is_subset and exclude_unset and self.merge_would_change(other):
+            return False
+        return is_subset
+
+    def merge_would_change(self, other: "NDBaseModel") -> bool:
+        """
+        # Summary
+
+        Return True when `merge(other)` would mutate `self` in a way the one-way dict-subset comparison in `get_diff`
+        cannot detect. The default implementation has no such side effects itself; it only recurses into nested
+        `NDBaseModel` fields explicitly set on `other` so that nested models overriding `merge` (e.g.
+        `StormControlMutexMixin`, which clears the counterpart of a mutually exclusive pair) can surface their
+        merge side effects to the top-level diff.
+
+        ## Raises
+
+        None
+        """
+        for field_name in other.model_fields_set:
+            value = getattr(other, field_name, None)
+            if value is None:
+                continue
+            current = getattr(self, field_name, None)
+            if isinstance(current, NDBaseModel) and isinstance(value, NDBaseModel):
+                if current.merge_would_change(value):
+                    return True
+        return False
 
     def merge(self, other: "NDBaseModel") -> "NDBaseModel":
         """

--- a/plugins/module_utils/models/interfaces/ethernet_access_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_access_interface.py
@@ -46,6 +46,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     SpeedEnum,
     StormControlActionEnum,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
@@ -59,7 +60,7 @@ _INTERFACE_NAME_PREFIX_RE = re.compile(r"^([A-Za-z]+)(.*)$")
 _CANONICAL_INTERFACE_TYPE = "Ethernet"
 
 
-class EthernetAccessPolicyModel(NDNestedModel):
+class EthernetAccessPolicyModel(StormControlMutexMixin):
     """
     # Summary
 

--- a/plugins/module_utils/models/interfaces/ethernet_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_trunk_host_interface.py
@@ -50,6 +50,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     StormControlActionEnum,
     TrunkHostPolicyTypeEnum,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
@@ -206,7 +207,7 @@ class EthernetTrunkHostVlanMappingEntryModel(NDNestedModel):
     provider_vlan_id: int | None = Field(default=None, alias="providerVlanId", ge=1, le=4094, description="Provider VLAN")
 
 
-class EthernetTrunkHostPolicyModel(NDNestedModel):
+class EthernetTrunkHostPolicyModel(StormControlMutexMixin):
     """
     # Summary
 
@@ -217,6 +218,7 @@ class EthernetTrunkHostPolicyModel(NDNestedModel):
     ### ValueError
 
     - If `allowed_vlans` is not `none`, `all`, or a comma-separated list of VLAN ids / ranges
+    - If both the percentage and pps level are set for the same storm-control class in a non-response context (via `StormControlMutexMixin`)
     """
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
@@ -344,33 +346,6 @@ class EthernetTrunkHostPolicyModel(NDNestedModel):
             result.pop("policy_type", None)
             result.pop("policyType", None)
         return result
-
-    @model_validator(mode="after")
-    def _validate_storm_control_level_exclusivity(self) -> EthernetTrunkHostPolicyModel:
-        """
-        # Summary
-
-        Reject setting both the percentage and the packets-per-second variant of the same storm-control traffic class.
-
-        For each traffic class (broadcast, multicast, unicast) ND accepts either the percentage level (`storm_control_<class>_level`) or the
-        packets-per-second level (`storm_control_<class>_level_pps`), never both. The pair is documented as mutually exclusive; enforcing it at
-        the model layer fails the conflict early with a clear error instead of leaving it to ND, serialization order, or API-side validation.
-
-        ## Raises
-
-        ### ValueError
-
-        - If both the percentage and the packets-per-second field are set for the same storm-control traffic class.
-        """
-        exclusive_pairs = (
-            ("storm_control_broadcast_level", "storm_control_broadcast_level_pps"),
-            ("storm_control_multicast_level", "storm_control_multicast_level_pps"),
-            ("storm_control_unicast_level", "storm_control_unicast_level_pps"),
-        )
-        for level_field, pps_field in exclusive_pairs:
-            if getattr(self, level_field) is not None and getattr(self, pps_field) is not None:
-                raise ValueError(f"{level_field} and {pps_field} are mutually exclusive; set only one.")
-        return self
 
     @model_validator(mode="after")
     def _validate_vlan_mapping_entries_present(self) -> EthernetTrunkHostPolicyModel:

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -51,6 +51,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     SpeedEnum,
     StormControlActionEnum,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
@@ -63,7 +64,7 @@ _INTERFACE_NAME_PREFIX_RE = re.compile(r"^([A-Za-z]+)(.*)$")
 _CANONICAL_MEMBER_TYPE = "Ethernet"
 
 
-class PortChannelAccessPolicyModel(NDNestedModel):
+class PortChannelAccessPolicyModel(StormControlMutexMixin):
     """
     # Summary
 

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -54,6 +54,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     StormControlActionEnum,
     TrunkPoHostPolicyTypeEnum,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
@@ -207,7 +208,7 @@ class PortChannelTrunkHostVlanMappingEntryModel(NDNestedModel):
     provider_vlan_id: int | None = Field(default=None, alias="providerVlanId", ge=1, le=4094, description="Provider VLAN id")
 
 
-class PortChannelTrunkHostPolicyModel(NDNestedModel):
+class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
     """
     # Summary
 

--- a/plugins/module_utils/models/interfaces/storm_control.py
+++ b/plugins/module_utils/models/interfaces/storm_control.py
@@ -49,7 +49,10 @@ class StormControlMutexMixin(NDNestedModel):  # pylint: disable=too-few-public-m
 
     ## Raises
 
-    None
+    ### ValueError
+
+    - If both the percentage and pps level are set for the same storm-control class (raised by
+      `_reject_storm_control_level_and_pps` during model validation; surfaces as a Pydantic `ValidationError` when constructing an inheriting model).
     """
 
     @model_validator(mode="after")

--- a/plugins/module_utils/models/interfaces/storm_control.py
+++ b/plugins/module_utils/models/interfaces/storm_control.py
@@ -18,11 +18,17 @@ intent is silently lost with no error and no diff to warn them.
 Because the wire round-trips faithfully there is no wire deviation to work around (no `TODO(X.Y.Z)` marker); this is
 a client-side fail-fast guard so the user learns at validation time rather than discovering the dropped pps on the
 device. `StormControlMutexMixin` centralizes the check so all five interface policy models share one implementation.
+
+The guard is scoped to user/proposed input only. Since ND legitimately echoes both values on GET, enforcing the
+rule while parsing an ND response would make `query`/`gathered`/`diff` raise before the module could report or
+remediate a device already in that state. The check therefore fires on `from_config()` (and any direct/non-response
+construction) but is skipped when the validation context carries `mode="response"` (set by `from_response()`), so
+the write path fails fast while the read path stays permissive.
 """
 
 from __future__ import annotations
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import model_validator
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ValidationInfo, model_validator
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 
 # (traffic class label, percentage attribute, pps attribute) for each storm-control class. The attribute names are
@@ -47,28 +53,39 @@ class StormControlMutexMixin(NDNestedModel):  # pylint: disable=too-few-public-m
     fields. The check reads the field values by attribute name, so a model missing one of the pairs is handled
     gracefully (a `None` from `getattr` simply cannot conflict).
 
+    The check is skipped when the validation context carries `mode="response"` (set by `NDBaseModel.from_response`),
+    so parsing an ND echo that carries both values never raises; it fires on `from_config` and any other
+    (non-response) construction so user/proposed input still fails fast. See the module docstring for the rationale.
+
     ## Raises
 
     ### ValueError
 
-    - If both the percentage and pps level are set for the same storm-control class (raised by
-      `_reject_storm_control_level_and_pps` during model validation; surfaces as a Pydantic `ValidationError` when constructing an inheriting model).
+    - If both the percentage and pps level are set for the same storm-control class in a non-response context (raised
+      by `_reject_storm_control_level_and_pps` during model validation; surfaces as a Pydantic `ValidationError` when constructing an inheriting model).
     """
 
     @model_validator(mode="after")
-    def _reject_storm_control_level_and_pps(self) -> "StormControlMutexMixin":
+    def _reject_storm_control_level_and_pps(self, info: ValidationInfo) -> "StormControlMutexMixin":
         """
         # Summary
 
         Reject any storm-control traffic class that has both its percentage level and its pps level set, naming the
         offending class(es) in the error so the user knows exactly which one to drop.
 
+        The check is skipped when the validation context carries `mode="response"` — ND legitimately echoes both
+        values on GET (issue #351), so `from_response()` parsing must stay permissive or `query`/`gathered`/`diff`
+        would raise before the module could report or remediate an existing device already in that state. Every other
+        path (`from_config`, direct construction, any non-response context) enforces the rule so writes fail fast.
+
         ## Raises
 
         ### ValueError
 
-        - If both the percentage and pps level are set for the same storm-control class (broadcast, multicast, or unicast).
+        - If both the percentage and pps level are set for the same storm-control class (broadcast, multicast, or unicast) outside a response context.
         """
+        if info.context and info.context.get("mode") == "response":
+            return self
         conflicts = [
             traffic_class
             for traffic_class, pct_attr, pps_attr in _STORM_CONTROL_CLASSES

--- a/plugins/module_utils/models/interfaces/storm_control.py
+++ b/plugins/module_utils/models/interfaces/storm_control.py
@@ -1,0 +1,81 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Shared storm-control mutual-exclusion validator for interface policy models.
+
+Every physical/port-channel/vPC host interface policy exposes, per traffic class (broadcast, multicast, unicast),
+both a percentage level (`storm_control_*_level`) and a packets-per-second level (`storm_control_*_level_pps`).
+These are mutually exclusive on NX-OS: `storm-control <class> level <pct>` and `storm-control <class> level pps <n>`
+are the same single setting, so only one may apply per class.
+
+ND does not enforce this at the API layer. Lab-verified on ND 4.3.1.75 and 4.2.1.10 (issue #351): a create/update
+that sets both for one class is accepted (HTTP 204/207) and ND echoes both values back on GET (so there is no
+perpetual diff), but at config generation ND silently applies the percentage and drops the pps. The user's pps
+intent is silently lost with no error and no diff to warn them.
+
+Because the wire round-trips faithfully there is no wire deviation to work around (no `TODO(X.Y.Z)` marker); this is
+a client-side fail-fast guard so the user learns at validation time rather than discovering the dropped pps on the
+device. `StormControlMutexMixin` centralizes the check so all five interface policy models share one implementation.
+"""
+
+from __future__ import annotations
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import model_validator
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+
+# (traffic class label, percentage attribute, pps attribute) for each storm-control class. The attribute names are
+# identical across all five interface policy models, so the mixin reads them positionally via getattr.
+_STORM_CONTROL_CLASSES: tuple[tuple[str, str, str], ...] = (
+    ("broadcast", "storm_control_broadcast_level", "storm_control_broadcast_level_pps"),
+    ("multicast", "storm_control_multicast_level", "storm_control_multicast_level_pps"),
+    ("unicast", "storm_control_unicast_level", "storm_control_unicast_level_pps"),
+)
+
+
+class StormControlMutexMixin(NDNestedModel):  # pylint: disable=too-few-public-methods
+    """
+    # Summary
+
+    Mixin for interface policy models that carry the paired `storm_control_<class>_level` (percentage) and
+    `storm_control_<class>_level_pps` (packets-per-second) fields. Rejects a config that sets both for the same
+    traffic class, since the two are mutually exclusive on NX-OS and ND silently keeps the percentage while dropping
+    the pps at config generation (issue #351, lab-verified on ND 4.3.1.75 and 4.2.1.10).
+
+    Add it to a policy model's bases (replacing the direct `NDNestedModel` base); the model keeps defining its own
+    fields. The check reads the field values by attribute name, so a model missing one of the pairs is handled
+    gracefully (a `None` from `getattr` simply cannot conflict).
+
+    ## Raises
+
+    None
+    """
+
+    @model_validator(mode="after")
+    def _reject_storm_control_level_and_pps(self) -> "StormControlMutexMixin":
+        """
+        # Summary
+
+        Reject any storm-control traffic class that has both its percentage level and its pps level set, naming the
+        offending class(es) in the error so the user knows exactly which one to drop.
+
+        ## Raises
+
+        ### ValueError
+
+        - If both the percentage and pps level are set for the same storm-control class (broadcast, multicast, or unicast).
+        """
+        conflicts = [
+            traffic_class
+            for traffic_class, pct_attr, pps_attr in _STORM_CONTROL_CLASSES
+            if getattr(self, pct_attr, None) is not None and getattr(self, pps_attr, None) is not None
+        ]
+        if conflicts:
+            classes = ", ".join(conflicts)
+            raise ValueError(
+                f"storm-control percentage and pps levels are mutually exclusive per traffic class, but both are set "
+                f"for: {classes}. NX-OS treats them as the same setting and ND silently applies the percentage and "
+                f"drops the pps at config generation; set only one of the two per class."
+            )
+        return self

--- a/plugins/module_utils/models/interfaces/storm_control.py
+++ b/plugins/module_utils/models/interfaces/storm_control.py
@@ -17,22 +17,37 @@ intent is silently lost with no error and no diff to warn them.
 
 Because the wire round-trips faithfully there is no wire deviation to work around (no `TODO(X.Y.Z)` marker); this is
 a client-side fail-fast guard so the user learns at validation time rather than discovering the dropped pps on the
-device. `StormControlMutexMixin` centralizes the check so all five interface policy models share one implementation.
+device. `StormControlMutexMixin` centralizes the check so all six interface policy models share one implementation.
 
 The guard is scoped to user/proposed input only. Since ND legitimately echoes both values on GET, enforcing the
 rule while parsing an ND response would make `query`/`gathered`/`diff` raise before the module could report or
 remediate a device already in that state. The check therefore fires on `from_config()` (and any direct/non-response
 construction) but is skipped when the validation context carries `mode="response"` (set by `from_response()`), so
 the write path fails fast while the read path stays permissive.
+
+Because the percentage and pps are two representations of one NX-OS threshold, the mixin also treats each pair as a
+single logical setting during the merge lifecycle (PR #360 review): `merge` clears an existing counterpart when the
+proposed config explicitly selects the other variant, and `merge_would_change` reports that pending clear to
+`get_diff` so a dual-valued ND echo plus a matching single-variant intent is classified as a change, not `no_diff`.
 """
 
 from __future__ import annotations
 
+from contextvars import ContextVar
+
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ValidationInfo, model_validator
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 
+# True while StormControlMutexMixin.merge() is mutating a model in place. Assignment validation re-runs the mutex on
+# every setattr with no validation context, so without this suspension any merge into a model legitimately holding
+# both values of a pair (a dual-valued ND echo, issue #351) would raise on the first assigned field — even an
+# unrelated one. Suspension is safe because merge's counterpart clearing guarantees the merge itself can never
+# introduce a new conflict: config input was already validated at construction, and response input is permissive by design.
+_MUTEX_SUSPENDED: ContextVar[bool] = ContextVar("storm_control_mutex_suspended", default=False)
+
 # (traffic class label, percentage attribute, pps attribute) for each storm-control class. The attribute names are
-# identical across all five interface policy models, so the mixin reads them positionally via getattr.
+# identical across all six interface policy models, so the mixin reads them positionally via getattr.
 _STORM_CONTROL_CLASSES: tuple[tuple[str, str, str], ...] = (
     ("broadcast", "storm_control_broadcast_level", "storm_control_broadcast_level_pps"),
     ("multicast", "storm_control_multicast_level", "storm_control_multicast_level_pps"),
@@ -40,7 +55,7 @@ _STORM_CONTROL_CLASSES: tuple[tuple[str, str, str], ...] = (
 )
 
 
-class StormControlMutexMixin(NDNestedModel):  # pylint: disable=too-few-public-methods
+class StormControlMutexMixin(NDNestedModel):
     """
     # Summary
 
@@ -56,6 +71,11 @@ class StormControlMutexMixin(NDNestedModel):  # pylint: disable=too-few-public-m
     The check is skipped when the validation context carries `mode="response"` (set by `NDBaseModel.from_response`),
     so parsing an ND echo that carries both values never raises; it fires on `from_config` and any other
     (non-response) construction so user/proposed input still fails fast. See the module docstring for the rationale.
+
+    The mixin also overrides `merge` and `merge_would_change` so the percentage/pps pair behaves as one logical
+    setting during the merged-state lifecycle: explicitly selecting one variant in proposed config clears an existing
+    counterpart (and is reported as a diff), while a merge that expresses no storm-control intent leaves a dual-valued
+    ND echo untouched.
 
     ## Raises
 
@@ -86,6 +106,8 @@ class StormControlMutexMixin(NDNestedModel):  # pylint: disable=too-few-public-m
         """
         if info.context and info.context.get("mode") == "response":
             return self
+        if _MUTEX_SUSPENDED.get():
+            return self
         conflicts = [
             traffic_class
             for traffic_class, pct_attr, pps_attr in _STORM_CONTROL_CLASSES
@@ -99,3 +121,68 @@ class StormControlMutexMixin(NDNestedModel):  # pylint: disable=too-few-public-m
                 f"drops the pps at config generation; set only one of the two per class."
             )
         return self
+
+    def merge(self, other: "NDBaseModel") -> "NDBaseModel":
+        """
+        # Summary
+
+        Merge `other` into `self`, treating each storm-control percentage/pps pair as one logical setting: when
+        `other` explicitly selects one variant for a class, the counterpart on `self` is cleared first so switching
+        units never passes through (or persists) a both-set state.
+
+        Mutex enforcement is suspended for the duration of the in-place merge because assignment validation re-runs
+        the mutex on every `setattr` with no validation context — a merge into a dual-valued ND echo (issue #351)
+        would otherwise raise on the first assigned field, even an unrelated one. The suspension cannot mask a real
+        conflict: `other` was validated at construction (so it never holds both variants of a pair), and the
+        counterpart clearing above guarantees the merge result holds at most one variant per class unless the dual
+        state was already present on `self` (a response echo, permissive by design).
+
+        ## Raises
+
+        None
+        """
+        token = _MUTEX_SUSPENDED.set(True)
+        try:
+            for counterpart_attr in self._counterparts_to_clear(other):
+                setattr(self, counterpart_attr, None)
+            return super().merge(other)
+        finally:
+            _MUTEX_SUSPENDED.reset(token)
+
+    def merge_would_change(self, other: "NDBaseModel") -> bool:
+        """
+        # Summary
+
+        Report the merge side effect of `merge`'s counterpart clearing to `get_diff`: when `other` explicitly selects
+        one variant of a storm-control pair and `self` holds the counterpart, merging would clear that counterpart —
+        a change the one-way dict-subset comparison cannot see (e.g. a dual-valued ND echo plus proposed config
+        matching the existing pps value, issue #351 / PR #360 review).
+
+        ## Raises
+
+        None
+        """
+        if self._counterparts_to_clear(other):
+            return True
+        return super().merge_would_change(other)
+
+    def _counterparts_to_clear(self, other: "NDBaseModel") -> list[str]:
+        """
+        # Summary
+
+        Return the attribute names on `self` that `merge(other)` must clear: for each storm-control class where
+        `other` explicitly selects one variant of the percentage/pps pair, the counterpart attribute on `self` if it
+        is currently set. Shared by `merge` (which performs the clearing) and `merge_would_change` (which reports it
+        to `get_diff`) so the two can never disagree.
+
+        ## Raises
+
+        None
+        """
+        to_clear: list[str] = []
+        for _traffic_class, pct_attr, pps_attr in _STORM_CONTROL_CLASSES:
+            if pct_attr in other.model_fields_set and getattr(other, pct_attr) is not None and getattr(self, pps_attr, None) is not None:
+                to_clear.append(pps_attr)
+            if pps_attr in other.model_fields_set and getattr(other, pps_attr) is not None and getattr(self, pct_attr, None) is not None:
+                to_clear.append(pct_attr)
+        return to_clear

--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -57,6 +57,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     SpeedEnum,
     StormControlActionEnum,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
@@ -69,7 +70,7 @@ _INTERFACE_NAME_PREFIX_RE = re.compile(r"^([A-Za-z]+)(.*)$")
 _CANONICAL_MEMBER_TYPE = "Ethernet"
 
 
-class AccessVpcHostPolicyModel(NDNestedModel):
+class AccessVpcHostPolicyModel(StormControlMutexMixin):
     """
     # Summary
 

--- a/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
@@ -60,6 +60,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     StormControlActionEnum,
     TrunkVpcHostPolicyTypeEnum,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
@@ -199,7 +200,7 @@ class TrunkVpcHostVlanMappingEntryModel(NDNestedModel):
     provider_vlan_id: int | None = Field(default=None, alias="providerVlanId", ge=1, le=4094, description="Provider VLAN id")
 
 
-class TrunkVpcHostPolicyModel(NDNestedModel):
+class TrunkVpcHostPolicyModel(StormControlMutexMixin):
     """
     # Summary
 

--- a/plugins/module_utils/nd_config_collection.py
+++ b/plugins/module_utils/nd_config_collection.py
@@ -4,8 +4,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Optional, List, Dict, Any, Literal
 from copy import deepcopy
+from typing import Any, Dict, List, Literal, Optional
+
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
@@ -176,6 +177,11 @@ class NDConfigCollection:
     def get_diff_collection(self, other: "NDConfigCollection") -> bool:
         """
         Check if two collections differ.
+
+        The per-item comparison runs in both directions because `get_diff_config` is a one-way subset test:
+        an `other` item that merely LOST a field relative to its `self` counterpart (e.g. a storm-control
+        percentage cleared by the pct/pps merge, PR #360 review) still satisfies the forward subset check and
+        would be misreported as unchanged. The reverse pass catches removals.
         """
         if not isinstance(other, NDConfigCollection):
             raise TypeError("Argument must be NDConfigCollection")
@@ -187,8 +193,8 @@ class NDConfigCollection:
             if self.get_diff_config(item) != "no_diff":
                 return True
 
-        for key in self.keys():
-            if other.get(key) is None:
+        for item in self:
+            if other.get_diff_config(item) != "no_diff":
                 return True
 
         return False

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -183,26 +183,32 @@ options:
                   storm_control_broadcast_level:
                     description:
                     - Broadcast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_broadcast_level_pps).
                     type: float
                   storm_control_broadcast_level_pps:
                     description:
                     - Broadcast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_broadcast_level).
                     type: int
                   storm_control_multicast_level:
                     description:
                     - Multicast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_multicast_level_pps).
                     type: float
                   storm_control_multicast_level_pps:
                     description:
                     - Multicast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_multicast_level).
                     type: int
                   storm_control_unicast_level:
                     description:
                     - Unicast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_unicast_level_pps).
                     type: float
                   storm_control_unicast_level_pps:
                     description:
                     - Unicast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_unicast_level).
                     type: int
   config_actions:
     description:

--- a/plugins/modules/nd_interface_port_channel_trunk_host.py
+++ b/plugins/modules/nd_interface_port_channel_trunk_host.py
@@ -225,26 +225,32 @@ options:
                   storm_control_broadcast_level:
                     description:
                     - Broadcast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_broadcast_level_pps).
                     type: float
                   storm_control_broadcast_level_pps:
                     description:
                     - Broadcast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_broadcast_level).
                     type: int
                   storm_control_multicast_level:
                     description:
                     - Multicast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_multicast_level_pps).
                     type: float
                   storm_control_multicast_level_pps:
                     description:
                     - Multicast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_multicast_level).
                     type: int
                   storm_control_unicast_level:
                     description:
                     - Unicast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_unicast_level_pps).
                     type: float
                   storm_control_unicast_level_pps:
                     description:
                     - Unicast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_unicast_level).
                     type: int
                   vlan_mapping:
                     description:

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -243,26 +243,32 @@ options:
                   storm_control_broadcast_level:
                     description:
                     - Broadcast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_broadcast_level_pps).
                     type: float
                   storm_control_broadcast_level_pps:
                     description:
                     - Broadcast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_broadcast_level).
                     type: int
                   storm_control_multicast_level:
                     description:
                     - Multicast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_multicast_level_pps).
                     type: float
                   storm_control_multicast_level_pps:
                     description:
                     - Multicast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_multicast_level).
                     type: int
                   storm_control_unicast_level:
                     description:
                     - Unicast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_unicast_level_pps).
                     type: float
                   storm_control_unicast_level_pps:
                     description:
                     - Unicast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_unicast_level).
                     type: int
   config_actions:
     description:

--- a/plugins/modules/nd_interface_vpc_trunk_host.py
+++ b/plugins/modules/nd_interface_vpc_trunk_host.py
@@ -257,26 +257,32 @@ options:
                   storm_control_broadcast_level:
                     description:
                     - Broadcast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_broadcast_level_pps).
                     type: float
                   storm_control_broadcast_level_pps:
                     description:
                     - Broadcast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_broadcast_level).
                     type: int
                   storm_control_multicast_level:
                     description:
                     - Multicast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_multicast_level_pps).
                     type: float
                   storm_control_multicast_level_pps:
                     description:
                     - Multicast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_multicast_level).
                     type: int
                   storm_control_unicast_level:
                     description:
                     - Unicast storm control level in percentage (0.00-100.00).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_unicast_level_pps).
                     type: float
                   storm_control_unicast_level_pps:
                     description:
                     - Unicast storm control level in packets per second (0-200000000).
+                    - Mutually exclusive with O(config[].config_data.network_os.policy.storm_control_unicast_level).
                     type: int
                   vlan_mapping:
                     description:

--- a/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/merged.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/merged.yaml
@@ -352,6 +352,146 @@
     that:
       - nm_merged_storm_idem is not changed
 
+# --- MERGED STORM-CONTROL LIFECYCLE (PR #360 review) ---
+# Percentage and pps are two representations of one NX-OS threshold. state:merged must
+# treat each pair as one logical setting: explicitly selecting one variant clears an
+# existing counterpart (reported as a change), and the follow-up idempotency re-apply
+# proves the counterpart was actually cleared on the wire -- if ND still echoed it, the
+# re-apply would classify the merge as a change and fail the "not changed" assert.
+
+- name: "MERGED STORM-CONTROL PCT->PPS: Switch broadcast storm control from percentage to pps"
+  cisco.nd.nd_interface_ethernet_trunk_host: &merge_eth48_storm_pps
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ ethernet_48_storm_control_pps }}"
+    state: merged
+  register: nm_merged_storm_pct_to_pps
+
+- name: "MERGED STORM-CONTROL PCT->PPS: Extract Ethernet1/48 after-state"
+  ansible.builtin.set_fact:
+    eth48_pps_after: >-
+      {{ nm_merged_storm_pct_to_pps.after | selectattr('switch_ip', 'equalto', test_switch_ip)
+         | selectattr('interface_name', 'equalto', 'Ethernet1/48') | first }}
+
+- name: "MERGED STORM-CONTROL PCT->PPS: Verify change reported, pps set, percentage cleared"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_storm_pct_to_pps is changed
+      - eth48_pps_after.config_data.network_os.policy.storm_control_broadcast_level_pps == 1000
+      - "'storm_control_broadcast_level' not in eth48_pps_after.config_data.network_os.policy"
+
+- name: "MERGED STORM-CONTROL PCT->PPS: Re-apply pps intent (proves ND cleared the percentage)"
+  cisco.nd.nd_interface_ethernet_trunk_host: *merge_eth48_storm_pps
+  register: nm_merged_storm_pps_idem
+
+- name: "MERGED STORM-CONTROL PCT->PPS: Verify idempotency"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_storm_pps_idem is not changed
+
+- name: "MERGED STORM-CONTROL PPS->PCT: Switch broadcast storm control back to percentage"
+  cisco.nd.nd_interface_ethernet_trunk_host: &merge_eth48_storm_pct_back
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ ethernet_48_storm_control_pct_switch_back }}"
+    state: merged
+  register: nm_merged_storm_pps_to_pct
+
+- name: "MERGED STORM-CONTROL PPS->PCT: Extract Ethernet1/48 after-state"
+  ansible.builtin.set_fact:
+    eth48_pct_after: >-
+      {{ nm_merged_storm_pps_to_pct.after | selectattr('switch_ip', 'equalto', test_switch_ip)
+         | selectattr('interface_name', 'equalto', 'Ethernet1/48') | first }}
+
+- name: "MERGED STORM-CONTROL PPS->PCT: Verify change reported, percentage set, pps cleared"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_storm_pps_to_pct is changed
+      - eth48_pct_after.config_data.network_os.policy.storm_control_broadcast_level == 42.5
+      - "'storm_control_broadcast_level_pps' not in eth48_pct_after.config_data.network_os.policy"
+
+- name: "MERGED STORM-CONTROL PPS->PCT: Re-apply percentage intent (proves ND cleared the pps)"
+  cisco.nd.nd_interface_ethernet_trunk_host: *merge_eth48_storm_pct_back
+  register: nm_merged_storm_pct_idem
+
+- name: "MERGED STORM-CONTROL PPS->PCT: Verify idempotency"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_storm_pct_idem is not changed
+
+# --- MERGED STORM-CONTROL DUAL-STATE REMEDIATION (issue #351 / PR #360 review) ---
+# Seed the exact controller state from issue #351 (both variants set for one class) via
+# raw nd_rest intent -- the module refuses to create it -- then verify the module can
+# read it, classifies matching single-variant intent as a change (the one-way subset
+# comparison alone would report no_diff), and remediates by clearing the percentage.
+
+- name: "MERGED STORM-CONTROL DUAL: Resolve test switch serial number"
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ test_fabric_name }}/switches"
+    method: get
+  register: sc360_switches
+
+- name: "MERGED STORM-CONTROL DUAL: Extract switch id for {{ test_switch_ip }}"
+  ansible.builtin.set_fact:
+    sc360_switch_id: >-
+      {{ (sc360_switches.current.switches | selectattr('fabricManagementIp', 'equalto', test_switch_ip)
+         | first).switchId }}
+
+# The PUT body must carry a switchId matching the path segment -- ND rejects the request with
+# 400 "Invalid switch ID" otherwise (the module's update path injects it the same way). The id is
+# resolved at runtime from test_switch_ip above; never hardcode it (9000v serials change on reload).
+- name: "MERGED STORM-CONTROL DUAL: Seed dual-valued broadcast storm-control intent via raw PUT"
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ test_fabric_name }}/switches/{{ sc360_switch_id }}/interfaces/Ethernet1%2F48"
+    method: put
+    content: "{{ ethernet_48_dual_seed_payload | combine({'switchId': sc360_switch_id}) }}"
+  register: sc360_dual_seed
+
+- name: "MERGED STORM-CONTROL DUAL: Read back seeded intent"
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ test_fabric_name }}/switches/{{ sc360_switch_id }}/interfaces/Ethernet1%2F48"
+    method: get
+  register: sc360_dual_readback
+
+- name: "MERGED STORM-CONTROL DUAL: Verify ND accepted and echoes both variants (issue #351 behavior)"
+  ansible.builtin.assert:
+    that:
+      - sc360_dual_readback.current.configData.networkOS.policy.stormControlBroadcastLevel == 50.0
+      - sc360_dual_readback.current.configData.networkOS.policy.stormControlBroadcastLevelPps == 12345
+
+- name: "MERGED STORM-CONTROL DUAL: Apply pps intent matching the value ND already echoes"
+  cisco.nd.nd_interface_ethernet_trunk_host: &merge_eth48_storm_remediate
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ ethernet_48_storm_control_pps_remediate }}"
+    state: merged
+  register: nm_merged_storm_remediate
+
+- name: "MERGED STORM-CONTROL DUAL: Extract Ethernet1/48 after-state"
+  ansible.builtin.set_fact:
+    eth48_remediate_after: >-
+      {{ nm_merged_storm_remediate.after | selectattr('switch_ip', 'equalto', test_switch_ip)
+         | selectattr('interface_name', 'equalto', 'Ethernet1/48') | first }}
+
+- name: "MERGED STORM-CONTROL DUAL: Verify matching pps intent is a change and the percentage is cleared"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_storm_remediate is changed
+      - eth48_remediate_after.config_data.network_os.policy.storm_control_broadcast_level_pps == 12345
+      - "'storm_control_broadcast_level' not in eth48_remediate_after.config_data.network_os.policy"
+
+- name: "MERGED STORM-CONTROL DUAL: Re-apply pps intent (remediated state is stable)"
+  cisco.nd.nd_interface_ethernet_trunk_host: *merge_eth48_storm_remediate
+  register: nm_merged_storm_remediate_idem
+
+- name: "MERGED STORM-CONTROL DUAL: Verify idempotency after remediation"
+  ansible.builtin.assert:
+    that:
+      - nm_merged_storm_remediate_idem is not changed
+
 # Clean up the storm-control test interface
 - name: "CLEANUP: Remove Ethernet1/48 (storm-control)"
   cisco.nd.nd_interface_ethernet_trunk_host:

--- a/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/setup.yaml
@@ -26,6 +26,9 @@
     var: setup_cleanup
   tags: always
 
+# The probe supplies an empty (but present) policy: the policy-required-on-create preflight (issue #350) rejects a
+# create item whose policy is None -- and it runs in check mode by design -- so a bare `policy:` would fail here
+# whenever the cleanup above actually removed the interface (making this probe a "new" item).
 - name: "DEBUG: Re-query to see if interfaces are still present after cleanup"
   cisco.nd.nd_interface_ethernet_trunk_host:
     output_level: "{{ nd_info.output_level }}"
@@ -36,7 +39,7 @@
           - Ethernet1/41
         config_data:
           network_os:
-            policy:
+            policy: {}
     state: merged
   check_mode: true
   register: debug_requery

--- a/tests/integration/targets/nd_interface_ethernet_trunk_host/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_trunk_host/vars/main.yaml
@@ -146,6 +146,58 @@ ethernet_48_storm_control:
         description: "Storm-control read-back test Ethernet1/48"
         storm_control_broadcast_level: 50.0
 
+# --- Storm-control merge-lifecycle test configs (PR #360 review) ---
+# Percentage and pps are two representations of one NX-OS threshold, so state:merged
+# must treat them as one logical setting: explicitly selecting one variant clears an
+# existing counterpart. These configs drive the pct->pps switch, the pps->pct switch
+# back, and remediation of the dual-valued intent ND accepts (issue #351).
+
+ethernet_48_storm_control_pps:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_names:
+    - Ethernet1/48
+  config_data:
+    network_os:
+      policy:
+        storm_control_broadcast_level_pps: 1000
+
+ethernet_48_storm_control_pct_switch_back:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_names:
+    - Ethernet1/48
+  config_data:
+    network_os:
+      policy:
+        storm_control_broadcast_level: 42.5
+
+ethernet_48_storm_control_pps_remediate:
+  switch_ip: "{{ test_switch_ip }}"
+  interface_names:
+    - Ethernet1/48
+  config_data:
+    network_os:
+      policy:
+        storm_control_broadcast_level_pps: 12345
+
+# Raw ND intent used to seed the dual-valued state via nd_rest. The module itself
+# rejects config that sets both variants for a class, so the seed must bypass it the
+# same way ND accepted the state in issue #351 (lab-verified on 4.2.1.10 / 4.3.1.75:
+# ND accepts and echoes both; generated CLI uses only the percentage).
+ethernet_48_dual_seed_payload:
+  interfaceName: Ethernet1/48
+  interfaceType: ethernet
+  configData:
+    mode: trunk
+    networkOS:
+      networkOSType: nx-os
+      policy:
+        policyType: trunkHost
+        adminState: true
+        allowedVlans: "100-200"
+        description: "Storm-control dual-state seed Ethernet1/48"
+        stormControlBroadcastLevel: 50.0
+        stormControlBroadcastLevelPps: 12345
+
 # --- Cleanup helper: all test interfaces ---
 
 cleanup_interface_names:

--- a/tests/unit/module_utils/models/test_storm_control_mutex.py
+++ b/tests/unit/module_utils/models/test_storm_control_mutex.py
@@ -162,3 +162,53 @@ def test_storm_control_mutex_00140(model_cls) -> None:
             storm_control_unicast_level=PCT,
             storm_control_unicast_level_pps=PPS,
         )
+
+
+@pytest.mark.parametrize("model_cls", POLICY_MODELS)
+@pytest.mark.parametrize("label,pct_attr,pps_attr", CLASS_FIELDS)
+def test_storm_control_mutex_00150(model_cls, label, pct_attr, pps_attr) -> None:
+    """
+    # Summary
+
+    User/proposed config parsed via `from_config()` rejects both-set-for-one-class (the write path fails fast).
+
+    ## Test
+
+    - A policy model is built from an Ansible config dict setting both the percentage and pps level for one class.
+    - A `ValidationError` is raised naming the offending traffic class.
+
+    ## Classes and Methods
+
+    - NDBaseModel.from_config()
+    - StormControlMutexMixin._reject_storm_control_level_and_pps()
+    """
+    with pytest.raises(ValidationError, match=label):
+        model_cls.from_config({pct_attr: PCT, pps_attr: PPS})
+
+
+@pytest.mark.parametrize("model_cls", POLICY_MODELS)
+@pytest.mark.parametrize("label,pct_attr,pps_attr", CLASS_FIELDS)
+def test_storm_control_mutex_00160(model_cls, label, pct_attr, pps_attr) -> None:
+    """
+    # Summary
+
+    An ND response parsed via `from_response()` accepts both values for one class and preserves them (the read path
+    stays permissive). ND accepts and echoes both the percentage and pps on GET (issue #351), so an existing device
+    in that state must be parseable for `query`/`gathered`/`diff` to report and remediate it.
+
+    ## Test
+
+    - A policy model is built from an ND response dict (aliased keys) setting both the percentage and pps level for one class.
+    - Construction does not raise, and both values round-trip onto the model.
+
+    ## Classes and Methods
+
+    - NDBaseModel.from_response()
+    - StormControlMutexMixin._reject_storm_control_level_and_pps()
+    """
+    pct_alias = model_cls.model_fields[pct_attr].alias
+    pps_alias = model_cls.model_fields[pps_attr].alias
+    with does_not_raise():
+        instance = model_cls.from_response({pct_alias: PCT, pps_alias: PPS})
+    assert getattr(instance, pct_attr) == PCT
+    assert getattr(instance, pps_attr) == PPS

--- a/tests/unit/module_utils/models/test_storm_control_mutex.py
+++ b/tests/unit/module_utils/models/test_storm_control_mutex.py
@@ -7,9 +7,13 @@
 """
 Unit tests for the shared storm-control percentage/pps mutual-exclusion validator (issue #351).
 
-Exercises `StormControlMutexMixin` as applied to all five interface policy models: a config that sets both the
+Exercises `StormControlMutexMixin` as applied to all six interface policy models: a config that sets both the
 percentage level and the pps level for the same traffic class must be rejected, while setting only one (or putting
 the percentage and pps on different classes) is accepted.
+
+Also exercises the response-to-diff-to-merge lifecycle at the top-level interface model layer (PR #360 review):
+explicitly selecting one variant of a pair in proposed config must count an existing counterpart as a difference
+and clear it during merge, and a dual-valued ND echo must survive unrelated merges untouched.
 """
 
 # pylint: disable=line-too-long
@@ -21,11 +25,30 @@ from __future__ import annotations
 from contextlib import contextmanager
 
 import pytest
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import EthernetAccessPolicyModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import PortChannelAccessPolicyModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import PortChannelTrunkHostPolicyModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import AccessVpcHostPolicyModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import TrunkVpcHostPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import (
+    EthernetAccessInterfaceModel,
+    EthernetAccessPolicyModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import (
+    EthernetTrunkHostInterfaceModel,
+    EthernetTrunkHostPolicyModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import (
+    PortChannelAccessInterfaceModel,
+    PortChannelAccessPolicyModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostInterfaceModel,
+    PortChannelTrunkHostPolicyModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
+    AccessVpcHostInterfaceModel,
+    AccessVpcHostPolicyModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import (
+    TrunkVpcHostInterfaceModel,
+    TrunkVpcHostPolicyModel,
+)
 from pydantic import ValidationError
 
 
@@ -38,6 +61,7 @@ def does_not_raise():
 # Every interface policy model that carries the paired storm-control fields.
 POLICY_MODELS = [
     EthernetAccessPolicyModel,
+    EthernetTrunkHostPolicyModel,
     PortChannelAccessPolicyModel,
     PortChannelTrunkHostPolicyModel,
     AccessVpcHostPolicyModel,
@@ -212,3 +236,281 @@ def test_storm_control_mutex_00160(model_cls, label, pct_attr, pps_attr) -> None
         instance = model_cls.from_response({pct_alias: PCT, pps_alias: PPS})
     assert getattr(instance, pct_attr) == PCT
     assert getattr(instance, pps_attr) == PPS
+
+
+# --- Top-level response-to-diff-to-merge lifecycle (PR #360 review) ---
+
+SWITCH_IP = "192.0.2.10"
+
+# (top-level interface model, policy model, ND-canonical interface name) for every interface family that carries
+# the paired storm-control fields.
+INTERFACE_MODELS = [
+    (EthernetAccessInterfaceModel, EthernetAccessPolicyModel, "Ethernet1/1"),
+    (EthernetTrunkHostInterfaceModel, EthernetTrunkHostPolicyModel, "Ethernet1/1"),
+    (PortChannelAccessInterfaceModel, PortChannelAccessPolicyModel, "port-channel501"),
+    (PortChannelTrunkHostInterfaceModel, PortChannelTrunkHostPolicyModel, "port-channel501"),
+    (AccessVpcHostInterfaceModel, AccessVpcHostPolicyModel, "vpc100"),
+    (TrunkVpcHostInterfaceModel, TrunkVpcHostPolicyModel, "vpc100"),
+]
+
+PCT_ALIAS = "stormControlBroadcastLevel"
+PPS_ALIAS = "stormControlBroadcastLevelPps"
+PCT_ATTR = "storm_control_broadcast_level"
+PPS_ATTR = "storm_control_broadcast_level_pps"
+
+
+def nd_interface_response(policy_cls, interface_name, policy_fields):
+    """Build an ND-shaped interface GET response dict carrying the given aliased policy fields."""
+    policy_type = policy_cls.model_fields["policy_type"].default
+    policy = {"policyType": getattr(policy_type, "value", policy_type)}
+    policy.update(policy_fields)
+    return {"switchIp": SWITCH_IP, "interfaceName": interface_name, "configData": {"networkOS": {"policy": policy}}}
+
+
+def proposed_config(interface_name, policy_fields):
+    """Build an Ansible-shaped proposed config dict carrying the given snake_case policy fields."""
+    return {"switch_ip": SWITCH_IP, "interface_name": interface_name, "config_data": {"network_os": {"policy": policy_fields}}}
+
+
+def policy_of(instance):
+    """Return the nested policy model of a top-level interface model instance."""
+    return instance.config_data.network_os.policy
+
+
+def test_storm_control_mutex_00170() -> None:
+    """
+    # Summary
+
+    A physical ethernet trunkHost interface response carrying both the percentage and pps level for one class is
+    parseable via the top-level `from_response()` (issue #351 regression, PR #360 review). ND 4.2.1.10 and 4.3.1.75
+    accept and echo this exact state, so query/gathered/diff initialization (and therefore every state, including
+    `deleted`) must be able to construct the model.
+
+    ## Test
+
+    - `EthernetTrunkHostInterfaceModel.from_response()` is called with an ND-shaped payload carrying both
+      `stormControlBroadcastLevel` and `stormControlBroadcastLevelPps`.
+    - Construction does not raise, and both values round-trip onto the nested policy model.
+
+    ## Classes and Methods
+
+    - NDBaseModel.from_response()
+    - StormControlMutexMixin._reject_storm_control_level_and_pps()
+    """
+    response = {
+        "switchIp": SWITCH_IP,
+        "interfaceName": "Ethernet1/1",
+        "configData": {
+            "networkOS": {
+                "policy": {
+                    "policyType": "trunkHost",
+                    "stormControlBroadcastLevel": 42.5,
+                    "stormControlBroadcastLevelPps": 12345,
+                }
+            }
+        },
+    }
+    with does_not_raise():
+        instance = EthernetTrunkHostInterfaceModel.from_response(response)
+    assert policy_of(instance).storm_control_broadcast_level == 42.5
+    assert policy_of(instance).storm_control_broadcast_level_pps == 12345
+
+
+@pytest.mark.parametrize("interface_cls,policy_cls,interface_name", INTERFACE_MODELS)
+def test_storm_control_mutex_00200(interface_cls, policy_cls, interface_name) -> None:
+    """
+    # Summary
+
+    `state: merged` can switch a storm-control class from percentage to pps: the diff reports a change and the merge
+    clears the percentage before assigning the pps, so the merged model never holds both (PR #360 review).
+
+    ## Test
+
+    - An existing model is built from an ND response carrying a percentage-only broadcast level.
+    - A proposed model is built from config carrying a pps-only broadcast level.
+    - `get_diff(exclude_unset=True)` reports a difference.
+    - `merge()` does not raise; the merged policy has the percentage cleared and the pps set.
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - StormControlMutexMixin.merge()
+    """
+    existing = interface_cls.from_response(nd_interface_response(policy_cls, interface_name, {PCT_ALIAS: PCT}))
+    proposed = interface_cls.from_config(proposed_config(interface_name, {PPS_ATTR: PPS}))
+    assert existing.get_diff(proposed, exclude_unset=True) is False
+    with does_not_raise():
+        merged = existing.merge(proposed)
+    assert getattr(policy_of(merged), PCT_ATTR) is None
+    assert getattr(policy_of(merged), PPS_ATTR) == PPS
+
+
+@pytest.mark.parametrize("interface_cls,policy_cls,interface_name", INTERFACE_MODELS)
+def test_storm_control_mutex_00210(interface_cls, policy_cls, interface_name) -> None:
+    """
+    # Summary
+
+    `state: merged` can switch a storm-control class from pps to percentage: the diff reports a change and the merge
+    clears the pps before assigning the percentage (PR #360 review).
+
+    ## Test
+
+    - An existing model is built from an ND response carrying a pps-only broadcast level.
+    - A proposed model is built from config carrying a percentage-only broadcast level.
+    - `get_diff(exclude_unset=True)` reports a difference.
+    - `merge()` does not raise; the merged policy has the pps cleared and the percentage set.
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - StormControlMutexMixin.merge()
+    """
+    existing = interface_cls.from_response(nd_interface_response(policy_cls, interface_name, {PPS_ALIAS: PPS}))
+    proposed = interface_cls.from_config(proposed_config(interface_name, {PCT_ATTR: PCT}))
+    assert existing.get_diff(proposed, exclude_unset=True) is False
+    with does_not_raise():
+        merged = existing.merge(proposed)
+    assert getattr(policy_of(merged), PPS_ATTR) is None
+    assert getattr(policy_of(merged), PCT_ATTR) == PCT
+
+
+@pytest.mark.parametrize("interface_cls,policy_cls,interface_name", INTERFACE_MODELS)
+def test_storm_control_mutex_00220(interface_cls, policy_cls, interface_name) -> None:
+    """
+    # Summary
+
+    A dual-valued ND echo (issue #351) plus proposed config matching the existing pps is a difference, not `no_diff`:
+    explicitly selecting the pps variant must clear the stale percentage even when the pps value already matches
+    (PR #360 review). The one-way subset comparison alone would miss this.
+
+    ## Test
+
+    - An existing model is built from an ND response carrying both the percentage and pps broadcast levels.
+    - A proposed model is built from config carrying the same pps value that ND already echoes.
+    - `get_diff(exclude_unset=True)` reports a difference.
+    - `merge()` does not raise; the merged policy has the percentage cleared and the pps preserved.
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.merge_would_change()
+    - StormControlMutexMixin.merge()
+    - StormControlMutexMixin.merge_would_change()
+    """
+    existing = interface_cls.from_response(nd_interface_response(policy_cls, interface_name, {PCT_ALIAS: PCT, PPS_ALIAS: PPS}))
+    proposed = interface_cls.from_config(proposed_config(interface_name, {PPS_ATTR: PPS}))
+    assert existing.get_diff(proposed, exclude_unset=True) is False
+    with does_not_raise():
+        merged = existing.merge(proposed)
+    assert getattr(policy_of(merged), PCT_ATTR) is None
+    assert getattr(policy_of(merged), PPS_ATTR) == PPS
+
+
+@pytest.mark.parametrize("interface_cls,policy_cls,interface_name", INTERFACE_MODELS)
+def test_storm_control_mutex_00230(interface_cls, policy_cls, interface_name) -> None:
+    """
+    # Summary
+
+    A dual-valued ND echo plus proposed config changing the pps value merges cleanly: the percentage is cleared and
+    the pps updated (PR #360 review).
+
+    ## Test
+
+    - An existing model is built from an ND response carrying both the percentage and pps broadcast levels.
+    - A proposed model is built from config carrying a different pps value.
+    - `get_diff(exclude_unset=True)` reports a difference.
+    - `merge()` does not raise; the merged policy has the percentage cleared and the new pps value set.
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - StormControlMutexMixin.merge()
+    """
+    existing = interface_cls.from_response(nd_interface_response(policy_cls, interface_name, {PCT_ALIAS: PCT, PPS_ALIAS: PPS}))
+    proposed = interface_cls.from_config(proposed_config(interface_name, {PPS_ATTR: 2000}))
+    assert existing.get_diff(proposed, exclude_unset=True) is False
+    with does_not_raise():
+        merged = existing.merge(proposed)
+    assert getattr(policy_of(merged), PCT_ATTR) is None
+    assert getattr(policy_of(merged), PPS_ATTR) == 2000
+
+
+@pytest.mark.parametrize("interface_cls,policy_cls,interface_name", INTERFACE_MODELS)
+def test_storm_control_mutex_00240(interface_cls, policy_cls, interface_name) -> None:
+    """
+    # Summary
+
+    An unrelated merged update against a dual-valued ND echo succeeds and leaves the storm-control state untouched:
+    the user expressed no storm-control intent, so the merge must not raise on (or silently alter) the echoed pair
+    (PR #360 review).
+
+    ## Test
+
+    - An existing model is built from an ND response carrying both the percentage and pps broadcast levels.
+    - A proposed model is built from config setting only `admin_state`.
+    - `merge()` does not raise; `admin_state` is updated and both storm-control values are preserved.
+
+    ## Classes and Methods
+
+    - StormControlMutexMixin.merge()
+    """
+    existing = interface_cls.from_response(nd_interface_response(policy_cls, interface_name, {PCT_ALIAS: PCT, PPS_ALIAS: PPS}))
+    proposed = interface_cls.from_config(proposed_config(interface_name, {"admin_state": True}))
+    with does_not_raise():
+        merged = existing.merge(proposed)
+    assert policy_of(merged).admin_state is True
+    assert getattr(policy_of(merged), PCT_ATTR) == PCT
+    assert getattr(policy_of(merged), PPS_ATTR) == PPS
+
+
+@pytest.mark.parametrize("interface_cls,policy_cls,interface_name", INTERFACE_MODELS)
+def test_storm_control_mutex_00250(interface_cls, policy_cls, interface_name) -> None:
+    """
+    # Summary
+
+    Counterpart clearing is scoped per traffic class: selecting a pps for multicast clears nothing on broadcast, and a
+    dual-valued broadcast echo survives the merge untouched (PR #360 review).
+
+    ## Test
+
+    - An existing model is built from an ND response carrying both broadcast levels (percentage and pps).
+    - A proposed model is built from config carrying a multicast pps level only.
+    - `merge()` does not raise; the broadcast pair is preserved and the multicast pps is set.
+
+    ## Classes and Methods
+
+    - StormControlMutexMixin.merge()
+    """
+    existing = interface_cls.from_response(nd_interface_response(policy_cls, interface_name, {PCT_ALIAS: PCT, PPS_ALIAS: PPS}))
+    proposed = interface_cls.from_config(proposed_config(interface_name, {"storm_control_multicast_level_pps": PPS}))
+    with does_not_raise():
+        merged = existing.merge(proposed)
+    assert getattr(policy_of(merged), PCT_ATTR) == PCT
+    assert getattr(policy_of(merged), PPS_ATTR) == PPS
+    assert policy_of(merged).storm_control_multicast_level_pps == PPS
+    assert policy_of(merged).storm_control_multicast_level is None
+
+
+@pytest.mark.parametrize("interface_cls,policy_cls,interface_name", INTERFACE_MODELS)
+def test_storm_control_mutex_00260(interface_cls, policy_cls, interface_name) -> None:
+    """
+    # Summary
+
+    No false positives: proposed config re-stating the variant the device already uses (same value, no counterpart
+    set) remains `no_diff`, so idempotent runs stay idempotent (PR #360 review).
+
+    ## Test
+
+    - An existing model is built from an ND response carrying a percentage-only broadcast level.
+    - A proposed model is built from config carrying the same percentage value.
+    - `get_diff(exclude_unset=True)` reports no difference.
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.merge_would_change()
+    - StormControlMutexMixin.merge_would_change()
+    """
+    existing = interface_cls.from_response(nd_interface_response(policy_cls, interface_name, {PCT_ALIAS: PCT}))
+    proposed = interface_cls.from_config(proposed_config(interface_name, {PCT_ATTR: PCT}))
+    assert existing.get_diff(proposed, exclude_unset=True) is True

--- a/tests/unit/module_utils/models/test_storm_control_mutex.py
+++ b/tests/unit/module_utils/models/test_storm_control_mutex.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the shared storm-control percentage/pps mutual-exclusion validator (issue #351).
+
+Exercises `StormControlMutexMixin` as applied to all five interface policy models: a config that sets both the
+percentage level and the pps level for the same traffic class must be rejected, while setting only one (or putting
+the percentage and pps on different classes) is accepted.
+"""
+
+# pylint: disable=line-too-long
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import EthernetAccessPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import PortChannelAccessPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import PortChannelTrunkHostPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import AccessVpcHostPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import TrunkVpcHostPolicyModel
+from pydantic import ValidationError
+
+
+@contextmanager
+def does_not_raise():
+    """A context manager that does not raise an exception."""
+    yield
+
+
+# Every interface policy model that carries the paired storm-control fields.
+POLICY_MODELS = [
+    EthernetAccessPolicyModel,
+    PortChannelAccessPolicyModel,
+    PortChannelTrunkHostPolicyModel,
+    AccessVpcHostPolicyModel,
+    TrunkVpcHostPolicyModel,
+]
+
+# (label, percentage attribute, pps attribute) per storm-control traffic class.
+CLASS_FIELDS = [
+    ("broadcast", "storm_control_broadcast_level", "storm_control_broadcast_level_pps"),
+    ("multicast", "storm_control_multicast_level", "storm_control_multicast_level_pps"),
+    ("unicast", "storm_control_unicast_level", "storm_control_unicast_level_pps"),
+]
+
+PCT = 50.0
+PPS = 1000
+
+
+@pytest.mark.parametrize("model_cls", POLICY_MODELS)
+@pytest.mark.parametrize("label,pct_attr,pps_attr", CLASS_FIELDS)
+def test_storm_control_mutex_00100(model_cls, label, pct_attr, pps_attr) -> None:
+    """
+    # Summary
+
+    Setting both the percentage and pps level for the same storm-control class is rejected.
+
+    ## Test
+
+    - A policy model is constructed with both `storm_control_<class>_level` and `storm_control_<class>_level_pps` set.
+    - A `ValidationError` is raised naming the offending traffic class.
+
+    ## Classes and Methods
+
+    - StormControlMutexMixin._reject_storm_control_level_and_pps()
+    """
+    with pytest.raises(ValidationError, match=label):
+        model_cls(**{pct_attr: PCT, pps_attr: PPS})
+
+
+@pytest.mark.parametrize("model_cls", POLICY_MODELS)
+@pytest.mark.parametrize("label,pct_attr,pps_attr", CLASS_FIELDS)
+def test_storm_control_mutex_00110(model_cls, label, pct_attr, pps_attr) -> None:
+    """
+    # Summary
+
+    Setting only the percentage, or only the pps, for a class is accepted.
+
+    ## Test
+
+    - The model is constructed with just the percentage level set, then just the pps level set.
+    - Neither construction raises.
+
+    ## Classes and Methods
+
+    - StormControlMutexMixin._reject_storm_control_level_and_pps()
+    """
+    with does_not_raise():
+        model_cls(**{pct_attr: PCT})
+    with does_not_raise():
+        model_cls(**{pps_attr: PPS})
+
+
+@pytest.mark.parametrize("model_cls", POLICY_MODELS)
+def test_storm_control_mutex_00120(model_cls) -> None:
+    """
+    # Summary
+
+    A policy with no storm-control levels set is accepted (the validator is a no-op when nothing conflicts).
+
+    ## Test
+
+    - The model is constructed with no storm-control fields.
+    - Construction does not raise.
+
+    ## Classes and Methods
+
+    - StormControlMutexMixin._reject_storm_control_level_and_pps()
+    """
+    with does_not_raise():
+        model_cls()
+
+
+@pytest.mark.parametrize("model_cls", POLICY_MODELS)
+def test_storm_control_mutex_00130(model_cls) -> None:
+    """
+    # Summary
+
+    A percentage on one class and a pps on a different class do not conflict (the check is per-class).
+
+    ## Test
+
+    - The model is constructed with `storm_control_broadcast_level` and `storm_control_multicast_level_pps` set.
+    - Construction does not raise.
+
+    ## Classes and Methods
+
+    - StormControlMutexMixin._reject_storm_control_level_and_pps()
+    """
+    with does_not_raise():
+        model_cls(storm_control_broadcast_level=PCT, storm_control_multicast_level_pps=PPS)
+
+
+@pytest.mark.parametrize("model_cls", POLICY_MODELS)
+def test_storm_control_mutex_00140(model_cls) -> None:
+    """
+    # Summary
+
+    When more than one class conflicts, the error names every offending class.
+
+    ## Test
+
+    - The model is constructed with both percentage and pps set for broadcast and for unicast.
+    - A `ValidationError` is raised naming both `broadcast` and `unicast`.
+
+    ## Classes and Methods
+
+    - StormControlMutexMixin._reject_storm_control_level_and_pps()
+    """
+    with pytest.raises(ValidationError, match=r"broadcast, unicast"):
+        model_cls(
+            storm_control_broadcast_level=PCT,
+            storm_control_broadcast_level_pps=PPS,
+            storm_control_unicast_level=PCT,
+            storm_control_unicast_level_pps=PPS,
+        )

--- a/tests/unit/module_utils/test_nd_output.py
+++ b/tests/unit/module_utils/test_nd_output.py
@@ -172,6 +172,48 @@ class TestNDOutputFormat:
         assert result["before"] == []
         assert result["diff"] == []
 
+    def test_format_changed_when_after_removes_a_field(self):
+        """
+        # Summary
+
+        `changed` is True when an operation only REMOVES a field from an item (PR #360 review follow-up).
+
+        The one-way subset comparison previously used by `get_diff_collection` classified an after-item that
+        lost a field (e.g. the storm-control percentage cleared by the pct/pps merge) as `no_diff` because a
+        strict subset still satisfies `issubset(after, before)` — so a real controller update was reported as
+        `changed: false`. Lab-verified against ND: the update executed and cleared the field, but the module
+        said nothing changed.
+
+        ## Test
+
+        - `before` holds a dual-valued storm-control policy (percentage and pps, as ND echoes for issue #351).
+        - `after` holds the remediated policy: same pps, percentage cleared.
+        - `format()` reports `changed` is True.
+
+        ## Classes and Methods
+
+        - NDOutput.format()
+        - NDConfigCollection.get_diff_collection()
+        """
+        from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import (
+            EthernetTrunkHostInterfaceModel,
+        )
+        from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+
+        def response(policy):
+            return {"switchIp": "192.0.2.10", "interfaceName": "Ethernet1/1", "configData": {"networkOS": {"policy": policy}}}
+
+        before_item = EthernetTrunkHostInterfaceModel.from_response(
+            response({"policyType": "trunkHost", "stormControlBroadcastLevel": 50.0, "stormControlBroadcastLevelPps": 12345})
+        )
+        after_item = EthernetTrunkHostInterfaceModel.from_response(response({"policyType": "trunkHost", "stormControlBroadcastLevelPps": 12345}))
+        before = NDConfigCollection(model_class=EthernetTrunkHostInterfaceModel, items=[before_item])
+        after = NDConfigCollection(model_class=EthernetTrunkHostInterfaceModel, items=[after_item])
+
+        output = NDOutput("normal")
+        output.assign(before=before, after=after)
+        assert output.format()["changed"] is True
+
 
 # =============================================================================
 # Test: NDOutput.assign


### PR DESCRIPTION
## Related Issue(s)

Closes #351

## Proposed Changes

Storm-control percentage (`storm_control_<class>_level`) and pps (`storm_control_<class>_level_pps`) levels are mutually exclusive per traffic class on NX-OS, but nothing enforced this. Lab verification (ND **4.3.1.75** and **4.2.1.10**, see #351) showed ND accepts both, echoes both back on GET — so there is **no perpetual diff** — but at config generation it silently applies the percentage and **drops the pps**, losing the user's intent with no error.

- Add `StormControlMutexMixin` (`plugins/module_utils/models/interfaces/storm_control.py`): a shared `model_validator(mode="after")` that rejects setting both the percentage and pps for the same class, naming the offending class(es).
- Reparent all five interface policy models to the mixin: `ethernet_access`, `port_channel_access`, `port_channel_trunk_host`, `vpc_access`, `vpc_trunk_host`.
- Document the per-class mutual exclusivity in the four modules that lacked the note (`ethernet_access` already had it).
- Add parametrized unit tests across all five models.

**No `TODO(X.Y.Z)` workaround marker** — the wire round-trips faithfully, so there is no wire deviation to suppress; this is a client-side fail-fast UX guard. Behavior recorded in the bug-tracker vault (`storm-control-percent-pps-not-mutually-exclusive`).

## Test Notes

- New `tests/unit/module_utils/models/test_storm_control_mutex.py` — 45 cases (5 models × the conflict/single/none/cross-class/multi-class matrix), all passing via `ndpytest`.
- Full model + orchestrator suite green (960 passed) — reparenting changes no existing behavior.
- `validate-modules` sanity clean on the four doc-changed modules.
- `black`, `isort`, `pylint`, `mypy` run on changed files (remaining pylint `R0801` duplicate-code is pre-existing sibling-argspec duplication tracked by #348; mypy `import-not-found` is the baseline collection-path environment behavior, identical on untouched siblings).

## Cisco Nexus Dashboard Version

4.2.1.10 (CCO) and 4.3.1.75 (development image)

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
