### PR TITLE
Add policy-required-on-create preflight for interface modules (#350)

### DIFF
--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -93,9 +93,19 @@ class NDStateMachine:
         Manage state according to desired configuration.
         """
         if self.state in ["merged", "replaced", "overridden"]:
+            proposed_items = list(self.proposed)
+
+            # Policy-required-on-create guard (issue #350) runs FIRST: it is local-only (self.existing is
+            # already in memory), so it fails before the API-backed capability preflight below and before
+            # _manage_create_update_state mutates self.existing, which NDOutput aliases as `after`. Create
+            # subset = proposed items not present in the existing inventory -- the same key-membership
+            # criterion get_diff_config uses to classify "new" (PR #362 review).
+            items_to_create = [item for item in proposed_items if self.existing.get(item.get_identifier_value()) is None]
+            self.model_orchestrator.preflight_create(items_to_create)
+
             # Capability preflight runs here -- before _manage_create_update_state, whose mutations are
             # skipped in check mode -- so dry-runs surface incapable switches (PR #275 / issue #273).
-            self.model_orchestrator.preflight(list(self.proposed))
+            self.model_orchestrator.preflight(proposed_items)
             self._manage_create_update_state()
 
             if self.state == "overridden":
@@ -176,10 +186,8 @@ class NDStateMachine:
                 if not self.ignore_errors:
                     raise NDStateMachineError(error_msg) from e
 
-        # Fail fast before any mutation if a create item carries no policy (issue #350). Create-only:
-        # a merged/replaced update may legitimately omit a policy that already exists on the switch, and
-        # state: deleted does not route through here, so only genuine new items are validated.
-        self.model_orchestrator.preflight_create(items_to_create)
+        # The policy-required-on-create guard (issue #350) runs in manage_state, before the capability
+        # preflight and before this method mutates self.existing (PR #362 review).
 
         # Execute updates (always individual)
         for item in items_to_update:

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -101,11 +101,26 @@ class NDStateMachine:
             # subset = proposed items not present in the existing inventory -- the same key-membership
             # criterion get_diff_config uses to classify "new" (PR #362 review).
             items_to_create = [item for item in proposed_items if self.existing.get(item.get_identifier_value()) is None]
-            self.model_orchestrator.preflight_create(items_to_create)
 
-            # Capability preflight runs here -- before _manage_create_update_state, whose mutations are
-            # skipped in check mode -- so dry-runs surface incapable switches (PR #275 / issue #273).
-            self.model_orchestrator.preflight(proposed_items)
+            # Normalize preflight failures to NDStateMachineError (PR #362 review, gmicol). Both preflight
+            # hooks raise a bare RuntimeError (base_interface.preflight_create / the capability preflight),
+            # but nd_interface_svi and nd_interface_subinterface_managed/_unmanaged catch only
+            # NDStateMachineError at their entrypoint. Without this wrap a policy-less (or capability) preflight
+            # failure in those modules escapes as an unhandled RuntimeError, bypassing fail_json and losing the
+            # structured before/after/changed output the guard exists to provide. This wrap deliberately does
+            # NOT route through _execute_operation: both preflights must run in check mode too, and
+            # _execute_operation skips execution during a dry-run.
+            try:
+                self.model_orchestrator.preflight_create(items_to_create)
+
+                # Capability preflight runs here -- before _manage_create_update_state, whose mutations are
+                # skipped in check mode -- so dry-runs surface incapable switches (PR #275 / issue #273).
+                self.model_orchestrator.preflight(proposed_items)
+            except NDStateMachineError:
+                raise
+            except Exception as e:
+                raise NDStateMachineError(f"Preflight failed: {e}") from e
+
             self._manage_create_update_state()
 
             if self.state == "overridden":

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -176,6 +176,11 @@ class NDStateMachine:
                 if not self.ignore_errors:
                     raise NDStateMachineError(error_msg) from e
 
+        # Fail fast before any mutation if a create item carries no policy (issue #350). Create-only:
+        # a merged/replaced update may legitimately omit a policy that already exists on the switch, and
+        # state: deleted does not route through here, so only genuine new items are validated.
+        self.model_orchestrator.preflight_create(items_to_create)
+
         # Execute updates (always individual)
         for item in items_to_update:
             self._execute_operation(self.model_orchestrator.update, item, error_msg_prefix=f"Failed to update {item.get_identifier_value()}")

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -138,6 +138,22 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         """
         return
 
+    def preflight_create(self, model_instances: Sequence[ModelType]) -> None:
+        """
+        # Summary
+
+        Pre-mutation hook invoked by `NDStateMachine` with only the items diffed as create (`new`) — before any
+        create/update API call, so it fails fast in check mode too. Distinct from `preflight`, which receives the
+        full proposed set; this hook sees the create-only subset so subclasses can enforce create-specific
+        requirements without rejecting legitimate policy-less updates. Base implementation is a no-op; interface
+        orchestrators override to require a policy on create.
+
+        ## Raises
+
+        None
+        """
+        return
+
     # NOTE: Generic CRUD API operations for simple endpoints with single identifier (e.g. "api/v1/infra/aaa/LocalUsers/{loginID}")
     def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
         try:

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -214,13 +214,16 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         Require a policy on every interface being created. ND rejects a policy-less create per-interface (`mode is
         required` / `invalid policyType ''`) and never creates an empty interface, but the failure surfaces as
-        `interface[0] '<name>'` inside a generic create error after a round-trip. This guard fails fast — before any
-        API call, in check mode too — naming the offending `(switch_ip, interface_name)` in module terms (issue #350).
+        `interface[0] '<name>'` inside a generic create error after a round-trip. This guard is local-only and fails
+        fast — before the API-backed capability preflight and before any mutation, in check mode too — naming the
+        offending `(switch_ip, interface_name)` in module terms (issue #350). Only the initial inventory fetch
+        precedes it.
 
-        Invoked by `NDStateMachine` with only the items diffed as create (`new`), so a `merged`/`replaced` update that
-        legitimately omits a policy already present on the switch is never affected. A config item with no `config_data`
-        (identifier only) is correct for `state: deleted`, which does not route through this hook. Offenders are
-        aggregated into a single `RuntimeError` so one message names every policy-less create item.
+        Invoked by `NDStateMachine` with only the proposed items not present in the existing inventory (the create
+        subset), so a `merged`/`replaced` update that legitimately omits a policy already present on the switch is
+        never affected. A config item with no `config_data` (identifier only) is correct for `state: deleted`, which
+        does not route through this hook. Offenders are aggregated into a single `RuntimeError` so one message names
+        every policy-less create item.
 
         ## Raises
 

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -208,6 +208,39 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         """
         self.validate_switches_capable(model_instances)
 
+    def preflight_create(self, model_instances: Sequence[ModelType]) -> None:
+        """
+        # Summary
+
+        Require a policy on every interface being created. ND rejects a policy-less create per-interface (`mode is
+        required` / `invalid policyType ''`) and never creates an empty interface, but the failure surfaces as
+        `interface[0] '<name>'` inside a generic create error after a round-trip. This guard fails fast — before any
+        API call, in check mode too — naming the offending `(switch_ip, interface_name)` in module terms (issue #350).
+
+        Invoked by `NDStateMachine` with only the items diffed as create (`new`), so a `merged`/`replaced` update that
+        legitimately omits a policy already present on the switch is never affected. A config item with no `config_data`
+        (identifier only) is correct for `state: deleted`, which does not route through this hook. Offenders are
+        aggregated into a single `RuntimeError` so one message names every policy-less create item.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any create item has no `config_data.network_os.policy`.
+        """
+        offenders: list[str] = []
+        for model_instance in model_instances:
+            config_data = getattr(model_instance, "config_data", None)
+            network_os = getattr(config_data, "network_os", None) if config_data is not None else None
+            policy = getattr(network_os, "policy", None) if network_os is not None else None
+            if policy is None:
+                offenders.append(f"(switch_ip={model_instance.switch_ip}, interface_name={model_instance.interface_name})")
+        if offenders:
+            raise RuntimeError(
+                f"Cannot create interface(s) without a policy (config_data.network_os.policy is required to create an interface) "
+                f"in fabric '{self.fabric_name}': {', '.join(offenders)}. Supply a policy, or use state: deleted to remove an interface."
+            )
+
     def validate_switches_capable(self, model_instances: Sequence[ModelType]) -> None:
         """
         # Summary

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -1037,3 +1037,232 @@ def test_base_interface_00860() -> None:
     assert len(warnings) == 1
     assert "Capability preflight skipped in check mode" in warnings[0]
     assert "FDO12345ABC" in warnings[0]
+
+
+# =============================================================================
+# Test: preflight_create() policy-required-on-create guard (issue #350)
+# =============================================================================
+
+
+def _iface_model(switch_ip: str, interface_name: str, *, policy: bool = True, config_data: bool = True, network_os: bool = True):
+    """Build a lightweight stand-in for an interface model instance for `preflight_create` tests.
+
+    `preflight_create` reads `config_data` -> `network_os` -> `policy` via `getattr`, so a `SimpleNamespace`
+    faithfully exercises the traversal without coupling these tests to any per-feature Pydantic model. Set
+    `config_data=False` for an identifier-only item, or `policy=False` for a `config_data` with no policy.
+    """
+    if not config_data:
+        config_data_obj = None
+    else:
+        network_os_obj = SimpleNamespace(policy=(SimpleNamespace() if policy else None)) if network_os else None
+        config_data_obj = SimpleNamespace(network_os=network_os_obj)
+    return SimpleNamespace(switch_ip=switch_ip, interface_name=interface_name, config_data=config_data_obj)
+
+
+def test_base_interface_00900() -> None:
+    """
+    # Summary
+
+    Verify `preflight_create` does not raise when every create item carries a policy.
+
+    ## Test
+
+    - Two items each have `config_data.network_os.policy` set
+    - `preflight_create` does not raise
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+
+    items = [_iface_model("192.168.12.151", "loopback100"), _iface_model("192.168.12.152", "loopback101")]
+    with does_not_raise():
+        instance.preflight_create(items)
+
+
+def test_base_interface_00910() -> None:
+    """
+    # Summary
+
+    Verify `preflight_create` raises `RuntimeError` for a create item with no `config_data` at all, naming the
+    offending `switch_ip`, `interface_name`, and the fabric.
+
+    ## Test
+
+    - One item has `config_data` of None (identifier only)
+    - `preflight_create` raises `RuntimeError` naming the switch_ip, interface_name, and fabric_1
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+
+    match = r"without a policy.*fabric 'fabric_1'.*switch_ip=192\.168\.12\.151, interface_name=loopback100"
+    with pytest.raises(RuntimeError, match=match):
+        instance.preflight_create([_iface_model("192.168.12.151", "loopback100", config_data=False)])
+
+
+def test_base_interface_00920() -> None:
+    """
+    # Summary
+
+    Verify `preflight_create` raises when `config_data` is present but `policy` is None (the `config_data`-without-policy
+    case, distinct from no `config_data` at all).
+
+    ## Test
+
+    - One item has `config_data.network_os` present but `policy` is None
+    - `preflight_create` raises `RuntimeError` naming the offending interface
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+
+    match = r"switch_ip=192\.168\.12\.151, interface_name=Vlan100"
+    with pytest.raises(RuntimeError, match=match):
+        instance.preflight_create([_iface_model("192.168.12.151", "Vlan100", policy=False)])
+
+
+def test_base_interface_00930() -> None:
+    """
+    # Summary
+
+    Verify `preflight_create` aggregates multiple offenders into a single `RuntimeError` naming each.
+
+    ## Test
+
+    - Two items both lack a policy
+    - `preflight_create` raises one `RuntimeError` naming both interface_names
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+
+    items = [
+        _iface_model("192.168.12.151", "loopback100", config_data=False),
+        _iface_model("192.168.12.152", "loopback101", policy=False),
+    ]
+    with pytest.raises(RuntimeError) as exc_info:
+        instance.preflight_create(items)
+    message = str(exc_info.value)
+    assert "interface_name=loopback100" in message
+    assert "interface_name=loopback101" in message
+
+
+def test_base_interface_00940() -> None:
+    """
+    # Summary
+
+    Verify `preflight_create` names only the policy-less offender and not the valid sibling in a mixed batch.
+
+    ## Test
+
+    - One item has a policy, one does not
+    - `preflight_create` raises `RuntimeError` naming the offender only
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+
+    items = [
+        _iface_model("192.168.12.151", "loopback_ok"),
+        _iface_model("192.168.12.152", "loopback_bad", config_data=False),
+    ]
+    with pytest.raises(RuntimeError) as exc_info:
+        instance.preflight_create(items)
+    message = str(exc_info.value)
+    assert "interface_name=loopback_bad" in message
+    assert "loopback_ok" not in message
+
+
+def test_base_interface_00950() -> None:
+    """
+    # Summary
+
+    Verify `preflight_create` is a no-op for an empty create set (the common case where a state run produces only updates).
+
+    ## Test
+
+    - `preflight_create([])` does not raise
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        instance.preflight_create([])
+
+
+def test_base_interface_00960() -> None:
+    """
+    # Summary
+
+    Verify `preflight_create` still raises in `--check` mode. The guard is a deterministic input-validation error with no
+    API dependency, so it fails fast in a dry-run rather than downgrading to a warning like the capability preflight.
+
+    ## Test
+
+    - `rest_send.check_mode` is True
+    - A policy-less create item still raises `RuntimeError`
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    rest_send.check_mode = True
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+
+    with pytest.raises(RuntimeError, match=r"without a policy"):
+        instance.preflight_create([_iface_model("192.168.12.151", "loopback100", config_data=False)])

--- a/tests/unit/module_utils/orchestrators/test_base_orchestrator.py
+++ b/tests/unit/module_utils/orchestrators/test_base_orchestrator.py
@@ -601,6 +601,38 @@ class TestPreflightNoOp:
 
 
 # =============================================================================
+# Test: preflight_create() generic no-op hook
+# =============================================================================
+
+
+class TestPreflightCreateNoOp:
+    """Tests for the generic preflight_create() pre-mutation hook on NDBaseOrchestrator.
+
+    NDStateMachine invokes preflight_create() with only the create (`new`) subset before any
+    create/update API call. The base implementation must be a no-op so non-interface orchestrators
+    (local_user, fabric_*) are unaffected even when an item carries no policy; interface orchestrators
+    override it to require a policy on create (issue #350).
+    """
+
+    def test_preflight_create_returns_none_and_issues_no_request(self):
+        """preflight_create() on the generic base returns None and makes no API call."""
+        # No responses seeded: any HTTP attempt would StopIteration.
+        rest_send = _make_rest_send([])
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        assert orch.preflight_create([StubModel(name="a"), StubModel(name="b")]) is None
+        assert results._tasks == []
+
+    def test_preflight_create_accepts_empty_sequence(self):
+        """preflight_create() tolerates an empty create set."""
+        rest_send = _make_rest_send([])
+        orch = _make_orchestrator(rest_send, results=None)
+
+        assert orch.preflight_create([]) is None
+
+
+# =============================================================================
 # Test: model_class must be a ClassVar, never a pydantic field (issue #344)
 # =============================================================================
 

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -5,16 +5,19 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 """
-Unit tests for `NDStateMachine` capability-preflight wiring.
+Unit tests for `NDStateMachine` preflight wiring.
 
-Verifies that `manage_state` invokes the orchestrator's `preflight` hook at a point that runs BEFORE
-mutation operations are gated by check mode (PR #275 / issue #273):
+Verifies that `manage_state` invokes the orchestrator's preflight hooks at points that run BEFORE
+mutation operations are gated by check mode:
 
-- For create/update states (merged/replaced/overridden) `preflight` is called over the proposed set,
-  in check mode as well as normal mode, even though the underlying create/update calls are skipped in
-  check mode.
-- For `deleted` state `preflight` is NOT called (removing configuration does not depend on a switch's
-  capability to host the interface type -- the documented out-of-scope decision).
+- For create/update states (merged/replaced/overridden) `preflight` (capability, PR #275 / issue #273) is
+  called over the proposed set, in check mode as well as normal mode, even though the underlying create/update
+  calls are skipped in check mode.
+- `preflight_create` (policy-required-on-create, issue #350) is called with only the create (`new`) subset,
+  ahead of the mutation loops; an already-present item re-submitted without a policy is not a create and is
+  not validated, and a failure propagates before any mutation.
+- For `deleted` state neither preflight is called (removing configuration does not depend on capability, and a
+  policy-less item is correct for delete -- the documented out-of-scope decision).
 
 These drive the full `NDStateMachine.manage_state` path with a spy orchestrator instance, so they cover
 the seam the per-method capability tests in `test_base_interface.py` cannot: the check-mode skip lives in
@@ -27,6 +30,7 @@ from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type  # pylint: disable=invalid-name
 
+import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
@@ -55,6 +59,11 @@ class _SpyLoopbackOrchestrator(LoopbackInterfaceOrchestrator):
 
     def preflight(self, model_instances) -> None:
         self._calls.append(("preflight", list(model_instances)))
+
+    def preflight_create(self, model_instances) -> None:
+        # Record-only, mirroring the `preflight` spy: the guard's own logic is covered in
+        # test_base_interface.py; here we assert only that manage_state reaches it with the create subset.
+        self._calls.append(("preflight_create", list(model_instances)))
 
     def create(self, model_instance, **kwargs) -> ResponseType:
         self._calls.append(("create", model_instance))
@@ -123,13 +132,14 @@ def test_nd_state_machine_00100() -> None:
     ## Test
 
     - `state: merged`, `check_mode: True`, one proposed interface (new vs empty inventory)
-    - `preflight` is recorded exactly once, with the single proposed model
+    - `preflight` is recorded, then `preflight_create` over the create subset (both run before the check-mode gate)
     - No `create`/`create_bulk` call is recorded (skipped in check mode)
 
     ## Classes and Methods
 
     - NDStateMachine.manage_state()
     - NDBaseInterfaceOrchestrator.preflight()
+    - NDBaseInterfaceOrchestrator.preflight_create()
     """
     instance = _build_state_machine(state="merged", check_mode=True, config=_CONFIG)
 
@@ -138,9 +148,11 @@ def test_nd_state_machine_00100() -> None:
 
     calls = instance.model_orchestrator._calls
     names = [name for name, _ in calls]
-    assert names == ["preflight"]
+    assert names == ["preflight", "preflight_create"]
     assert len(calls[0][1]) == 1
     assert calls[0][1][0].get_identifier_value() == ("192.168.12.151", "loopback10")
+    # preflight_create receives the same single new item (create subset)
+    assert [m.get_identifier_value() for m in calls[1][1]] == [("192.168.12.151", "loopback10")]
 
 
 def test_nd_state_machine_00110() -> None:
@@ -154,14 +166,15 @@ def test_nd_state_machine_00110() -> None:
     ## Test
 
     - `state: merged`, `check_mode: False`, one proposed interface
-    - `preflight` is recorded, then `create_bulk` is recorded (loopback supports bulk create)
-    - `preflight` appears before `create_bulk`
+    - `preflight`, then `preflight_create`, then `create_bulk` are recorded (loopback supports bulk create)
+    - Both preflights precede the mutation
 
     ## Classes and Methods
 
     - NDStateMachine.manage_state()
     - NDStateMachine._manage_create_update_state()
     - NDBaseInterfaceOrchestrator.preflight()
+    - NDBaseInterfaceOrchestrator.preflight_create()
     """
     instance = _build_state_machine(state="merged", check_mode=False, config=_CONFIG)
 
@@ -169,7 +182,7 @@ def test_nd_state_machine_00110() -> None:
         instance.manage_state()
 
     names = [name for name, _ in instance.model_orchestrator._calls]
-    assert names == ["preflight", "create_bulk"]
+    assert names == ["preflight", "preflight_create", "create_bulk"]
 
 
 def test_nd_state_machine_00120() -> None:
@@ -182,7 +195,7 @@ def test_nd_state_machine_00120() -> None:
     ## Test
 
     - `state: deleted`, `check_mode: True`, one proposed interface
-    - No `preflight` call is recorded
+    - Neither `preflight` nor `preflight_create` is recorded (a policy-less item is correct for delete)
     - No mutation is recorded either (nothing matches the empty inventory, and check mode skips mutations)
 
     ## Classes and Methods
@@ -197,6 +210,7 @@ def test_nd_state_machine_00120() -> None:
 
     names = [name for name, _ in instance.model_orchestrator._calls]
     assert "preflight" not in names
+    assert "preflight_create" not in names
 
 
 def test_nd_state_machine_00130() -> None:
@@ -228,3 +242,88 @@ def test_nd_state_machine_00130() -> None:
     assert names.count("preflight") == 1
     assert names[0] == "preflight"
     assert len(calls[0][1]) == 1
+
+
+class _ExistingLoopbackSpy(_SpyLoopbackOrchestrator):
+    """Spy whose inventory already contains loopback10, so a re-submitted policy-less item is not a create."""
+
+    def query_all(self, model_instance=None, **kwargs) -> ResponseType:
+        return [{"switchIp": "192.168.12.151", "interfaceName": "loopback10", "interfaceType": "loopback"}]
+
+
+def test_nd_state_machine_00140() -> None:
+    """
+    # Summary
+
+    Verify the create-only scoping of `preflight_create`: an interface already present in ND, re-submitted under
+    `merged` without a policy, is NOT treated as a create and therefore is NOT passed to `preflight_create`. This is
+    the invariant behind issue #350's decision to validate only creates -- a `merged` re-apply (or update) may
+    legitimately omit a policy that already exists on the switch.
+
+    ## Test
+
+    - Inventory already contains `loopback10`; proposed re-sends the same identifier-only item under `merged`
+    - The item diffs as `no_diff`, so `items_to_create` is empty
+    - `preflight_create` is recorded with an empty list and `manage_state` does not raise
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_create_update_state()
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+    spy = _ExistingLoopbackSpy(rest_send=_build_rest_send())
+    module = _build_module(state="merged", check_mode=False, config=_CONFIG)
+    instance = NDStateMachine(module=module, model_orchestrator=spy)
+
+    with does_not_raise():
+        instance.manage_state()
+
+    calls = instance.model_orchestrator._calls
+    preflight_create_calls = [args for name, args in calls if name == "preflight_create"]
+    assert preflight_create_calls == [[]]
+    # No create was attempted (item already existed)
+    assert "create" not in [name for name, _ in calls]
+    assert "create_bulk" not in [name for name, _ in calls]
+
+
+class _RaisingPreflightCreateSpy(_SpyLoopbackOrchestrator):
+    """Spy whose `preflight_create` raises for any create item, to assert the error halts the run before mutation."""
+
+    def preflight_create(self, model_instances) -> None:
+        self._calls.append(("preflight_create", list(model_instances)))
+        if model_instances:
+            raise RuntimeError("Cannot create interface(s) without a policy")
+
+
+def test_nd_state_machine_00150() -> None:
+    """
+    # Summary
+
+    Verify a `preflight_create` failure propagates out of `manage_state` BEFORE any mutation, even outside check mode.
+    This guards the seam: the guard is wired ahead of the create/update execution loops, so a policy-less create fails
+    fast with no `create`/`create_bulk` side effect.
+
+    ## Test
+
+    - `state: merged`, `check_mode: False`, one new policy-less item
+    - `preflight_create` raises `RuntimeError`, which propagates from `manage_state`
+    - No `create`/`create_bulk` call is recorded (failed before the mutation loop)
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_create_update_state()
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+    spy = _RaisingPreflightCreateSpy(rest_send=_build_rest_send())
+    module = _build_module(state="merged", check_mode=False, config=_CONFIG)
+    instance = NDStateMachine(module=module, model_orchestrator=spy)
+
+    with pytest.raises(RuntimeError, match=r"without a policy"):
+        instance.manage_state()
+
+    names = [name for name, _ in instance.model_orchestrator._calls]
+    assert "preflight_create" in names
+    assert "create" not in names
+    assert "create_bulk" not in names

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -31,6 +31,7 @@ from __future__ import absolute_import, annotations, division, print_function
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
@@ -303,12 +304,15 @@ def test_nd_state_machine_00150() -> None:
 
     Verify a `preflight_create` failure propagates out of `manage_state` BEFORE any mutation, even outside check mode.
     This guards the seam: the guard is wired ahead of the create/update execution loops, so a policy-less create fails
-    fast with no `create`/`create_bulk` side effect.
+    fast with no `create`/`create_bulk` side effect. The raw `RuntimeError` from the guard is normalized to
+    `NDStateMachineError` so module entrypoints that catch only `NDStateMachineError` still route through `fail_json`
+    (PR #362 review).
 
     ## Test
 
     - `state: merged`, `check_mode: False`, one new policy-less item
-    - `preflight_create` raises `RuntimeError`, which propagates from `manage_state`
+    - `preflight_create` raises `RuntimeError`, which `manage_state` re-raises as `NDStateMachineError`
+    - The original `RuntimeError` is preserved as the exception `__cause__`
     - No `create`/`create_bulk` call is recorded (failed before the mutation loop)
 
     ## Classes and Methods
@@ -321,8 +325,10 @@ def test_nd_state_machine_00150() -> None:
     module = _build_module(state="merged", check_mode=False, config=_CONFIG)
     instance = NDStateMachine(module=module, model_orchestrator=spy)
 
-    with pytest.raises(RuntimeError, match=r"without a policy"):
+    with pytest.raises(NDStateMachineError, match=r"without a policy") as exc_info:
         instance.manage_state()
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
 
     names = [name for name, _ in instance.model_orchestrator._calls]
     assert "preflight_create" in names
@@ -342,7 +348,7 @@ def test_nd_state_machine_00160() -> None:
     ## Test
 
     - `state: merged`, `check_mode: False`, one new policy-less item; `preflight_create` raises `RuntimeError`
-    - The error propagates from `manage_state`
+    - The error propagates from `manage_state` (normalized to `NDStateMachineError`)
     - `output.format()` reports `changed is False`, `before == []`, and `after == []` (no phantom item)
 
     ## Classes and Methods
@@ -355,7 +361,7 @@ def test_nd_state_machine_00160() -> None:
     module = _build_module(state="merged", check_mode=False, config=_CONFIG)
     instance = NDStateMachine(module=module, model_orchestrator=spy)
 
-    with pytest.raises(RuntimeError, match=r"without a policy"):
+    with pytest.raises(NDStateMachineError, match=r"without a policy"):
         instance.manage_state()
 
     output = instance.output.format()
@@ -393,7 +399,7 @@ def test_nd_state_machine_00170() -> None:
 
     - `state: merged`, `check_mode: False`, one new policy-less item
     - Capability `preflight` is rigged to raise, and `preflight_create` is the real `base_interface` guard
-    - The policy error (`without a policy`) propagates, not the capability error
+    - The policy error (`without a policy`) propagates (normalized to `NDStateMachineError`), not the capability error
     - The recorded call order shows `preflight_create` first
 
     ## Classes and Methods
@@ -405,8 +411,56 @@ def test_nd_state_machine_00170() -> None:
     module = _build_module(state="merged", check_mode=False, config=_CONFIG)
     instance = NDStateMachine(module=module, model_orchestrator=spy)
 
-    with pytest.raises(RuntimeError, match=r"without a policy"):
+    with pytest.raises(NDStateMachineError, match=r"without a policy"):
         instance.manage_state()
 
     names = [name for name, _ in instance.model_orchestrator._calls]
     assert names[0] == "preflight_create"
+
+
+class _CapabilityOnlyFailingSpy(_SpyLoopbackOrchestrator):
+    """Spy whose capability `preflight` raises while `preflight_create` is the record-only no-op inherited from
+    `_SpyLoopbackOrchestrator`. Isolates the capability-preflight leg so a test can assert its bare `RuntimeError`
+    is normalized to `NDStateMachineError` by `manage_state` -- the latent gap the PR #362 review wrap also closes.
+    """
+
+    def preflight(self, model_instances) -> None:
+        self._calls.append(("preflight", list(model_instances)))
+        raise RuntimeError("capability preflight failed: switch not capable")
+
+
+def test_nd_state_machine_00180() -> None:
+    """
+    # Summary
+
+    Verify a capability `preflight` failure is normalized to `NDStateMachineError` by `manage_state`, not left as a
+    bare `RuntimeError`. Without this, nd_interface_svi and nd_interface_subinterface_managed/_unmanaged -- which catch
+    only `NDStateMachineError` at their entrypoint -- would let a capability-preflight failure escape as an unhandled
+    exception, bypassing `fail_json` and the structured before/after/changed output (PR #362 review, gmicol). The
+    policy guard passes here (record-only spy) so the capability leg is the raising one, and no mutation runs.
+
+    ## Test
+
+    - `state: merged`, `check_mode: False`, one new item; `preflight_create` is the record-only no-op, capability
+      `preflight` raises `RuntimeError`
+    - `manage_state` re-raises as `NDStateMachineError` carrying the capability message, with the `RuntimeError` as
+      `__cause__`
+    - No `create`/`create_bulk` call is recorded (failed before the mutation loop)
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDBaseInterfaceOrchestrator.preflight()
+    """
+    spy = _CapabilityOnlyFailingSpy(rest_send=_build_rest_send())
+    module = _build_module(state="merged", check_mode=False, config=_CONFIG)
+    instance = NDStateMachine(module=module, model_orchestrator=spy)
+
+    with pytest.raises(NDStateMachineError, match=r"capability preflight failed") as exc_info:
+        instance.manage_state()
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    names = [name for name, _ in instance.model_orchestrator._calls]
+    assert "create" not in names
+    assert "create_bulk" not in names

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -10,12 +10,12 @@ Unit tests for `NDStateMachine` preflight wiring.
 Verifies that `manage_state` invokes the orchestrator's preflight hooks at points that run BEFORE
 mutation operations are gated by check mode:
 
-- For create/update states (merged/replaced/overridden) `preflight` (capability, PR #275 / issue #273) is
-  called over the proposed set, in check mode as well as normal mode, even though the underlying create/update
-  calls are skipped in check mode.
-- `preflight_create` (policy-required-on-create, issue #350) is called with only the create (`new`) subset,
-  ahead of the mutation loops; an already-present item re-submitted without a policy is not a create and is
-  not validated, and a failure propagates before any mutation.
+- For create/update states (merged/replaced/overridden) `preflight_create` (policy-required-on-create, issue #350)
+  runs FIRST, with only the create subset (proposed items not present in the existing inventory): it is local-only,
+  so it fails before any API-backed preflight and before `existing` is mutated (PR #362 review). An already-present
+  item re-submitted without a policy is not a create and is not validated.
+- `preflight` (capability, PR #275 / issue #273) is then called over the proposed set, in check mode as well as
+  normal mode, even though the underlying create/update calls are skipped in check mode.
 - For `deleted` state neither preflight is called (removing configuration does not depend on capability, and a
   policy-less item is correct for delete -- the documented out-of-scope decision).
 
@@ -132,7 +132,7 @@ def test_nd_state_machine_00100() -> None:
     ## Test
 
     - `state: merged`, `check_mode: True`, one proposed interface (new vs empty inventory)
-    - `preflight` is recorded, then `preflight_create` over the create subset (both run before the check-mode gate)
+    - `preflight_create` is recorded first over the create subset, then `preflight` (both run before the check-mode gate)
     - No `create`/`create_bulk` call is recorded (skipped in check mode)
 
     ## Classes and Methods
@@ -148,11 +148,11 @@ def test_nd_state_machine_00100() -> None:
 
     calls = instance.model_orchestrator._calls
     names = [name for name, _ in calls]
-    assert names == ["preflight", "preflight_create"]
-    assert len(calls[0][1]) == 1
-    assert calls[0][1][0].get_identifier_value() == ("192.168.12.151", "loopback10")
-    # preflight_create receives the same single new item (create subset)
-    assert [m.get_identifier_value() for m in calls[1][1]] == [("192.168.12.151", "loopback10")]
+    assert names == ["preflight_create", "preflight"]
+    # preflight_create receives the single new item (create subset)
+    assert [m.get_identifier_value() for m in calls[0][1]] == [("192.168.12.151", "loopback10")]
+    assert len(calls[1][1]) == 1
+    assert calls[1][1][0].get_identifier_value() == ("192.168.12.151", "loopback10")
 
 
 def test_nd_state_machine_00110() -> None:
@@ -166,7 +166,7 @@ def test_nd_state_machine_00110() -> None:
     ## Test
 
     - `state: merged`, `check_mode: False`, one proposed interface
-    - `preflight`, then `preflight_create`, then `create_bulk` are recorded (loopback supports bulk create)
+    - `preflight_create`, then `preflight`, then `create_bulk` are recorded (loopback supports bulk create)
     - Both preflights precede the mutation
 
     ## Classes and Methods
@@ -182,7 +182,7 @@ def test_nd_state_machine_00110() -> None:
         instance.manage_state()
 
     names = [name for name, _ in instance.model_orchestrator._calls]
-    assert names == ["preflight", "preflight_create", "create_bulk"]
+    assert names == ["preflight_create", "preflight", "create_bulk"]
 
 
 def test_nd_state_machine_00120() -> None:
@@ -224,7 +224,7 @@ def test_nd_state_machine_00130() -> None:
     ## Test
 
     - `state: overridden`, `check_mode: True`, one proposed interface
-    - `preflight` is recorded exactly once, with the proposed model
+    - `preflight` is recorded exactly once, with the proposed model, after the policy guard
     - No mutation is recorded (check mode)
 
     ## Classes and Methods
@@ -240,8 +240,9 @@ def test_nd_state_machine_00130() -> None:
     calls = instance.model_orchestrator._calls
     names = [name for name, _ in calls]
     assert names.count("preflight") == 1
-    assert names[0] == "preflight"
-    assert len(calls[0][1]) == 1
+    assert names[0] == "preflight_create"
+    assert names[1] == "preflight"
+    assert len(calls[1][1]) == 1
 
 
 class _ExistingLoopbackSpy(_SpyLoopbackOrchestrator):
@@ -327,3 +328,85 @@ def test_nd_state_machine_00150() -> None:
     assert "preflight_create" in names
     assert "create" not in names
     assert "create_bulk" not in names
+
+
+def test_nd_state_machine_00160() -> None:
+    """
+    # Summary
+
+    Verify a `preflight_create` failure leaves the module output unchanged: `changed` is `False` and `after` equals
+    `before`, with no phantom item for the rejected create. Guards the PR #362 review finding where `self.existing`
+    (aliased by `NDOutput` as `after`) was mutated before the policy guard ran, so a failed policy-less create
+    reported `changed=True` and the never-created interface in `after`.
+
+    ## Test
+
+    - `state: merged`, `check_mode: False`, one new policy-less item; `preflight_create` raises `RuntimeError`
+    - The error propagates from `manage_state`
+    - `output.format()` reports `changed is False`, `before == []`, and `after == []` (no phantom item)
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_create_update_state()
+    - NDOutput.format()
+    """
+    spy = _RaisingPreflightCreateSpy(rest_send=_build_rest_send())
+    module = _build_module(state="merged", check_mode=False, config=_CONFIG)
+    instance = NDStateMachine(module=module, model_orchestrator=spy)
+
+    with pytest.raises(RuntimeError, match=r"without a policy"):
+        instance.manage_state()
+
+    output = instance.output.format()
+    assert output["changed"] is False
+    assert output["before"] == []
+    assert output["after"] == []
+
+
+class _CapabilityFailingSpy(_SpyLoopbackOrchestrator):
+    """Spy whose capability `preflight` raises, while `preflight_create` delegates to the real policy guard.
+
+    Models the PR #362 review scenario: a policy-less create targeting a switch that fails capability preflight.
+    The local-only policy guard must win, so the user sees the clearer `config_data.network_os.policy` error rather
+    than a switch/capability error.
+    """
+
+    def preflight(self, model_instances) -> None:
+        self._calls.append(("preflight", list(model_instances)))
+        raise RuntimeError("capability preflight failed: switch not capable")
+
+    def preflight_create(self, model_instances) -> None:
+        self._calls.append(("preflight_create", list(model_instances)))
+        LoopbackInterfaceOrchestrator.preflight_create(self, model_instances)
+
+
+def test_nd_state_machine_00170() -> None:
+    """
+    # Summary
+
+    Verify the local-only policy guard runs BEFORE the API-backed capability preflight, so a policy-less create
+    surfaces the policy error even when capability preflight would also fail (PR #362 review finding: the guard
+    was previously masked by switch resolution / `capableSwitches` failures that ran first).
+
+    ## Test
+
+    - `state: merged`, `check_mode: False`, one new policy-less item
+    - Capability `preflight` is rigged to raise, and `preflight_create` is the real `base_interface` guard
+    - The policy error (`without a policy`) propagates, not the capability error
+    - The recorded call order shows `preflight_create` first
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDBaseInterfaceOrchestrator.preflight_create()
+    """
+    spy = _CapabilityFailingSpy(rest_send=_build_rest_send())
+    module = _build_module(state="merged", check_mode=False, config=_CONFIG)
+    instance = NDStateMachine(module=module, model_orchestrator=spy)
+
+    with pytest.raises(RuntimeError, match=r"without a policy"):
+        instance.manage_state()
+
+    names = [name for name, _ in instance.model_orchestrator._calls]
+    assert names[0] == "preflight_create"


### PR DESCRIPTION
## Related Issue(s)

Closes #350

## Proposed Changes

Adds a state-aware fail-fast guard that rejects an interface **create** item carrying no policy, before any API round-trip (in `--check` mode too), naming the offending `(switch_ip, interface_name)` in module terms.

Background: interface argspecs require only `switch_ip` / `interface_name`, and `config_data` is `Optional` with no create-time validator, so a policy-less config item is accepted on create. A policy-less item is correct and intended for `state: deleted` (identifier only), so a blanket model validator would be wrong — the gap is specifically the **create** path under `merged` / `replaced` / `overridden`.

Lab verification (this work, ND 4.2.1.10, fabric SITE1 / leaf S1_LE1) confirmed ND rejects a policy-less create **per-interface** and never creates an empty interface — but the failure surfaces as `interface[0] '<name>'` inside a generic create error after a round-trip. So this is a nice-to-have fail-fast UX guard, not a correctness gap (down-scoped per the issue discussion).

Changes:

- `orchestrators/base.py` — generic no-op `preflight_create()` hook on `NDBaseOrchestrator`, mirroring the existing `preflight()` hook so non-interface orchestrators (local_user, fabric_*) are unaffected.
- `orchestrators/base_interface.py` — override that aggregates create items missing `config_data.network_os.policy` into a single `RuntimeError`, naming each offender and the fabric.
- `nd_state_machine.py` — calls `preflight_create(items_to_create)` after the create/update split and before the mutation loops. **Create-only by construction**: a `merged`/`replaced` update that legitimately omits a policy already present on the switch is never validated, and `state: deleted` does not route through the hook.

Mirrors the structure of the merged capability-preflight PR #275 (hook + override + state-machine wiring), but is purely local (no API call).

## Test Notes

Unit-only, matching PR #275 (no integration precedent for a preflight failure; ND's real behavior is already lab-verified):

- `test_base_interface.py` — 7 `preflight_create` behavior tests (offenders raise naming switch_ip/interface_name, `config_data` None vs `policy` None, multiple/mixed offenders, empty no-op, still raises in `--check`).
- `test_base_orchestrator.py` — base hook is a no-op for non-interface orchestrators.
- `test_nd_state_machine.py` — wiring: `preflight_create` runs with the create subset ahead of the check-mode gate; create-only scoping (an already-present item re-submitted without a policy is not validated); failure propagates before any mutation; not called for `deleted`.

Two integration tests should be added to each nd_interface_* module (issues will be opened).  1) Merge/Create with no config and 2) Merge/Create with empty config.
 
Verification (in the `nd-dev` container):

- Full unit suite: 1222 passed, 0 failures.
- `black` / `isort`: clean.
- `pylint`: message-id baseline identical to develop (zero new findings).
- `mypy`: changed-file errors identical to develop (only pre-existing environmental import-not-found).
- `ansible-test sanity --test pep8` on the changed files: clean.

## Cisco Nexus Dashboard Version

4.2.1.10

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)