### PR TITLE
Address PR #269/#270 doc review comments; enforce netflow_monitor with netflow

### DIFF
--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -38,6 +38,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
     SerializationInfo,
     field_validator,
     model_serializer,
+    model_validator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
@@ -95,7 +96,7 @@ class PortChannelAccessPolicyModel(StormControlMutexMixin):
     monitor: bool | None = Field(default=None, alias="monitor", description="Enable switchport monitor for SPAN/ERSPAN")
     mtu: MtuEnum | None = Field(default=None, alias="mtu", description="Interface MTU")
     netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
-    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name (required when `netflow=true`)")
     netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name")
     policy_type: AccessPoHostPolicyTypeEnum = Field(
         default=AccessPoHostPolicyTypeEnum.ACCESS_PO_HOST, alias="policyType", frozen=True, description="Interface policy type (hardcoded for this module)"
@@ -154,6 +155,26 @@ class PortChannelAccessPolicyModel(StormControlMutexMixin):
     )
 
     # --- Validators ---
+
+    @model_validator(mode="after")
+    def _validate_netflow_monitor_present(self) -> PortChannelAccessPolicyModel:
+        """
+        # Summary
+
+        Reject enabling `netflow` without supplying a `netflow_monitor`.
+
+        The DOCUMENTATION and field description state that `netflow_monitor` is required when `netflow` is true. Enforcing it at the model layer
+        fails an incomplete policy early with a clear error instead of pushing a netflow config with no monitor and deferring the outcome to ND.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `netflow` is true and `netflow_monitor` is missing or empty.
+        """
+        if self.netflow is True and not self.netflow_monitor:
+            raise ValueError("netflow_monitor must be provided when netflow is true.")
+        return self
 
     @field_validator("ports", mode="before")
     @classmethod

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -40,6 +40,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
     SerializationInfo,
     field_validator,
     model_serializer,
+    model_validator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
@@ -256,7 +257,7 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
     native_vlan: int | None = Field(default=None, alias="nativeVlan", ge=1, le=4094, description="Trunk native VLAN id")
     negotiate_auto: bool | None = Field(default=None, alias="negotiateAuto", description="Enable link auto-negotiation")
     netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
-    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name")
+    netflow_monitor: str | None = Field(default=None, alias="netflowMonitor", description="Layer 2 Netflow monitor name (required when `netflow=true`)")
     netflow_sampler: str | None = Field(default=None, alias="netflowSampler", description="Netflow sampler name")
     orphan_port: bool | None = Field(
         default=None, alias="orphanPort", description="Configure as a vPC orphan port (suspended by secondary peer on vPC failure)"
@@ -325,6 +326,26 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
     )
 
     # --- Validators ---
+
+    @model_validator(mode="after")
+    def _validate_netflow_monitor_present(self) -> PortChannelTrunkHostPolicyModel:
+        """
+        # Summary
+
+        Reject enabling `netflow` without supplying a `netflow_monitor`.
+
+        The DOCUMENTATION and field description state that `netflow_monitor` is required when `netflow` is true. Enforcing it at the model layer
+        fails an incomplete policy early with a clear error instead of pushing a netflow config with no monitor and deferring the outcome to ND.
+
+        ## Raises
+
+        ### ValueError
+
+        - If `netflow` is true and `netflow_monitor` is missing or empty.
+        """
+        if self.netflow is True and not self.netflow_monitor:
+            raise ValueError("netflow_monitor must be provided when netflow is true.")
+        return self
 
     @field_validator("ports", mode="before")
     @classmethod

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -12,10 +12,10 @@ DOCUMENTATION = r"""
 ---
 module: nd_interface_port_channel_access
 version_added: "2.0.0"
-short_description: Manage port-channel accessPoHost interfaces on Cisco Nexus Dashboard
+short_description: Manage port-channel (accessPoHost) interfaces on Cisco Nexus Dashboard
 description:
-- Manage port-channel accessPoHost interfaces on Cisco Nexus Dashboard.
-- It supports creating, updating, querying, and deleting accessPoHost port-channel configurations on switches within a fabric.
+- Manage port-channel (accessPoHost) interfaces on Cisco Nexus Dashboard.
+- It supports creating, updating, and deleting (accessPoHost) port-channel configurations on switches within a fabric.
 - Each config item represents one port-channel interface. Member ethernet interfaces are listed in
   O(config[].config_data.network_os.policy.ports) and inherit access-mode configuration from the port-channel policy.
 - Member interface field mutability is restricted while members of a port-channel; only description, admin_state, and
@@ -30,7 +30,7 @@ options:
     required: true
   config:
     description:
-    - The list of port-channel accessPoHost interfaces to configure.
+    - The list of port-channel (accessPoHost) interfaces to configure.
     - Each item specifies the target switch, the port-channel interface name, and its configuration.
     - Multiple switches can be configured in a single task.
     - The structure mirrors the ND Manage Interfaces API payload.
@@ -61,7 +61,7 @@ options:
             suboptions:
               policy:
                 description:
-                - The policy configuration for the accessPoHost port-channel.
+                - The policy configuration for the (accessPoHost) port-channel.
                 type: dict
                 suboptions:
                   admin_state:
@@ -136,6 +136,7 @@ options:
                   netflow_monitor:
                     description:
                     - The netflow Layer-2 monitor name for the port-channel.
+                    - Required when O(config[].config_data.network_os.policy.netflow=true).
                     type: str
                   netflow_sampler:
                     description:

--- a/plugins/modules/nd_interface_port_channel_trunk_host.py
+++ b/plugins/modules/nd_interface_port_channel_trunk_host.py
@@ -30,7 +30,7 @@ options:
     required: true
   config:
     description:
-    - The list of port-channel trunkPoHost interfaces to configure.
+    - The list of port-channel (trunkPoHost) interfaces to configure.
     - Each item specifies the target switch, the port-channel interface name, and its configuration.
     - Multiple switches can be configured in a single task.
     - The structure mirrors the ND Manage Interfaces API payload.
@@ -61,7 +61,7 @@ options:
             suboptions:
               policy:
                 description:
-                - The policy configuration for the trunkPoHost port-channel.
+                - The policy configuration for the (trunkPoHost) port-channel.
                 type: dict
                 suboptions:
                   admin_state:
@@ -161,6 +161,7 @@ options:
                   netflow_monitor:
                     description:
                     - The netflow Layer-2 monitor name for the port-channel.
+                    - Required when O(config[].config_data.network_os.policy.netflow=true).
                     type: str
                   netflow_sampler:
                     description:

--- a/tests/unit/module_utils/models/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_access_interface.py
@@ -1434,3 +1434,27 @@ def test_port_channel_access_interface_01120(field, enum_cls, key):
     else:
         expected = [e.value for e in enum_cls]
     assert policy_spec[field]["choices"] == expected
+
+
+def test_port_channel_access_interface_01130():
+    """
+    # Summary
+
+    Verify `_validate_netflow_monitor_present`: `netflow_monitor` is required when `netflow` is true.
+
+    ## Test
+
+    - `netflow=True` without `netflow_monitor` is rejected
+    - `netflow=True` with `netflow_monitor` is accepted
+    - `netflow=False` (or unset) without `netflow_monitor` is accepted
+
+    ## Classes and Methods
+
+    - PortChannelAccessPolicyModel._validate_netflow_monitor_present()
+    """
+    with pytest.raises(ValidationError, match="netflow_monitor must be provided when netflow is true"):
+        PortChannelAccessPolicyModel(netflow=True)
+    with does_not_raise():
+        PortChannelAccessPolicyModel(netflow=True, netflow_monitor="MONITOR-1")
+        PortChannelAccessPolicyModel(netflow=False)
+        PortChannelAccessPolicyModel()

--- a/tests/unit/module_utils/models/test_port_channel_trunk_host_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_trunk_host_interface.py
@@ -1987,3 +1987,27 @@ def test_port_channel_trunk_host_interface_01130():
     assert "customer_vlan_id" in entries_spec["options"]
     assert "dot1q_tunnel" in entries_spec["options"]
     assert "provider_vlan_id" in entries_spec["options"]
+
+
+def test_port_channel_trunk_host_interface_01140():
+    """
+    # Summary
+
+    Verify `_validate_netflow_monitor_present`: `netflow_monitor` is required when `netflow` is true.
+
+    ## Test
+
+    - `netflow=True` without `netflow_monitor` is rejected
+    - `netflow=True` with `netflow_monitor` is accepted
+    - `netflow=False` (or unset) without `netflow_monitor` is accepted
+
+    ## Classes and Methods
+
+    - PortChannelTrunkHostPolicyModel._validate_netflow_monitor_present()
+    """
+    with pytest.raises(ValidationError, match="netflow_monitor must be provided when netflow is true"):
+        PortChannelTrunkHostPolicyModel(netflow=True)
+    with does_not_raise():
+        PortChannelTrunkHostPolicyModel(netflow=True, netflow_monitor="MONITOR-1")
+        PortChannelTrunkHostPolicyModel(netflow=False)
+        PortChannelTrunkHostPolicyModel()


### PR DESCRIPTION
## Related Issue(s)

None — follow-ups to review comments on merged PRs #269 and #270 (threads linked below).

## Proposed Changes

- Parenthesize the policyType references in module DOCUMENTATION — `(accessPoHost)` / `(trunkPoHost)` — and drop "querying" from the access module description, per review suggestions:
  - https://github.com/CiscoDevNet/ansible-nd/pull/269#discussion_r3496486301
  - https://github.com/CiscoDevNet/ansible-nd/pull/269#discussion_r3496641167
  - https://github.com/CiscoDevNet/ansible-nd/pull/269#discussion_r3496641998
  - https://github.com/CiscoDevNet/ansible-nd/pull/269#discussion_r3496642767
  - https://github.com/CiscoDevNet/ansible-nd/pull/270#discussion_r3496658590
  - https://github.com/CiscoDevNet/ansible-nd/pull/270#discussion_r3496659094
- Document that `netflow_monitor` is required when `netflow=true` in both modules' DOCUMENTATION and model field descriptions, and enforce it with the same `model_validator` that `nd_interface_svi` uses (`_validate_netflow_monitor_present`), so an incomplete netflow policy fails early with a clear error instead of deferring the outcome to ND. Per https://github.com/CiscoDevNet/ansible-nd/pull/269#discussion_r3496600902.
- Unit tests for the new validator in both policy models.

## Test Notes

- Unit tests pass: `ndpytest tests/unit/module_utils/models/test_port_channel_access_interface.py tests/unit/module_utils/models/test_port_channel_trunk_host_interface.py` — 302 passed (includes 2 new validator tests).
- `ndlint` (ansible-lint, production profile) passes on both modules.
- `black`, `isort`, `pylint`, `mypy` run on all changed files — no new findings (remaining pylint/mypy messages are pre-existing import-resolution noise, identical on untouched files).
- DOCUMENTATION blocks re-parsed as YAML to verify the doc edits.

## Cisco Nexus Dashboard Version

4.2

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Deb5UWoTfAZa6kq7khAEu6