### PR TITLE
Relocate nd_argument_spec to nd_argument_specs.py; add config_actions_spec fragment

### DIFF
--- a/changelogs/fragments/relocate_nd_argument_spec.yml
+++ b/changelogs/fragments/relocate_nd_argument_spec.yml
@@ -2,5 +2,6 @@
 minor_changes:
   - Relocate ``nd_argument_spec()`` to ``plugins/module_utils/nd_argument_specs.py`` as the single source of truth;
     ``nd.py`` and ``nd_v2.py`` continue to re-export it, so existing imports keep working unchanged.
-  - Add shared ``config_actions_spec()`` argument-spec fragment (``save``/``deploy``/``type``) with an include-allowlist,
-    so modules can compose the subset of config actions they support instead of hand-writing the block.
+  - Add shared ``config_actions_spec()`` argument-spec fragment (``save``/``deploy``/``type``, where ``type`` accepts
+    ``resource``, ``switch``, or ``global``) with an include-allowlist, so modules can compose the subset of config actions
+    they support instead of hand-writing the block.

--- a/changelogs/fragments/relocate_nd_argument_spec.yml
+++ b/changelogs/fragments/relocate_nd_argument_spec.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - Relocate ``nd_argument_spec()`` to ``plugins/module_utils/nd_argument_specs.py`` as the single source of truth;
+    ``nd.py`` and ``nd_v2.py`` continue to re-export it, so existing imports keep working unchanged.
+  - Add shared ``config_actions_spec()`` argument-spec fragment (``save``/``deploy``/``type``) with an include-allowlist,
+    so modules can compose the subset of config actions they support instead of hand-writing the block.

--- a/plugins/module_utils/nd.py
+++ b/plugins/module_utils/nd.py
@@ -13,10 +13,14 @@ from copy import deepcopy
 from functools import reduce
 
 from ansible.module_utils._text import to_native, to_text
-from ansible.module_utils.basic import env_fallback, json
+from ansible.module_utils.basic import json
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible_collections.cisco.nd.plugins.module_utils.constants import ALLOWED_STATES_TO_APPEND_SENT_AND_PROPOSED
+
+# nd_argument_spec is re-exported for backward compatibility: it was originally defined in this file and existing modules import it from here.
+# New code should import it from nd_argument_specs directly (see issue #384).
+from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import nd_argument_spec  # noqa: F401  pylint: disable=unused-import
 from ansible_collections.cisco.nd.plugins.module_utils.utils import issubset
 
 
@@ -69,21 +73,6 @@ def update_qs(params):
     """Append key-value pairs to self.filter_string"""
     accepted_params = dict((k, v) for (k, v) in params.items() if v is not None)
     return "?" + urlencode(accepted_params)
-
-
-def nd_argument_spec():
-    return dict(
-        host=dict(type="str", required=False, aliases=["hostname"], fallback=(env_fallback, ["ND_HOST"])),
-        port=dict(type="int", required=False, fallback=(env_fallback, ["ND_PORT"])),
-        username=dict(type="str", fallback=(env_fallback, ["ND_USERNAME", "ANSIBLE_NET_USERNAME"])),
-        password=dict(type="str", required=False, no_log=True, fallback=(env_fallback, ["ND_PASSWORD", "ANSIBLE_NET_PASSWORD"])),
-        output_level=dict(type="str", default="normal", choices=["debug", "info", "normal"], fallback=(env_fallback, ["ND_OUTPUT_LEVEL"])),
-        timeout=dict(type="int", default=30, fallback=(env_fallback, ["ND_TIMEOUT"])),
-        use_proxy=dict(type="bool", fallback=(env_fallback, ["ND_USE_PROXY"])),
-        use_ssl=dict(type="bool", fallback=(env_fallback, ["ND_USE_SSL"])),
-        validate_certs=dict(type="bool", fallback=(env_fallback, ["ND_VALIDATE_CERTS"])),
-        login_domain=dict(type="str", fallback=(env_fallback, ["ND_LOGIN_DOMAIN"])),
-    )
 
 
 # Copied from ansible's module uri.py (url): https://github.com/ansible/ansible/blob/cdf62edc65f564fff6b7e575e084026fa7faa409/lib/ansible/modules/uri.py

--- a/plugins/module_utils/nd_argument_specs.py
+++ b/plugins/module_utils/nd_argument_specs.py
@@ -1,8 +1,90 @@
 # Copyright: (c) 2023, Shreyas Srish (@shrsr) <ssrish@cisco.com>
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""
+# nd_argument_specs.py
 
-from __future__ import absolute_import, division, print_function
+Shared argument-spec building blocks for ND modules: the common connection/authentication spec (`nd_argument_spec`) and reusable
+fragments (`config_actions_spec`, `ntp_server_spec`, ...) that modules compose into their `argument_spec`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from ansible.module_utils.basic import env_fallback
+
+
+def nd_argument_spec() -> dict[str, Any]:
+    """
+    # Summary
+
+    Return the common connection/authentication argument spec accepted by all ND modules.
+
+    ## Raises
+
+    None
+    """
+    return {
+        "host": {"type": "str", "required": False, "aliases": ["hostname"], "fallback": (env_fallback, ["ND_HOST"])},
+        "port": {"type": "int", "required": False, "fallback": (env_fallback, ["ND_PORT"])},
+        "username": {"type": "str", "fallback": (env_fallback, ["ND_USERNAME", "ANSIBLE_NET_USERNAME"])},
+        "password": {"type": "str", "required": False, "no_log": True, "fallback": (env_fallback, ["ND_PASSWORD", "ANSIBLE_NET_PASSWORD"])},
+        "output_level": {"type": "str", "default": "normal", "choices": ["debug", "info", "normal"], "fallback": (env_fallback, ["ND_OUTPUT_LEVEL"])},
+        "timeout": {"type": "int", "default": 30, "fallback": (env_fallback, ["ND_TIMEOUT"])},
+        "use_proxy": {"type": "bool", "fallback": (env_fallback, ["ND_USE_PROXY"])},
+        "use_ssl": {"type": "bool", "fallback": (env_fallback, ["ND_USE_SSL"])},
+        "validate_certs": {"type": "bool", "fallback": (env_fallback, ["ND_VALIDATE_CERTS"])},
+        "login_domain": {"type": "str", "fallback": (env_fallback, ["ND_LOGIN_DOMAIN"])},
+    }
+
+
+def _select_options(options: dict[str, Any], include: Iterable[str] | None) -> dict[str, Any]:
+    """
+    # Summary
+
+    Return a copy of `options` filtered to the allowlist `include`. `include=None` selects every option.
+
+    An allowlist (rather than an exclude list) is deliberate: options added to a shared fragment in the future must never silently appear in
+    modules that composed the fragment before the addition.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `include` names an option that does not exist in `options`
+    """
+    if include is None:
+        return dict(options)
+    include_set = set(include)
+    unknown = include_set - options.keys()
+    if unknown:
+        raise ValueError(f"Unknown option name(s) in include: {', '.join(sorted(unknown))}. Valid options: {', '.join(sorted(options))}.")
+    return {key: value for key, value in options.items() if key in include_set}
+
+
+def config_actions_spec(include: Iterable[str] | None = None) -> dict[str, Any]:
+    """
+    # Summary
+
+    Return the shared `config_actions` argument spec fragment, filtered to the allowlist `include`.
+
+    The full option set is `save`, `deploy`, and `type`. Modules that expose only a subset pass the option names they support, e.g.
+    `config_actions_spec(include=("deploy",))` for the `nd_interface_*` modules.
+
+    ## Raises
+
+    ### ValueError
+
+    - If `include` names an option that is not part of the fragment
+    """
+    options: dict[str, Any] = {
+        "save": {"type": "bool", "default": True},
+        "deploy": {"type": "bool", "default": True},
+        "type": {"type": "str", "default": "switch", "choices": ["switch", "global"]},
+    }
+    return {"config_actions": {"type": "dict", "options": _select_options(options, include)}}
 
 
 def ntp_server_spec():

--- a/plugins/module_utils/nd_argument_specs.py
+++ b/plugins/module_utils/nd_argument_specs.py
@@ -73,6 +73,10 @@ def config_actions_spec(include: Iterable[str] | None = None) -> dict[str, Any]:
     The full option set is `save`, `deploy`, and `type`. Modules that expose only a subset pass the option names they support, e.g.
     `config_actions_spec(include=("deploy",))` for the `nd_interface_*` modules.
 
+    `type` accepts `resource`, `switch`, and `global`, per the contract in issue #368. The companion per-resource `deploy` key described in that
+    issue is not part of this fragment yet: it lives in each module's `config` suboptions and its interaction with `config_actions` (mutually
+    exclusive, or gated on `type == "resource"`) is still under discussion on #368. It will be added as a separate fragment once settled.
+
     ## Raises
 
     ### ValueError
@@ -82,7 +86,7 @@ def config_actions_spec(include: Iterable[str] | None = None) -> dict[str, Any]:
     options: dict[str, Any] = {
         "save": {"type": "bool", "default": True},
         "deploy": {"type": "bool", "default": True},
-        "type": {"type": "str", "default": "switch", "choices": ["switch", "global"]},
+        "type": {"type": "str", "default": "switch", "choices": ["resource", "switch", "global"]},
     }
     return {"config_actions": {"type": "dict", "options": _select_options(options, include)}}
 

--- a/plugins/module_utils/nd_v2.py
+++ b/plugins/module_utils/nd_v2.py
@@ -48,35 +48,17 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
-from ansible.module_utils.basic import env_fallback
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDModuleError
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
+# nd_argument_spec is re-exported for backward compatibility: this file previously defined its own copy and nd_manage_switches imports it from here.
+# New code should import it from nd_argument_specs directly (see issue #384).
+from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import nd_argument_spec  # noqa: F401  pylint: disable=unused-import
 from ansible_collections.cisco.nd.plugins.module_utils.rest.protocols.response_handler import ResponseHandlerProtocol
 from ansible_collections.cisco.nd.plugins.module_utils.rest.protocols.sender import SenderProtocol
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
-
-
-def nd_argument_spec() -> dict[str, Any]:
-    """
-    Return the common argument spec for ND modules.
-
-    This function provides the standard arguments that all ND modules
-    should accept for connection and authentication.
-    """
-    return dict(
-        host=dict(type="str", required=False, aliases=["hostname"], fallback=(env_fallback, ["ND_HOST"])),
-        port=dict(type="int", required=False, fallback=(env_fallback, ["ND_PORT"])),
-        username=dict(type="str", fallback=(env_fallback, ["ND_USERNAME", "ANSIBLE_NET_USERNAME"])),
-        password=dict(type="str", required=False, no_log=True, fallback=(env_fallback, ["ND_PASSWORD", "ANSIBLE_NET_PASSWORD"])),
-        output_level=dict(type="str", default="normal", choices=["debug", "info", "normal"], fallback=(env_fallback, ["ND_OUTPUT_LEVEL"])),
-        timeout=dict(type="int", default=30, fallback=(env_fallback, ["ND_TIMEOUT"])),
-        use_proxy=dict(type="bool", fallback=(env_fallback, ["ND_USE_PROXY"])),
-        use_ssl=dict(type="bool", fallback=(env_fallback, ["ND_USE_SSL"])),
-        validate_certs=dict(type="bool", fallback=(env_fallback, ["ND_VALIDATE_CERTS"])),
-        login_domain=dict(type="str", fallback=(env_fallback, ["ND_LOGIN_DOMAIN"])),
-    )
 
 
 class NDModule:

--- a/tests/unit/module_utils/test_nd_argument_specs.py
+++ b/tests/unit/module_utils/test_nd_argument_specs.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@arobel) <arobel@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for nd_argument_specs.py
+
+Tests the shared argument-spec functions: the common connection/authentication spec (nd_argument_spec) and the
+config_actions fragment with its include-allowlist selection (config_actions_spec, _select_options).
+"""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import (
+    _select_options,
+    config_actions_spec,
+    nd_argument_spec,
+)
+
+
+def test_nd_argument_specs_00000() -> None:
+    """
+    # Summary
+
+    Verify `nd_argument_spec()` returns the complete connection/authentication spec with expected keys, defaults, and `no_log` on `password`.
+
+    ## Test
+
+    - The key set matches the historical spec from nd.py exactly
+    - `password` has `no_log=True`
+    - `timeout` defaults to 30 and `output_level` defaults to "normal"
+    - `host` carries the `hostname` alias
+
+    ## Classes and Methods
+
+    - nd_argument_specs.nd_argument_spec()
+    """
+    spec = nd_argument_spec()
+    assert set(spec.keys()) == {
+        "host",
+        "port",
+        "username",
+        "password",
+        "output_level",
+        "timeout",
+        "use_proxy",
+        "use_ssl",
+        "validate_certs",
+        "login_domain",
+    }
+    assert spec["password"]["no_log"] is True
+    assert spec["timeout"]["default"] == 30
+    assert spec["output_level"]["default"] == "normal"
+    assert spec["output_level"]["choices"] == ["debug", "info", "normal"]
+    assert spec["host"]["aliases"] == ["hostname"]
+
+
+def test_nd_argument_specs_00001() -> None:
+    """
+    # Summary
+
+    Verify `nd_argument_spec()` returns a fresh dict on every call so callers can mutate their copy safely.
+
+    ## Test
+
+    - Two calls return equal but distinct objects
+    - Mutating one result does not affect a subsequent call
+
+    ## Classes and Methods
+
+    - nd_argument_specs.nd_argument_spec()
+    """
+    first = nd_argument_spec()
+    second = nd_argument_spec()
+    assert first == second
+    assert first is not second
+    del first["host"]
+    assert "host" in nd_argument_spec()
+
+
+def test_nd_argument_specs_00100() -> None:
+    """
+    # Summary
+
+    Verify `config_actions_spec()` with no allowlist returns the full fragment: `save`, `deploy`, and `type` options.
+
+    ## Test
+
+    - Top-level shape is a single `config_actions` dict of type "dict"
+    - All three options are present with expected defaults and choices
+
+    ## Classes and Methods
+
+    - nd_argument_specs.config_actions_spec()
+    """
+    spec = config_actions_spec()
+    assert set(spec.keys()) == {"config_actions"}
+    assert spec["config_actions"]["type"] == "dict"
+    options = spec["config_actions"]["options"]
+    assert set(options.keys()) == {"save", "deploy", "type"}
+    assert options["save"] == {"type": "bool", "default": True}
+    assert options["deploy"] == {"type": "bool", "default": True}
+    assert options["type"] == {"type": "str", "default": "switch", "choices": ["switch", "global"]}
+
+
+def test_nd_argument_specs_00101() -> None:
+    """
+    # Summary
+
+    Verify `config_actions_spec(include=("deploy",))` reproduces the deploy-only block hand-written in the `nd_interface_*` modules today.
+
+    ## Test
+
+    - The returned fragment equals the exact dict currently duplicated across the interface modules
+
+    ## Classes and Methods
+
+    - nd_argument_specs.config_actions_spec()
+    """
+    expected = {
+        "config_actions": {
+            "type": "dict",
+            "options": {
+                "deploy": {"type": "bool", "default": True},
+            },
+        },
+    }
+    assert config_actions_spec(include=("deploy",)) == expected
+
+
+def test_nd_argument_specs_00102() -> None:
+    """
+    # Summary
+
+    Verify `config_actions_spec()` raises `ValueError` when `include` names an option that is not part of the fragment.
+
+    ## Test
+
+    - An unknown option name in `include` raises `ValueError` naming the offender and the valid options
+
+    ## Classes and Methods
+
+    - nd_argument_specs.config_actions_spec()
+    - nd_argument_specs._select_options()
+    """
+    match = r"Unknown option name\(s\) in include: bogus\. Valid options: deploy, save, type\."
+    with pytest.raises(ValueError, match=match):
+        result = config_actions_spec(include=("deploy", "bogus"))  # pylint: disable=unused-variable
+
+
+def test_nd_argument_specs_00200() -> None:
+    """
+    # Summary
+
+    Verify `_select_options()` allowlist behavior: `include=None` selects every option as a copy; an allowlist selects exactly those options.
+
+    ## Test
+
+    - `include=None` returns an equal but distinct dict (mutating the copy does not affect the source)
+    - An allowlist returns only the named options
+    - An empty allowlist returns an empty dict
+
+    ## Classes and Methods
+
+    - nd_argument_specs._select_options()
+    """
+    options = {"save": {"type": "bool"}, "deploy": {"type": "bool"}}
+    everything = _select_options(options, None)
+    assert everything == options
+    assert everything is not options
+    del everything["save"]
+    assert "save" in options
+    assert _select_options(options, ("save",)) == {"save": {"type": "bool"}}
+    assert _select_options(options, ()) == {}

--- a/tests/unit/module_utils/test_nd_argument_specs.py
+++ b/tests/unit/module_utils/test_nd_argument_specs.py
@@ -105,7 +105,7 @@ def test_nd_argument_specs_00100() -> None:
     assert set(options.keys()) == {"save", "deploy", "type"}
     assert options["save"] == {"type": "bool", "default": True}
     assert options["deploy"] == {"type": "bool", "default": True}
-    assert options["type"] == {"type": "str", "default": "switch", "choices": ["switch", "global"]}
+    assert options["type"] == {"type": "str", "default": "switch", "choices": ["resource", "switch", "global"]}
 
 
 def test_nd_argument_specs_00101() -> None:


### PR DESCRIPTION
## Related Issue(s)

Prerequisite task (task 0) of #384 — not `Fixes`, since #384 remains open as the tracking issue.

## Proposed Changes

- Relocate `nd_argument_spec()` to `plugins/module_utils/nd_argument_specs.py` (single source of truth), joining the existing shared fragments (`ntp_server_spec`, `network_spec`, ...). The relocated function adopts the typed variant that previously lived in `nd_v2.py`.
- `nd.py` and `nd_v2.py` re-export it with explicit backward-compat comments, so **no module imports change in this PR** (re-pointing Gen-3 modules is tracked per-module under #384 task 1). This intentionally does better than the `issubset()` relocation (#310), which shipped without the re-export note or changelog entry.
- Remove `nd_v2.py`'s duplicate definition in favor of the shared one.
- Add `config_actions_spec()` shared argspec fragment (full option set: `save`/`deploy`/`type`, matching the superset used by `nd_manage_switches`), with an include-allowlist via `_select_options()` so modules compose only the options they support — `config_actions_spec(include=("deploy",))` reproduces the deploy-only block currently hand-written in the eight `nd_interface_*` modules byte-for-byte. An allowlist (not an exclude list) is deliberate: options added to a shared fragment later must never silently appear in modules that composed it earlier.
- Add unit tests (`tests/unit/module_utils/test_nd_argument_specs.py`) and a changelog fragment.

## Test Notes

- `ndpytest tests/unit/` — 2169 passed (includes 6 new tests)
- `black`, `isort`: clean; `ansible-lint`: 0 failures on changed files; changelog fragment passes YAML validation
- `pylint`/`mypy`: no new findings attributable to this change (both files carry pre-existing environmental import-resolution noise; verified against the develop baseline)
- Runtime verification inside nd-dev: `nd.py` and `nd_v2.py` re-exports resolve to the same function object, and `config_actions_spec(include=("deploy",))` equals the current interface-module block
- `ansible-test sanity --test import` could not run in the offline nd-dev machine (pip bootstrap requires network); CI will exercise it

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [ ] manage
* [ ] onemanage
* [x] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Deb5UWoTfAZa6kq7khAEu6