### PR TITLE
Hoist query_all switch scoping + interface cache into NDBaseInterfaceOrchestrator

### DIFF
--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -68,7 +68,8 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         # Summary
 
         Initialize mutable private state after Pydantic model construction. Pydantic disallows `Field()` on
-        underscore-prefixed names, so these are set here to ensure each instance gets its own list.
+        underscore-prefixed names, so these are set here to ensure each instance gets its own container: the
+        deploy/remove queues and the per-switch interface cache read by `_switch_interfaces`.
 
         ## Raises
 
@@ -76,6 +77,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         """
         self._pending_deploys: list[tuple[str, str]] = []
         self._pending_removes: list[tuple[str, str]] = []
+        self._switch_interfaces_cache: dict[str, dict[str, dict]] = {}
 
     @property
     def fabric_name(self) -> str:
@@ -118,6 +120,56 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         - If no switch matches the given IP in the fabric.
         """
         return self.fabric_context.get_switch_id(switch_ip)
+
+    def _switch_interfaces(self, switch_id: str) -> dict[str, dict]:
+        """
+        # Summary
+
+        Return every interface on `switch_id`, keyed by lower-cased interface name. The underlying
+        `interfaceList` GET is issued at most once per switch per module run; the result is cached so
+        that `query_all` and any other per-interface lookups (e.g. ethernet's port-channel membership
+        check) share a single fetch per switch rather than each querying the controller independently.
+
+        Requires the subclass's `query_all_endpoint` to be the per-switch interfaces-list GET
+        (`EpManageInterfacesListGet`). Subclasses whose `query_all_endpoint` targets a different
+        resource (e.g. `MaintenanceModeOrchestrator`, which lists switches) must not call this method.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Via `_request` if the interface-list API request fails with a non-404 status.
+        """
+        if switch_id not in self._switch_interfaces_cache:
+            api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
+            self._switch_interfaces_cache[switch_id] = {iface["interfaceName"].lower(): iface for iface in interfaces if iface.get("interfaceName")}
+        return self._switch_interfaces_cache[switch_id]
+
+    def _switches_to_query(self) -> dict[str, str]:
+        """
+        # Summary
+
+        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
+
+        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
+        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
+        config, so only those switches are returned. This keeps the interface-list request count proportional to
+        config size rather than fabric size (CLAUDE.md performance rule: no per-switch fan-out over the whole fabric).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Via `FabricContext.switch_map` if the switches API query fails.
+        """
+        switch_map = self.fabric_context.switch_map
+        if self.rest_send.params.get("state") == "overridden":
+            return switch_map
+        config_items = self.rest_send.params.get("config") or []
+        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
+        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
 
     @property
     def capability_preflight(self) -> InterfaceCapabilityPreflight:

--- a/plugins/module_utils/orchestrators/ethernet_base.py
+++ b/plugins/module_utils/orchestrators/ethernet_base.py
@@ -98,9 +98,8 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         # Summary
 
         Initialize ethernet-specific mutable private state after Pydantic model construction. Extends
-        `NDBaseInterfaceOrchestrator.model_post_init` to add the normalize queue (initialized the same
-        way as the sibling `_pending_deploys` / `_pending_removes` queues) and the per-switch interface
-        cache read by `_switch_interfaces`.
+        `NDBaseInterfaceOrchestrator.model_post_init` to add the normalize and reset queues (initialized
+        the same way as the sibling `_pending_deploys` / `_pending_removes` queues).
 
         ## Raises
 
@@ -109,7 +108,6 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         super().model_post_init(__context)
         self._pending_normalizes: list[tuple[str, str]] = []
         self._pending_resets: list[tuple[str, str]] = []
-        self._switch_interfaces_cache: dict[str, dict[str, dict]] = {}
 
     def _managed_policy_types(self) -> set[str]:
         """
@@ -176,28 +174,6 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
             return False
         policy = existing_data.get("configData", {}).get("networkOS", {}).get("policy") or {}
         return any(policy.get(field) is not None for field in InterfaceDefaultConfig.UNRESETTABLE_FIELDS)
-
-    def _switch_interfaces(self, switch_id: str) -> dict[str, dict]:
-        """
-        # Summary
-
-        Return every interface on `switch_id`, keyed by lower-cased interface name. The underlying
-        `interfaceList` GET is issued at most once per switch per module run; the result is cached so
-        that `query_all` and the port-channel membership check share a single fetch per switch rather
-        than each querying the controller independently.
-
-        ## Raises
-
-        ### RuntimeError
-
-        - Via `_request` if the interface-list API request fails with a non-404 status.
-        """
-        if switch_id not in self._switch_interfaces_cache:
-            api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-            interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
-            self._switch_interfaces_cache[switch_id] = {iface["interfaceName"].lower(): iface for iface in interfaces if iface.get("interfaceName")}
-        return self._switch_interfaces_cache[switch_id]
 
     def _existing_interface(self, interface_name: str, switch_id: str) -> dict | None:
         """
@@ -640,30 +616,6 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
             return self._request(path=api_endpoint.path, verb=api_endpoint.verb)
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
-
-    def _switches_to_query(self) -> dict[str, str]:
-        """
-        # Summary
-
-        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
-
-        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
-        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
-        config, so only those switches are returned. This keeps the interface-list request count proportional to
-        config size rather than fabric size.
-
-        ## Raises
-
-        ### RuntimeError
-
-        - Via `FabricContext.switch_map` if the switches API query fails.
-        """
-        switch_map = self.fabric_context.switch_map
-        if self.rest_send.params.get("state") == "overridden":
-            return switch_map
-        config_items = self.rest_send.params.get("config") or []
-        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
-        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
 
     def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
         """

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -228,8 +228,11 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         """
         # Summary
 
-        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for user-managed
-        loopback interfaces only (`policyType: "loopback"`).
+        Validate the fabric context and query interfaces, filtering for user-managed loopback interfaces only
+        (`policyType: "loopback"`).
+
+        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`,
+        and limited to switches named in the user config for all other states.
 
         System-provisioned loopbacks (e.g. Loopback0 routing, Loopback1 VTEP with `policyType: "underlayLoopback"`) and
         non-standard policy templates (`ipfmLoopback`, `userDefined`) are excluded - those will be managed by dedicated modules.
@@ -250,12 +253,8 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         try:
             self.validate_prerequisites()
             all_loopbacks = []
-            for switch_ip, switch_id in self.fabric_context.switch_map.items():
-                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                if not isinstance(result, dict):
-                    continue
-                interfaces = result.get("interfaces", []) or []
+            for switch_ip, switch_id in self._switches_to_query().items():
+                interfaces = list(self._switch_interfaces(switch_id).values())
                 loopbacks = [iface for iface in interfaces if iface.get("interfaceType") == "loopback"]
                 managed = [lb for lb in loopbacks if lb.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") == "loopback"]
                 for iface in managed:

--- a/plugins/module_utils/orchestrators/port_channel_base.py
+++ b/plugins/module_utils/orchestrators/port_channel_base.py
@@ -243,30 +243,6 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
-    def _switches_to_query(self) -> dict[str, str]:
-        """
-        # Summary
-
-        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
-
-        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
-        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
-        config, so only those switches are returned. This keeps the interface-list request count proportional to
-        config size rather than fabric size (CLAUDE.md performance rule: no per-switch fan-out over the whole fabric).
-
-        ## Raises
-
-        ### RuntimeError
-
-        - Via `FabricContext.switch_map` if the switches API query fails.
-        """
-        switch_map = self.fabric_context.switch_map
-        if self.rest_send.params.get("state") == "overridden":
-            return switch_map
-        config_items = self.rest_send.params.get("config") or []
-        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
-        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
-
     def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
         """
         # Summary

--- a/plugins/module_utils/orchestrators/subinterface_managed_interface.py
+++ b/plugins/module_utils/orchestrators/subinterface_managed_interface.py
@@ -250,9 +250,12 @@ class SubinterfaceManagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[Subin
         """
         # Summary
 
-        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
-        subinterfaces with `interfaceType: "subInterface"` and `policyType: "subinterface"` (managed variant). The
+        Validate the fabric context and query interfaces, filtering for subinterfaces with
+        `interfaceType: "subInterface"` and `policyType: "subinterface"` (managed variant). The
         unmanaged variant (`monitorSubinterface`) is managed by a separate orchestrator and is excluded here.
+
+        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`,
+        and limited to switches named in the user config for all other states.
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning
         any data.
@@ -273,12 +276,8 @@ class SubinterfaceManagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[Subin
         try:
             self.validate_prerequisites()
             all_subifs = []
-            for switch_ip, switch_id in self.fabric_context.switch_map.items():
-                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                if not isinstance(result, dict):
-                    continue
-                interfaces = result.get("interfaces", []) or []
+            for switch_ip, switch_id in self._switches_to_query().items():
+                interfaces = list(self._switch_interfaces(switch_id).values())
                 subifs = [iface for iface in interfaces if iface.get("interfaceType") == "subInterface"]
                 managed = [
                     iface for iface in subifs if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_policy_types

--- a/plugins/module_utils/orchestrators/subinterface_unmanaged_interface.py
+++ b/plugins/module_utils/orchestrators/subinterface_unmanaged_interface.py
@@ -234,10 +234,13 @@ class SubinterfaceUnmanagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[Sub
         """
         # Summary
 
-        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for
-        subinterfaces with `interfaceType: "subInterface"` and `policyType` in the unmanaged set
+        Validate the fabric context and query interfaces, filtering for subinterfaces with
+        `interfaceType: "subInterface"` and `policyType` in the unmanaged set
         (`monitorSubinterface`). The managed variant (`subinterface`) is managed by a separate orchestrator and is
         excluded here.
+
+        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`,
+        and limited to switches named in the user config for all other states.
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning
         any data.
@@ -258,12 +261,8 @@ class SubinterfaceUnmanagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[Sub
         try:
             self.validate_prerequisites()
             all_subifs = []
-            for switch_ip, switch_id in self.fabric_context.switch_map.items():
-                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                if not isinstance(result, dict):
-                    continue
-                interfaces = result.get("interfaces", []) or []
+            for switch_ip, switch_id in self._switches_to_query().items():
+                interfaces = list(self._switch_interfaces(switch_id).values())
                 subifs = [iface for iface in interfaces if iface.get("interfaceType") == "subInterface"]
                 unmanaged = [
                     iface for iface in subifs if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in unmanaged_policy_types

--- a/plugins/module_utils/orchestrators/svi_interface.py
+++ b/plugins/module_utils/orchestrators/svi_interface.py
@@ -222,9 +222,12 @@ class SviInterfaceOrchestrator(NDBaseInterfaceOrchestrator[SviInterfaceModel]):
         """
         # Summary
 
-        Validate the fabric context and query all interfaces across ALL switches in the fabric, filtering for SVI
-        interfaces with `policyType: "svi"`. Other policy types (e.g. underlay-managed VLAN interfaces with different
-        policy types) are excluded so this orchestrator does not interfere with fabric-managed SVIs.
+        Validate the fabric context and query interfaces, filtering for SVI interfaces with `policyType: "svi"`.
+        Other policy types (e.g. underlay-managed VLAN interfaces with different policy types) are excluded so this
+        orchestrator does not interfere with fabric-managed SVIs.
+
+        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`,
+        and limited to switches named in the user config for all other states.
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
 
@@ -243,12 +246,8 @@ class SviInterfaceOrchestrator(NDBaseInterfaceOrchestrator[SviInterfaceModel]):
         try:
             self.validate_prerequisites()
             all_svis = []
-            for switch_ip, switch_id in self.fabric_context.switch_map.items():
-                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                if not isinstance(result, dict):
-                    continue
-                interfaces = result.get("interfaces", []) or []
+            for switch_ip, switch_id in self._switches_to_query().items():
+                interfaces = list(self._switch_interfaces(switch_id).values())
                 svis = [iface for iface in interfaces if iface.get("interfaceType") == "svi"]
                 managed = [
                     iface for iface in svis if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_policy_types

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -324,30 +324,6 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
-    def _switches_to_query(self) -> dict[str, str]:
-        """
-        # Summary
-
-        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
-
-        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
-        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
-        config, so only those switches are returned. This keeps the interface-list request count proportional to
-        config size rather than fabric size (CLAUDE.md performance rule: no per-switch fan-out over the whole fabric).
-
-        ## Raises
-
-        ### RuntimeError
-
-        - Via `FabricContext.switch_map` if the switches API query fails.
-        """
-        switch_map = self.fabric_context.switch_map
-        if self.rest_send.params.get("state") == "overridden":
-            return switch_map
-        config_items = self.rest_send.params.get("config") or []
-        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
-        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
-
     def _configured_switch_ip_by_interface_name(self) -> dict[str, str]:
         """
         # Summary

--- a/tests/unit/module_utils/fixtures/fixture_data/test_loopback_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_loopback_interface.json
@@ -468,6 +468,55 @@
         "DATA": {"switches": []}
     },
 
+    "test_loopback_interface_00750a": {
+        "TEST_NOTES": ["query_all config-scoped: fabric summary (local + default) for validate_prerequisites"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a",
+            "local": true,
+            "fabricStatus": "default"
+        }
+    },
+    "test_loopback_interface_00750b": {
+        "TEST_NOTES": [
+            "query_all config-scoped: switches list (2 switches), but config names only 192.168.12.151.",
+            "Expect: query_all (state!=overridden) scopes to the config switch and never GETs FDO12345ABD's interfaces."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"},
+                {"fabricManagementIp": "192.168.12.152", "switchId": "FDO12345ABD"}
+            ]
+        }
+    },
+    "test_loopback_interface_00750c": {
+        "TEST_NOTES": [
+            "query_all config-scoped: interfaces for the config-named switch FDO12345ABC - one user-managed loopback.",
+            "If query_all were NOT config-scoped it would also GET FDO12345ABD and exhaust the response generator."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "loopback10",
+                    "interfaceType": "loopback",
+                    "configData": {"networkOS": {"policy": {"policyType": "loopback"}}}
+                }
+            ]
+        }
+    },
+
     "test_loopback_interface_00800a": {
         "TEST_NOTES": ["deploy queue de-dup: switches list"],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_managed_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_managed_interface.json
@@ -100,6 +100,55 @@
         "MESSAGE": "Not Found",
         "DATA": {}
     },
+    "test_query_all_config_scoped_00440a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_config_scoped_00440b": {
+        "TEST_NOTES": [
+            "Switch list: two switches in fabric_1, but config names only 192.168.1.1.",
+            "Expect: query_all (state!=overridden) scopes to the config switch and never GETs FDO22222BBB's interfaces."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_query_all_config_scoped_00440c": {
+        "TEST_NOTES": [
+            "Interfaces for the config-named switch FDO11111AAA: one managed subinterface.",
+            "If query_all were NOT config-scoped it would also GET FDO22222BBB and exhaust the response generator."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Ethernet1/3.2",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "subinterface", "description": "kept"}}
+                    }
+                }
+            ]
+        }
+    },
     "test_query_one_happy_path_00500a": {
         "TEST_NOTES": ["Switch list for switch_id resolution"],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_unmanaged_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_subinterface_unmanaged_interface.json
@@ -466,5 +466,51 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
         "MESSAGE": "OK",
         "DATA": []
+    },
+    "test_subinterface_unmanaged_interface_00705a": {
+        "TEST_NOTES": ["query_all config-scoped: fabric summary (local + default) for validate_prerequisites"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a", "local": true, "fabricStatus": "default"}
+    },
+    "test_subinterface_unmanaged_interface_00705b": {
+        "TEST_NOTES": [
+            "query_all config-scoped: switches list (2 switches), but config names only 192.168.12.151.",
+            "Expect: query_all (state!=overridden) scopes to the config switch and never GETs FDO12345ABD's interfaces."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.12.151", "switchId": "FDO12345ABC"},
+                {"fabricManagementIp": "192.168.12.152", "switchId": "FDO12345ABD"}
+            ]
+        }
+    },
+    "test_subinterface_unmanaged_interface_00705c": {
+        "TEST_NOTES": [
+            "query_all config-scoped: interfaces for the config-named switch FDO12345ABC - one unmanaged subinterface.",
+            "If query_all were NOT config-scoped it would also GET FDO12345ABD and exhaust the response generator."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO12345ABC/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "Ethernet1/3.20",
+                    "interfaceType": "subInterface",
+                    "configData": {
+                        "mode": "unmanaged",
+                        "networkOS": {"policy": {"policyType": "monitorSubinterface"}}
+                    }
+                }
+            ]
+        }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_svi_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_svi_interface.json
@@ -110,6 +110,55 @@
         "MESSAGE": "Not Found",
         "DATA": {}
     },
+    "test_query_all_config_scoped_00440a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists (for validate_prerequisites)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_query_all_config_scoped_00440b": {
+        "TEST_NOTES": [
+            "Switch list: two switches in fabric_1, but config names only 192.168.1.1.",
+            "Expect: query_all (state!=overridden) scopes to the config switch and never GETs FDO22222BBB's interfaces."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+                {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+            ]
+        }
+    },
+    "test_query_all_config_scoped_00440c": {
+        "TEST_NOTES": [
+            "Interfaces for the config-named switch FDO11111AAA: one SVI.",
+            "If query_all were NOT config-scoped it would also GET FDO22222BBB and exhaust the response generator."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vlan100",
+                    "interfaceType": "svi",
+                    "configData": {
+                        "mode": "managed",
+                        "networkOS": {"networkOSType": "nx-os", "policy": {"policyType": "svi", "description": "kept"}}
+                    }
+                }
+            ]
+        }
+    },
     "test_query_one_happy_path_00500a": {
         "TEST_NOTES": ["Switch list for switch_id resolution"],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -48,8 +48,16 @@ def responses_loopback_interface(key: str):
     return load_fixture("test_loopback_interface")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator) -> RestSend:
-    """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> RestSend:
+    """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    """
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
@@ -59,7 +67,13 @@ def _build_rest_send(gen_responses: ResponseGenerator) -> RestSend:
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": "fabric_1"})
+    params: dict = {"check_mode": False, "fabric_name": "fabric_1"}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -680,11 +694,12 @@ def test_loopback_interface_00700() -> None:
     """
     # Summary
 
-    Verify `query_all` validates prerequisites, iterates all switches in the fabric, filters interfaces to `policyType: loopback`,
-    and enriches each result with `switchIp`.
+    Verify `query_all` validates prerequisites, iterates all switches in the fabric (`state: overridden` is fabric-wide
+    per `_switches_to_query`), filters interfaces to `policyType: loopback`, and enriches each result with `switchIp`.
 
     ## Test
 
+    - state is `overridden`, so `_switches_to_query` returns the full switch map
     - Fabric summary fetched once (validate_prerequisites)
     - Switches-list fetched once (switch_map)
     - Per-switch interfaces fetched (two switches in fixture)
@@ -694,6 +709,7 @@ def test_loopback_interface_00700() -> None:
     ## Classes and Methods
 
     - LoopbackInterfaceOrchestrator.query_all()
+    - NDBaseInterfaceOrchestrator._switches_to_query()
     - NDBaseInterfaceOrchestrator.validate_prerequisites()
     """
     method_name = inspect.stack()[0][3]
@@ -705,7 +721,7 @@ def test_loopback_interface_00700() -> None:
         yield responses_loopback_interface(f"{method_name}d")
 
     gen_responses = ResponseGenerator(responses())
-    rest_send = _build_rest_send(gen_responses)
+    rest_send = _build_rest_send(gen_responses, state="overridden")
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
@@ -729,6 +745,7 @@ def test_loopback_interface_00710() -> None:
 
     ## Test
 
+    - state is `overridden`, so the switch's interfaces are fetched (fabric-wide scope)
     - Switch's interfaces list contains only ethernet entries
     - `query_all` returns an empty list
 
@@ -744,7 +761,7 @@ def test_loopback_interface_00710() -> None:
         yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
-    rest_send = _build_rest_send(gen_responses)
+    rest_send = _build_rest_send(gen_responses, state="overridden")
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
@@ -761,6 +778,7 @@ def test_loopback_interface_00720() -> None:
 
     ## Test
 
+    - state is `overridden`, so the switch's interfaces are fetched (fabric-wide scope)
     - Switch's interfaces list contains only `policyType: underlayLoopback` entries (Loopback0/Loopback1 system loopbacks)
     - `query_all` returns an empty list
 
@@ -776,7 +794,7 @@ def test_loopback_interface_00720() -> None:
         yield responses_loopback_interface(f"{method_name}c")
 
     gen_responses = ResponseGenerator(responses())
-    rest_send = _build_rest_send(gen_responses)
+    rest_send = _build_rest_send(gen_responses, state="overridden")
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
@@ -847,6 +865,49 @@ def test_loopback_interface_00740() -> None:
         result = instance.query_all()
 
     assert result == []
+
+
+def test_loopback_interface_00750() -> None:
+    """
+    # Summary
+
+    Verify `query_all` scopes its per-switch interface-list fan-out to switches named in the user config when
+    `state` is not `overridden`, rather than querying every switch in the fabric.
+
+    ## Test
+
+    - Fabric has two switches (192.168.12.151, 192.168.12.152), but config names only 192.168.12.151
+    - state is `merged` (non-overridden), so `_switches_to_query` returns only the config switch
+    - Only the config switch's interfaces are fetched; the second switch is never queried (the response
+      generator yields exactly three responses — summary, switch list, switch-1 interfaces — and would raise
+      if a second per-switch GET were issued)
+    - Result contains only the user-managed loopback on the config switch
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator._switches_to_query()
+    - LoopbackInterfaceOrchestrator.query_all()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_loopback_interface(f"{method_name}a")
+        yield responses_loopback_interface(f"{method_name}b")
+        yield responses_loopback_interface(f"{method_name}c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.12.151", "interface_name": "loopback10"}]
+
+    with does_not_raise():
+        rest_send = _build_rest_send(gen_responses, state="merged", config=config)
+        instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+        result = instance.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "loopback10"
+    assert result[0]["switchIp"] == "192.168.12.151"
 
 
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py
@@ -45,8 +45,17 @@ def responses_subif(key: str):
     return load_fixture("test_subinterface_managed_interface")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
-    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    """
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
@@ -56,7 +65,13 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -64,9 +79,14 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     return rest_send
 
 
-def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> SubinterfaceManagedInterfaceOrchestrator:
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> SubinterfaceManagedInterfaceOrchestrator:
     """Construct an orchestrator with the file-based RestSend injected."""
-    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
     return SubinterfaceManagedInterfaceOrchestrator(rest_send=rest_send)
 
 
@@ -198,11 +218,13 @@ def test_subinterface_managed_orchestrator_00400() -> None:
     """
     # Summary
 
-    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=subInterface AND
-    managed policyType=subinterface, and injects `switchIp` onto each kept interface.
+    Verify `query_all` validates the fabric, iterates all switches (`state: overridden` is fabric-wide per
+    `_switches_to_query`), filters to interfaceType=subInterface AND managed policyType=subinterface, and
+    injects `switchIp` onto each kept interface.
 
     ## Test
 
+    - state is `overridden`, so `_switches_to_query` returns the full switch map
     - Fabric summary returns 200
     - Two switches in the switch list
     - Switch 1 returns: managed subinterface (kept), ethernet (filtered by interfaceType),
@@ -213,6 +235,7 @@ def test_subinterface_managed_orchestrator_00400() -> None:
     ## Classes and Methods
 
     - SubinterfaceManagedInterfaceOrchestrator.query_all()
+    - NDBaseInterfaceOrchestrator._switches_to_query()
     """
 
     def responses():
@@ -224,7 +247,7 @@ def test_subinterface_managed_orchestrator_00400() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        orchestrator = _build_orchestrator(gen_responses)
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
         result = orchestrator.query_all()
 
     assert isinstance(result, list)
@@ -266,6 +289,47 @@ def test_subinterface_managed_orchestrator_00420() -> None:
 
     with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
         orchestrator.query_all()
+
+
+def test_subinterface_managed_orchestrator_00440() -> None:
+    """
+    # Summary
+
+    Verify `query_all` scopes its per-switch interface-list fan-out to switches named in the user config when
+    `state` is not `overridden`, rather than querying every switch in the fabric.
+
+    ## Test
+
+    - Fabric has two switches (192.168.1.1, 192.168.1.2), but config names only 192.168.1.1
+    - state is `merged` (non-overridden), so `_switches_to_query` returns only the config switch
+    - Only the config switch's interfaces are fetched; the second switch is never queried (the response
+      generator yields exactly three responses — summary, switch list, switch-1 interfaces — and would raise
+      if a second per-switch GET were issued)
+    - Result contains only the managed subinterface on the config switch
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator._switches_to_query()
+    - SubinterfaceManagedInterfaceOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_subif("test_query_all_config_scoped_00440a")
+        yield responses_subif("test_query_all_config_scoped_00440b")
+        yield responses_subif("test_query_all_config_scoped_00440c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "Ethernet1/3.2"}]
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="merged", config=config)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "Ethernet1/3.2"
+    assert result[0]["switchIp"] == "192.168.1.1"
 
 
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_subinterface_unmanaged_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_subinterface_unmanaged_interface.py
@@ -33,8 +33,16 @@ def responses_subinterface_unmanaged_interface(key: str):
     return load_fixture("test_subinterface_unmanaged_interface")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator) -> RestSend:
-    """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`."""
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> RestSend:
+    """Build a `RestSend` wired to a file-based `Sender` and `ResponseHandler`.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    """
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
@@ -44,7 +52,13 @@ def _build_rest_send(gen_responses: ResponseGenerator) -> RestSend:
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": "fabric_1"})
+    params: dict = {"check_mode": False, "fabric_name": "fabric_1"}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -613,11 +627,13 @@ def test_subinterface_unmanaged_interface_00700(monkeypatch) -> None:
     """
     # Summary
 
-    Verify `query_all` validates prerequisites, iterates all switches, filters for `monitorSubinterface` policyType,
-    and enriches each result with `switchIp`.
+    Verify `query_all` validates prerequisites, iterates all switches in the fabric (`state: overridden` is
+    fabric-wide per `_switches_to_query`), filters for `monitorSubinterface` policyType, and enriches each
+    result with `switchIp`.
 
     ## Test
 
+    - state is `overridden`, so `_switches_to_query` returns the full switch map
     - Fabric summary fetched once (validate_prerequisites)
     - Switches-list fetched once (switch_map)
     - Switch A returns a mix: one managed subinterface (policyType=subinterface) + one unmanaged (policyType=monitorSubinterface)
@@ -627,6 +643,7 @@ def test_subinterface_unmanaged_interface_00700(monkeypatch) -> None:
     ## Classes and Methods
 
     - SubinterfaceUnmanagedInterfaceOrchestrator.query_all()
+    - NDBaseInterfaceOrchestrator._switches_to_query()
     - NDBaseInterfaceOrchestrator.validate_prerequisites()
     """
     method_name = inspect.stack()[0][3]
@@ -638,9 +655,9 @@ def test_subinterface_unmanaged_interface_00700(monkeypatch) -> None:
         yield responses_subinterface_unmanaged_interface(f"{method_name}d")
 
     gen = ResponseGenerator(responses())
-    rest_send = _build_rest_send(gen)
+    rest_send = _build_rest_send(gen, state="overridden")
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "overridden"})
 
     with does_not_raise():
         result = orchestrator.query_all()
@@ -729,6 +746,7 @@ def test_subinterface_unmanaged_interface_00703(monkeypatch) -> None:
 
     ## Test
 
+    - state is `overridden`, so the switch's interfaces are fetched (fabric-wide scope)
     - One switch with only ethernet interfaces
     - `query_all` returns []
 
@@ -744,9 +762,9 @@ def test_subinterface_unmanaged_interface_00703(monkeypatch) -> None:
         yield responses_subinterface_unmanaged_interface(f"{method_name}c")
 
     gen = ResponseGenerator(responses())
-    rest_send = _build_rest_send(gen)
+    rest_send = _build_rest_send(gen, state="overridden")
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "overridden"})
 
     with does_not_raise():
         result = orchestrator.query_all()
@@ -763,6 +781,7 @@ def test_subinterface_unmanaged_interface_00704(monkeypatch) -> None:
 
     ## Test
 
+    - state is `overridden`, so the switch's interfaces are fetched (fabric-wide scope)
     - Fabric summary returns valid (local, default)
     - Switches list returns one switch
     - That switch's interfaces GET returns a bare list as DATA
@@ -770,6 +789,46 @@ def test_subinterface_unmanaged_interface_00704(monkeypatch) -> None:
 
     ## Classes and Methods
 
+    - SubinterfaceUnmanagedInterfaceOrchestrator.query_all()
+    - NDBaseInterfaceOrchestrator._switch_interfaces()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_subinterface_unmanaged_interface(f"{method_name}a")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}b")
+        yield responses_subinterface_unmanaged_interface(f"{method_name}c")
+
+    gen = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen, state="overridden")
+
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "overridden"})
+
+    with does_not_raise():
+        result = orchestrator.query_all()
+
+    assert result == []
+
+
+def test_subinterface_unmanaged_interface_00705(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify `query_all` scopes its per-switch interface-list fan-out to switches named in the user config when
+    `state` is not `overridden`, rather than querying every switch in the fabric.
+
+    ## Test
+
+    - Fabric has two switches (192.168.12.151, 192.168.12.152), but config names only 192.168.12.151
+    - state is `merged` (non-overridden), so `_switches_to_query` returns only the config switch
+    - Only the config switch's interfaces are fetched; the second switch is never queried (the response
+      generator yields exactly three responses — summary, switch list, switch-1 interfaces — and would raise
+      if a second per-switch GET were issued)
+    - Result contains only the unmanaged subinterface on the config switch
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator._switches_to_query()
     - SubinterfaceUnmanagedInterfaceOrchestrator.query_all()
     """
     method_name = inspect.stack()[0][3]
@@ -780,11 +839,16 @@ def test_subinterface_unmanaged_interface_00704(monkeypatch) -> None:
         yield responses_subinterface_unmanaged_interface(f"{method_name}c")
 
     gen = ResponseGenerator(responses())
-    rest_send = _build_rest_send(gen)
+
+    config = [{"switch_ip": "192.168.12.151", "interface_name": "Ethernet1/3.20"}]
+    rest_send = _build_rest_send(gen, state="merged", config=config)
 
     orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
 
     with does_not_raise():
         result = orchestrator.query_all()
 
-    assert result == []
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "Ethernet1/3.20"
+    assert result[0]["switchIp"] == "192.168.12.151"

--- a/tests/unit/module_utils/orchestrators/test_subinterface_unmanaged_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_subinterface_unmanaged_interface.py
@@ -155,7 +155,7 @@ def test_subinterface_unmanaged_interface_00100(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
 
     with does_not_raise():
@@ -200,7 +200,7 @@ def test_subinterface_unmanaged_interface_00101(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
 
     with pytest.raises(RuntimeError, match=r"Create failed.*ND rejected"):
@@ -235,7 +235,7 @@ def test_subinterface_unmanaged_interface_00102(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
 
     match = r"Create failed for .*Ethernet1/3\.20"
@@ -276,7 +276,7 @@ def test_subinterface_unmanaged_interface_00200(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
 
     with does_not_raise():
@@ -316,7 +316,7 @@ def test_subinterface_unmanaged_interface_00201(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
 
     match = r"Update failed for .*Ethernet1/3\.20"
@@ -358,7 +358,7 @@ def test_subinterface_unmanaged_interface_00300(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "deleted"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
 
     with does_not_raise():
@@ -394,7 +394,7 @@ def test_subinterface_unmanaged_interface_00301(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "deleted"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
 
     match = r"No switch found with fabricManagementIp '192\.168\.12\.151'"
@@ -437,7 +437,7 @@ def test_subinterface_unmanaged_interface_00400(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     models = [
         SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20"),
         SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.21"),
@@ -487,7 +487,7 @@ def test_subinterface_unmanaged_interface_00401(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     models = [
         SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20"),
         SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.152", interface_name="Ethernet1/3.20"),
@@ -529,7 +529,7 @@ def test_subinterface_unmanaged_interface_00500(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "deleted"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     models = [
         SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20"),
         SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.152", interface_name="Ethernet1/3.20"),
@@ -574,7 +574,7 @@ def test_subinterface_unmanaged_interface_00600(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
 
     with does_not_raise():
@@ -610,7 +610,7 @@ def test_subinterface_unmanaged_interface_00601(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
     model = SubinterfaceUnmanagedInterfaceModel(switch_ip="192.168.12.151", interface_name="Ethernet1/3.20")
 
     match = r"Query failed for .*Ethernet1/3\.20"
@@ -697,7 +697,7 @@ def test_subinterface_unmanaged_interface_00701(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
         result = orchestrator.query_all()
@@ -731,7 +731,7 @@ def test_subinterface_unmanaged_interface_00702(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
 
     match = r"Query all failed.*deployment freeze"
     with pytest.raises(RuntimeError, match=match):

--- a/tests/unit/module_utils/orchestrators/test_subinterface_unmanaged_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_subinterface_unmanaged_interface.py
@@ -657,7 +657,7 @@ def test_subinterface_unmanaged_interface_00700(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen, state="overridden")
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "overridden"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
         result = orchestrator.query_all()
@@ -764,7 +764,7 @@ def test_subinterface_unmanaged_interface_00703(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen, state="overridden")
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "overridden"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
         result = orchestrator.query_all()
@@ -802,7 +802,7 @@ def test_subinterface_unmanaged_interface_00704(monkeypatch) -> None:
     gen = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen, state="overridden")
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "overridden"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
         result = orchestrator.query_all()
@@ -843,7 +843,7 @@ def test_subinterface_unmanaged_interface_00705(monkeypatch) -> None:
     config = [{"switch_ip": "192.168.12.151", "interface_name": "Ethernet1/3.20"}]
     rest_send = _build_rest_send(gen, state="merged", config=config)
 
-    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send, fabric_name="fabric_1", params={"state": "merged"})
+    orchestrator = SubinterfaceUnmanagedInterfaceOrchestrator(rest_send=rest_send)
 
     with does_not_raise():
         result = orchestrator.query_all()

--- a/tests/unit/module_utils/orchestrators/test_svi_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_svi_interface.py
@@ -44,8 +44,17 @@ def responses_svi(key: str):
     return load_fixture("test_svi_interface")[key]
 
 
-def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> RestSend:
-    """Build a RestSend wired to the file-based Sender and the real ResponseHandler."""
+def _build_rest_send(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> RestSend:
+    """Build a RestSend wired to the file-based Sender and the real ResponseHandler.
+
+    `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    """
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
     sender.gen = gen_responses
@@ -55,7 +64,13 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    if state is not None:
+        params["state"] = state
+    if config is not None:
+        params["config"] = config
+
+    rest_send = RestSend(params)
     rest_send.sender = sender
     rest_send.response_handler = response_handler
     rest_send.unit_test = True
@@ -63,9 +78,14 @@ def _build_rest_send(gen_responses: ResponseGenerator, fabric_name: str = "fabri
     return rest_send
 
 
-def _build_orchestrator(gen_responses: ResponseGenerator, fabric_name: str = "fabric_1") -> SviInterfaceOrchestrator:
+def _build_orchestrator(
+    gen_responses: ResponseGenerator,
+    fabric_name: str = "fabric_1",
+    state: str | None = None,
+    config: list[dict] | None = None,
+) -> SviInterfaceOrchestrator:
     """Construct an orchestrator with the file-based RestSend injected."""
-    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name)
+    rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
     return SviInterfaceOrchestrator(rest_send=rest_send)
 
 
@@ -127,11 +147,13 @@ def test_svi_orchestrator_00400() -> None:
     """
     # Summary
 
-    Verify `query_all` validates the fabric, iterates all switches, filters to interfaceType=svi AND policyType=svi,
-    and injects `switchIp` onto each kept interface.
+    Verify `query_all` validates the fabric, iterates all switches (`state: overridden` is fabric-wide per
+    `_switches_to_query`), filters to interfaceType=svi AND policyType=svi, and injects `switchIp` onto each
+    kept interface.
 
     ## Test
 
+    - state is `overridden`, so `_switches_to_query` returns the full switch map
     - Fabric summary returns 200
     - Two switches in the switch list
     - Switch 1 returns: SVI (kept), ethernet (filtered by interfaceType), SVI with policyType=underlaySvi (filtered by policyType)
@@ -141,6 +163,7 @@ def test_svi_orchestrator_00400() -> None:
     ## Classes and Methods
 
     - SviInterfaceOrchestrator.query_all()
+    - NDBaseInterfaceOrchestrator._switches_to_query()
     """
 
     def responses():
@@ -152,7 +175,7 @@ def test_svi_orchestrator_00400() -> None:
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        orchestrator = _build_orchestrator(gen_responses)
+        orchestrator = _build_orchestrator(gen_responses, state="overridden")
         result = orchestrator.query_all()
 
     assert isinstance(result, list)
@@ -194,6 +217,47 @@ def test_svi_orchestrator_00420() -> None:
 
     with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
         orchestrator.query_all()
+
+
+def test_svi_orchestrator_00440() -> None:
+    """
+    # Summary
+
+    Verify `query_all` scopes its per-switch interface-list fan-out to switches named in the user config when
+    `state` is not `overridden`, rather than querying every switch in the fabric.
+
+    ## Test
+
+    - Fabric has two switches (192.168.1.1, 192.168.1.2), but config names only 192.168.1.1
+    - state is `merged` (non-overridden), so `_switches_to_query` returns only the config switch
+    - Only the config switch's interfaces are fetched; the second switch is never queried (the response
+      generator yields exactly three responses — summary, switch list, switch-1 interfaces — and would raise
+      if a second per-switch GET were issued)
+    - Result contains only the SVI on the config switch
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator._switches_to_query()
+    - SviInterfaceOrchestrator.query_all()
+    """
+
+    def responses():
+        yield responses_svi("test_query_all_config_scoped_00440a")
+        yield responses_svi("test_query_all_config_scoped_00440b")
+        yield responses_svi("test_query_all_config_scoped_00440c")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "vlan100"}]
+
+    with does_not_raise():
+        orchestrator = _build_orchestrator(gen_responses, state="merged", config=config)
+        result = orchestrator.query_all()
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vlan100"
+    assert result[0]["switchIp"] == "192.168.1.1"
 
 
 # =============================================================================


### PR DESCRIPTION
## Related Issue(s)

Relates to #349 (implements the short-term mitigation; the long-term `overridden` fan-out collapse remains blocked on ND shipping a fabric-wide interface-config endpoint, so this PR does not close the issue). Pre-pays a slice of #348 by lifting the duplicated `_switches_to_query` copies into the shared base.

## Proposed Changes

- Move `_switches_to_query()` and the `_switch_interfaces` per-switch cache from `ethernet_base.py` into `NDBaseInterfaceOrchestrator` (`base_interface.py`); delete the byte-identical `_switches_to_query` copies in `port_channel_base.py` and `vpc_interface_base.py`
- Adopt the pattern in the four orchestrators that still walked the full fabric switch map in `query_all`: `svi_interface`, `subinterface_managed_interface`, `subinterface_unmanaged_interface`, and `loopback_interface` (loopback has the identical fabric-wide loop even though it is not yet listed on #349) — a single-interface `merged` run now issues one interface-list GET instead of one per fabric switch
- `_switch_interfaces` documents its endpoint contract: the subclass's `query_all_endpoint` must be the per-switch interfaces-list GET (`MaintenanceModeOrchestrator` inherits the base with a switches-list endpoint and must not call it)
- Tests: thread `state`/`config` through the four adopters' test harnesses, pin the existing fabric-wide `query_all` tests to `state=overridden` (fixtures unchanged; they now double as overridden-stays-fabric-wide coverage), and add one config-scoped test per orchestrator proving the second switch is never queried

## Test Notes

- Full unit tree passes inside nd-dev: `ndpytest tests/unit/` (2191 passed, including the 4 new config-scoped tests)
- `pylint` and `mypy` compared against a develop baseline: zero new findings (duplicate-code count dropped 37 → 34; mypy's 237 pre-existing errors identical)
- `black`/`isort` clean; sanity `import` and `validate-modules` pass via `ndtest`

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHD3LNRaa8sT5uUcAHL82Z