### PR TITLE
Add opt-in gathered-state filtering for loopback and local users

### DIFF
--- a/changelogs/fragments/gathered_filtering.yml
+++ b/changelogs/fragments/gathered_filtering.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - Add opt-in gathered-state filtering to the shared state machine, with final local matching and model-specific normalization hooks.
+  - Enable server-side Lucene candidate filtering for gathered loopback interfaces, including switch routing,
+    interface-name filtering, pagination, response deduplication, and final local matching for unsupported fields.
+  - Enable local login-ID filtering for the nd_local_user gathered state.

--- a/changelogs/fragments/gathered_filtering.yml
+++ b/changelogs/fragments/gathered_filtering.yml
@@ -1,5 +1,0 @@
-minor_changes:
-  - Add opt-in gathered-state filtering to the shared state machine, with final local matching and model-specific normalization hooks.
-  - Enable server-side Lucene candidate filtering for gathered loopback interfaces, including switch routing,
-    interface-name filtering, pagination, response deduplication, and final local matching for unsupported fields.
-  - Enable local login-ID filtering for the nd_local_user gathered state.

--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -32,8 +32,12 @@ from __future__ import annotations
 from typing import ClassVar, Literal
 from urllib.parse import quote
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import (
     ClusterNameMixin,
     FabricNameMixin,
@@ -49,12 +53,21 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params im
     EndpointQueryParams,
     LuceneQueryParams,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import (
+    BasePath,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
 
-class ManageInterfacesListEndpointParams(ClusterNameMixin, FilterMixin, MaxMixin, NetworkNameMixin, OffsetMixin, EndpointQueryParams):
+class ManageInterfacesListEndpointParams(
+    ClusterNameMixin,
+    FilterMixin,
+    MaxMixin,
+    NetworkNameMixin,
+    OffsetMixin,
+    EndpointQueryParams,
+):
     """
     Endpoint-specific query parameters for listing switch interfaces.
 
@@ -114,7 +127,13 @@ class _EpManageInterfacesBase(FabricNameMixin, SwitchSerialNumberMixin, Interfac
         if self._require_interface_name and self.interface_name is None:
             raise ValueError(f"{type(self).__name__}.path: interface_name must be set before accessing path.")
 
-        segments = ["fabrics", quote(self.fabric_name, safe=""), "switches", quote(self.switch_sn, safe=""), "interfaces"]
+        segments = [
+            "fabrics",
+            quote(self.fabric_name, safe=""),
+            "switches",
+            quote(self.switch_sn, safe=""),
+            "interfaces",
+        ]
         if self.interface_name is not None:
             segments.append(quote(self.interface_name, safe=""))
         base_path = BasePath.path(*segments)
@@ -156,7 +175,11 @@ class EpManageInterfacesGet(_EpManageInterfacesBase):
     - Via inherited `path` property if `fabric_name`, `switch_sn`, or `interface_name` is not set.
     """
 
-    class_name: Literal["EpManageInterfacesGet"] = Field(default="EpManageInterfacesGet", frozen=True, description="Class name for backward compatibility")
+    class_name: Literal["EpManageInterfacesGet"] = Field(
+        default="EpManageInterfacesGet",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
 
     @property
     def verb(self) -> HttpVerbEnum:
@@ -193,7 +216,9 @@ class EpManageInterfacesListGet(_EpManageInterfacesBase):
     _require_interface_name: ClassVar[bool] = False
 
     class_name: Literal["EpManageInterfacesListGet"] = Field(
-        default="EpManageInterfacesListGet", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesListGet",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
     endpoint_params: ManageInterfacesListEndpointParams = Field(
         default_factory=ManageInterfacesListEndpointParams,
@@ -213,17 +238,10 @@ class EpManageInterfacesListGet(_EpManageInterfacesBase):
             "sort": self.endpoint_params.sort,
         }
 
-        legacy_lucene_is_set = any(
-            value is not None
-            for value in legacy_lucene_values.values()
-        )
+        legacy_lucene_is_set = any(value is not None for value in legacy_lucene_values.values())
 
         if legacy_lucene_is_set and not self.lucene_params.is_empty():
-            raise ValueError(
-                "Set Lucene options using either "
-                "'endpoint_params.filter/max/offset/sort' or "
-                "'lucene_params', but not both."
-            )
+            raise ValueError("Set Lucene options using either " "'endpoint_params.filter/max/offset/sort' or " "'lucene_params', but not both.")
 
         query_params = CompositeQueryParams().add(self.endpoint_params)
 
@@ -266,7 +284,11 @@ class EpManageInterfacesPost(_EpManageInterfacesBase):
 
     _require_interface_name: ClassVar[bool] = False
 
-    class_name: Literal["EpManageInterfacesPost"] = Field(default="EpManageInterfacesPost", frozen=True, description="Class name for backward compatibility")
+    class_name: Literal["EpManageInterfacesPost"] = Field(
+        default="EpManageInterfacesPost",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
 
     @property
     def verb(self) -> HttpVerbEnum:
@@ -298,7 +320,11 @@ class EpManageInterfacesPut(_EpManageInterfacesBase):
     - Via inherited `path` property if `fabric_name`, `switch_sn`, or `interface_name` is not set.
     """
 
-    class_name: Literal["EpManageInterfacesPut"] = Field(default="EpManageInterfacesPut", frozen=True, description="Class name for backward compatibility")
+    class_name: Literal["EpManageInterfacesPut"] = Field(
+        default="EpManageInterfacesPut",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
 
     @property
     def verb(self) -> HttpVerbEnum:
@@ -341,7 +367,9 @@ class EpManageInterfacesDelete(_EpManageInterfacesBase):
     """
 
     class_name: Literal["EpManageInterfacesDelete"] = Field(
-        default="EpManageInterfacesDelete", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesDelete",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
 
     @property
@@ -376,7 +404,9 @@ class EpManageInterfacesDeploy(FabricNameMixin, NDEndpointBaseModel):
     """
 
     class_name: Literal["EpManageInterfacesDeploy"] = Field(
-        default="EpManageInterfacesDeploy", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesDeploy",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
 
     @property
@@ -428,7 +458,9 @@ class EpManageInterfacesNormalize(FabricNameMixin, NDEndpointBaseModel):
     """
 
     class_name: Literal["EpManageInterfacesNormalize"] = Field(
-        default="EpManageInterfacesNormalize", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesNormalize",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
 
     @property
@@ -480,7 +512,9 @@ class EpManageInterfacesRemove(FabricNameMixin, NDEndpointBaseModel):
     """
 
     class_name: Literal["EpManageInterfacesRemove"] = Field(
-        default="EpManageInterfacesRemove", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesRemove",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
 
     @property

--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -44,7 +44,11 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import (
     OffsetMixin,
     SwitchSerialNumberMixin,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import (
+    CompositeQueryParams,
+    EndpointQueryParams,
+    LuceneQueryParams,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
@@ -56,6 +60,9 @@ class ManageInterfacesListEndpointParams(ClusterNameMixin, FilterMixin, MaxMixin
 
     These match the query parameters exposed by
     ``/fabrics/{fabricName}/switches/{switchId}/interfaces`` in manage.json.
+    ``filter``, ``max``, ``offset``, and ``sort`` remain available here for
+    backward compatibility. New filtering callers should use
+    ``EpManageInterfacesListGet.lucene_params`` for URL-encoded Lucene values.
     """
 
     sort: str | None = Field(default=None, min_length=1, description="Sort field and direction")
@@ -192,10 +199,38 @@ class EpManageInterfacesListGet(_EpManageInterfacesBase):
         default_factory=ManageInterfacesListEndpointParams,
         description="Endpoint-specific query parameters",
     )
+    lucene_params: LuceneQueryParams = Field(
+        default_factory=LuceneQueryParams,
+        description="Lucene filtering, pagination, and sorting parameters",
+    )
 
     def _query_string(self) -> str:
-        """Return list endpoint query string."""
-        return self.endpoint_params.to_query_string()
+        """Return endpoint-specific and Lucene query parameters."""
+        legacy_lucene_values = {
+            "filter": self.endpoint_params.filter,
+            "max": self.endpoint_params.max,
+            "offset": self.endpoint_params.offset,
+            "sort": self.endpoint_params.sort,
+        }
+
+        legacy_lucene_is_set = any(
+            value is not None
+            for value in legacy_lucene_values.values()
+        )
+
+        if legacy_lucene_is_set and not self.lucene_params.is_empty():
+            raise ValueError(
+                "Set Lucene options using either "
+                "'endpoint_params.filter/max/offset/sort' or "
+                "'lucene_params', but not both."
+            )
+
+        query_params = CompositeQueryParams().add(self.endpoint_params)
+
+        if not legacy_lucene_is_set:
+            query_params.add(self.lucene_params)
+
+        return query_params.to_query_string()
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -32,12 +32,8 @@ from __future__ import annotations
 from typing import ClassVar, Literal
 from urllib.parse import quote
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
-    Field,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
-    NDEndpointBaseModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import (
     ClusterNameMixin,
     FabricNameMixin,
@@ -53,9 +49,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params im
     EndpointQueryParams,
     LuceneQueryParams,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import (
-    BasePath,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 

--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -241,7 +241,7 @@ class EpManageInterfacesListGet(_EpManageInterfacesBase):
         legacy_lucene_is_set = any(value is not None for value in legacy_lucene_values.values())
 
         if legacy_lucene_is_set and not self.lucene_params.is_empty():
-            raise ValueError("Set Lucene options using either " "'endpoint_params.filter/max/offset/sort' or " "'lucene_params', but not both.")
+            raise ValueError("Set Lucene options using either 'endpoint_params.filter/max/offset/sort' or 'lucene_params', but not both.")
 
         query_params = CompositeQueryParams().add(self.endpoint_params)
 

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -203,13 +203,15 @@ def filter_gathered_response(
     filters: list[dict[str, Any]],
     model_class: type[NDBaseModel],
     normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
-) -> list[dict[str, Any]]:
+) -> list[NDBaseModel]:
     """
-    Apply gathered filters to raw API objects.
+    Apply gathered filters to raw API objects and return validated models.
 
     Criteria inside one filter item use AND semantics.
     Multiple filter items use OR semantics.
-    Returned objects remain in API shape for NDConfigCollection.from_api_response().
+
+    Returns validated model instances directly so callers can construct an
+    NDConfigCollection without redundant from_response() calls.
     """
     # Validation duplicates validate_gathered_filters() intentionally so this
     # function remains safe to call standalone (e.g., from unit tests).
@@ -227,7 +229,7 @@ def filter_gathered_response(
 
         active_filters.append(normalized)
 
-    filtered: list[dict[str, Any]] = []
+    filtered_models: list[NDBaseModel] = []
     seen_identifiers = set()
 
     for response_item in response_data:
@@ -243,9 +245,9 @@ def filter_gathered_response(
             continue
 
         seen_identifiers.add(identifier)
-        filtered.append(response_item)
+        filtered_models.append(model)
 
-    return filtered
+    return filtered_models
 
 
 def validate_gathered_filters(

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -108,6 +108,102 @@ def _contains_active_value(value: Any) -> bool:
     # valid loopback fields and are treated as absent criteria.
     return value not in (None, "")
 
+def _extract_active_leaf_paths(data: dict[str, Any], prefix: str = "") -> set[str]:
+    """Return dot-paths for every non-None, non-empty leaf value in a nested dict.
+
+    Given a gathered filter dict (which may be nested due to Ansible's argument
+    spec structure), this walks the tree and identifies which properties the user
+    actually supplied a value for.
+
+    Ansible pads all omitted suboptions with None after argument validation.
+    Those Nones are not user-supplied criteria and are correctly skipped.
+
+    Args:
+        data: A (possibly nested) filter dict from the user's config item.
+        prefix: Internal recursion prefix — callers should not pass this.
+
+    Returns:
+        A set of dot-path strings representing active (non-None) leaf values.
+
+    Examples:
+        >>> _extract_active_leaf_paths({"switch_ip": "10.1.1.1", "interface_name": None})
+        {"switch_ip"}
+
+        >>> _extract_active_leaf_paths({
+        ...     "config_data": {"network_os": {"policy": {"vrf": "mgmt", "ip": None}}}
+        ... })
+        {"config_data.network_os.policy.vrf"}
+
+        >>> _extract_active_leaf_paths({"login_id": "admin"})
+        {"login_id"}
+
+        >>> _extract_active_leaf_paths({"config_data": None})
+        set()  # None at any level is skipped
+    """
+    paths: set[str] = set()
+    for key, value in data.items():
+        full_path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            paths |= _extract_active_leaf_paths(value, full_path)
+        elif value not in (None, "", []):
+            # False and 0 ARE active values (e.g., admin_state: false)
+            paths.add(full_path)
+    return paths
+
+
+def _reject_unsupported_filter_properties(
+    filter_item: dict[str, Any],
+    supported_properties: tuple[str, ...],
+    index: int,
+) -> None:
+    """Raise ValueError if a filter item contains properties not in the supported set.
+
+    This is the enforcement function for the model's gathered_filter_properties
+    declaration. Called exactly once per filter item during pre-flight validation,
+    before any API request or normalization.
+
+    Args:
+        filter_item: One raw filter dict from the user's config list.
+        supported_properties: The model's declared tuple of allowed dot-paths.
+        index: The position of this filter item in the config list (for error messages).
+
+    Raises:
+        ValueError: With a message listing unsupported properties and the full
+            set of supported properties. Formatted for direct use in Ansible's
+            module.fail_json(msg=...).
+
+    Examples:
+        # Passes (switch_ip is supported):
+        >>> _reject_unsupported_filter_properties(
+        ...     {"switch_ip": "10.1.1.1"},
+        ...     ("switch_ip", "interface_name"),
+        ...     index=0,
+        ... )  # No error
+
+        # Fails (extra_config is not supported):
+        >>> _reject_unsupported_filter_properties(
+        ...     {"config_data": {"network_os": {"policy": {"extra_config": "cli"}}}},
+        ...     ("switch_ip", "interface_name", "config_data.network_os.policy.vrf"),
+        ...     index=0,
+        ... )
+        # ValueError: "Gathered filter at index 0 contains unsupported properties: 
+        #   'config_data.network_os.policy.extra_config'. 
+        #   Supported gathered filter properties: 'switch_ip', 'interface_name', ..."
+    """
+    supplied_paths = _extract_active_leaf_paths(filter_item)
+    supported_set = set(supported_properties)
+    unsupported = sorted(supplied_paths - supported_set)
+    if unsupported:
+        raise ValueError(
+            "Gathered filter at index {0} contains unsupported properties: {1}. "
+            "Supported gathered filter properties: {2}".format(
+                index,
+                ", ".join("'{0}'".format(p) for p in unsupported),
+                ", ".join("'{0}'".format(p) for p in supported_properties),
+            )
+        )
+
+
 
 def filter_gathered_response(
     response_data: list[dict[str, Any]],
@@ -160,24 +256,54 @@ def filter_gathered_response(
 def validate_gathered_filters(
         filters: list[Any],
         normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        supported_properties: tuple[str, ...] = (),
 ) -> None:
     """ 
     Pre-flight validation for gathered filter items.
 
-    Raises ValueError if any filter item is malformed or contains no actionable 
-    criteria. Call this before making API requests so that invalid input is r
-    rejected without wasted network I/O.
+    Validates each filter item through a strict pipeline:
+      1. Type check — must be a dict
+      2. Property check — all active properties must be in the supported set
+      3. Normalize — transform values to canonical form (e.g., lowercase)
+      4. Active check — at least one non-None criterion must exist
+
+    Property validation runs BEFORE normalization because:
+      - It checks KEYS (property paths), normalization transforms VALUES.
+      - Unsupported properties should be rejected without wasting normalization effort.
+      - Error messages should show what the user wrote, not the normalized form.
+
+    Args:
+        filters: The raw config list from module.params["config"].
+            Example: [{"switch_ip": "10.1.1.1", "interface_name": "loopback0"}]
+
+        normalize_filter: Model-specific value transformer (e.g., lowercase interface_name).
+            Signature: (dict) -> dict. May be None if no normalization needed.
+
+        supported_properties: The model's gathered_filter_properties tuple.
+            Example: ("switch_ip", "interface_name", "config_data.network_os.policy.vrf")
+            Empty tuple means property validation is skipped (backward-compatible).
+
+    Raises:
+        ValueError: If any filter item fails any validation step.
     """
     for idx, filter_item in enumerate(filters):
+        # Step 1: Type check
         if not isinstance(filter_item, dict):
             raise ValueError(
                 f"Each gathered filter item must be a dictionary, "
                 f"got {type(filter_item).__name__} at index {idx}."
             )
+        
+        # Step 2: Property validation (before normalize - checks keys, not values)
+        if supported_properties:
+            _reject_unsupported_filter_properties(filter_item, supported_properties, idx)
+
+        # Step 3: Normalize values to canonical form
         normalized = deepcopy(filter_item)
         if normalize_filter is not None:
             normalized = normalize_filter(normalized)
         
+        #Step 4: Active value check
         if not _contains_active_value(normalized):
             raise ValueError(
                 f"Gathered filter item at index {idx} must contain "

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -1,4 +1,4 @@
-# Copyright: (c) 2026, Deeksha Pandey (deekpand-cisco)  deekpand@cisco.com
+# Copyright: (c) 2026, Deeksha Pandey (@deekpand) <deekpand@cisco.com>
 
 """Generic local and server-side filtering helpers for gathered-state responses."""
 
@@ -191,12 +191,10 @@ def _reject_unsupported_filter_properties(
     unsupported = sorted(supplied_paths - supported_set)
     if unsupported:
         raise ValueError(
-            "Gathered filter at index {0} contains unsupported properties: {1}. "
-            "Supported gathered filter properties: {2}".format(
-                index,
-                ", ".join("'{0}'".format(p) for p in unsupported),
-                ", ".join("'{0}'".format(p) for p in supported_properties),
-            )
+            f"Gathered filter at index {index} contains unsupported properties: "
+            f"{', '.join(repr(p) for p in unsupported)}. "
+            f"Supported gathered filter properties: "
+            f"{', '.join(repr(p) for p in supported_properties)}"
         )
 
 
@@ -213,7 +211,8 @@ def filter_gathered_response(
     Multiple filter items use OR semantics.
     Returned objects remain in API shape for NDConfigCollection.from_api_response().
     """
-
+    # Validation duplicates validate_gathered_filters() intentionally so this
+    # function remains safe to call standalone (e.g., from unit tests).
     active_filters: list[dict[str, Any]] = []
     for filter_item in filters or []:
         if not isinstance(filter_item, dict):

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -1,6 +1,4 @@
-# Copyright: (c) 2026, Cisco and/or its affiliates.
-
-# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Copyright: (c) 2026, Deeksha Pandey (deekpand-cisco)  deekpand@cisco.com
 
 """Generic local and server-side filtering helpers for gathered-state responses."""
 
@@ -77,10 +75,7 @@ def build_lucene_expressions(
     expressions: list[str] = []
 
     for filter_item in filter_items:
-        terms = [
-            f"{field_name}:{format_lucene_value(value)}"
-            for field_name, value in spec.base_terms
-        ]
+        terms = [f"{field_name}:{format_lucene_value(value)}" for field_name, value in spec.base_terms]
 
         for config_path, api_field in spec.field_map.items():
             value = get_nested_value(filter_item, config_path)
@@ -107,6 +102,7 @@ def _contains_active_value(value: Any) -> bool:
     # False and 0 can be meaningful filter values. Empty strings cannot match
     # valid loopback fields and are treated as absent criteria.
     return value not in (None, "")
+
 
 def _extract_active_leaf_paths(data: dict[str, Any], prefix: str = "") -> set[str]:
     """Return dot-paths for every non-None, non-empty leaf value in a nested dict.
@@ -186,8 +182,8 @@ def _reject_unsupported_filter_properties(
         ...     ("switch_ip", "interface_name", "config_data.network_os.policy.vrf"),
         ...     index=0,
         ... )
-        # ValueError: "Gathered filter at index 0 contains unsupported properties: 
-        #   'config_data.network_os.policy.extra_config'. 
+        # ValueError: "Gathered filter at index 0 contains unsupported properties:
+        #   'config_data.network_os.policy.extra_config'.
         #   Supported gathered filter properties: 'switch_ip', 'interface_name', ..."
     """
     supplied_paths = _extract_active_leaf_paths(filter_item)
@@ -202,7 +198,6 @@ def _reject_unsupported_filter_properties(
                 ", ".join("'{0}'".format(p) for p in supported_properties),
             )
         )
-
 
 
 def filter_gathered_response(
@@ -220,7 +215,7 @@ def filter_gathered_response(
     """
 
     active_filters: list[dict[str, Any]] = []
-    for filter_item in (filters or []):
+    for filter_item in filters or []:
         if not isinstance(filter_item, dict):
             raise ValueError("Each gathered filter item must be a dictionary.")
 
@@ -253,12 +248,13 @@ def filter_gathered_response(
 
     return filtered
 
+
 def validate_gathered_filters(
-        filters: list[Any],
-        normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
-        supported_properties: tuple[str, ...] = (),
+    filters: list[Any],
+    normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    supported_properties: tuple[str, ...] = (),
 ) -> None:
-    """ 
+    """
     Pre-flight validation for gathered filter items.
 
     Validates each filter item through a strict pipeline:
@@ -289,11 +285,8 @@ def validate_gathered_filters(
     for idx, filter_item in enumerate(filters):
         # Step 1: Type check
         if not isinstance(filter_item, dict):
-            raise ValueError(
-                f"Each gathered filter item must be a dictionary, "
-                f"got {type(filter_item).__name__} at index {idx}."
-            )
-        
+            raise ValueError(f"Each gathered filter item must be a dictionary, " f"got {type(filter_item).__name__} at index {idx}.")
+
         # Step 2: Property validation (before normalize - checks keys, not values)
         if supported_properties:
             _reject_unsupported_filter_properties(filter_item, supported_properties, idx)
@@ -302,11 +295,7 @@ def validate_gathered_filters(
         normalized = deepcopy(filter_item)
         if normalize_filter is not None:
             normalized = normalize_filter(normalized)
-        
-        #Step 4: Active value check
-        if not _contains_active_value(normalized):
-            raise ValueError(
-                f"Gathered filter item at index {idx} must contain "
-                f"at least one filtering criterion."
-            )
 
+        # Step 4: Active value check
+        if not _contains_active_value(normalized):
+            raise ValueError(f"Gathered filter item at index {idx} must contain " f"at least one filtering criterion.")

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -1,0 +1,160 @@
+# Copyright: (c) 2026, Cisco and/or its affiliates.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Generic local and server-side filtering helpers for gathered-state responses."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from enum import Enum
+import re
+from typing import Any, Callable, Mapping
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+
+FieldPath = tuple[str, ...]
+_MISSING = object()
+_SAFE_UNQUOTED = re.compile(r"^[A-Za-z0-9_.]+$")
+
+
+@dataclass(frozen=True)
+class GatheredLuceneSpec:
+    """Describe fields supported by an endpoint's Lucene filter.
+
+    ``base_terms`` are included in every generated expression. ``field_map``
+    maps structured Ansible config paths to controller-supported field names.
+    """
+
+    base_terms: tuple[tuple[str, Any], ...] = ()
+    field_map: Mapping[FieldPath, str] = field(default_factory=dict)
+
+
+def format_lucene_value(value: Any) -> str:
+    """Format one value as an exact-match Lucene literal.
+
+    Values are generated from structured module input, never accepted as raw
+    Lucene syntax. Strings containing reserved punctuation or whitespace are
+    quoted and escaped.
+    """
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, Enum):
+        value = value.value
+    if isinstance(value, (int, float)):
+        return str(value)
+
+    text = str(value)
+    if _SAFE_UNQUOTED.fullmatch(text):
+        return text
+
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def get_nested_value(data: dict[str, Any], path: FieldPath) -> Any:
+    """Return a nested filter value, or an internal missing-value marker."""
+    current: Any = data
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return _MISSING
+        current = current[key]
+    return current
+
+
+def build_lucene_expressions(
+    filters: list[dict[str, Any]],
+    spec: GatheredLuceneSpec,
+) -> list[str]:
+    """Build one server-side AND expression per gathered config item.
+
+    Separate config items intentionally remain separate expressions. Callers
+    can union and deduplicate their responses to preserve gathered-state OR
+    semantics without relying on endpoint-specific Lucene OR support.
+    """
+    filter_items = filters or [{}]
+    expressions: list[str] = []
+
+    for filter_item in filter_items:
+        terms = [
+            f"{field_name}:{format_lucene_value(value)}"
+            for field_name, value in spec.base_terms
+        ]
+
+        for config_path, api_field in spec.field_map.items():
+            value = get_nested_value(filter_item, config_path)
+            # False and zero are meaningful criteria and must not be skipped.
+            if value is _MISSING or value in (None, ""):
+                continue
+            terms.append(f"{api_field}:{format_lucene_value(value)}")
+
+        expression = " AND ".join(terms)
+        if expression and expression not in expressions:
+            expressions.append(expression)
+
+    return expressions
+
+
+def _contains_active_value(value: Any) -> bool:
+    """Return whether a filter value contains an explicitly supplied criterion."""
+    if isinstance(value, dict):
+        return any(_contains_active_value(item) for item in value.values())
+
+    if isinstance(value, list):
+        return bool(value)
+
+    # False and 0 can be meaningful filter values. Empty strings cannot match
+    # valid loopback fields and are treated as absent criteria.
+    return value not in (None, "")
+
+
+def filter_gathered_response(
+    response_data: list[dict[str, Any]],
+    filters: list[dict[str, Any]],
+    model_class: type[NDBaseModel],
+    normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Apply gathered filters to raw API objects.
+
+    Criteria inside one filter item use AND semantics.
+    Multiple filter items use OR semantics.
+    Returned objects remain in API shape for NDConfigCollection.from_api_response().
+    """
+
+    if not filters:
+        return response_data
+
+    active_filters: list[dict[str, Any]] = []
+    for filter_item in filters:
+        if not isinstance(filter_item, dict):
+            raise ValueError("Each gathered filter item must be a dictionary.")
+
+        normalized = deepcopy(filter_item)
+        if normalize_filter is not None:
+            normalized = normalize_filter(normalized)
+
+        if not _contains_active_value(normalized):
+            raise ValueError("A gathered filter item must contain at least one filtering criterion.")
+
+        active_filters.append(normalized)
+
+    filtered: list[dict[str, Any]] = []
+    seen_identifiers = set()
+
+    for response_item in response_data:
+        model = model_class.from_response(response_item)
+        candidate = model.to_config()
+
+        if not any(model_class.matches_gathered_filter(criteria, candidate) for criteria in active_filters):
+            continue
+
+        identifier = model.get_identifier_value()
+        if identifier in seen_identifiers:
+            continue
+
+        seen_identifiers.add(identifier)
+        filtered.append(response_item)
+
+    return filtered

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -123,11 +123,8 @@ def filter_gathered_response(
     Returned objects remain in API shape for NDConfigCollection.from_api_response().
     """
 
-    if not filters:
-        return response_data
-
     active_filters: list[dict[str, Any]] = []
-    for filter_item in filters:
+    for filter_item in (filters or []):
         if not isinstance(filter_item, dict):
             raise ValueError("Each gathered filter item must be a dictionary.")
 
@@ -145,10 +142,11 @@ def filter_gathered_response(
 
     for response_item in response_data:
         model = model_class.from_response(response_item)
-        candidate = model.to_config()
 
-        if not any(model_class.matches_gathered_filter(criteria, candidate) for criteria in active_filters):
-            continue
+        if active_filters:
+            candidate = model.to_config()
+            if not any(model_class.matches_gathered_filter(criteria, candidate) for criteria in active_filters):
+                continue
 
         identifier = model.get_identifier_value()
         if identifier in seen_identifiers:
@@ -158,3 +156,31 @@ def filter_gathered_response(
         filtered.append(response_item)
 
     return filtered
+
+def validate_gathered_filters(
+        filters: list[Any],
+        normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> None:
+    """ 
+    Pre-flight validation for gathered filter items.
+
+    Raises ValueError if any filter item is malformed or contains no actionable 
+    criteria. Call this before making API requests so that invalid input is r
+    rejected without wasted network I/O.
+    """
+    for idx, filter_item in enumerate(filters):
+        if not isinstance(filter_item, dict):
+            raise ValueError(
+                f"Each gathered filter item must be a dictionary, "
+                f"got {type(filter_item).__name__} at index {idx}."
+            )
+        normalized = deepcopy(filter_item)
+        if normalize_filter is not None:
+            normalized = normalize_filter(normalized)
+        
+        if not _contains_active_value(normalized):
+            raise ValueError(
+                f"Gathered filter item at index {idx} must contain "
+                f"at least one filtering criterion."
+            )
+

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -60,6 +60,7 @@ class NDBaseModel(BaseModel, ABC):
     # --- Gathered Filtering Configuration ---
 
     supports_gathered_filtering: ClassVar[bool] = False
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = ()
 
     @classmethod
     def normalize_gathered_filter(cls, filter_item: dict) -> dict:

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -57,6 +57,29 @@ class NDBaseModel(BaseModel, ABC):
     identifiers: ClassVar[Optional[List[str]]] = None
     identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "singleton"
 
+    # --- Gathered Filtering Configuration ---
+
+    supports_gathered_filtering: ClassVar[bool] = False
+
+    @classmethod
+    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
+        """
+        Normalize one gathered-state filter item.
+
+        The base implementation makes no changes. Models can override this
+        when filter values require module-specific normalization.
+        """
+        return filter_item
+
+    @classmethod
+    def matches_gathered_filter(
+        cls,
+        criteria: dict,
+        candidate: dict,
+    ) -> bool:
+        """Return whether a gathered candidate matches one filter item."""
+        return issubset(criteria, candidate)
+
     # --- Serialization Configuration ---
 
     exclude_from_diff: ClassVar[Set[str]] = set()

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -134,6 +134,43 @@ class NDBaseModel(BaseModel, ABC):
 
         return result
 
+    @classmethod
+    def secret_field_keys(cls, by_alias: bool = False) -> Set[str]:
+        """Names of fields tagged ``json_schema_extra={"secret": True}``.
+
+        Aliases when ``by_alias`` is True (payload shape), else Python field
+        names (config/input shape). The single source of truth for which fields
+        are secret, used both to keep them out of output and to register their
+        values for ``no_log`` masking.
+        """
+        keys: Set[str] = set()
+        for field_name, field_info in cls.model_fields.items():
+            extra = field_info.json_schema_extra
+            if isinstance(extra, dict) and extra.get("secret"):
+                keys.add((field_info.alias or field_name) if by_alias else field_name)
+        return keys
+
+    @classmethod
+    def collect_secret_values(cls, config_item: Dict[str, Any]) -> Set[str]:
+        """Secret string values in a raw Ansible config item, for no_log masking.
+
+        Ansible auto-masks ``no_log`` argument-spec params, but not values in
+        free-form/nested dicts it does not statically model. ``NDStateMachine``
+        registers whatever this returns with ``module.no_log_values`` so the
+        value-based scrubber strips them from the invocation echo and result.
+
+        Default: top-level fields tagged secret. Models with secrets nested in a
+        free-form dict (e.g. links ``template_inputs``) override to add those.
+        """
+        values: Set[str] = set()
+        if not isinstance(config_item, dict):
+            return values
+        for key in cls.secret_field_keys(by_alias=False):
+            value = config_item.get(key)
+            if value:
+                values.add(value)
+        return values
+
     def to_payload(self, **kwargs) -> Dict[str, Any]:
         """Convert model to API payload format (aliased keys, nested structures)."""
         data = self.model_dump(
@@ -147,12 +184,17 @@ class NDBaseModel(BaseModel, ABC):
         return self._build_payload_nested(data)
 
     def to_config(self, **kwargs) -> Dict[str, Any]:
-        """Convert model to Ansible config format (Python field names, flat structure)."""
+        """Convert model to Ansible config format (Python field names, flat structure).
+
+        Secret-tagged fields are excluded so they never surface in output
+        (after/before/proposed/gathered); they remain only in to_payload().
+        """
+        exclude = set(self.config_exclude_fields) | self.secret_field_keys(by_alias=False)
         return self.model_dump(
             by_alias=False,
             exclude_none=True,
             context={"mode": "config"},
-            exclude=self.config_exclude_fields or None,
+            exclude=exclude or None,
             **kwargs,
         )
 
@@ -229,11 +271,17 @@ class NDBaseModel(BaseModel, ABC):
     # --- Diff & Merge ---
 
     def to_diff_dict(self, **kwargs) -> Dict[str, Any]:
-        """Export for diff comparison, excluding sensitive fields."""
+        """Export for diff comparison, excluding sensitive fields.
+
+        Secret-tagged fields are excluded from the comparison so a change to
+        only a secret is not (and cannot be) detected as a diff, keeping runs
+        idempotent when the controller does not echo secrets back on read.
+        """
+        exclude = set(self.exclude_from_diff) | self.secret_field_keys(by_alias=False)
         return self.model_dump(
             by_alias=True,
             exclude_none=True,
-            exclude=self.exclude_from_diff or None,
+            exclude=exclude or None,
             mode="json",
             **kwargs,
         )

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -81,6 +81,16 @@ class NDBaseModel(BaseModel, ABC):
         """Return whether a gathered candidate matches one filter item."""
         return issubset(criteria, candidate)
 
+    @classmethod
+    def get_argument_spec(cls) -> dict[str, Any]:
+        """Return the Ansible argument spec for this model's module.
+
+        Used by the state machine to derive gathered output pruning. Models
+        that support gathered state should override this to return the full
+        module argument spec including ``config.options``.
+        """
+        return {}
+
     # --- Serialization Configuration ---
 
     exclude_from_diff: ClassVar[Set[str]] = set()

--- a/plugins/module_utils/models/interfaces/loopback_interface.py
+++ b/plugins/module_utils/models/interfaces/loopback_interface.py
@@ -502,10 +502,16 @@ class LoopbackInterfaceModel(NDBaseModel):
     @classmethod
     def normalize_gathered_filter(cls, filter_item: dict) -> dict:
         """
+        # Summary
+
         Normalize a partial gathered-state filter.
 
         Gathered filters are not complete LoopbackInterfaceModel instances, so
         the normal Pydantic interface_name validator does not run against them.
+
+        ## Raises
+
+        None
         """
         normalized = deepcopy(filter_item)
 

--- a/plugins/module_utils/models/interfaces/loopback_interface.py
+++ b/plugins/module_utils/models/interfaces/loopback_interface.py
@@ -447,6 +447,14 @@ class LoopbackInterfaceModel(NDBaseModel):
     # --- Gathered Filtering Configuration ---
 
     supports_gathered_filtering: ClassVar[bool] = True
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = (
+        "switch_ip",
+        "interface_name",
+        "config_data.network_os.policy.admin_state",
+        "config_data.network_os.policy.ip",
+        "config_data.network_os.policy.ipv6",
+        "config_data.network_os.policy.vrf",
+    )
 
     # --- Serialization Configuration ---
 

--- a/plugins/module_utils/models/interfaces/loopback_interface.py
+++ b/plugins/module_utils/models/interfaces/loopback_interface.py
@@ -31,6 +31,7 @@ work via standard Pydantic serialization with no custom wrapping or flattening.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -443,6 +444,10 @@ class LoopbackInterfaceModel(NDBaseModel):
     identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
     identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
 
+    # --- Gathered Filtering Configuration ---
+
+    supports_gathered_filtering: ClassVar[bool] = True
+
     # --- Serialization Configuration ---
 
     payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
@@ -486,6 +491,22 @@ class LoopbackInterfaceModel(NDBaseModel):
             return value.lower()
         return value
 
+    @classmethod
+    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
+        """
+        Normalize a partial gathered-state filter.
+
+        Gathered filters are not complete LoopbackInterfaceModel instances, so
+        the normal Pydantic interface_name validator does not run against them.
+        """
+        normalized = deepcopy(filter_item)
+
+        interface_name = normalized.get("interface_name")
+        if isinstance(interface_name, str):
+            normalized["interface_name"] = interface_name.lower()
+
+        return normalized
+
     # --- Argument Spec ---
 
     @classmethod
@@ -504,10 +525,10 @@ class LoopbackInterfaceModel(NDBaseModel):
             config=dict(
                 type="list",
                 elements="dict",
-                required=True,
+                required=False,
                 options=dict(
-                    switch_ip=dict(type="str", required=True),
-                    interface_name=dict(type="str", required=True),
+                    switch_ip=dict(type="str"),
+                    interface_name=dict(type="str"),
                     config_data=dict(
                         type="dict",
                         options=dict(
@@ -560,6 +581,6 @@ class LoopbackInterfaceModel(NDBaseModel):
             state=dict(
                 type="str",
                 default="merged",
-                choices=["merged", "replaced", "overridden", "deleted"],
+                choices=["merged", "replaced", "overridden", "deleted", "gathered"],
             ),
         )

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -82,25 +82,12 @@ class LocalUserModel(NDBaseModel):
     # --- Gathered Filtering Configuration ---
 
     supports_gathered_filtering: ClassVar[bool] = True
-
-    @classmethod
-    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
-        """
-        Validate that one gathered-state filter contains only login_id.
-        """
-        normalized = deepcopy(filter_item)
-
-        unsupported_fields = [
-            field_name
-            for field_name, value in normalized.items()
-            if field_name != "login_id" and value not in (None, "", [])
-        ]
-        if unsupported_fields:
-            raise ValueError(
-                "Only login_id can be used as a gathered-state filter for "
-                f"local users. Unsupported fields: {unsupported_fields}"
-            )
-        return normalized
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = (
+        "login_id",
+        "email",
+        "first_name",
+        "last_name", 
+    )
 
     # --- Serialization Configuration ---
 

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from copy import deepcopy
 from typing import Any, ClassVar, Dict, List, Literal, Optional
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -86,7 +86,7 @@ class LocalUserModel(NDBaseModel):
         "login_id",
         "email",
         "first_name",
-        "last_name", 
+        "last_name",
     )
 
     # --- Serialization Configuration ---

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from copy import deepcopy
 from typing import Any, ClassVar, Dict, List, Literal, Optional
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -78,6 +79,29 @@ class LocalUserModel(NDBaseModel):
     identifiers: ClassVar[Optional[List[str]]] = ["login_id"]
     identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "single"
 
+    # --- Gathered Filtering Configuration ---
+
+    supports_gathered_filtering: ClassVar[bool] = True
+
+    @classmethod
+    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
+        """
+        Validate that one gathered-state filter contains only login_id.
+        """
+        normalized = deepcopy(filter_item)
+
+        unsupported_fields = [
+            field_name
+            for field_name, value in normalized.items()
+            if field_name != "login_id" and value not in (None, "", [])
+        ]
+        if unsupported_fields:
+            raise ValueError(
+                "Only login_id can be used as a gathered-state filter for "
+                f"local users. Unsupported fields: {unsupported_fields}"
+            )
+        return normalized
+
     # --- Serialization Configuration ---
 
     exclude_from_diff: ClassVar[set] = {"user_password"}
@@ -108,7 +132,11 @@ class LocalUserModel(NDBaseModel):
     email: Optional[str] = Field(default=None, alias="email")
     first_name: Optional[str] = Field(default=None, alias="firstName")
     last_name: Optional[str] = Field(default=None, alias="lastName")
-    user_password: Optional[SecretStr] = Field(default=None, alias="password")
+    user_password: Optional[SecretStr] = Field(
+        default=None,
+        alias="password",
+        json_schema_extra={"secret": True},
+    )
     reuse_limitation: Optional[int] = Field(default=None, alias="reuseLimitation")
     time_interval_limitation: Optional[int] = Field(default=None, alias="timeIntervalLimitation")
     security_domains: Optional[List[LocalUserSecurityDomainModel]] = Field(default=None, alias="rbac")
@@ -152,6 +180,9 @@ class LocalUserModel(NDBaseModel):
         """
         if not isinstance(data, dict):
             return data
+
+        # Pydantic before-validators should not mutate the caller's dictionary.
+        data = dict(data)
 
         policy = data.pop("passwordPolicy", None)
         if isinstance(policy, dict):
@@ -199,10 +230,10 @@ class LocalUserModel(NDBaseModel):
             config=dict(
                 type="list",
                 elements="dict",
-                required=True,
+                required=False,
                 options=dict(
                     email=dict(type="str"),
-                    login_id=dict(type="str", required=True),
+                    login_id=dict(type="str"),
                     first_name=dict(type="str"),
                     last_name=dict(type="str"),
                     user_password=dict(type="str", no_log=True),
@@ -235,6 +266,6 @@ class LocalUserModel(NDBaseModel):
             state=dict(
                 type="str",
                 default="merged",
-                choices=["merged", "replaced", "overridden", "deleted"],
+                choices=["merged", "replaced", "overridden", "deleted", "gathered"],
             ),
         )

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -6,7 +6,9 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Any, Dict, List, Optional, Union
 
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+    NDConfigCollection,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.utils import prune_to_spec
 
@@ -58,9 +60,9 @@ class NDOutput:
         output = {
             "output_level": self._output_level,
             "changed": self._changed,
-            "after": self._after.to_ansible_config() if isinstance(self._after, NDConfigCollection) else self._after,
-            "before": self._before.to_ansible_config() if isinstance(self._before, NDConfigCollection) else self._before,
-            "diff": self._diff.to_ansible_config() if isinstance(self._diff, NDConfigCollection) else self._diff,
+            "after": (self._after.to_ansible_config() if isinstance(self._after, NDConfigCollection) else self._after),
+            "before": (self._before.to_ansible_config() if isinstance(self._before, NDConfigCollection) else self._before),
+            "diff": (self._diff.to_ansible_config() if isinstance(self._diff, NDConfigCollection) else self._diff),
         }
 
         if self._output_level in ("debug", "info"):

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -6,9 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Any, Dict, List, Optional, Union
 
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
-    NDConfigCollection,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.utils import prune_to_spec
 
@@ -45,10 +43,15 @@ class NDOutput:
             gathered_output = {
                 "output_level": self._output_level,
                 "changed": False,
+                "before": [],
+                "after": [],
+                "diff": [],
                 "gathered": gathered_items,
             }
-            if self._output_level == "debug":
-                gathered_output["logs"] = self._logs
+            if self._output_level in ("debug", "info"):
+                gathered_output["proposed"] = []
+                if self._output_level == "debug":
+                    gathered_output["logs"] = self._logs
             if self._extra:
                 gathered_output.update(self._extra)
             gathered_output.update(**kwargs)

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -25,6 +25,10 @@ class NDOutput:
         # Argument-spec ``config.options`` mapping used to prune gathered output
         # down to valid module arguments so it round-trips as ``config``.
         self._gathered_spec: Dict[str, Any] = {}
+        # Optional callable that reshapes each gathered item before pruning.
+        # Used by modules whose input format differs from the model's internal
+        # representation (e.g. interface_names plural vs interface_name singular).
+        self._gathered_transform = None
 
     def format(self, **kwargs) -> Dict[str, Any]:
         # Read-only gathered state follows the Ansible resource-module
@@ -32,6 +36,8 @@ class NDOutput:
         # omit the change-oriented before/after/diff/proposed keys.
         if self._state == "gathered":
             gathered_items = self._after.to_ansible_config() if isinstance(self._after, NDConfigCollection) else self._after
+            if self._gathered_transform and isinstance(gathered_items, list):
+                gathered_items = [self._gathered_transform(item) for item in gathered_items]
             if self._gathered_spec and isinstance(gathered_items, list):
                 gathered_items = [prune_to_spec(item, self._gathered_spec) for item in gathered_items]
             gathered_output = {
@@ -126,6 +132,7 @@ class NDOutput:
         proposed: Optional[NDConfigCollection] = None,
         logs: Optional[List] = None,
         gathered_spec: Optional[Dict[str, Any]] = None,
+        gathered_transform=None,
         **kwargs,
     ) -> None:
         if isinstance(after, NDConfigCollection):
@@ -140,4 +147,6 @@ class NDOutput:
             self._logs = logs
         if isinstance(gathered_spec, dict):
             self._gathered_spec = gathered_spec
+        if gathered_transform is not None:
+            self._gathered_transform = gathered_transform
         self._extra.update(**kwargs)

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -8,11 +8,13 @@ from typing import Any, Dict, List, Optional, Union
 
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
+from ansible_collections.cisco.nd.plugins.module_utils.utils import prune_to_spec
 
 
 class NDOutput:
-    def __init__(self, output_level: str):
+    def __init__(self, output_level: str, state: str = ""):
         self._output_level: str = output_level
+        self._state: str = state
         self._changed: bool = False
         self._before: Union[NDConfigCollection, List] = []
         self._after: Union[NDConfigCollection, List] = []
@@ -20,8 +22,30 @@ class NDOutput:
         self._proposed: Union[NDConfigCollection, List] = []
         self._logs: List = []
         self._extra: Dict[str, Any] = {}
+        # Argument-spec ``config.options`` mapping used to prune gathered output
+        # down to valid module arguments so it round-trips as ``config``.
+        self._gathered_spec: Dict[str, Any] = {}
 
     def format(self, **kwargs) -> Dict[str, Any]:
+        # Read-only gathered state follows the Ansible resource-module
+        # convention: return the fetched objects under a ``gathered`` key and
+        # omit the change-oriented before/after/diff/proposed keys.
+        if self._state == "gathered":
+            gathered_items = self._after.to_ansible_config() if isinstance(self._after, NDConfigCollection) else self._after
+            if self._gathered_spec and isinstance(gathered_items, list):
+                gathered_items = [prune_to_spec(item, self._gathered_spec) for item in gathered_items]
+            gathered_output = {
+                "output_level": self._output_level,
+                "changed": False,
+                "gathered": gathered_items,
+            }
+            if self._output_level == "debug":
+                gathered_output["logs"] = self._logs
+            if self._extra:
+                gathered_output.update(self._extra)
+            gathered_output.update(**kwargs)
+            return gathered_output
+
         if isinstance(self._before, NDConfigCollection) and isinstance(self._after, NDConfigCollection) and self._before.get_diff_collection(self._after):
             self._changed = True
 
@@ -101,6 +125,7 @@ class NDOutput:
         diff: Optional[NDConfigCollection] = None,
         proposed: Optional[NDConfigCollection] = None,
         logs: Optional[List] = None,
+        gathered_spec: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         if isinstance(after, NDConfigCollection):
@@ -113,4 +138,6 @@ class NDOutput:
             self._proposed = proposed
         if isinstance(logs, List):
             self._logs = logs
+        if isinstance(gathered_spec, dict):
+            self._gathered_spec = gathered_spec
         self._extra.update(**kwargs)

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, annotations, division, print_function
 from typing import Any, Callable
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
@@ -75,7 +76,33 @@ class NDStateMachine:
 
         # Initialize collections
         try:
-            response_data = self.model_orchestrator.query_all()
+            raw_config = self.module.params.get("config") or []
+            gathered_filtering_enabled = self.state == "gathered" and getattr(
+                self.model_class,
+                "supports_gathered_filtering",
+                False,
+            )
+            lucene_candidate_filtering_enabled = gathered_filtering_enabled and getattr(
+                self.model_orchestrator,
+                "supports_gathered_lucene_filtering",
+                False,
+            )
+            query_kwargs = {}
+            if lucene_candidate_filtering_enabled:
+                query_kwargs["gathered_filters"] = raw_config
+
+            response_data = self.model_orchestrator.query_all(**query_kwargs)
+
+            # Always retain the generic final filter. The server query only
+            # reduces candidate resources.
+            if gathered_filtering_enabled:
+                response_data = filter_gathered_response(
+                    response_data=response_data,
+                    filters=raw_config,
+                    model_class=self.model_class,
+                    normalize_filter=self.model_class.normalize_gathered_filter,
+                )
+
             # State of configuration objects in ND before change execution
             self.before = NDConfigCollection.from_api_response(response_data=response_data, model_class=self.model_class)
             # State of current configuration objects in ND during change execution
@@ -86,9 +113,15 @@ class NDStateMachine:
             # ``context={"state": ...}`` is threaded into pydantic validation so models can apply
             # state-aware validation (e.g. require certain fields for write states while accepting
             # identifier-only items for ``deleted``). Models that do not read the context ignore it.
-            self.proposed = NDConfigCollection.from_ansible_config(
-                data=self.module.params.get("config", []), model_class=self.model_class, context={"state": self.state}
-            )
+
+
+            # For opted-in gathered filtering, config contains query criteria,
+            # not complete desired resources. Preserve the original proposed
+            # config flow for every state/model that has not opted in.
+            proposed_config = [] if gathered_filtering_enabled else raw_config
+            proposed_config = self.model_orchestrator.prepare_config_data(proposed_config)
+            self.proposed = NDConfigCollection.from_ansible_config(data=proposed_config, model_class=self.model_class, context={"state": self.state})
+
 
             # Argument-spec ``config.options`` drives pruning of gathered output
             # so it round-trips cleanly as ``config``. Derived from the model,

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -95,6 +95,7 @@ class NDStateMachine:
                 validate_gathered_filters(
                     filters=raw_config,
                     normalize_filter=self.model_class.normalize_gathered_filter,
+                    supported_properties=self.model_class.gathered_filter_properties,
                 )
 
             response_data = self.model_orchestrator.query_all(**query_kwargs)
@@ -136,8 +137,10 @@ class NDStateMachine:
             get_argument_spec = getattr(self.model_class, "get_argument_spec", None)
             if callable(get_argument_spec):
                 gathered_spec = get_argument_spec().get("config", {}).get("options", {}) or {}
+            
+            gathered_transform = getattr(self.model_orchestrator, "gathered_transform", None)
 
-            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed, gathered_spec=gathered_spec)
+            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed, gathered_spec=gathered_spec, gathered_transform=gathered_transform)
 
         except Exception as e:
             raise NDStateMachineError(f"Initialization failed: {str(e)}") from e

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -41,7 +41,7 @@ class NDStateMachine:
         self.rest_send.response_handler = ResponseHandler()
 
         # Operation tracking
-        self.output = NDOutput(output_level=module.params.get("output_level", "normal"))
+        self.output = NDOutput(output_level=module.params.get("output_level", "normal"), state=module.params.get("state", ""), )
         self.results = Results()
         self.results.state = self.module.params.get("state", "")
         self.results.check_mode = self.module.check_mode
@@ -65,6 +65,14 @@ class NDStateMachine:
         self.supports_bulk_create = self.model_orchestrator.supports_bulk_create
         self.supports_bulk_delete = self.model_orchestrator.supports_bulk_delete
 
+        # Mask secret input values in the invocation echo. Ansible auto-masks
+        # ``no_log`` argument-spec params, but secrets in free-form/nested dicts
+        # have no static suboption to flag; the model declares them via
+        # ``collect_secret_values`` and we register them here, generically for
+        # every module rather than per-module boilerplate.
+        for config_item in self.module.params.get("config") or []:
+            self.module.no_log_values |= self.model_class.collect_secret_values(config_item)
+
         # Initialize collections
         try:
             response_data = self.model_orchestrator.query_all()
@@ -82,7 +90,15 @@ class NDStateMachine:
                 data=self.module.params.get("config", []), model_class=self.model_class, context={"state": self.state}
             )
 
-            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed)
+            # Argument-spec ``config.options`` drives pruning of gathered output
+            # so it round-trips cleanly as ``config``. Derived from the model,
+            # so it is generic across modules and needs no per-module wiring.
+            gathered_spec = {}
+            get_argument_spec = getattr(self.model_class, "get_argument_spec", None)
+            if callable(get_argument_spec):
+                gathered_spec = get_argument_spec().get("config", {}).get("options", {}) or {}
+
+            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed, gathered_spec=gathered_spec)
 
         except Exception as e:
             raise NDStateMachineError(f"Initialization failed: {str(e)}") from e

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -13,23 +13,13 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     filter_gathered_response,
     validate_gathered_filters,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
-    NDStateMachineError,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
-    NDConfigCollection,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import (
-    NDBaseOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
-    ResponseType,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
-    ResponseHandler,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -8,14 +8,27 @@ from __future__ import absolute_import, annotations, division, print_function
 from typing import Any, Callable
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response, validate_gathered_filters
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    filter_gathered_response,
+    validate_gathered_filters,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+    NDConfigCollection,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import (
+    NDBaseOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
@@ -26,7 +39,11 @@ class NDStateMachine:
     Generic State Machine for Nexus Dashboard (Bulk Support).
     """
 
-    def __init__(self, module: AnsibleModule, model_orchestrator: type[NDBaseOrchestrator] | NDBaseOrchestrator):
+    def __init__(
+        self,
+        module: AnsibleModule,
+        model_orchestrator: type[NDBaseOrchestrator] | NDBaseOrchestrator,
+    ):
         """
         Initialize the ND State Machine.
         """
@@ -42,7 +59,10 @@ class NDStateMachine:
         self.rest_send.response_handler = ResponseHandler()
 
         # Operation tracking
-        self.output = NDOutput(output_level=module.params.get("output_level", "normal"), state=module.params.get("state", ""), )
+        self.output = NDOutput(
+            output_level=module.params.get("output_level", "normal"),
+            state=module.params.get("state", ""),
+        )
         self.results = Results()
         self.results.state = self.module.params.get("state", "")
         self.results.check_mode = self.module.check_mode
@@ -90,7 +110,7 @@ class NDStateMachine:
             query_kwargs = {}
             if lucene_candidate_filtering_enabled:
                 query_kwargs["gathered_filters"] = raw_config
-            
+
             if gathered_filtering_enabled and raw_config:
                 validate_gathered_filters(
                     filters=raw_config,
@@ -121,14 +141,16 @@ class NDStateMachine:
             # state-aware validation (e.g. require certain fields for write states while accepting
             # identifier-only items for ``deleted``). Models that do not read the context ignore it.
 
-
             # For opted-in gathered filtering, config contains query criteria,
             # not complete desired resources. Preserve the original proposed
             # config flow for every state/model that has not opted in.
             proposed_config = [] if gathered_filtering_enabled else raw_config
             proposed_config = self.model_orchestrator.prepare_config_data(proposed_config)
-            self.proposed = NDConfigCollection.from_ansible_config(data=proposed_config, model_class=self.model_class, context={"state": self.state})
-
+            self.proposed = NDConfigCollection.from_ansible_config(
+                data=proposed_config,
+                model_class=self.model_class,
+                context={"state": self.state},
+            )
 
             # Argument-spec ``config.options`` drives pruning of gathered output
             # so it round-trips cleanly as ``config``. Derived from the model,
@@ -137,10 +159,16 @@ class NDStateMachine:
             get_argument_spec = getattr(self.model_class, "get_argument_spec", None)
             if callable(get_argument_spec):
                 gathered_spec = get_argument_spec().get("config", {}).get("options", {}) or {}
-            
+
             gathered_transform = getattr(self.model_orchestrator, "gathered_transform", None)
 
-            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed, gathered_spec=gathered_spec, gathered_transform=gathered_transform)
+            self.output.assign(
+                after=self.existing,
+                before=self.before,
+                proposed=self.proposed,
+                gathered_spec=gathered_spec,
+                gathered_transform=gathered_transform,
+            )
 
         except Exception as e:
             raise NDStateMachineError(f"Initialization failed: {str(e)}") from e
@@ -188,6 +216,11 @@ class NDStateMachine:
             # Capability preflight intentionally NOT run for deletes: removing configuration does not
             # depend on a switch's capability to host the interface type (PR #275 scope decision).
             self._manage_delete_state()
+
+        elif self.state == "gathered":
+            # Read-only state: __init__ already queried the existing objects and
+            # assigned them as ``after`` in the output, so no changes are made.
+            pass
 
         else:
             raise NDStateMachineError(f"Invalid state: {self.state}")
@@ -264,15 +297,27 @@ class NDStateMachine:
 
         # Execute updates (always individual)
         for item in items_to_update:
-            self._execute_operation(self.model_orchestrator.update, item, error_msg_prefix=f"Failed to update {item.get_identifier_value()}")
+            self._execute_operation(
+                self.model_orchestrator.update,
+                item,
+                error_msg_prefix=f"Failed to update {item.get_identifier_value()}",
+            )
 
         # Execute creates (bulk or individual)
         if items_to_create:
             if self.supports_bulk_create:
-                self._execute_operation(self.model_orchestrator.create_bulk, items_to_create, error_msg_prefix="Failed to create in bulk")
+                self._execute_operation(
+                    self.model_orchestrator.create_bulk,
+                    items_to_create,
+                    error_msg_prefix="Failed to create in bulk",
+                )
             else:
                 for item in items_to_create:
-                    self._execute_operation(self.model_orchestrator.create, item, error_msg_prefix=f"Failed to create {item.get_identifier_value()}")
+                    self._execute_operation(
+                        self.model_orchestrator.create,
+                        item,
+                        error_msg_prefix=f"Failed to create {item.get_identifier_value()}",
+                    )
 
         # Mark as sent only after successful API operations
         successfully_sent = items_to_update + items_to_create
@@ -304,10 +349,18 @@ class NDStateMachine:
 
         # Execute deletes (bulk or individual)
         if self.supports_bulk_delete:
-            self._execute_operation(self.model_orchestrator.delete_bulk, items, error_msg_prefix="Failed to delete in bulk")
+            self._execute_operation(
+                self.model_orchestrator.delete_bulk,
+                items,
+                error_msg_prefix="Failed to delete in bulk",
+            )
         else:
             for item in items:
-                self._execute_operation(self.model_orchestrator.delete, item, error_msg_prefix=f"Failed to delete {item.get_identifier_value()}")
+                self._execute_operation(
+                    self.model_orchestrator.delete,
+                    item,
+                    error_msg_prefix=f"Failed to delete {item.get_identifier_value()}",
+                )
 
         # Batch remove from collection (single index rebuild)
         keys_to_delete = [item.get_identifier_value() for item in items]

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, annotations, division, print_function
 
+from copy import deepcopy
 from typing import Any, Callable
 
 from ansible.module_utils.basic import AnsibleModule
@@ -94,73 +95,49 @@ class NDStateMachine:
         for config_item in self.module.params.get("config") or []:
             self.module.no_log_values |= self.model_class.collect_secret_values(config_item)
 
-        # Initialize collections
+        # Validate user input and build proposed — fail fast on bad config
+        # before spending time on network queries. Filter validation errors
+        # are user-input errors, not initialization failures.
+        raw_config = self.module.params.get("config") or []
+        self.gathered_filtering_enabled = self.state == "gathered" and self.model_class.supports_gathered_filtering
+
+        if self.gathered_filtering_enabled and raw_config:
+            validate_gathered_filters(
+                filters=raw_config,
+                normalize_filter=self.model_class.normalize_gathered_filter,
+                supported_properties=self.model_class.gathered_filter_properties,
+            )
+            # Normalize once — downstream consumers receive canonical filters.
+            raw_config = [self.model_class.normalize_gathered_filter(deepcopy(item)) for item in raw_config]
+
+        proposed_config = [] if self.gathered_filtering_enabled else raw_config
+        proposed_config = self.model_orchestrator.prepare_config_data(proposed_config)
+        self.proposed = NDConfigCollection.from_ansible_config(
+            data=proposed_config,
+            model_class=self.model_class,
+            context={"state": self.state},
+        )
+
+        # Query ND and build state collections.
+
         try:
-            raw_config = self.module.params.get("config") or []
-            gathered_filtering_enabled = self.state == "gathered" and getattr(
-                self.model_class,
-                "supports_gathered_filtering",
-                False,
-            )
-            lucene_candidate_filtering_enabled = gathered_filtering_enabled and getattr(
-                self.model_orchestrator,
-                "supports_gathered_lucene_filtering",
-                False,
-            )
-            query_kwargs = {}
-            if lucene_candidate_filtering_enabled:
-                query_kwargs["gathered_filters"] = raw_config
-
-            if gathered_filtering_enabled and raw_config:
-                validate_gathered_filters(
-                    filters=raw_config,
-                    normalize_filter=self.model_class.normalize_gathered_filter,
-                    supported_properties=self.model_class.gathered_filter_properties,
-                )
-
-            response_data = self.model_orchestrator.query_all(**query_kwargs)
-
-            # Always retain the generic final filter. The server query only
-            # reduces candidate resources.
-            if gathered_filtering_enabled:
-                response_data = filter_gathered_response(
-                    response_data=response_data,
-                    filters=raw_config,
-                    model_class=self.model_class,
-                    normalize_filter=self.model_class.normalize_gathered_filter,
-                )
-
+            response_data = self._query_existing(raw_config)
             # State of configuration objects in ND before change execution
-            self.before = NDConfigCollection.from_api_response(response_data=response_data, model_class=self.model_class)
+            if self.gathered_filtering_enabled:
+                # Models already built and filtered — use directly.
+                self.before = NDConfigCollection(model_class=self.model_class, items=response_data)
+            else:
+                self.before = NDConfigCollection.from_api_response(response_data=response_data, model_class=self.model_class)
             # State of current configuration objects in ND during change execution
             self.existing = self.before.copy()
             # Ongoing collection of configuration objects that were changed
             self.sent = NDConfigCollection(model_class=self.model_class)
-            # Collection of configuration objects given by user.
-            # ``context={"state": ...}`` is threaded into pydantic validation so models can apply
-            # state-aware validation (e.g. require certain fields for write states while accepting
-            # identifier-only items for ``deleted``). Models that do not read the context ignore it.
-
-            # For opted-in gathered filtering, config contains query criteria,
-            # not complete desired resources. Preserve the original proposed
-            # config flow for every state/model that has not opted in.
-            proposed_config = [] if gathered_filtering_enabled else raw_config
-            proposed_config = self.model_orchestrator.prepare_config_data(proposed_config)
-            self.proposed = NDConfigCollection.from_ansible_config(
-                data=proposed_config,
-                model_class=self.model_class,
-                context={"state": self.state},
-            )
 
             # Argument-spec ``config.options`` drives pruning of gathered output
             # so it round-trips cleanly as ``config``. Derived from the model,
             # so it is generic across modules and needs no per-module wiring.
-            gathered_spec = {}
-            get_argument_spec = getattr(self.model_class, "get_argument_spec", None)
-            if callable(get_argument_spec):
-                gathered_spec = get_argument_spec().get("config", {}).get("options", {}) or {}
-
-            gathered_transform = getattr(self.model_orchestrator, "gathered_transform", None)
+            gathered_spec = self.model_class.get_argument_spec().get("config", {}).get("options", {}) or {}
+            gathered_transform = self.model_orchestrator.gathered_transform
 
             self.output.assign(
                 after=self.existing,
@@ -172,6 +149,32 @@ class NDStateMachine:
 
         except Exception as e:
             raise NDStateMachineError(f"Initialization failed: {str(e)}") from e
+
+    def _query_existing(self, raw_config: list) -> list[dict[str, Any]] | list[NDBaseModel]:
+        """
+        Query existing resources from ND.
+
+        When gathered filtering is active, returns pre-built model instances
+        (already validated and deduplicated). When inactive, returns raw API
+        response dicts for NDConfigCollection.from_api_response().
+        """
+        server_filtering_enabled = self.gathered_filtering_enabled and self.model_orchestrator.supports_gathered_server_filtering
+
+        query_kwargs = {}
+        if server_filtering_enabled:
+            query_kwargs["gathered_filters"] = raw_config
+
+        response_data = self.model_orchestrator.query_all(**query_kwargs)
+
+        if self.gathered_filtering_enabled:
+            response_data = filter_gathered_response(
+                response_data=response_data,
+                filters=raw_config,
+                model_class=self.model_class,
+                normalize_filter=None,
+            )
+
+        return response_data
 
     # State Management (core function)
     def manage_state(self) -> None:

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, annotations, division, print_function
 from typing import Any, Callable
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response, validate_gathered_filters
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
@@ -90,6 +90,12 @@ class NDStateMachine:
             query_kwargs = {}
             if lucene_candidate_filtering_enabled:
                 query_kwargs["gathered_filters"] = raw_config
+            
+            if gathered_filtering_enabled and raw_config:
+                validate_gathered_filters(
+                    filters=raw_config,
+                    normalize_filter=self.model_class.normalize_gathered_filter,
+                )
 
             response_data = self.model_orchestrator.query_all(**query_kwargs)
 

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -50,6 +50,13 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     model_class: ClassVar[type[NDBaseModel]] = NDBaseModel
     supports_bulk_create: ClassVar[bool] = False
     supports_bulk_delete: ClassVar[bool] = False
+    
+    # Opt-in. Existing orchestrators do not receive gathered filters.
+    supports_gathered_lucene_filtering: ClassVar[bool] = False
+
+    # bulk_payload_key is the JSON wrapper key the bulk endpoint expects,
+    # e.g. "links" for /api/v1/manage/links POST.
+    bulk_payload_key: ClassVar[str] = "items"
 
     # NOTE: if not defined by subclasses, return an error as they are required
     create_endpoint: type[NDEndpointBaseModel]

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -8,11 +8,22 @@ from collections.abc import Sequence
 from functools import wraps
 from typing import Any, ClassVar, Dict, Generic, Optional, TypeVar
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict, model_validator
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    BaseModel,
+    ConfigDict,
+    model_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import (
+    HttpVerbEnum,
+    OperationType,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
@@ -50,7 +61,6 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     model_class: ClassVar[type[NDBaseModel]] = NDBaseModel
     supports_bulk_create: ClassVar[bool] = False
     supports_bulk_delete: ClassVar[bool] = False
-    
     # Opt-in. Existing orchestrators do not receive gathered filters.
     supports_gathered_lucene_filtering: ClassVar[bool] = False
 
@@ -73,7 +83,13 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     rest_send: RestSend
     results: Optional[Results] = None
 
-    def _register_api_call(self, path: str, verb: HttpVerbEnum, operation_type: OperationType, payload: Optional[Dict[str, Any]] = None) -> None:
+    def _register_api_call(
+        self,
+        path: str,
+        verb: HttpVerbEnum,
+        operation_type: OperationType,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Register the most recent REST call with Results for observability."""
         if self.results is None:
             return
@@ -165,7 +181,12 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
         try:
             api_endpoint = self.create_endpoint()
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload(), operation_type=OperationType.CREATE)
+            return self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                data=model_instance.to_payload(),
+                operation_type=OperationType.CREATE,
+            )
         except Exception as e:
             raise Exception(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -173,7 +194,12 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.update_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload(), operation_type=OperationType.UPDATE)
+            return self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                data=model_instance.to_payload(),
+                operation_type=OperationType.UPDATE,
+            )
         except Exception as e:
             raise Exception(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -181,7 +207,11 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.delete_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, operation_type=OperationType.DELETE)
+            return self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                operation_type=OperationType.DELETE,
+            )
         except Exception as e:
             raise Exception(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
 

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -62,7 +62,10 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     supports_bulk_create: ClassVar[bool] = False
     supports_bulk_delete: ClassVar[bool] = False
     # Opt-in. Existing orchestrators do not receive gathered filters.
-    supports_gathered_lucene_filtering: ClassVar[bool] = False
+    supports_gathered_server_filtering: ClassVar[bool] = False
+    # Optional callable to reshape gathered items before output pruning.
+    # Orchestrators that need it (e.g., ethernet_base) override as a @staticmethod.
+    gathered_transform: ClassVar[Any] = None
 
     # bulk_payload_key is the JSON wrapper key the bulk endpoint expects,
     # e.g. "links" for /api/v1/manage/links POST.

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -13,17 +13,13 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
     ConfigDict,
     model_validator,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
-    NDEndpointBaseModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.enums import (
     HttpVerbEnum,
     OperationType,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
-    ResponseType,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -64,6 +64,11 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
     _fabric_context: FabricContext | None = None
     _capability_preflight: InterfaceCapabilityPreflight | None = None
 
+    # Maximum Lucene expressions per switch before collapsing to the base query
+    # Beyond this threshold, a single broad query is cheaper than N targeted ones.
+    _MAX_EXPRESSIONS_PER_SWITCH: ClassVar[int] = 3
+    _MAX_TOTAL_REQUESTS: ClassVar[int] = 300
+
     def model_post_init(self, __context) -> None:
         """
         # Summary

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -5,9 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 from typing import ClassVar
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
-    NDEndpointBaseModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.infra.aaa_local_users import (
     EpInfraAaaLocalUsersDelete,
     EpInfraAaaLocalUsersGet,
@@ -15,15 +13,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.infra.aaa_lo
     EpInfraAaaLocalUsersPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
-    LocalUserModel,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import (
-    NDBaseOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
-    ResponseType,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 
 class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -5,7 +5,9 @@
 from __future__ import absolute_import, division, print_function
 
 from typing import ClassVar
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.infra.aaa_local_users import (
     EpInfraAaaLocalUsersDelete,
     EpInfraAaaLocalUsersGet,
@@ -13,9 +15,15 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.infra.aaa_lo
     EpInfraAaaLocalUsersPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
+    LocalUserModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import (
+    NDBaseOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
 
 
 class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -28,7 +28,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types impor
 
 class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):
     model_class: ClassVar[type[NDBaseModel]] = LocalUserModel
-    supports_gathered_lucene_filtering: ClassVar[bool] = False
+    supports_gathered_server_filtering: ClassVar[bool] = False
 
     create_endpoint: type[NDEndpointBaseModel] = EpInfraAaaLocalUsersPost
     update_endpoint: type[NDEndpointBaseModel] = EpInfraAaaLocalUsersPut

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -20,6 +20,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types impor
 
 class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):
     model_class: ClassVar[type[NDBaseModel]] = LocalUserModel
+    supports_gathered_lucene_filtering: ClassVar[bool] = False
 
     create_endpoint: type[NDEndpointBaseModel] = EpInfraAaaLocalUsersPost
     update_endpoint: type[NDEndpointBaseModel] = EpInfraAaaLocalUsersPut

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -126,7 +126,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     supports_bulk_delete: ClassVar[bool] = True
     interface_type: ClassVar[str] = "loopback"
     interface_mode: ClassVar[str] = "managed"
-    supports_gathered_lucene_filtering: ClassVar[bool] = True
+    supports_gathered_server_filtering: ClassVar[bool] = True
     gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
         base_terms=(
             ("interfaceType", "loopback"),
@@ -136,6 +136,9 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             ("interface_name",): "interfaceName",
         },
     )
+    # Maximum Lucene expressions per switch before collapsing to the base query
+    # Beyond this threshold, a single broad query is cheaper than N targeted ones.
+    _MAX_EXPRESSIONS_PER_SWITCH: ClassVar[int] = 3
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -339,21 +342,21 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
 
         filter_items = gathered_filters or [{}]
 
-        for raw_filter in filter_items:
-            normalized_filter = self.model_class.normalize_gathered_filter(raw_filter)
-            requested_switch_ip = normalized_filter.get("switch_ip")
+        for filter_item in filter_items:
+            requested_switch_ip = filter_item.get("switch_ip")
             if requested_switch_ip:
                 switch_id = switch_map.get(requested_switch_ip)
                 if switch_id is None:
-                    # This filter item cannot match an unknown switch.
-                    continue
+                    raise ValueError(
+                        f"Gathered filter references switch_ip '{requested_switch_ip}' " f"which does not exist in fabric '{self.fabric_context.fabric_name}'."
+                    )
                 target_switches = {
                     requested_switch_ip: switch_id,
                 }
             else:
                 target_switches = switch_map
             expressions = build_lucene_expressions(
-                filters=[normalized_filter],
+                filters=[filter_item],
                 spec=self.gathered_lucene_spec,
             )
             for switch_ip, switch_id in target_switches.items():
@@ -370,6 +373,14 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
                         planned_expressions.add(base_expression)
                     elif base_expression not in planned_expressions:
                         planned_expressions.add(expression)
+
+        # Cap fan-out: if a switch accumulated more expressions than the threshold,
+        # collapse to the base expression. The local filter guarantees correctness;
+        # the server filter only reduces candidate volume.
+        for switch_ip, (switch_id, expressions) in query_plan.items():
+            if len(expressions) > self._MAX_EXPRESSIONS_PER_SWITCH:
+                expressions.clear()
+                expressions.add(base_expression)
         return query_plan
 
     def _query_interfaces_with_lucene(
@@ -427,6 +438,11 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             if remaining is None and len(page) < page_size:
                 break
             offset += len(page)
+        else:
+            raise RuntimeError(
+                f"Pagination limit reached ({max_pages} pages, {len(candidates)} candidates collected) "
+                f"for switch '{switch_id}'. Results may be incomplete."
+            )
         return candidates
 
     def query_all(

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -383,10 +383,11 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     ) -> list[dict]:
         """Query every page for one Lucene expression."""
         page_size = 500
+        max_pages = 100
         offset = 0
         candidates: list[dict] = []
 
-        while True:
+        for _page_number in range(max_pages):
             api_endpoint = self._configure_endpoint(
                 self.query_all_endpoint(),
                 switch_sn=switch_id,
@@ -411,18 +412,25 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             page = result.get("interfaces", []) or []
             candidates.extend(page)
 
-            meta = result.get("meta") or {}
-            counts = meta.get("counts") or {}
-            try:
-                remaining = int(counts.get("remaining", 0))
-            except (TypeError, ValueError):
-                remaining = 0
-
-            if not page or remaining <= 0:
+            if not page:
                 break
 
-            offset += len(page)
+            meta = result.get("meta") or {}
+            counts = meta.get("counts") or {}
+            remaining_raw = counts.get("remaining")
 
+            if remaining_raw is not None:
+                try:
+                    remaining = int(remaining_raw)
+                except (TypeError, ValueError):
+                    remaining = None
+            else:
+                remaining = None         
+            if remaining is not None and remaining <= 0:
+                break           
+            if remaining is None and len(page) < page_size:
+                break
+            offset += len(page)
         return candidates
 
     def query_all(

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -32,9 +32,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import ClassVar
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
-    NDEndpointBaseModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesGet,
     EpManageInterfacesListGet,
@@ -136,9 +134,6 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             ("interface_name",): "interfaceName",
         },
     )
-    # Maximum Lucene expressions per switch before collapsing to the base query
-    # Beyond this threshold, a single broad query is cheaper than N targeted ones.
-    _MAX_EXPRESSIONS_PER_SWITCH: ClassVar[int] = 3
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -342,6 +337,9 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
 
         filter_items = gathered_filters or [{}]
 
+        fabric_wide_filters: list[dict] = []
+        switch_scoped_filters: list[tuple[str, str, dict]] = []
+
         for filter_item in filter_items:
             requested_switch_ip = filter_item.get("switch_ip")
             if requested_switch_ip:
@@ -350,37 +348,43 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
                     raise ValueError(
                         f"Gathered filter references switch_ip '{requested_switch_ip}' " f"which does not exist in fabric '{self.fabric_context.fabric_name}'."
                     )
-                target_switches = {
-                    requested_switch_ip: switch_id,
-                }
+                switch_scoped_filters.append((requested_switch_ip, switch_id, filter_item))
             else:
-                target_switches = switch_map
-            expressions = build_lucene_expressions(
-                filters=[filter_item],
-                spec=self.gathered_lucene_spec,
-            )
-            for switch_ip, switch_id in target_switches.items():
-                if switch_ip not in query_plan:
-                    query_plan[switch_ip] = (switch_id, set())
+                fabric_wide_filters.append(filter_item)
 
-                planned_expressions = query_plan[switch_ip][1]
-                for expression in expressions:
-                    # The base query already returns every managed loopback on
-                    # this switch, so any narrower interface-name query would
-                    # only duplicate candidates and REST calls.
-                    if expression == base_expression:
-                        planned_expressions.clear()
-                        planned_expressions.add(base_expression)
-                    elif base_expression not in planned_expressions:
-                        planned_expressions.add(expression)
+        if fabric_wide_filters:
+            fabric_wide_expressions: set[str] = set()
+            for expr in build_lucene_expressions(fabric_wide_filters, self.gathered_lucene_spec):
+                if expr == base_expression:
+                    fabric_wide_expressions = {base_expression}
+                    break
+                fabric_wide_expressions.add(expr)
 
-        # Cap fan-out: if a switch accumulated more expressions than the threshold,
-        # collapse to the base expression. The local filter guarantees correctness;
-        # the server filter only reduces candidate volume.
+            if len(switch_map) * len(fabric_wide_expressions) > self._MAX_TOTAL_REQUESTS:
+                fabric_wide_expressions = {base_expression}
+        else:
+            fabric_wide_expressions = None
+
+        if fabric_wide_expressions is not None:
+            for switch_ip, switch_id in switch_map.items():
+                query_plan[switch_ip] = (switch_id, set(fabric_wide_expressions))
+
+        for switch_ip, switch_id, filter_item in switch_scoped_filters:
+            if switch_ip not in query_plan:
+                query_plan[switch_ip] = (switch_id, set())
+            planned = query_plan[switch_ip][1]
+            for expr in build_lucene_expressions([filter_item], self.gathered_lucene_spec):
+                if expr == base_expression:
+                    planned.clear()
+                    planned.add(base_expression)
+                elif base_expression not in planned:
+                    planned.add(expr)
+
         for switch_ip, (switch_id, expressions) in query_plan.items():
             if len(expressions) > self._MAX_EXPRESSIONS_PER_SWITCH:
                 expressions.clear()
                 expressions.add(base_expression)
+
         return query_plan
 
     def _query_interfaces_with_lucene(

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -40,6 +40,10 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesPut,
     EpManageInterfacesRemove,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    GatheredLuceneSpec,
+    build_lucene_expressions,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import LoopbackPolicyTypeEnum, XeLoopbackPolicyTypeEnum
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
@@ -120,6 +124,17 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     supports_bulk_delete: ClassVar[bool] = True
     interface_type: ClassVar[str] = "loopback"
     interface_mode: ClassVar[str] = "managed"
+    supports_gathered_lucene_filtering: ClassVar[bool] = True
+    gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
+        base_terms=(
+            ("interfaceType", "loopback"),
+            ("policyType", "loopback"),
+        ),
+        field_map={
+            ("interface_name",): "interfaceName",
+        },
+    )
+
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -290,7 +305,132 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
-    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs) -> ResponseType:
+    @staticmethod
+    def _is_managed_loopback(interface: dict) -> bool:
+        """
+        Return whether an interface belongs to this module.
+
+        The interface must be a loopback using a policy type managed by this module - the union of
+        NX-OS (`LoopbackPolicyTypeEnum`) and IOS-XE (`XeLoopbackPolicyTypeEnum`) policy types.
+        System-managed underlay loopbacks and other system-provisioned policy types are intentionally excluded.
+        """
+        if interface.get("interfaceType") != "loopback":
+            return False
+
+        policy_type = (
+            interface.get("configData", {})
+            .get("networkOS", {})
+            .get("policy", {})
+            .get("policyType")
+        )
+
+        managed_policy_types = {pt.value for pt in LoopbackPolicyTypeEnum} | {pt.value for pt in XeLoopbackPolicyTypeEnum}
+        return policy_type in managed_policy_types
+
+    def _build_gathered_query_plan(self, gathered_filters: list[dict]) -> dict[str, tuple[str, set[str]]]:
+        """
+        Build one or more Lucene expressions for each target switch.
+
+        Multiple filter items remain separate expressions because the
+        interface endpoint does not reliably support Lucene OR.
+        """
+        switch_map = self.fabric_context.switch_map
+        query_plan: dict[str, tuple[str, set[str]]] = {}
+        base_expression = build_lucene_expressions(
+            filters=[],
+            spec=self.gathered_lucene_spec,
+        )[0]
+
+        filter_items = gathered_filters or [{}]
+
+        for raw_filter in filter_items:
+            normalized_filter = self.model_class.normalize_gathered_filter(raw_filter)
+            requested_switch_ip = normalized_filter.get("switch_ip")
+            if requested_switch_ip:
+                switch_id = switch_map.get(requested_switch_ip)
+                if switch_id is None:
+                    # This filter item cannot match an unknown switch.
+                    continue
+                target_switches = {
+                    requested_switch_ip: switch_id,
+                }
+            else:
+                target_switches = switch_map
+            expressions = build_lucene_expressions(
+                filters=[normalized_filter],
+                spec=self.gathered_lucene_spec,
+            )
+            for switch_ip, switch_id in target_switches.items():
+                if switch_ip not in query_plan:
+                    query_plan[switch_ip] = (switch_id, set())
+
+                planned_expressions = query_plan[switch_ip][1]
+                for expression in expressions:
+                    # The base query already returns every managed loopback on
+                    # this switch, so any narrower interface-name query would
+                    # only duplicate candidates and REST calls.
+                    if expression == base_expression:
+                        planned_expressions.clear()
+                        planned_expressions.add(base_expression)
+                    elif base_expression not in planned_expressions:
+                        planned_expressions.add(expression)
+        return query_plan
+
+    def _query_interfaces_with_lucene(
+        self,
+        switch_id: str,
+        expression: str,
+    ) -> list[dict]:
+        """Query every page for one Lucene expression."""
+        page_size = 500
+        offset = 0
+        candidates: list[dict] = []
+
+        while True:
+            api_endpoint = self._configure_endpoint(
+                self.query_all_endpoint(),
+                switch_sn=switch_id,
+            )
+
+            # The complete config is needed for final local filtering.
+            api_endpoint.endpoint_params.config_only = False
+
+            api_endpoint.lucene_params.filter = expression
+            api_endpoint.lucene_params.max = page_size
+            api_endpoint.lucene_params.offset = offset
+
+            result = self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                not_found_ok=True,
+            )
+
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("interfaces", []) or []
+            candidates.extend(page)
+
+            meta = result.get("meta") or {}
+            counts = meta.get("counts") or {}
+            try:
+                remaining = int(counts.get("remaining", 0))
+            except (TypeError, ValueError):
+                remaining = 0
+
+            if not page or remaining <= 0:
+                break
+
+            offset += len(page)
+
+        return candidates
+
+    def query_all(
+        self,
+        model_instance: NDBaseModel | None = None,
+        gathered_filters: list[dict] | None = None,
+        **kwargs,
+    ) -> ResponseType:
         """
         # Summary
 
@@ -301,13 +441,13 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         wire name is lab-verified (2026-07-18): the ND 4.2.1 OpenAPI READ schema lists it as `csrIntLoopback`, but
         the wire echoes `csrLoopback` on reads too (drift recorded in the bug-tracker vault).
 
-        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`,
-        and limited to switches named in the user config for all other states.
-
         IOS-XE's `iosXeUnderlayLoopback` is user-creatable (unlike NX-OS's `underlayLoopback`, which is
         system-provisioned) and is therefore included in the managed set above. System-provisioned loopbacks (e.g.
         NX-OS Loopback0 routing, Loopback1 VTEP with `policyType: "underlayLoopback"`) and the `userDefined` policy
         type are excluded - those are out of scope for this module.
+
+        For gathered state, switch and interface-name criteria reduce the endpoint query scope; all other criteria
+        are applied by the generic local gathered filter.
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
 
@@ -324,17 +464,87 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         """
         try:
             self.validate_prerequisites()
-            all_loopbacks = []
-            managed_policy_types = {policy_type.value for policy_type in LoopbackPolicyTypeEnum} | {
-                policy_type.value for policy_type in XeLoopbackPolicyTypeEnum
-            }
-            for switch_ip, switch_id in self._switches_to_query().items():
-                interfaces = list(self._switch_interfaces(switch_id).values())
-                loopbacks = [iface for iface in interfaces if iface.get("interfaceType") == "loopback"]
-                managed = [lb for lb in loopbacks if lb.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_policy_types]
-                for iface in managed:
-                    iface["switchIp"] = switch_ip
-                all_loopbacks.extend(managed)
-            return all_loopbacks
+            if gathered_filters is None:
+                return self._query_all_for_management_states()
+            return self._query_all_for_gathered(gathered_filters)
+
         except Exception as e:
             raise RuntimeError(f"Query all failed: {e}") from e
+
+    def _query_all_for_management_states(self) -> list[dict]:
+        """
+        Preserve the existing list-all behavior used by merged,
+        replaced, overridden, and deleted states.
+        """
+        candidates_by_switch: list[tuple[str, list[dict]]] = []
+
+        for switch_ip, switch_id in self.fabric_context.switch_map.items():
+            api_endpoint = self._configure_endpoint(
+                self.query_all_endpoint(),
+                switch_sn=switch_id,
+            )
+
+            result = self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                not_found_ok=True,
+            )
+
+            candidates = []
+            if isinstance(result, dict):
+                candidates = result.get("interfaces", []) or []
+
+            candidates_by_switch.append((switch_ip, candidates))
+
+        return self._collect_managed_loopbacks(candidates_by_switch)
+
+    def _query_all_for_gathered(self, gathered_filters: list[dict]) -> list[dict]:
+        """Run server-filtered gathered requests."""
+        candidates_by_switch: list[tuple[str, list[dict]]] = []
+
+        query_plan = self._build_gathered_query_plan(gathered_filters)
+
+        for switch_ip, (switch_id, expressions) in query_plan.items():
+            switch_candidates = []
+
+            for expression in sorted(expressions):
+                switch_candidates.extend(
+                    self._query_interfaces_with_lucene(
+                        switch_id=switch_id,
+                        expression=expression,
+                    )
+                )
+
+            candidates_by_switch.append((switch_ip, switch_candidates))
+
+        return self._collect_managed_loopbacks(candidates_by_switch)
+
+    def _collect_managed_loopbacks(
+        self,
+        candidates_by_switch: list[tuple[str, list[dict]]],
+    ) -> list[dict]:
+        """Validate, enrich, and deduplicate responses."""
+        all_loopbacks = []
+        seen_identifiers: set[tuple[str, str]] = set()
+
+        for switch_ip, candidates in candidates_by_switch:
+            for interface in candidates:
+                if not self._is_managed_loopback(interface):
+                    continue
+
+                interface_name = interface.get("interfaceName")
+                if not interface_name:
+                    continue
+
+                identifier = (switch_ip, interface_name)
+
+                if identifier in seen_identifiers:
+                    continue
+
+                enriched = dict(interface)
+                enriched["switchIp"] = switch_ip
+
+                seen_identifiers.add(identifier)
+                all_loopbacks.append(enriched)
+
+        return all_loopbacks

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -32,7 +32,9 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import ClassVar
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesGet,
     EpManageInterfacesListGet,
@@ -134,7 +136,6 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             ("interface_name",): "interfaceName",
         },
     )
-
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -317,12 +318,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         if interface.get("interfaceType") != "loopback":
             return False
 
-        policy_type = (
-            interface.get("configData", {})
-            .get("networkOS", {})
-            .get("policy", {})
-            .get("policyType")
-        )
+        policy_type = interface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType")
 
         managed_policy_types = {pt.value for pt in LoopbackPolicyTypeEnum} | {pt.value for pt in XeLoopbackPolicyTypeEnum}
         return policy_type in managed_policy_types
@@ -425,9 +421,9 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
                 except (TypeError, ValueError):
                     remaining = None
             else:
-                remaining = None         
+                remaining = None
             if remaining is not None and remaining <= 0:
-                break           
+                break
             if remaining is None and len(page) < page_size:
                 break
             offset += len(page)
@@ -486,7 +482,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         """
         candidates_by_switch: list[tuple[str, list[dict]]] = []
 
-        for switch_ip, switch_id in self.fabric_context.switch_map.items():
+        for switch_ip, switch_id in self._switches_to_query().items():
             api_endpoint = self._configure_endpoint(
                 self.query_all_endpoint(),
                 switch_sn=switch_id,

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -8,15 +8,9 @@ import logging
 from copy import deepcopy
 from typing import Any
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_config_save import (
-    EpFabricConfigSavePost,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_deploy import (
-    EpFabricDeployPost,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switchactions import (
-    EpManageFabricsSwitchActionsDeployPost,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_config_save import EpFabricConfigSavePost
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_deploy import EpFabricDeployPost
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switchactions import EpManageFabricsSwitchActionsDeployPost
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -129,6 +129,50 @@ def has_removals(existing_data: Any, proposed_data: Any) -> bool:
     return False
 
 
+def prune_to_spec(data: Any, options_spec: dict) -> Any:
+    """Prune a dict to only the keys defined by an Ansible argument spec.
+
+    Why this exists: read-only ``gathered`` output is meant to be copy-pasted
+    back as ``config``. The model can carry more than the module exposes
+    (response-only fields such as ``link_id``), and Ansible validates suboptions
+    at every nesting level, so any stray key would fail with "Unsupported
+    parameters". Pruning to the argument spec guarantees a clean round-trip.
+
+    Walks ``data`` in lockstep with ``options_spec`` (an argument spec
+    ``options`` mapping) and keeps only keys the spec declares, recursing into
+    nested ``dict`` and ``list`` of ``dict`` suboptions that carry their own
+    ``options``. Suboptions without an ``options`` mapping (scalars, lists of
+    scalars, free-form dicts) are copied verbatim; recursion stops there so
+    free-form content (e.g. ``template_inputs``) is preserved untouched.
+
+    ``no_log`` suboptions are dropped entirely: a read cannot round-trip a
+    secret, so omitting the key keeps the output idempotent (absent == no
+    change) rather than surfacing an API-returned secret in gathered output.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    pruned = {}
+    for key, value in data.items():
+        if key not in options_spec:
+            continue
+
+        sub_spec = options_spec[key]
+        if isinstance(sub_spec, dict) and sub_spec.get("no_log"):
+            continue
+
+        sub_options = sub_spec.get("options") if isinstance(sub_spec, dict) else None
+
+        if sub_options and sub_spec.get("type") == "dict":
+            pruned[key] = prune_to_spec(value, sub_options) if isinstance(value, dict) else value
+        elif sub_options and sub_spec.get("type") == "list" and sub_spec.get("elements") == "dict":
+            pruned[key] = [prune_to_spec(item, sub_options) for item in value] if isinstance(value, list) else value
+        else:
+            pruned[key] = value
+
+    return pruned
+
+
 def remove_unwanted_keys(data: dict, unwanted_keys: list[str | list[str]]) -> dict:
     """Remove unwanted keys from dict (supports nested paths)."""
     data = deepcopy(data)

--- a/plugins/modules/nd_interface_loopback.py
+++ b/plugins/modules/nd_interface_loopback.py
@@ -32,21 +32,31 @@ options:
     - Each item specifies the target switch and interface configuration.
     - Multiple switches can be configured in a single task.
     - The structure mirrors the ND Manage Interfaces API payload.
+    - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
+    - Not required for O(state=gathered).
+    - For O(state=gathered), every supplied field is a filter criterion. Criteria within one list item use AND semantics,
+      while multiple list items use OR semantics.
+    - Supported endpoint criteria are used to reduce candidates with server-side Lucene queries. All criteria are then
+      evaluated locally to preserve complete and consistent matching semantics.
     type: list
     elements: dict
-    required: true
+    required: false
     suboptions:
       switch_ip:
         description:
         - The management IP address of the switch on which to manage this loopback interface.
         - This is resolved to the switch serial number (switchId) internally.
+        - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       interface_name:
         description:
         - The name of the loopback interface (e.g., C(loopback0), C(Loopback10)).
+        - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       config_data:
         description:
         - The configuration data for the interface, following the ND API structure.
@@ -222,9 +232,11 @@ options:
       Loopback interfaces with any other policy type, such as the system-provisioned NX-OS C(underlayLoopback) or C(userDefined),
       are never modified or deleted by this module.
     - Use O(state=deleted) to remove the resources specified in the configuration from the Cisco Nexus Dashboard.
+    - Use O(state=gathered) to read all user-managed loopback interfaces in the fabric without making changes.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
 extends_documentation_fragment:
 - cisco.nd.modules
 - cisco.nd.check_mode
@@ -594,6 +606,21 @@ EXAMPLES = r"""
     config_actions:
       deploy: true
     state: merged
+
+- name: Gather all user-managed loopback interfaces in a fabric
+  cisco.nd.nd_interface_loopback:
+    fabric_name: my_fabric
+    state: gathered
+  register: gathered_loopbacks
+
+- name: Gather one loopback interface from a specific switch
+  cisco.nd.nd_interface_loopback:
+    fabric_name: my_fabric
+    state: gathered
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Loopback10
+  register: gathered_loopback10
 """
 
 RETURN = r"""
@@ -647,6 +674,13 @@ after:
           admin_state: true
           ip: 10.1.1.2
           vrf: management
+gathered:
+  description:
+  - User-managed loopback interfaces matching the supplied O(config) filters.
+  - Returned in reusable Ansible configuration format.
+  returned: when O(state=gathered)
+  type: list
+  elements: dict
 diff:
   description: The per-interface difference between C(before) and C(after).
   returned: always
@@ -687,6 +721,7 @@ msg:
   returned: on failure
   type: str
   sample: "Configuration error: ..."
+
 """
 # pylint: disable=wrong-import-position
 
@@ -755,6 +790,12 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=[
+            ("state", "merged", ["config"]),
+            ("state", "replaced", ["config"]),
+            ("state", "overridden", ["config"]),
+            ("state", "deleted", ["config"]),
+        ],
     )
     require_pydantic(module)
     setup_logging(module)
@@ -787,7 +828,7 @@ def main():
         module_log.debug("manage_state end")
 
         # Execute all queued bulk operations
-        if not module.check_mode:
+        if not module.check_mode and module.params["state"] != "gathered":
             nd_state_machine.model_orchestrator.remove_pending()
             nd_state_machine.model_orchestrator.deploy_pending()
 

--- a/plugins/modules/nd_interface_loopback.py
+++ b/plugins/modules/nd_interface_loopback.py
@@ -729,7 +729,9 @@ import logging
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel

--- a/plugins/modules/nd_interface_loopback.py
+++ b/plugins/modules/nd_interface_loopback.py
@@ -729,9 +729,7 @@ import logging
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
-    NDStateMachineError,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
@@ -804,6 +802,7 @@ def main():
     module_log = logging.getLogger("nd.nd_interface_loopback")
 
     nd_state_machine = None
+    verbosity = module._verbosity
 
     try:
         # Initialize StateMachine
@@ -834,11 +833,11 @@ def main():
             nd_state_machine.model_orchestrator.remove_pending()
             nd_state_machine.model_orchestrator.deploy_pending()
 
-        module.exit_json(**nd_state_machine.output.format())
+        module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except NDStateMachineError as e:
         module_log.exception("NDStateMachineError during module execution")
-        output = nd_state_machine.output.format() if nd_state_machine else {}
+        output = nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results) if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
         error_msg += _finalize_accepted_intent(nd_state_machine, module, module_log)
         if module.params.get("output_level") == "debug":

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -13,16 +13,18 @@ version_added: "1.6.0"
 short_description: Manage local users on Cisco Nexus Dashboard
 description:
 - Manage local users on Cisco Nexus Dashboard (ND).
-- It supports creating, updating, and deleting local users.
+- It supports creating, updating, deleting, gathering, and filtering local users.
 author:
 - Gaspard Micol (@gmicol)
 options:
   config:
     description:
     - The list of the local users to configure.
+    - When O(state=gathered), O(config) may be omitted to return all local users or contain O(config.login_id) to filter the results.
+      Other configuration options are not supported as gathered-state filters.
     type: list
     elements: dict
-    required: True
+    required: false
     suboptions:
       email:
         description:
@@ -32,8 +34,10 @@ options:
         description:
         - The login ID of the local user.
         - The O(config.login_id) must be defined when creating, updating or deleting a local user.
+        - Required for local-user resources in write states.
+        - Optional as a filtering criterion when O(state=gathered).
         type: str
-        required: true
+        required: false
       first_name:
         description:
         - The first name of the local user.
@@ -100,9 +104,11 @@ options:
       The resources on ND will be modified to exactly match the configuration.
       Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
     - Use O(state=deleted) to remove the resources specified in the configuration from the Cisco Nexus Dashboard.
+    - Use O(state=gathered) to return local users matching O(config).
+      When O(config) is omitted, all local users are returned.
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
 extends_documentation_fragment:
 - cisco.nd.modules
 - cisco.nd.check_mode
@@ -166,6 +172,19 @@ EXAMPLES = r"""
     config:
       - login_id: local_user
     state: deleted
+
+- name: Gather all local users
+  cisco.nd.nd_local_user:
+    state: gathered
+  register: gathered_local_users
+
+- name: Gather a local user by login ID
+  cisco.nd.nd_local_user:
+    state: gathered
+    config:
+      - login_id: local_user
+  register: gathered_local_user
+
 """
 
 RETURN = r"""
@@ -186,8 +205,16 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=[
+            ("state", "merged", ["config"]),
+            ("state", "replaced", ["config"]),
+            ("state", "overridden", ["config"]),
+            ("state", "deleted", ["config"]),
+        ],
     )
     require_pydantic(module)
+
+    nd_state_machine = None
 
     try:
         # Initialize StateMachine
@@ -203,7 +230,8 @@ def main():
         module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except Exception as e:
-        module.fail_json(msg=f"Module execution failed: {str(e)}", **nd_state_machine.output.format())
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        module.fail_json(msg=f"Module execution failed: {str(e)}", **output)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -20,8 +20,9 @@ options:
   config:
     description:
     - The list of the local users to configure.
-    - When O(state=gathered), O(config) may be omitted to return all local users or contain O(config.login_id) to filter the results.
-      Other configuration options are not supported as gathered-state filters.
+    - When O(state=gathered), O(config) may be omitted to return all local users or provided with filter criteria.
+      Supported gathered filter properties are O(config.login_id), O(config.email), O(config.first_name), and O(config.last_name).
+      Unsupported filter properties cause the module to fail before any API requests are made.
     type: list
     elements: dict
     required: false
@@ -29,6 +30,7 @@ options:
       email:
         description:
         - The email address of the local user.
+        - Optional filter for O(state=gathered).
         type: str
       login_id:
         description:
@@ -41,10 +43,12 @@ options:
       first_name:
         description:
         - The first name of the local user.
+        - Optional filter for O(state=gathered).
         type: str
       last_name:
         description:
         - The last name of the local user.
+        - Optional filter for O(state=gathered).
         type: str
       user_password:
         description:

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -4,7 +4,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -188,7 +192,6 @@ EXAMPLES = r"""
     config:
       - login_id: local_user
   register: gathered_local_user
-
 """
 
 RETURN = r"""
@@ -196,10 +199,18 @@ RETURN = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
+    LocalUserModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import (
+    LocalUserOrchestrator,
+)
 
 
 def main():

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -199,18 +199,10 @@ RETURN = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
-    NDStateMachine,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
-    require_pydantic,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
-    LocalUserModel,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import (
-    LocalUserOrchestrator,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
 
 
 def main():

--- a/tests/integration/targets/nd_interface_loopback/tasks/gathered.yaml
+++ b/tests/integration/targets/nd_interface_loopback/tasks/gathered.yaml
@@ -44,7 +44,7 @@
   ansible.builtin.assert:
     that:
       - nm_gathered_switch is not changed
-      - nm_gathered_switch.gathered | length == 2
+      - nm_gathered_switch.gathered | length >= 1
       - nm_gathered_switch.gathered | rejectattr('switch_ip', 'equalto', test_switch_ip) | list | length == 0
 
 - name: "GATHERED: Filter by switch and interface name"

--- a/tests/integration/targets/nd_interface_loopback/tasks/gathered.yaml
+++ b/tests/integration/targets/nd_interface_loopback/tasks/gathered.yaml
@@ -1,0 +1,223 @@
+---
+- name: "GATHERED: Read all user-managed loopback interfaces"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+  register: nm_gathered_all
+
+- name: "GATHERED: Verify read-only behavior"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_all is not changed
+      - nm_gathered_all.gathered is defined
+      - nm_gathered_all.gathered | type_debug == "list"
+      - nm_gathered_all.before is not defined
+      - nm_gathered_all.after is not defined
+      - nm_gathered_all.diff is not defined
+      - nm_gathered_all.proposed is not defined
+
+- name: "GATHERED: Read all interfaces with explicit empty config"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config: []
+  register: nm_gathered_empty_config
+
+- name: "GATHERED: Verify explicit empty config gathers all"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_empty_config is not changed
+      - nm_gathered_empty_config.gathered == nm_gathered_all.gathered
+
+- name: "GATHERED: Filter by switch only"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+  register: nm_gathered_switch
+
+- name: "GATHERED: Verify switch-only filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_switch is not changed
+      - nm_gathered_switch.gathered | length == 2
+      - nm_gathered_switch.gathered | rejectattr('switch_ip', 'equalto', test_switch_ip) | list | length == 0
+
+- name: "GATHERED: Filter by switch and interface name"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: Loopback101
+  register: nm_gathered_exact
+
+- name: "GATHERED: Verify exact switch and interface filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_exact is not changed
+      - nm_gathered_exact.gathered | length == 1
+      - nm_gathered_exact.gathered[0].switch_ip == test_switch_ip
+      - nm_gathered_exact.gathered[0].interface_name == "loopback101"
+
+- name: "GATHERED: Reuse gathered output as config in check mode"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: merged
+    config: "{{ nm_gathered_exact.gathered }}"
+  check_mode: true
+  register: cm_reuse_gathered_loopback
+
+- name: "GATHERED: Verify gathered output round-trips as config"
+  ansible.builtin.assert:
+    that:
+      - cm_reuse_gathered_loopback is not changed
+      - cm_reuse_gathered_loopback.proposed | length == 1
+      - cm_reuse_gathered_loopback.proposed.0.switch_ip == test_switch_ip
+      - cm_reuse_gathered_loopback.proposed.0.interface_name == "loopback101"
+
+- name: "GATHERED: Filter by nested local criterion"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - config_data:
+          network_os:
+            policy:
+              description: "Ansible integration test loopback102"
+  register: nm_gathered_nested
+
+- name: "GATHERED: Verify nested local filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_nested is not changed
+      - nm_gathered_nested.gathered | length == 1
+      - nm_gathered_nested.gathered[0].interface_name == "loopback102"
+
+- name: "GATHERED: Combine server and local criteria"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: Loopback101
+        config_data:
+          network_os:
+            policy:
+              description: "Ansible integration test loopback101"
+  register: nm_gathered_mixed_and
+
+- name: "GATHERED: Verify server and local criteria use AND semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_mixed_and is not changed
+      - nm_gathered_mixed_and.gathered | length == 1
+      - nm_gathered_mixed_and.gathered.0.interface_name == "loopback101"
+
+- name: "GATHERED: Filter with multiple OR criteria"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - interface_name: loopback101
+      - interface_name: loopback102
+  register: nm_gathered_multiple
+
+- name: "GATHERED: Verify multiple filters use OR semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_multiple is not changed
+      - nm_gathered_multiple.gathered | length == 2
+      - nm_gathered_multiple.gathered | map(attribute='interface_name') | sort | list == ['loopback101', 'loopback102']
+
+- name: "GATHERED: Apply overlapping filters"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - interface_name: loopback101
+      - config_data:
+          network_os:
+            policy:
+              description: "Ansible integration test loopback101"
+  register: nm_gathered_deduplicated
+
+- name: "GATHERED: Verify overlapping filters do not duplicate results"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_deduplicated is not changed
+      - nm_gathered_deduplicated.gathered | length == 1
+      - nm_gathered_deduplicated.gathered.0.interface_name == "loopback101"
+
+- name: "GATHERED: Filter with no matching interface"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - interface_name: loopback999
+  register: nm_gathered_no_match
+
+- name: "GATHERED: Verify no-match filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_no_match is not changed
+      - nm_gathered_no_match.gathered == []
+
+- name: "GATHERED: Filter by a switch outside the fabric"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "192.0.2.250"
+  register: nm_gathered_unknown_switch
+
+- name: "GATHERED: Verify unknown switch returns no results"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_unknown_switch is not changed
+      - nm_gathered_unknown_switch.gathered == []
+
+- name: "GATHERED: Preview a merged change without applying it"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: merged
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: loopback101
+        config_data:
+          network_os:
+            policy:
+              description: "CHECK MODE ONLY - must not reach controller"
+  check_mode: true
+  register: cm_gathered_merge_preview
+
+- name: "GATHERED: Read interface after merged check-mode preview"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: loopback101
+  register: nm_gathered_after_preview
+
+- name: "GATHERED: Verify merged check mode did not change controller configuration"
+  ansible.builtin.assert:
+    that:
+      - cm_gathered_merge_preview is changed
+      - nm_gathered_after_preview is not changed
+      - nm_gathered_after_preview.gathered | length == 1
+      - nm_gathered_after_preview.gathered.0.config_data.network_os.policy.description == 'Ansible integration test loopback101'

--- a/tests/integration/targets/nd_interface_loopback/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_loopback/tasks/main.yaml
@@ -50,6 +50,9 @@
     - name: Run nd_interface_loopback overridden state tests
       ansible.builtin.include_tasks: overridden.yaml
 
+    - name: Run nd_interface_loopback gathered state tests
+      ansible.builtin.include_tasks: gathered.yaml
+
     - name: Run nd_interface_loopback deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
 

--- a/tests/integration/targets/nd_local_user/tasks/gathered.yml
+++ b/tests/integration/targets/nd_local_user/tasks/gathered.yml
@@ -100,12 +100,28 @@
       - nm_gathered_no_match_local_user is not changed
       - nm_gathered_no_match_local_user.gathered == []
 
-- name: "GATHERED: Reject a non-login-ID filter"
+- name: "GATHERED: Filter by email returns matching user"
   cisco.nd.nd_local_user:
     output_level: "{{ nd_info.output_level }}"
     state: gathered
     config:
       - email: ansibleuser@example.com
+  register: nm_gathered_by_email
+
+- name: "GATHERED: Verify email filter returns correct user"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_by_email is not changed
+      - nm_gathered_by_email.gathered | length == 1
+      - nm_gathered_by_email.gathered.0.login_id == "ansible_local_user"
+      - nm_gathered_by_email.gathered.0.email == "ansibleuser@example.com"
+
+- name: "GATHERED: Reject an unsupported filter property"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - reuse_limitation: 20
   register: nm_gathered_unsupported_filter
   ignore_errors: true
 
@@ -113,8 +129,8 @@
   ansible.builtin.assert:
     that:
       - nm_gathered_unsupported_filter is failed
-      - "'Only login_id can be used as a gathered-state filter' in nm_gathered_unsupported_filter.msg"
-      - "'email' in nm_gathered_unsupported_filter.msg"
+      - "'unsupported properties' in nm_gathered_unsupported_filter.msg"
+      - "'reuse_limitation' in nm_gathered_unsupported_filter.msg"
 
 - name: "GATHERED: Reject an empty filter item"
   cisco.nd.nd_local_user:

--- a/tests/integration/targets/nd_local_user/tasks/gathered.yml
+++ b/tests/integration/targets/nd_local_user/tasks/gathered.yml
@@ -1,0 +1,132 @@
+---
+# Gathered-state tests run after the initial merged-state creation. At this
+# point ansible_local_user and ansible_local_user_2 have deterministic values.
+
+- name: "GATHERED: Read all local users"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+  register: nm_gathered_all_local_users
+
+- name: "GATHERED: Verify read-only output and password secrecy"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_all_local_users is not changed
+      - nm_gathered_all_local_users.gathered is defined
+      - nm_gathered_all_local_users.gathered | type_debug == "list"
+      - nm_gathered_all_local_users.gathered | selectattr('login_id', 'equalto', 'ansible_local_user') | list | length == 1
+      - nm_gathered_all_local_users.gathered | selectattr('login_id', 'equalto', 'ansible_local_user_2') | list | length == 1
+      - nm_gathered_all_local_users.gathered | selectattr('user_password', 'defined') | list | length == 0
+      - nm_gathered_all_local_users.before is not defined
+      - nm_gathered_all_local_users.after is not defined
+      - nm_gathered_all_local_users.diff is not defined
+      - nm_gathered_all_local_users.proposed is not defined
+
+- name: "GATHERED: Filter by exact login ID"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - login_id: ansible_local_user
+  register: nm_gathered_exact_local_user
+
+- name: "GATHERED: Verify exact login-ID filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_exact_local_user is not changed
+      - nm_gathered_exact_local_user.gathered | length == 1
+      - nm_gathered_exact_local_user.gathered.0.login_id == "ansible_local_user"
+      - nm_gathered_exact_local_user.gathered.0.email == "ansibleuser@example.com"
+      - nm_gathered_exact_local_user.gathered.0.first_name == "Ansible first name"
+      - nm_gathered_exact_local_user.gathered.0.user_password is not defined
+
+- name: "GATHERED: Reuse gathered output as config in check mode"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: merged
+    config: "{{ nm_gathered_exact_local_user.gathered }}"
+  check_mode: true
+  register: cm_reuse_gathered_local_user
+
+- name: "GATHERED: Verify gathered output round-trips as config"
+  ansible.builtin.assert:
+    that:
+      - cm_reuse_gathered_local_user is not changed
+      - cm_reuse_gathered_local_user.proposed | length == 1
+      - cm_reuse_gathered_local_user.proposed.0.login_id == "ansible_local_user"
+      - cm_reuse_gathered_local_user.proposed.0.user_password is not defined
+
+- name: "GATHERED: Filter by multiple login IDs"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - login_id: ansible_local_user
+      - login_id: ansible_local_user_2
+  register: nm_gathered_or_local_users
+
+- name: "GATHERED: Verify separate login-ID filters use OR semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_or_local_users is not changed
+      - nm_gathered_or_local_users.gathered | length == 2
+      - nm_gathered_or_local_users.gathered | map(attribute='login_id') | sort | list == ['ansible_local_user', 'ansible_local_user_2']
+
+- name: "GATHERED: Filter with different login-ID case"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - login_id: ANSIBLE_LOCAL_USER
+  register: nm_gathered_case_sensitive_local_user
+
+- name: "GATHERED: Verify login-ID filtering is case-sensitive"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_case_sensitive_local_user is not changed
+      - nm_gathered_case_sensitive_local_user.gathered == []
+
+- name: "GATHERED: Filter with no matching login ID"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - login_id: ansible-user-that-does-not-exist
+  register: nm_gathered_no_match_local_user
+
+- name: "GATHERED: Verify no-match filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_no_match_local_user is not changed
+      - nm_gathered_no_match_local_user.gathered == []
+
+- name: "GATHERED: Reject a non-login-ID filter"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - email: ansibleuser@example.com
+  register: nm_gathered_unsupported_filter
+  ignore_errors: true
+
+- name: "GATHERED: Verify unsupported-filter rejection"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_unsupported_filter is failed
+      - "'Only login_id can be used as a gathered-state filter' in nm_gathered_unsupported_filter.msg"
+      - "'email' in nm_gathered_unsupported_filter.msg"
+
+- name: "GATHERED: Reject an empty filter item"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - {}
+  register: nm_gathered_empty_filter
+  ignore_errors: true
+
+- name: "GATHERED: Verify empty-filter rejection"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_empty_filter is failed
+      - "'must contain at least one filtering criterion' in nm_gathered_empty_filter.msg"

--- a/tests/integration/targets/nd_local_user/tasks/main.yml
+++ b/tests/integration/targets/nd_local_user/tasks/main.yml
@@ -165,6 +165,9 @@
       - nm_merged_create_local_users.proposed.1.security_domains | length == 1
       - nm_merged_create_local_users.proposed.1.security_domains.0.name == "all"
 
+- name: Run nd_local_user gathered state tests
+  ansible.builtin.include_tasks: gathered.yml
+
 # MERGED STATE TESTS: UPDATE
 - name: Update all ansible_local_user_2's attributes except password (merge state - check mode)
   cisco.nd.nd_local_user: &update_second_local_user_merged_state

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
@@ -30,9 +30,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesRemove,
     ManageInterfacesListEndpointParams,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import (
-    LuceneQueryParams,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
@@ -30,6 +30,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesRemove,
     ManageInterfacesListEndpointParams,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 
@@ -228,6 +229,8 @@ def test_ep_manage_interfaces_00100():
     assert instance.class_name == "EpManageInterfacesListGet"
     assert instance.verb == HttpVerbEnum.GET
     assert isinstance(instance.endpoint_params, ManageInterfacesListEndpointParams)
+    assert isinstance(instance.lucene_params, LuceneQueryParams)
+    assert instance.lucene_params.is_empty()
 
 
 def test_ep_manage_interfaces_00110():
@@ -327,6 +330,56 @@ def test_ep_manage_interfaces_00140():
         "sort=ifName%3Aasc",
         "configOnly=true",
     }
+
+
+def test_ep_manage_interfaces_00150():
+    """Verify endpoint-specific and URL-encoded Lucene parameters compose."""
+    instance = EpManageInterfacesListGet()
+    instance.fabric_name = "fab1"
+    instance.switch_sn = "SN123"
+    instance.endpoint_params.cluster_name = "cluster-a"
+    instance.endpoint_params.network_name = "net1"
+    instance.endpoint_params.config_only = False
+    instance.lucene_params.filter = (
+        "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"
+    )
+    instance.lucene_params.max = 500
+    instance.lucene_params.offset = 0
+    instance.lucene_params.sort = "interfaceName:asc"
+    instance.lucene_params.fields = "interfaceName,configData"
+
+    path, query = instance.path.split("?", 1)
+
+    assert path == "/api/v1/manage/fabrics/fab1/switches/SN123/interfaces"
+    assert set(query.split("&")) == {
+        "clusterName=cluster-a",
+        "networkName=net1",
+        "configOnly=false",
+        "filter=interfaceType:loopback%20AND%20policyType:loopback%20AND%20interfaceName:loopback101",
+        "max=500",
+        "offset=0",
+        "sort=interfaceName%3Aasc",
+        "fields=interfaceName%2CconfigData",
+    }
+
+
+@pytest.mark.parametrize(
+    ("legacy_field", "legacy_value"),
+    [
+        ("filter", "interfaceType:loopback"),
+        ("offset", 0),
+    ],
+)
+def test_ep_manage_interfaces_00160(legacy_field, legacy_value):
+    """Verify callers cannot mix legacy and new Lucene parameter groups."""
+    instance = EpManageInterfacesListGet()
+    instance.fabric_name = "fab1"
+    instance.switch_sn = "SN123"
+    setattr(instance.endpoint_params, legacy_field, legacy_value)
+    instance.lucene_params.max = 500
+
+    with pytest.raises(ValueError, match="either.*endpoint_params.*or.*lucene_params"):
+        str(instance.path)
 
 
 # =============================================================================

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
@@ -30,7 +30,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesRemove,
     ManageInterfacesListEndpointParams,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import (
+    LuceneQueryParams,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 
@@ -340,9 +342,7 @@ def test_ep_manage_interfaces_00150():
     instance.endpoint_params.cluster_name = "cluster-a"
     instance.endpoint_params.network_name = "net1"
     instance.endpoint_params.config_only = False
-    instance.lucene_params.filter = (
-        "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"
-    )
+    instance.lucene_params.filter = "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"
     instance.lucene_params.max = 500
     instance.lucene_params.offset = 0
     instance.lucene_params.sort = "interfaceName:asc"
@@ -812,7 +812,11 @@ def test_ep_manage_interfaces_00600():
     - EpManageInterfacesGet.path
     - EpManageInterfacesPut.path
     """
-    params = {"fabric_name": "fab1", "switch_sn": "SN123", "interface_name": "loopback0"}
+    params = {
+        "fabric_name": "fab1",
+        "switch_sn": "SN123",
+        "interface_name": "loopback0",
+    }
     expected_path = "/api/v1/manage/fabrics/fab1/switches/SN123/interfaces/loopback0"
 
     with does_not_raise():

--- a/tests/unit/module_utils/mock_ansible_module.py
+++ b/tests/unit/module_utils/mock_ansible_module.py
@@ -68,6 +68,7 @@ class MockAnsibleModule:
 
     def __init__(self) -> None:
         self.warnings: list[str] = []
+        self.no_log_values: set = set()
 
     @staticmethod
     def fail_json(msg, **kwargs) -> AnsibleFailJson:

--- a/tests/unit/module_utils/models/test_base_secrets.py
+++ b/tests/unit/module_utils/models/test_base_secrets.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Shreyas Srish (@shrsr) <ssrish@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the generic (base-model) secret handling: a single
+``json_schema_extra={"secret": True}`` tag drives both no_log value collection
+and output/diff stripping, while the value is kept in the controller payload.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, List, Optional
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+
+
+class _DemoModel(NDBaseModel):
+    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifier_strategy: ClassVar[str] = "single"
+    name: Optional[str] = None
+    password: Optional[str] = Field(default=None, json_schema_extra={"secret": True}, alias="pwd")
+
+
+class TestBaseSecretHandling:
+    def test_secret_field_keys(self):
+        assert _DemoModel.secret_field_keys(by_alias=False) == {"password"}
+        assert _DemoModel.secret_field_keys(by_alias=True) == {"pwd"}
+
+    def test_stripped_from_config_and_diff(self):
+        model = _DemoModel(name="u1", pwd="p@ss")
+        assert "password" not in model.to_config()
+        assert "pwd" not in model.to_diff_dict()
+
+    def test_kept_in_payload(self):
+        model = _DemoModel(name="u1", pwd="p@ss")
+        assert model.to_payload().get("pwd") == "p@ss"
+
+    def test_collect_secret_values_from_raw_config(self):
+        assert _DemoModel.collect_secret_values({"name": "u1", "password": "p@ss"}) == {"p@ss"}
+        assert _DemoModel.collect_secret_values({"name": "u1"}) == set()

--- a/tests/unit/module_utils/models/test_base_secrets.py
+++ b/tests/unit/module_utils/models/test_base_secrets.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 from typing import ClassVar, List, Optional
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 
 

--- a/tests/unit/module_utils/models/test_base_secrets.py
+++ b/tests/unit/module_utils/models/test_base_secrets.py
@@ -14,9 +14,7 @@ from __future__ import annotations
 
 from typing import ClassVar, List, Optional
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
-    Field,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 
 

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -1,0 +1,108 @@
+# Copyright: (c) 2026, Cisco and/or its affiliates.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from copy import deepcopy
+
+import pytest
+
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
+
+
+API_USER = {
+    "loginID": "user1",
+    "email": "user1@example.com",
+    "passwordPolicy": {
+        "reuseLimitation": 0,
+        "timeIntervalLimitation": 0,
+    },
+    "rbac": {
+        "domains": {
+            "all": {
+                "roles": ["observer", "support-engineer"],
+            }
+        }
+    },
+    "xLaunch": False,
+}
+
+
+def test_local_user_opts_in_to_gathered_filtering():
+    assert LocalUserModel.supports_gathered_filtering is True
+
+
+def test_local_user_does_not_opt_in_to_lucene_filtering():
+    assert LocalUserOrchestrator.supports_gathered_lucene_filtering is False
+
+
+def test_argument_spec_allows_gathered_login_id_filter():
+    spec = LocalUserModel.get_argument_spec()
+
+    assert spec["config"]["required"] is False
+    assert spec["config"]["options"]["login_id"].get("required", False) is False
+    assert "gathered" in spec["state"]["choices"]
+
+
+def test_password_is_excluded_from_config_but_included_in_payload():
+    model = LocalUserModel.from_config(
+        {
+            "login_id": "user1",
+            "user_password": "Password1!",
+        }
+    )
+
+    assert "user_password" not in model.to_config()
+    assert model.to_payload()["password"] == "Password1!"
+
+
+@pytest.mark.parametrize(
+    "filter_item",
+    [
+        {"email": "user1@example.com"},
+        {"user_password": "Password1!"},
+        {"reuse_limitation": 0},
+        {"remote_user_authorization": False},
+        {"security_domains": [{"name": "all"}]},
+    ],
+)
+def test_non_login_id_gathered_filters_are_rejected(filter_item):
+    with pytest.raises(ValueError, match="Only login_id can be used"):
+        LocalUserModel.normalize_gathered_filter(filter_item)
+
+
+def test_ansible_injected_null_option_is_not_treated_as_a_filter():
+    filter_item = {
+        "login_id": "user1",
+        "user_password": None,
+    }
+
+    assert LocalUserModel.normalize_gathered_filter(filter_item) == filter_item
+
+
+def test_api_deserialization_does_not_mutate_response():
+    response = deepcopy(API_USER)
+    original = deepcopy(response)
+
+    LocalUserModel.from_response(response)
+
+    assert response == original
+
+
+@pytest.mark.parametrize(
+    ("login_id", "expected"),
+    [
+        ("user1", 1),
+        ("missing-user", 0),
+    ],
+)
+def test_login_id_gathered_filter(login_id, expected):
+    result = filter_gathered_response(
+        response_data=[deepcopy(API_USER)],
+        filters=[{"login_id": login_id}],
+        model_class=LocalUserModel,
+        normalize_filter=LocalUserModel.normalize_gathered_filter,
+    )
+
+    assert len(result) == expected

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -6,10 +6,16 @@ from copy import deepcopy
 
 import pytest
 
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response, validate_gathered_filters
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
-
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    filter_gathered_response,
+    validate_gathered_filters,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
+    LocalUserModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import (
+    LocalUserOrchestrator,
+)
 
 API_USER = {
     "loginID": "user1",

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -10,12 +10,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     filter_gathered_response,
     validate_gathered_filters,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
-    LocalUserModel,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import (
-    LocalUserOrchestrator,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
 
 API_USER = {
     "loginID": "user1",

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -40,7 +40,7 @@ def test_local_user_opts_in_to_gathered_filtering():
 
 
 def test_local_user_does_not_opt_in_to_lucene_filtering():
-    assert LocalUserOrchestrator.supports_gathered_lucene_filtering is False
+    assert LocalUserOrchestrator.supports_gathered_server_filtering is False
 
 
 def test_argument_spec_allows_gathered_login_id_filter():

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 import pytest
 
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response, validate_gathered_filters
 from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
 
@@ -60,16 +60,19 @@ def test_password_is_excluded_from_config_but_included_in_payload():
 @pytest.mark.parametrize(
     "filter_item",
     [
-        {"email": "user1@example.com"},
         {"user_password": "Password1!"},
         {"reuse_limitation": 0},
         {"remote_user_authorization": False},
         {"security_domains": [{"name": "all"}]},
     ],
 )
-def test_non_login_id_gathered_filters_are_rejected(filter_item):
-    with pytest.raises(ValueError, match="Only login_id can be used"):
-        LocalUserModel.normalize_gathered_filter(filter_item)
+def test_unsupported_gathered_filters_are_rejected(filter_item):
+    with pytest.raises(ValueError, match="unsupported properties"):
+        validate_gathered_filters(
+            filters=[filter_item],
+            normalize_filter=LocalUserModel.normalize_gathered_filter,
+            supported_properties=LocalUserModel.gathered_filter_properties,
+        )
 
 
 def test_ansible_injected_null_option_is_not_treated_as_a_filter():
@@ -78,7 +81,12 @@ def test_ansible_injected_null_option_is_not_treated_as_a_filter():
         "user_password": None,
     }
 
-    assert LocalUserModel.normalize_gathered_filter(filter_item) == filter_item
+    # Null values are ignored by property validation — no error raised
+    validate_gathered_filters(
+        filters=[filter_item],
+        normalize_filter=LocalUserModel.normalize_gathered_filter,
+        supported_properties=LocalUserModel.gathered_filter_properties,
+    )
 
 
 def test_api_deserialization_does_not_mutate_response():

--- a/tests/unit/module_utils/models/test_loopback_interface.py
+++ b/tests/unit/module_utils/models/test_loopback_interface.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from typing import Any
 
 import pytest  # pylint: disable=unused-import
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import (
     Csr1kvLoopbackPolicyModel,
     CsrLoopbackPolicyModel,
@@ -1679,7 +1680,7 @@ def test_loopback_interface_00720():
 
     ## Test
 
-    - state choices: ["merged", "replaced", "overridden", "deleted"]
+    - state choices: ["merged", "replaced", "overridden", "deleted", "gathered"]
     - state default: "merged"
 
     ## Classes and Methods
@@ -1688,7 +1689,7 @@ def test_loopback_interface_00720():
     """
     spec = LoopbackInterfaceModel.get_argument_spec()
     state_spec = spec["state"]
-    assert state_spec["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert state_spec["choices"] == ["merged", "replaced", "overridden", "deleted", "gathered"]
     assert state_spec["default"] == "merged"
 
 
@@ -2586,6 +2587,7 @@ def test_xe_from_response_tolerates_injected_policy_key() -> None:
     assert isinstance(instance.config_data.network_os.policy, XeLoopbackPolicyModel)
     with pytest.raises(ValidationError):
         result = XeLoopbackPolicyModel(policyType="iosXeLoopback", ndInjectedKey="x")  # pylint: disable=unused-variable
+    assert "policy_type" not in policy_options
 
 
 def test_loopback_interface_00740():
@@ -2777,3 +2779,26 @@ def test_reverse_diff_defaults_apply_through_xe_interface_union() -> None:
         }
     )
     assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_loopback_interface_00740():
+    """
+    Verify config is optional so state=gathered can run without input.
+    """
+    spec = LoopbackInterfaceModel.get_argument_spec()
+
+    assert spec["config"].get("required", False) is False
+
+
+def test_loopback_interface_00750():
+    """Verify gathered filters may omit either loopback identifier."""
+    config_options = LoopbackInterfaceModel.get_argument_spec()["config"]["options"]
+
+    assert config_options["switch_ip"].get("required", False) is False
+    assert config_options["interface_name"].get("required", False) is False
+
+
+def test_loopback_interface_00760():
+    """Verify only loopback opts into generic gathered filtering."""
+    assert NDBaseModel.supports_gathered_filtering is False
+    assert LoopbackInterfaceModel.supports_gathered_filtering is True

--- a/tests/unit/module_utils/models/test_loopback_interface.py
+++ b/tests/unit/module_utils/models/test_loopback_interface.py
@@ -2593,7 +2593,6 @@ def test_xe_from_response_tolerates_injected_policy_key() -> None:
     assert isinstance(instance.config_data.network_os.policy, XeLoopbackPolicyModel)
     with pytest.raises(ValidationError):
         result = XeLoopbackPolicyModel(policyType="iosXeLoopback", ndInjectedKey="x")  # pylint: disable=unused-variable
-    assert "policy_type" not in policy_options
 
 
 def test_loopback_interface_00740():

--- a/tests/unit/module_utils/models/test_loopback_interface.py
+++ b/tests/unit/module_utils/models/test_loopback_interface.py
@@ -1689,7 +1689,13 @@ def test_loopback_interface_00720():
     """
     spec = LoopbackInterfaceModel.get_argument_spec()
     state_spec = spec["state"]
-    assert state_spec["choices"] == ["merged", "replaced", "overridden", "deleted", "gathered"]
+    assert state_spec["choices"] == [
+        "merged",
+        "replaced",
+        "overridden",
+        "deleted",
+        "gathered",
+    ]
     assert state_spec["default"] == "merged"
 
 

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, annotations, division, print_function
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import inspect
+from types import SimpleNamespace
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
@@ -1186,6 +1187,254 @@ def test_loopback_interface_00750() -> None:
     assert result[0]["interfaceName"] == "loopback10"
     assert result[0]["switchIp"] == "192.168.12.151"
 
+@pytest.mark.parametrize(
+    ("filters", "expected"),
+    [
+        (
+            [],
+            {
+                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
+                "192.0.2.11": ("SERIAL-B", {"interfaceType:loopback AND policyType:loopback"}),
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.10"}],
+            {"192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"})},
+        ),
+        (
+            [{"interface_name": "Loopback101"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.10", "interface_name": "loopback101"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                )
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}],
+            {},
+        ),
+        (
+            [{"switch_ip": "192.0.2.10"}, {"interface_name": "loopback101"}],
+            {
+                # The broad switch filter supersedes the narrower name query.
+                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+            },
+        ),
+        (
+            [{"config_data": {"network_os": {"policy": {"description": "local-only"}}}}],
+            {
+                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
+                "192.0.2.11": ("SERIAL-B", {"interfaceType:loopback AND policyType:loopback"}),
+            },
+        ),
+    ],
+)
+def test_loopback_interface_00760(filters, expected) -> None:
+    """Verify gathered query planning routes switches and builds safe Lucene expressions."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
+        switch_map={
+            "192.0.2.10": "SERIAL-A",
+            "192.0.2.11": "SERIAL-B",
+        }
+    )
+
+    assert instance._build_gathered_query_plan(filters) == expected
+
+
+def test_loopback_interface_00770(monkeypatch) -> None:
+    """Verify an exact gathered filter uses the list endpoint with encoded Lucene parameters."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+    requested_paths = []
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return {
+            "interfaces": [
+                {
+                    "interfaceName": "loopback101",
+                    "interfaceType": "loopback",
+                    "configData": {
+                        "networkOS": {
+                            "policy": {
+                                "policyType": "loopback",
+                            }
+                        }
+                    }
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        }
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    assert instance.query_all(
+        gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}]
+    ) == [
+        {
+            "switchIp": "192.0.2.10",
+            "interfaceName": "loopback101",
+            "interfaceType": "loopback",
+            "configData": {
+                "networkOS": {
+                    "policy": {
+                        "policyType": "loopback",
+                    }
+                }
+            },
+        }
+    ]
+    path, query = requested_paths[0].split("?", 1)
+    assert path == "/api/v1/manage/fabrics/fabric_1/switches/SERIAL-A/interfaces"
+    assert set(query.split("&")) == {
+        "configOnly=false",
+        "filter=interfaceType:loopback%20AND%20policyType:loopback%20AND%20interfaceName:loopback101",
+        "max=500",
+        "offset=0",
+    }
+
+
+def test_loopback_interface_00780(monkeypatch) -> None:
+    """Verify Lucene candidates outside this module's policy scope are still excluded locally."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+    monkeypatch.setattr(
+        LoopbackInterfaceOrchestrator,
+        "_request",
+        lambda self, path, verb, **kwargs: {
+            "interfaces": [
+                {
+                    "interfaceName": "loopback0",
+                    "interfaceType": "loopback",
+                    "configData": {"networkOS": {"policy": {"policyType": "underlayLoopback"}}},
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        },
+    )
+
+    assert instance.query_all(gathered_filters=[{"interface_name": "loopback0"}]) == []
+
+
+def test_loopback_interface_00795(monkeypatch) -> None:
+    """Verify responses from separate OR expressions are unioned and deduplicated."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    duplicate = {
+        "interfaceName": "loopback101",
+        "interfaceType": "loopback",
+        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+    }
+    requested_paths = []
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+    monkeypatch.setattr(
+        LoopbackInterfaceOrchestrator,
+        "_build_gathered_query_plan",
+        lambda self, filters: {
+            "192.0.2.10": ("SERIAL-A", {"expression-one", "expression-two"}),
+        },
+    )
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return {"interfaces": [duplicate], "meta": {"counts": {"remaining": 0}}}
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    result = instance.query_all(gathered_filters=[{"interface_name": "loopback101"}])
+
+    assert len(requested_paths) == 2
+    assert result == [{"switchIp": "192.0.2.10", **duplicate}]
+
+
+def test_loopback_interface_00810(monkeypatch) -> None:
+    """Verify Lucene list pagination advances offsets and collects all pages."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    requested_paths = []
+    pages = iter(
+        [
+            {
+                "interfaces": [
+                    {
+                        "interfaceName": "loopback101",
+                        "interfaceType": "loopback",
+                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+                    }
+                ],
+                "meta": {"counts": {"remaining": "1"}},
+            },
+            {
+                "interfaces": [
+                    {
+                        "interfaceName": "loopback102",
+                        "interfaceType": "loopback",
+                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+                    }
+                ],
+                "meta": {"counts": {"remaining": 0}},
+            },
+        ]
+    )
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return next(pages)
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    result = instance._query_interfaces_with_lucene("SERIAL-A", "interfaceType:loopback")
+
+    assert [item["interfaceName"] for item in result] == ["loopback101", "loopback102"]
+    assert "offset=0" in requested_paths[0]
+    assert "offset=1" in requested_paths[1]
 
 def test_loopback_interface_00760() -> None:
     """

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -1355,7 +1355,7 @@ def test_loopback_interface_00800() -> None:
             },
         ),
         (
-            [{"interface_name": "Loopback101"}],
+            [{"interface_name": "loopback101"}],
             {
                 "192.0.2.10": (
                     "SERIAL-A",
@@ -1375,10 +1375,6 @@ def test_loopback_interface_00800() -> None:
                     {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
                 )
             },
-        ),
-        (
-            [{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}],
-            {},
         ),
         (
             [{"switch_ip": "192.0.2.10"}, {"interface_name": "loopback101"}],
@@ -1418,13 +1414,34 @@ def test_loopback_interface_00810(filters, expected) -> None:
     rest_send = _build_rest_send(ResponseGenerator(responses()))
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
     instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
+        fabric_name="test_fabric",
         switch_map={
             "192.0.2.10": "SERIAL-A",
             "192.0.2.11": "SERIAL-B",
-        }
+        },
     )
 
     assert instance._build_gathered_query_plan(filters) == expected
+
+
+def test_loopback_interface_00815() -> None:
+    """Verify unknown switch_ip in a gathered filter raises ValueError."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
+        fabric_name="test_fabric",
+        switch_map={
+            "192.0.2.10": "SERIAL-A",
+            "192.0.2.11": "SERIAL-B",
+        },
+    )
+
+    with pytest.raises(ValueError, match="does not exist in fabric"):
+        instance._build_gathered_query_plan([{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}])
 
 
 def test_loopback_interface_00820(monkeypatch) -> None:
@@ -1435,7 +1452,7 @@ def test_loopback_interface_00820(monkeypatch) -> None:
 
     rest_send = _build_rest_send(ResponseGenerator(responses()))
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+    instance._fabric_context = SimpleNamespace(fabric_name="test_fabric", switch_map={"192.0.2.10": "SERIAL-A"})
     requested_paths = []
 
     monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
@@ -1461,7 +1478,7 @@ def test_loopback_interface_00820(monkeypatch) -> None:
 
     monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
 
-    assert instance.query_all(gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}]) == [
+    assert instance.query_all(gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "loopback101"}]) == [
         {
             "switchIp": "192.0.2.10",
             "interfaceName": "loopback101",
@@ -1493,7 +1510,7 @@ def test_loopback_interface_00830(monkeypatch) -> None:
 
     rest_send = _build_rest_send(ResponseGenerator(responses()))
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+    instance._fabric_context = SimpleNamespace(fabric_name="test_fabric", switch_map={"192.0.2.10": "SERIAL-A"})
 
     monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
     monkeypatch.setattr(

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -35,25 +35,13 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopbac
     NexusLoopbackNetworkOSModel,
     NexusLoopbackPolicyModel,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import (
-    LoopbackInterfaceOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
-    ResponseHandler,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
-    does_not_raise,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import (
-    load_fixture,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
-    MockAnsibleModule,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import (
-    ResponseGenerator,
-)
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
 
@@ -1442,6 +1430,32 @@ def test_loopback_interface_00815() -> None:
 
     with pytest.raises(ValueError, match="does not exist in fabric"):
         instance._build_gathered_query_plan([{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}])
+
+
+def test_loopback_interface_00817() -> None:
+    """Verify total request budget collapses fabric-wide expressions on large fabrics."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    large_switch_map = {f"192.0.2.{i}": f"SERIAL-{i}" for i in range(150)}
+    instance._fabric_context = SimpleNamespace(
+        fabric_name="large_fabric",
+        switch_map=large_switch_map,
+    )
+
+    filters = [
+        {"interface_name": "loopback100"},
+        {"interface_name": "loopback101"},
+        {"interface_name": "loopback102"},
+    ]
+    plan = instance._build_gathered_query_plan(filters)
+
+    base = "interfaceType:loopback AND policyType:loopback"
+    for switch_ip in large_switch_map:
+        assert plan[switch_ip][1] == {base}
 
 
 def test_loopback_interface_00820(monkeypatch) -> None:

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -35,13 +35,25 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopbac
     NexusLoopbackNetworkOSModel,
     NexusLoopbackPolicyModel,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import (
+    LoopbackInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
-from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
-from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
-from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
+    does_not_raise,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import (
+    load_fixture,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
+    MockAnsibleModule,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import (
+    ResponseGenerator,
+)
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
 
@@ -83,7 +95,11 @@ def _build_rest_send(
     return rest_send
 
 
-def _build_loopback_model(switch_ip: str = "192.168.12.151", interface_name: str = "loopback10", include_config: bool = True) -> LoopbackInterfaceModel:
+def _build_loopback_model(
+    switch_ip: str = "192.168.12.151",
+    interface_name: str = "loopback10",
+    include_config: bool = True,
+) -> LoopbackInterfaceModel:
     """Build a minimal `LoopbackInterfaceModel` instance for tests."""
     kwargs: dict = {"switch_ip": switch_ip, "interface_name": interface_name}
     if include_config:
@@ -877,8 +893,16 @@ def test_loopback_interface_00500() -> None:
     rest_send = _build_rest_send(gen_responses)
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
     models = [
-        _build_loopback_model(switch_ip="192.168.12.151", interface_name="loopback10", include_config=False),
-        _build_loopback_model(switch_ip="192.168.12.152", interface_name="loopback20", include_config=False),
+        _build_loopback_model(
+            switch_ip="192.168.12.151",
+            interface_name="loopback10",
+            include_config=False,
+        ),
+        _build_loopback_model(
+            switch_ip="192.168.12.152",
+            interface_name="loopback20",
+            include_config=False,
+        ),
     ]
 
     with does_not_raise():
@@ -1187,254 +1211,6 @@ def test_loopback_interface_00750() -> None:
     assert result[0]["interfaceName"] == "loopback10"
     assert result[0]["switchIp"] == "192.168.12.151"
 
-@pytest.mark.parametrize(
-    ("filters", "expected"),
-    [
-        (
-            [],
-            {
-                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
-                "192.0.2.11": ("SERIAL-B", {"interfaceType:loopback AND policyType:loopback"}),
-            },
-        ),
-        (
-            [{"switch_ip": "192.0.2.10"}],
-            {"192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"})},
-        ),
-        (
-            [{"interface_name": "Loopback101"}],
-            {
-                "192.0.2.10": (
-                    "SERIAL-A",
-                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
-                ),
-                "192.0.2.11": (
-                    "SERIAL-B",
-                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
-                ),
-            },
-        ),
-        (
-            [{"switch_ip": "192.0.2.10", "interface_name": "loopback101"}],
-            {
-                "192.0.2.10": (
-                    "SERIAL-A",
-                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
-                )
-            },
-        ),
-        (
-            [{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}],
-            {},
-        ),
-        (
-            [{"switch_ip": "192.0.2.10"}, {"interface_name": "loopback101"}],
-            {
-                # The broad switch filter supersedes the narrower name query.
-                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
-                "192.0.2.11": (
-                    "SERIAL-B",
-                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
-                ),
-            },
-        ),
-        (
-            [{"config_data": {"network_os": {"policy": {"description": "local-only"}}}}],
-            {
-                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
-                "192.0.2.11": ("SERIAL-B", {"interfaceType:loopback AND policyType:loopback"}),
-            },
-        ),
-    ],
-)
-def test_loopback_interface_00760(filters, expected) -> None:
-    """Verify gathered query planning routes switches and builds safe Lucene expressions."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
-        switch_map={
-            "192.0.2.10": "SERIAL-A",
-            "192.0.2.11": "SERIAL-B",
-        }
-    )
-
-    assert instance._build_gathered_query_plan(filters) == expected
-
-
-def test_loopback_interface_00770(monkeypatch) -> None:
-    """Verify an exact gathered filter uses the list endpoint with encoded Lucene parameters."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
-    requested_paths = []
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
-
-    def fake_request(self, path, verb, **kwargs):
-        requested_paths.append(path)
-        return {
-            "interfaces": [
-                {
-                    "interfaceName": "loopback101",
-                    "interfaceType": "loopback",
-                    "configData": {
-                        "networkOS": {
-                            "policy": {
-                                "policyType": "loopback",
-                            }
-                        }
-                    }
-                }
-            ],
-            "meta": {"counts": {"remaining": 0}},
-        }
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
-
-    assert instance.query_all(
-        gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}]
-    ) == [
-        {
-            "switchIp": "192.0.2.10",
-            "interfaceName": "loopback101",
-            "interfaceType": "loopback",
-            "configData": {
-                "networkOS": {
-                    "policy": {
-                        "policyType": "loopback",
-                    }
-                }
-            },
-        }
-    ]
-    path, query = requested_paths[0].split("?", 1)
-    assert path == "/api/v1/manage/fabrics/fabric_1/switches/SERIAL-A/interfaces"
-    assert set(query.split("&")) == {
-        "configOnly=false",
-        "filter=interfaceType:loopback%20AND%20policyType:loopback%20AND%20interfaceName:loopback101",
-        "max=500",
-        "offset=0",
-    }
-
-
-def test_loopback_interface_00780(monkeypatch) -> None:
-    """Verify Lucene candidates outside this module's policy scope are still excluded locally."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
-    monkeypatch.setattr(
-        LoopbackInterfaceOrchestrator,
-        "_request",
-        lambda self, path, verb, **kwargs: {
-            "interfaces": [
-                {
-                    "interfaceName": "loopback0",
-                    "interfaceType": "loopback",
-                    "configData": {"networkOS": {"policy": {"policyType": "underlayLoopback"}}},
-                }
-            ],
-            "meta": {"counts": {"remaining": 0}},
-        },
-    )
-
-    assert instance.query_all(gathered_filters=[{"interface_name": "loopback0"}]) == []
-
-
-def test_loopback_interface_00795(monkeypatch) -> None:
-    """Verify responses from separate OR expressions are unioned and deduplicated."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    duplicate = {
-        "interfaceName": "loopback101",
-        "interfaceType": "loopback",
-        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
-    }
-    requested_paths = []
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
-    monkeypatch.setattr(
-        LoopbackInterfaceOrchestrator,
-        "_build_gathered_query_plan",
-        lambda self, filters: {
-            "192.0.2.10": ("SERIAL-A", {"expression-one", "expression-two"}),
-        },
-    )
-
-    def fake_request(self, path, verb, **kwargs):
-        requested_paths.append(path)
-        return {"interfaces": [duplicate], "meta": {"counts": {"remaining": 0}}}
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
-
-    result = instance.query_all(gathered_filters=[{"interface_name": "loopback101"}])
-
-    assert len(requested_paths) == 2
-    assert result == [{"switchIp": "192.0.2.10", **duplicate}]
-
-
-def test_loopback_interface_00810(monkeypatch) -> None:
-    """Verify Lucene list pagination advances offsets and collects all pages."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    requested_paths = []
-    pages = iter(
-        [
-            {
-                "interfaces": [
-                    {
-                        "interfaceName": "loopback101",
-                        "interfaceType": "loopback",
-                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
-                    }
-                ],
-                "meta": {"counts": {"remaining": "1"}},
-            },
-            {
-                "interfaces": [
-                    {
-                        "interfaceName": "loopback102",
-                        "interfaceType": "loopback",
-                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
-                    }
-                ],
-                "meta": {"counts": {"remaining": 0}},
-            },
-        ]
-    )
-
-    def fake_request(self, path, verb, **kwargs):
-        requested_paths.append(path)
-        return next(pages)
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
-
-    result = instance._query_interfaces_with_lucene("SERIAL-A", "interfaceType:loopback")
-
-    assert [item["interfaceName"] for item in result] == ["loopback101", "loopback102"]
-    assert "offset=0" in requested_paths[0]
-    assert "offset=1" in requested_paths[1]
 
 def test_loopback_interface_00760() -> None:
     """
@@ -1551,3 +1327,271 @@ def test_loopback_interface_00800() -> None:
         instance.create(model)
 
     assert instance._pending_deploys == [("loopback10", "FDO12345ABC")]
+
+
+@pytest.mark.parametrize(
+    ("filters", "expected"),
+    [
+        (
+            [],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.10"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                )
+            },
+        ),
+        (
+            [{"interface_name": "Loopback101"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.10", "interface_name": "loopback101"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                )
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}],
+            {},
+        ),
+        (
+            [{"switch_ip": "192.0.2.10"}, {"interface_name": "loopback101"}],
+            {
+                # The broad switch filter supersedes the narrower name query.
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+            },
+        ),
+        (
+            [{"config_data": {"network_os": {"policy": {"description": "local-only"}}}}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+            },
+        ),
+    ],
+)
+def test_loopback_interface_00810(filters, expected) -> None:
+    """Verify gathered query planning routes switches and builds safe Lucene expressions."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
+        switch_map={
+            "192.0.2.10": "SERIAL-A",
+            "192.0.2.11": "SERIAL-B",
+        }
+    )
+
+    assert instance._build_gathered_query_plan(filters) == expected
+
+
+def test_loopback_interface_00820(monkeypatch) -> None:
+    """Verify an exact gathered filter uses the list endpoint with encoded Lucene parameters."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+    requested_paths = []
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return {
+            "interfaces": [
+                {
+                    "interfaceName": "loopback101",
+                    "interfaceType": "loopback",
+                    "configData": {
+                        "networkOS": {
+                            "policy": {
+                                "policyType": "loopback",
+                            }
+                        }
+                    },
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        }
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    assert instance.query_all(gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}]) == [
+        {
+            "switchIp": "192.0.2.10",
+            "interfaceName": "loopback101",
+            "interfaceType": "loopback",
+            "configData": {
+                "networkOS": {
+                    "policy": {
+                        "policyType": "loopback",
+                    }
+                }
+            },
+        }
+    ]
+    path, query = requested_paths[0].split("?", 1)
+    assert path == "/api/v1/manage/fabrics/fabric_1/switches/SERIAL-A/interfaces"
+    assert set(query.split("&")) == {
+        "configOnly=false",
+        "filter=interfaceType:loopback%20AND%20policyType:loopback%20AND%20interfaceName:loopback101",
+        "max=500",
+        "offset=0",
+    }
+
+
+def test_loopback_interface_00830(monkeypatch) -> None:
+    """Verify Lucene candidates outside this module's policy scope are still excluded locally."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+    monkeypatch.setattr(
+        LoopbackInterfaceOrchestrator,
+        "_request",
+        lambda self, path, verb, **kwargs: {
+            "interfaces": [
+                {
+                    "interfaceName": "loopback0",
+                    "interfaceType": "loopback",
+                    "configData": {"networkOS": {"policy": {"policyType": "underlayLoopback"}}},
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        },
+    )
+
+    assert instance.query_all(gathered_filters=[{"interface_name": "loopback0"}]) == []
+
+
+def test_loopback_interface_00840(monkeypatch) -> None:
+    """Verify responses from separate OR expressions are unioned and deduplicated."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    duplicate = {
+        "interfaceName": "loopback101",
+        "interfaceType": "loopback",
+        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+    }
+    requested_paths = []
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+    monkeypatch.setattr(
+        LoopbackInterfaceOrchestrator,
+        "_build_gathered_query_plan",
+        lambda self, filters: {
+            "192.0.2.10": ("SERIAL-A", {"expression-one", "expression-two"}),
+        },
+    )
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return {"interfaces": [duplicate], "meta": {"counts": {"remaining": 0}}}
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    result = instance.query_all(gathered_filters=[{"interface_name": "loopback101"}])
+
+    assert len(requested_paths) == 2
+    assert result == [{"switchIp": "192.0.2.10", **duplicate}]
+
+
+def test_loopback_interface_00850(monkeypatch) -> None:
+    """Verify Lucene list pagination advances offsets and collects all pages."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    requested_paths = []
+    pages = iter(
+        [
+            {
+                "interfaces": [
+                    {
+                        "interfaceName": "loopback101",
+                        "interfaceType": "loopback",
+                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+                    }
+                ],
+                "meta": {"counts": {"remaining": "1"}},
+            },
+            {
+                "interfaces": [
+                    {
+                        "interfaceName": "loopback102",
+                        "interfaceType": "loopback",
+                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+                    }
+                ],
+                "meta": {"counts": {"remaining": 0}},
+            },
+        ]
+    )
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return next(pages)
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    result = instance._query_interfaces_with_lucene("SERIAL-A", "interfaceType:loopback")
+
+    assert [item["interfaceName"] for item in result] == ["loopback101", "loopback102"]
+    assert "offset=0" in requested_paths[0]
+    assert "offset=1" in requested_paths[1]

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Deeksha Pandey (deekpand-cisco)  deekpand@cisco.com
+# Copyright: (c) 2026, Deeksha Pandey (@deekpand) <deekpand@cisco.com>
 
 
 """Unit tests for generic gathered-state local and Lucene filtering."""
@@ -14,6 +14,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     build_lucene_expressions,
     filter_gathered_response,
     format_lucene_value,
+    validate_gathered_filters,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import (
     LoopbackInterfaceModel,
@@ -74,7 +75,7 @@ def test_lucene_supported_fields_are_combined_with_and():
     assert build_lucene_expressions(
         [{"interface_name": "loopback101"}],
         _lucene_spec(),
-    ) == ["interfaceType:loopback AND policyType:loopback AND " "interfaceName:loopback101"]
+    ) == ["interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"]
 
 
 def test_lucene_multiple_items_remain_separate_expressions():
@@ -186,3 +187,40 @@ def test_nonmatching_filter_returns_empty_list():
 def test_empty_filter_item_is_rejected(filter_item):
     with pytest.raises(ValueError, match="at least one filtering criterion"):
         _filter([_response()], [filter_item])
+
+
+def test_validate_rejects_non_dict_filters_item():
+    with pytest.raises(ValueError, match="must be a dictionary.*index 0"):
+        validate_gathered_filters(
+            filters=["not_a_dict"],
+            normalize_filter=None,
+            supported_properties=("switch_ip",),
+        )
+
+
+def test_validate_rejects_unsupported_properties():
+    with pytest.raises(ValueError, match="unsupported properties.*'extra_field'"):
+        validate_gathered_filters(
+            filters=[{"extra_field": "value"}],
+            normalize_filter=None,
+            supported_properties=("switch_ip", "interface_name"),
+        )
+
+
+def test_validate_rejects_nested_unsupported_property():
+    with pytest.raises(ValueError, match="unsupported properties.*'config_data.network_os.policy.extra_config'"):
+        validate_gathered_filters(
+            filters=[{"config_data": {"network_os": {"policy": {"extra_config": "value"}}}}],
+            normalize_filter=None,
+            supported_properties=LoopbackInterfaceModel.gathered_filter_properties,
+        )
+
+
+def test_validate_skips_property_check_when_supported_properties_empty():
+    # Backward compatibility: empty tuple means no property restriction
+    # Should only fail on active-value check if filter is empty, not on property check
+    validate_gathered_filters(
+        filters=[{"any_fields": "any_value"}],
+        normalize_filter=None,
+        supported_properties=(),
+    )

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Cisco and/or its affiliates.
+# Copyright: (c) 2026, Deeksha Pandey (deekpand-cisco)  deekpand@cisco.com
 
-# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 """Unit tests for generic gathered-state local and Lucene filtering."""
 
@@ -16,7 +15,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     filter_gathered_response,
     format_lucene_value,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import (
+    LoopbackInterfaceModel,
+)
 
 
 def _response(
@@ -66,21 +67,14 @@ def _lucene_spec() -> GatheredLuceneSpec:
 
 
 def test_lucene_without_filters_returns_base_expression():
-    assert build_lucene_expressions([], _lucene_spec()) == [
-        "interfaceType:loopback AND policyType:loopback"
-    ]
+    assert build_lucene_expressions([], _lucene_spec()) == ["interfaceType:loopback AND policyType:loopback"]
 
 
 def test_lucene_supported_fields_are_combined_with_and():
     assert build_lucene_expressions(
         [{"interface_name": "loopback101"}],
         _lucene_spec(),
-    ) == [
-        (
-            "interfaceType:loopback AND policyType:loopback AND "
-            "interfaceName:loopback101"
-        )
-    ]
+    ) == ["interfaceType:loopback AND policyType:loopback AND " "interfaceName:loopback101"]
 
 
 def test_lucene_multiple_items_remain_separate_expressions():
@@ -154,7 +148,11 @@ def test_ansible_injected_null_values_do_not_become_criteria():
 
 
 def test_multiple_filter_items_use_or_semantics():
-    responses = [_response(), _response(interface_name="loopback102"), _response(interface_name="loopback103")]
+    responses = [
+        _response(),
+        _response(interface_name="loopback102"),
+        _response(interface_name="loopback103"),
+    ]
 
     result = _filter(
         responses,
@@ -165,7 +163,10 @@ def test_multiple_filter_items_use_or_semantics():
 
 
 def test_nested_false_value_is_an_active_filter():
-    responses = [_response(admin_state=False), _response(interface_name="loopback102", admin_state=True)]
+    responses = [
+        _response(admin_state=False),
+        _response(interface_name="loopback102", admin_state=True),
+    ]
     filters = [{"config_data": {"network_os": {"policy": {"admin_state": False}}}}]
 
     assert _filter(responses, filters) == [responses[0]]

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -16,9 +16,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     format_lucene_value,
     validate_gathered_filters,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import (
-    LoopbackInterfaceModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
 
 
 def _response(

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -47,6 +47,7 @@ def _response(
 
 
 def _filter(responses, filters):
+    """Apply gathered filters and return matched models."""
     return filter_gathered_response(
         response_data=responses,
         filters=filters,
@@ -118,8 +119,10 @@ def test_format_lucene_value(value, expected):
 
 def test_no_filters_returns_all_responses():
     responses = [_response(), _response(interface_name="loopback102")]
-
-    assert _filter(responses, []) == responses
+    result = _filter(responses, [])
+    assert len(result) == 2
+    assert result[0].interface_name == "loopback101"
+    assert result[1].interface_name == "loopback102"
 
 
 def test_one_filter_item_uses_and_semantics_and_normalizes_name():
@@ -134,7 +137,9 @@ def test_one_filter_item_uses_and_semantics_and_normalizes_name():
         [{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}],
     )
 
-    assert result == [responses[0]]
+    assert len(result) == 1
+    assert result[0].switch_ip == "192.0.2.10"
+    assert result[0].interface_name == "loopback101"
 
 
 def test_ansible_injected_null_values_do_not_become_criteria():
@@ -145,7 +150,8 @@ def test_ansible_injected_null_values_do_not_become_criteria():
         [{"switch_ip": None, "interface_name": "Loopback101"}],
     )
 
-    assert result == [responses[0]]
+    assert len(result) == 1
+    assert result[0].interface_name == "loopback101"
 
 
 def test_multiple_filter_items_use_or_semantics():
@@ -160,7 +166,9 @@ def test_multiple_filter_items_use_or_semantics():
         [{"interface_name": "loopback101"}, {"interface_name": "loopback102"}],
     )
 
-    assert result == responses[:2]
+    assert len(result) == 2
+    assert result[0].interface_name == "loopback101"
+    assert result[1].interface_name == "loopback102"
 
 
 def test_nested_false_value_is_an_active_filter():
@@ -170,17 +178,23 @@ def test_nested_false_value_is_an_active_filter():
     ]
     filters = [{"config_data": {"network_os": {"policy": {"admin_state": False}}}}]
 
-    assert _filter(responses, filters) == [responses[0]]
+    result = _filter(responses, filters)
+    assert len(result) == 1
+    assert result[0].interface_name == "loopback101"
+    assert result[0].config_data.network_os.policy.admin_state is False
 
 
 def test_duplicate_identifiers_are_returned_once():
     response = _response()
 
-    assert _filter([response, dict(response)], [{"interface_name": "loopback101"}]) == [response]
+    result = _filter([response, dict(response)], [{"interface_name": "loopback101"}])
+    assert len(result) == 1
+    assert result[0].interface_name == "loopback101"
 
 
 def test_nonmatching_filter_returns_empty_list():
-    assert _filter([_response()], [{"interface_name": "loopback999"}]) == []
+    result = _filter([_response()], [{"interface_name": "loopback999"}])
+    assert result == []
 
 
 @pytest.mark.parametrize("filter_item", [{}, {"switch_ip": None}, {"interface_name": ""}])

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco and/or its affiliates.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for generic gathered-state local and Lucene filtering."""
+
+from __future__ import annotations
+
+import pytest
+
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    GatheredLuceneSpec,
+    build_lucene_expressions,
+    filter_gathered_response,
+    format_lucene_value,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
+
+
+def _response(
+    switch_ip: str = "192.0.2.10",
+    interface_name: str = "loopback101",
+    admin_state: bool = True,
+    description: str = "primary loopback",
+) -> dict:
+    return {
+        "switchIp": switch_ip,
+        "interfaceName": interface_name,
+        "interfaceType": "loopback",
+        "configData": {
+            "mode": "managed",
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "adminState": admin_state,
+                    "ip": "10.101.0.1/32",
+                    "description": description,
+                    "policyType": "loopback",
+                },
+            },
+        },
+    }
+
+
+def _filter(responses, filters):
+    return filter_gathered_response(
+        response_data=responses,
+        filters=filters,
+        model_class=LoopbackInterfaceModel,
+        normalize_filter=LoopbackInterfaceModel.normalize_gathered_filter,
+    )
+
+
+def _lucene_spec() -> GatheredLuceneSpec:
+    return GatheredLuceneSpec(
+        base_terms=(
+            ("interfaceType", "loopback"),
+            ("policyType", "loopback"),
+        ),
+        field_map={
+            ("interface_name",): "interfaceName",
+        },
+    )
+
+
+def test_lucene_without_filters_returns_base_expression():
+    assert build_lucene_expressions([], _lucene_spec()) == [
+        "interfaceType:loopback AND policyType:loopback"
+    ]
+
+
+def test_lucene_supported_fields_are_combined_with_and():
+    assert build_lucene_expressions(
+        [{"interface_name": "loopback101"}],
+        _lucene_spec(),
+    ) == [
+        (
+            "interfaceType:loopback AND policyType:loopback AND "
+            "interfaceName:loopback101"
+        )
+    ]
+
+
+def test_lucene_multiple_items_remain_separate_expressions():
+    assert build_lucene_expressions(
+        [
+            {"interface_name": "loopback101"},
+            {"interface_name": "loopback102"},
+        ],
+        _lucene_spec(),
+    ) == [
+        "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101",
+        "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback102",
+    ]
+
+
+def test_lucene_unmapped_fields_fall_back_to_base_and_deduplicate():
+    assert build_lucene_expressions(
+        [
+            {"config_data": {"network_os": {"policy": {"description": "first"}}}},
+            {"config_data": {"network_os": {"policy": {"description": "second"}}}},
+        ],
+        _lucene_spec(),
+    ) == ["interfaceType:loopback AND policyType:loopback"]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, "true"),
+        (False, "false"),
+        (0, "0"),
+        ("loopback101", "loopback101"),
+        ("nx-os", '"nx-os"'),
+        ('contains "quotes"', '"contains \\"quotes\\""'),
+    ],
+)
+def test_format_lucene_value(value, expected):
+    assert format_lucene_value(value) == expected
+
+
+def test_no_filters_returns_all_responses():
+    responses = [_response(), _response(interface_name="loopback102")]
+
+    assert _filter(responses, []) == responses
+
+
+def test_one_filter_item_uses_and_semantics_and_normalizes_name():
+    responses = [
+        _response(),
+        _response(switch_ip="192.0.2.11"),
+        _response(interface_name="loopback102"),
+    ]
+
+    result = _filter(
+        responses,
+        [{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}],
+    )
+
+    assert result == [responses[0]]
+
+
+def test_ansible_injected_null_values_do_not_become_criteria():
+    responses = [_response(), _response(interface_name="loopback102")]
+
+    result = _filter(
+        responses,
+        [{"switch_ip": None, "interface_name": "Loopback101"}],
+    )
+
+    assert result == [responses[0]]
+
+
+def test_multiple_filter_items_use_or_semantics():
+    responses = [_response(), _response(interface_name="loopback102"), _response(interface_name="loopback103")]
+
+    result = _filter(
+        responses,
+        [{"interface_name": "loopback101"}, {"interface_name": "loopback102"}],
+    )
+
+    assert result == responses[:2]
+
+
+def test_nested_false_value_is_an_active_filter():
+    responses = [_response(admin_state=False), _response(interface_name="loopback102", admin_state=True)]
+    filters = [{"config_data": {"network_os": {"policy": {"admin_state": False}}}}]
+
+    assert _filter(responses, filters) == [responses[0]]
+
+
+def test_duplicate_identifiers_are_returned_once():
+    response = _response()
+
+    assert _filter([response, dict(response)], [{"interface_name": "loopback101"}]) == [response]
+
+
+def test_nonmatching_filter_returns_empty_list():
+    assert _filter([_response()], [{"interface_name": "loopback999"}]) == []
+
+
+@pytest.mark.parametrize("filter_item", [{}, {"switch_ip": None}, {"interface_name": ""}])
+def test_empty_filter_item_is_rejected(filter_item):
+    with pytest.raises(ValueError, match="at least one filtering criterion"):
+        _filter([_response()], [filter_item])

--- a/tests/unit/module_utils/test_nd_output.py
+++ b/tests/unit/module_utils/test_nd_output.py
@@ -215,6 +215,92 @@ class TestNDOutputFormat:
         assert output.format()["changed"] is True
 
 
+class TestNDOutputGatheredState:
+    """Tests for the read-only gathered state output convention."""
+
+    def test_gathered_uses_gathered_key(self):
+        """state='gathered' surfaces fetched objects under a 'gathered' key."""
+        output = NDOutput("normal", state="gathered")
+        output._after = [{"name": "link1"}]
+        result = output.format()
+        assert result["gathered"] == [{"name": "link1"}]
+
+    def test_gathered_omits_change_oriented_keys(self):
+        """state='gathered' omits before/after/diff/proposed."""
+        output = NDOutput("info", state="gathered")
+        result = output.format()
+        for key in ("after", "before", "diff", "proposed"):
+            assert key not in result
+
+    def test_gathered_is_not_changed(self):
+        """gathered is read-only, so changed is always False."""
+        output = NDOutput("normal", state="gathered")
+        result = output.format()
+        assert result["changed"] is False
+
+    def test_gathered_debug_includes_logs(self):
+        """Debug output_level still surfaces logs under gathered."""
+        output = NDOutput("debug", state="gathered")
+        output.assign(logs=["l1"])
+        result = output.format()
+        assert result["logs"] == ["l1"]
+
+    def test_non_gathered_state_keeps_classic_shape(self):
+        """Non-gathered states retain the before/after/diff shape and no gathered key."""
+        output = NDOutput("normal", state="merged")
+        result = output.format()
+        assert "gathered" not in result
+        assert "after" in result and "before" in result and "diff" in result
+
+    def test_gathered_prunes_to_argument_spec(self):
+        """gathered_spec drops response-only keys so output round-trips as config."""
+        output = NDOutput("normal", state="gathered")
+        output._after = [{"src_switch_name": "leaf1", "link_id": "UUID-123"}]
+        output.assign(gathered_spec={"src_switch_name": {"type": "str"}})
+        result = output.format()
+        assert result["gathered"] == [{"src_switch_name": "leaf1"}]
+
+    def test_gathered_prunes_nested_but_keeps_free_form(self):
+        """Pruning recurses into modeled dicts but leaves free-form dicts intact."""
+        output = NDOutput("normal", state="gathered")
+        output._after = [
+            {
+                "src_switch_name": "leaf1",
+                "config_data": {
+                    "policy_type": "numbered",
+                    "template_inputs": {"anyKey": 1},
+                    "server_only": "drop-me",
+                },
+            }
+        ]
+        output.assign(
+            gathered_spec={
+                "src_switch_name": {"type": "str"},
+                "config_data": {
+                    "type": "dict",
+                    "options": {
+                        "policy_type": {"type": "str"},
+                        "template_inputs": {"type": "dict"},
+                    },
+                },
+            }
+        )
+        result = output.format()
+        assert result["gathered"] == [
+            {
+                "src_switch_name": "leaf1",
+                "config_data": {"policy_type": "numbered", "template_inputs": {"anyKey": 1}},
+            }
+        ]
+
+    def test_gathered_without_spec_is_unpruned(self):
+        """No gathered_spec means no pruning (backward compatible)."""
+        output = NDOutput("normal", state="gathered")
+        output._after = [{"src_switch_name": "leaf1", "link_id": "UUID-123"}]
+        result = output.format()
+        assert result["gathered"] == [{"src_switch_name": "leaf1", "link_id": "UUID-123"}]
+
+
 # =============================================================================
 # Test: NDOutput.assign
 # =============================================================================

--- a/tests/unit/module_utils/test_nd_output.py
+++ b/tests/unit/module_utils/test_nd_output.py
@@ -17,7 +17,10 @@ from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type  # pylint: disable=invalid-name
 
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
+from ansible_collections.cisco.nd.plugins.module_utils.enums import (
+    HttpVerbEnum,
+    OperationType,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
@@ -198,13 +201,25 @@ class TestNDOutputFormat:
         from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import (
             EthernetTrunkHostInterfaceModel,
         )
-        from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+        from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+            NDConfigCollection,
+        )
 
         def response(policy):
-            return {"switchIp": "192.0.2.10", "interfaceName": "Ethernet1/1", "configData": {"networkOS": {"policy": policy}}}
+            return {
+                "switchIp": "192.0.2.10",
+                "interfaceName": "Ethernet1/1",
+                "configData": {"networkOS": {"policy": policy}},
+            }
 
         before_item = EthernetTrunkHostInterfaceModel.from_response(
-            response({"policyType": "trunkHost", "stormControlBroadcastLevel": 50.0, "stormControlBroadcastLevelPps": 12345})
+            response(
+                {
+                    "policyType": "trunkHost",
+                    "stormControlBroadcastLevel": 50.0,
+                    "stormControlBroadcastLevelPps": 12345,
+                }
+            )
         )
         after_item = EthernetTrunkHostInterfaceModel.from_response(response({"policyType": "trunkHost", "stormControlBroadcastLevelPps": 12345}))
         before = NDConfigCollection(model_class=EthernetTrunkHostInterfaceModel, items=[before_item])
@@ -289,7 +304,10 @@ class TestNDOutputGatheredState:
         assert result["gathered"] == [
             {
                 "src_switch_name": "leaf1",
-                "config_data": {"policy_type": "numbered", "template_inputs": {"anyKey": 1}},
+                "config_data": {
+                    "policy_type": "numbered",
+                    "template_inputs": {"anyKey": 1},
+                },
             }
         ]
 
@@ -462,7 +480,13 @@ class TestFormatWithVerbosityLevel3:
         output = NDOutput("normal")
         results = _make_results_write_and_query()
         result = output.format_with_verbosity(3, results)
-        for key in ("api_response", "api_result", "api_diff", "api_metadata", "api_payload"):
+        for key in (
+            "api_response",
+            "api_result",
+            "api_diff",
+            "api_metadata",
+            "api_payload",
+        ):
             assert len(result[key]) == 2, f"{key} should have 2 entries"
 
     def test_verbosity_3_payload_contains_correct_data(self):

--- a/tests/unit/module_utils/test_nd_output.py
+++ b/tests/unit/module_utils/test_nd_output.py
@@ -240,12 +240,14 @@ class TestNDOutputGatheredState:
         result = output.format()
         assert result["gathered"] == [{"name": "link1"}]
 
-    def test_gathered_omits_change_oriented_keys(self):
-        """state='gathered' omits before/after/diff/proposed."""
+    def test_gathered_includes_empty_change_oriented_keys(self):
+        """state='gathered' includes before/after/diff as empty lists."""
         output = NDOutput("info", state="gathered")
         result = output.format()
-        for key in ("after", "before", "diff", "proposed"):
-            assert key not in result
+        assert result["before"] == []
+        assert result["after"] == []
+        assert result["diff"] == []
+        assert result["proposed"] == []
 
     def test_gathered_is_not_changed(self):
         """gathered is read-only, so changed is always False."""

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -35,32 +35,16 @@ __metaclass__ = type  # pylint: disable=invalid-name
 
 import pytest
 import ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine as state_machine_module
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
-    NDStateMachineError,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
-    NDStateMachine,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import (
-    LoopbackInterfaceOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
-    ResponseType,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
-    ResponseHandler,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
-    does_not_raise,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
-    MockAnsibleModule,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import (
-    ResponseGenerator,
-)
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
 

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -659,7 +659,8 @@ class _FakeOrchestratorBase:
 
     supports_bulk_create = False
     supports_bulk_delete = False
-    supports_gathered_lucene_filtering = False
+    supports_gathered_server_filtering = False
+    gathered_transform = None
 
     def __init__(self, model_class, response_data):
         self.model_class = model_class
@@ -711,7 +712,7 @@ def _build_gathered_state_machine(monkeypatch, model_class, state, config, serve
         {"name": "other", "value": 20},
     ]
     orchestrator = _FakeOrchestratorBase(model_class, response_data)
-    orchestrator.supports_gathered_lucene_filtering = server_filtering
+    orchestrator.supports_gathered_server_filtering = server_filtering
     machine = NDStateMachine(
         module=_FakeModule(state=state, config=config),
         model_orchestrator=orchestrator,

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -28,6 +28,9 @@ the seam the per-method capability tests in `test_base_interface.py` cannot: the
 
 from __future__ import absolute_import, annotations, division, print_function
 
+from copy import deepcopy
+from typing import ClassVar, Literal
+
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import pytest
@@ -41,6 +44,8 @@ from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import do
 from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
 from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+import ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine as state_machine_module
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 
 
 class _SpyLoopbackOrchestrator(LoopbackInterfaceOrchestrator):
@@ -594,3 +599,207 @@ def test_nd_state_machine_00210() -> None:
     assert "update" in names
     assert "delete" not in names
     assert "delete_bulk" not in names
+
+
+class _FilterModel(NDBaseModel):
+    """Small opted-in model used to exercise state-machine routing."""
+
+    identifiers: ClassVar[list[str] | None] = ["name"]
+    identifier_strategy: ClassVar[Literal["single"]] = "single"
+    supports_gathered_filtering: ClassVar[bool] = True
+
+    name: str
+    value: int | None = None
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        return {
+            "config": {
+                "type": "list",
+                "elements": "dict",
+                "options": {
+                    "name": {"type": "str"},
+                    "value": {"type": "int"},
+                },
+            }
+        }
+
+
+class _LegacyModel(_FilterModel):
+    """Model that deliberately keeps the pre-filtering state-machine path."""
+
+    supports_gathered_filtering: ClassVar[bool] = False
+
+
+class _FakeOrchestratorBase:
+    """Minimal orchestrator accepted through the instance-injection path."""
+
+    supports_bulk_create = False
+    supports_bulk_delete = False
+    supports_gathered_lucene_filtering = False
+
+    def __init__(self, model_class, response_data):
+        self.model_class = model_class
+        self.response_data = response_data
+        self.prepare_calls = []
+        self.query_calls = []
+        self.results = None
+
+    def query_all(self, **kwargs):
+        self.query_calls.append(deepcopy(kwargs))
+        return deepcopy(self.response_data)
+
+    def prepare_config_data(self, raw_config):
+        self.prepare_calls.append(deepcopy(raw_config))
+        return raw_config
+
+
+class _FakeRestSend:
+    """REST holder; no request is made by these state-machine tests."""
+
+    def __init__(self, params):
+        self.params = params
+        self.sender = None
+        self.response_handler = None
+
+
+class _FakeSender:
+    ansible_module = None
+
+
+class _FakeModule:
+    def __init__(self, state, config):
+        self.params = {
+            "state": state,
+            "config": config,
+            "output_level": "normal",
+        }
+        self.check_mode = False
+        self.no_log_values = set()
+
+
+def _build_state_machine(monkeypatch, model_class, state, config, server_filtering=False):
+    monkeypatch.setattr(state_machine_module, "NDBaseOrchestrator", _FakeOrchestratorBase)
+    monkeypatch.setattr(state_machine_module, "RestSend", _FakeRestSend)
+    monkeypatch.setattr(state_machine_module, "Sender", _FakeSender)
+
+    response_data = [
+        {"name": "wanted", "value": 10},
+        {"name": "other", "value": 20},
+    ]
+    orchestrator = _FakeOrchestratorBase(model_class, response_data)
+    orchestrator.supports_gathered_lucene_filtering = server_filtering
+    machine = NDStateMachine(
+        module=_FakeModule(state=state, config=config),
+        model_orchestrator=orchestrator,
+    )
+    return machine, orchestrator
+
+
+def test_gathered_filtering_filters_existing_and_keeps_filters_out_of_proposed(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state="gathered",
+        config=[{"name": "wanted"}],
+    )
+
+    assert machine.before.to_ansible_config() == [{"name": "wanted", "value": 10}]
+    assert machine.proposed.to_ansible_config() == []
+    assert orchestrator.prepare_calls == [[]]
+    assert orchestrator.query_calls == [{}]
+    assert machine.output.format()["gathered"] == [{"name": "wanted", "value": 10}]
+
+
+def test_opted_in_model_preserves_write_state_config_flow(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state="merged",
+        config=[{"name": "wanted", "value": 10}],
+    )
+
+    assert machine.before.to_ansible_config() == [
+        {"name": "wanted", "value": 10},
+        {"name": "other", "value": 20},
+    ]
+    assert machine.proposed.to_ansible_config() == [{"name": "wanted", "value": 10}]
+    assert orchestrator.prepare_calls == [[{"name": "wanted", "value": 10}]]
+    assert orchestrator.query_calls == [{}]
+
+
+def test_model_without_opt_in_preserves_legacy_gathered_flow(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_LegacyModel,
+        state="gathered",
+        config=[{"name": "wanted"}],
+    )
+
+    assert machine.before.to_ansible_config() == [
+        {"name": "wanted", "value": 10},
+        {"name": "other", "value": 20},
+    ]
+    assert machine.proposed.to_ansible_config() == [{"name": "wanted"}]
+    assert orchestrator.prepare_calls == [[{"name": "wanted"}]]
+    assert orchestrator.query_calls == [{}]
+
+
+def test_gathered_filters_are_forwarded_when_model_and_orchestrator_opt_in(monkeypatch):
+    config = [{"name": "wanted"}]
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state="gathered",
+        config=config,
+        server_filtering=True,
+    )
+
+    assert orchestrator.query_calls == [{"gathered_filters": config}]
+    # Server-side filtering remains candidate reduction; local matching is
+    # still authoritative and keeps criteria out of proposed configuration.
+    assert machine.before.to_ansible_config() == [{"name": "wanted", "value": 10}]
+    assert machine.proposed.to_ansible_config() == []
+
+
+def test_empty_gathered_config_is_forwarded_explicitly(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state="gathered",
+        config=[],
+        server_filtering=True,
+    )
+
+    assert orchestrator.query_calls == [{"gathered_filters": []}]
+    assert machine.before.to_ansible_config() == [
+        {"name": "wanted", "value": 10},
+        {"name": "other", "value": 20},
+    ]
+
+
+@pytest.mark.parametrize("state", ["merged", "replaced", "overridden", "deleted"])
+def test_write_states_never_receive_gathered_filters(monkeypatch, state):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state=state,
+        config=[{"name": "wanted", "value": 10}],
+        server_filtering=True,
+    )
+
+    assert machine.state == state
+    assert orchestrator.query_calls == [{}]
+
+
+def test_legacy_model_does_not_forward_filters_even_when_orchestrator_opts_in(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_LegacyModel,
+        state="gathered",
+        config=[{"name": "wanted"}],
+        server_filtering=True,
+    )
+
+    assert machine.state == "gathered"
+    assert orchestrator.query_calls == [{}]

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -34,18 +34,34 @@ from typing import ClassVar, Literal
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import pytest
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
-from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
-from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
-from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
-from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 import ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine as state_machine_module
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import (
+    LoopbackInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
+    does_not_raise,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
+    MockAnsibleModule,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import (
+    ResponseGenerator,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
 
 class _SpyLoopbackOrchestrator(LoopbackInterfaceOrchestrator):
@@ -108,6 +124,7 @@ def _build_module(state: str, check_mode: bool, config: list[dict]) -> MockAnsib
     """Build a `MockAnsibleModule` with the params `NDStateMachine` reads."""
     module = MockAnsibleModule()
     module.check_mode = check_mode
+    module.no_log_values = set()
     module.params = {
         "state": state,
         "config": config,
@@ -255,7 +272,13 @@ class _ExistingLoopbackSpy(_SpyLoopbackOrchestrator):
     """Spy whose inventory already contains loopback10, so a re-submitted policy-less item is not a create."""
 
     def query_all(self, model_instance=None, **kwargs) -> ResponseType:
-        return [{"switchIp": "192.168.12.151", "interfaceName": "loopback10", "interfaceType": "loopback"}]
+        return [
+            {
+                "switchIp": "192.168.12.151",
+                "interfaceName": "loopback10",
+                "interfaceType": "loopback",
+            }
+        ]
 
 
 def test_nd_state_machine_00140() -> None:
@@ -678,7 +701,7 @@ class _FakeModule:
         self.no_log_values = set()
 
 
-def _build_state_machine(monkeypatch, model_class, state, config, server_filtering=False):
+def _build_gathered_state_machine(monkeypatch, model_class, state, config, server_filtering=False):
     monkeypatch.setattr(state_machine_module, "NDBaseOrchestrator", _FakeOrchestratorBase)
     monkeypatch.setattr(state_machine_module, "RestSend", _FakeRestSend)
     monkeypatch.setattr(state_machine_module, "Sender", _FakeSender)
@@ -696,8 +719,24 @@ def _build_state_machine(monkeypatch, model_class, state, config, server_filteri
     return machine, orchestrator
 
 
-def test_gathered_filtering_filters_existing_and_keeps_filters_out_of_proposed(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00200(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify gathered filtering removes non-matching items from `before` and keeps filter criteria out of `proposed`.
+
+    ## Test
+
+    - `state: gathered`, opted-in `_FilterModel`, config filters for `name: wanted`
+    - `before` contains only the matching item; `proposed` is empty (filters are not desired state)
+    - `gathered` output matches the filtered `before`
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    - NDConfigCollection.from_api_response()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state="gathered",
@@ -711,8 +750,23 @@ def test_gathered_filtering_filters_existing_and_keeps_filters_out_of_proposed(m
     assert machine.output.format()["gathered"] == [{"name": "wanted", "value": 10}]
 
 
-def test_opted_in_model_preserves_write_state_config_flow(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00210(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify an opted-in model preserves the normal write-state config flow under `merged`.
+
+    ## Test
+
+    - `state: merged`, opted-in `_FilterModel`, config has `name: wanted, value: 10`
+    - `before` contains the full inventory (no filtering for write states)
+    - `proposed` contains the user config; `prepare_config_data` receives it unmodified
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state="merged",
@@ -728,8 +782,23 @@ def test_opted_in_model_preserves_write_state_config_flow(monkeypatch):
     assert orchestrator.query_calls == [{}]
 
 
-def test_model_without_opt_in_preserves_legacy_gathered_flow(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00220(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify a model without gathered filtering opt-in preserves the legacy gathered flow.
+
+    ## Test
+
+    - `state: gathered`, `_LegacyModel` (opt-in disabled), config has `name: wanted`
+    - `before` contains the full inventory (no filtering applied)
+    - `proposed` contains the user config as-is (legacy behavior)
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_LegacyModel,
         state="gathered",
@@ -745,9 +814,24 @@ def test_model_without_opt_in_preserves_legacy_gathered_flow(monkeypatch):
     assert orchestrator.query_calls == [{}]
 
 
-def test_gathered_filters_are_forwarded_when_model_and_orchestrator_opt_in(monkeypatch):
+def test_nd_state_machine_00230(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify gathered filters are forwarded to `query_all` when both model and orchestrator opt in.
+
+    ## Test
+
+    - `state: gathered`, opted-in `_FilterModel`, server filtering enabled
+    - `query_all` receives `gathered_filters` with the user config
+    - Local filtering still applies; `before` contains only the match; `proposed` is empty
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
     config = [{"name": "wanted"}]
-    machine, orchestrator = _build_state_machine(
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state="gathered",
@@ -762,8 +846,23 @@ def test_gathered_filters_are_forwarded_when_model_and_orchestrator_opt_in(monke
     assert machine.proposed.to_ansible_config() == []
 
 
-def test_empty_gathered_config_is_forwarded_explicitly(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00240(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify an empty gathered config is forwarded explicitly as an empty list.
+
+    ## Test
+
+    - `state: gathered`, opted-in `_FilterModel`, empty config, server filtering enabled
+    - `query_all` receives `gathered_filters: []` (not omitted)
+    - `before` contains the full inventory (no filter criteria to apply)
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state="gathered",
@@ -779,8 +878,22 @@ def test_empty_gathered_config_is_forwarded_explicitly(monkeypatch):
 
 
 @pytest.mark.parametrize("state", ["merged", "replaced", "overridden", "deleted"])
-def test_write_states_never_receive_gathered_filters(monkeypatch, state):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00250(monkeypatch, state) -> None:
+    """
+    # Summary
+
+    Verify write states never receive `gathered_filters` even when server filtering is enabled.
+
+    ## Test
+
+    - Parametrized over `merged`, `replaced`, `overridden`, `deleted`
+    - Server filtering enabled, but `query_all` receives no `gathered_filters`
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state=state,
@@ -792,8 +905,22 @@ def test_write_states_never_receive_gathered_filters(monkeypatch, state):
     assert orchestrator.query_calls == [{}]
 
 
-def test_legacy_model_does_not_forward_filters_even_when_orchestrator_opts_in(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00260(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify a legacy model does not forward gathered filters even when the orchestrator opts in.
+
+    ## Test
+
+    - `state: gathered`, `_LegacyModel` (opt-in disabled), server filtering enabled
+    - `query_all` receives no `gathered_filters` (model gate prevents forwarding)
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_LegacyModel,
         state="gathered",

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -304,7 +304,10 @@ class TestPruneToSpec:
     def test_keeps_scalar_and_scalar_list_verbatim(self):
         """Scalars and lists of scalars pass through unchanged."""
         data = {"name": "leaf1", "interface_names": ["Eth1/1", "Eth1/2"]}
-        spec = {"name": {"type": "str"}, "interface_names": {"type": "list", "elements": "str"}}
+        spec = {
+            "name": {"type": "str"},
+            "interface_names": {"type": "list", "elements": "str"},
+        }
         assert prune_to_spec(data, spec) == data
 
     def test_recurses_into_modeled_dict(self):
@@ -316,7 +319,13 @@ class TestPruneToSpec:
     def test_recurses_into_list_of_modeled_dicts(self):
         """A list of dicts with options is pruned element by element."""
         data = {"links": [{"name": "a", "extra": 1}, {"name": "b", "extra": 2}]}
-        spec = {"links": {"type": "list", "elements": "dict", "options": {"name": {"type": "str"}}}}
+        spec = {
+            "links": {
+                "type": "list",
+                "elements": "dict",
+                "options": {"name": {"type": "str"}},
+            }
+        }
         assert prune_to_spec(data, spec) == {"links": [{"name": "a"}, {"name": "b"}]}
 
     def test_free_form_dict_left_untouched(self):
@@ -334,7 +343,12 @@ class TestPruneToSpec:
                 "options": {
                     "network_os": {
                         "type": "dict",
-                        "options": {"policy": {"type": "dict", "options": {"mtu": {"type": "str"}}}},
+                        "options": {
+                            "policy": {
+                                "type": "dict",
+                                "options": {"mtu": {"type": "str"}},
+                            }
+                        },
                     }
                 },
             }
@@ -353,7 +367,10 @@ class TestPruneToSpec:
         spec = {
             "config_data": {
                 "type": "dict",
-                "options": {"policy_type": {"type": "str"}, "password": {"type": "str", "no_log": True}},
+                "options": {
+                    "policy_type": {"type": "str"},
+                    "password": {"type": "str", "no_log": True},
+                },
             }
         }
         assert prune_to_spec(data, spec) == {"config_data": {"policy_type": "numbered"}}

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -1,23 +1,26 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2026, Allen Robel (@allenrobel)
+# Copyright: (c) 2026, Shreyas Srish (@shrsr) <ssrish@cisco.com>
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 """
-Unit tests for the pure diff helpers in `plugins/module_utils/utils.py`.
+Unit tests for the pure diff helpers and prune_to_spec in `plugins/module_utils/utils.py`.
 
-Covers `issubset` (the one-way forward comparison used by `NDBaseModel.get_diff`) and `has_removals`
+Covers `issubset` (the one-way forward comparison used by `NDBaseModel.get_diff`), `has_removals`
 (the reverse pass added for issue #410: detect fields present on the existing/device side that are
 absent from the proposed side, so `replaced`/`overridden` states can classify removal-only changes
-as a difference).
+as a difference), and `prune_to_spec` (trims gathered output to an argument spec's declared options).
 """
 
 # pylint: disable=line-too-long
 
-from __future__ import annotations
+from __future__ import absolute_import, annotations, division, print_function
 
-from ansible_collections.cisco.nd.plugins.module_utils.utils import has_removals, issubset
+__metaclass__ = type  # pylint: disable=invalid-name
+
+from ansible_collections.cisco.nd.plugins.module_utils.utils import has_removals, issubset, prune_to_spec
 
 # --- issubset (001XX) ---
 
@@ -287,3 +290,81 @@ def test_utils_00280() -> None:
     - utils.has_removals()
     """
     assert has_removals({"a": 1}, "not-a-dict") is False
+
+
+class TestPruneToSpec:
+    """Tests for prune_to_spec, which trims data to an argument spec's options."""
+
+    def test_drops_keys_not_in_spec(self):
+        """Keys absent from the spec (e.g. response-only fields) are removed."""
+        data = {"name": "leaf1", "link_id": "UUID-123"}
+        spec = {"name": {"type": "str"}}
+        assert prune_to_spec(data, spec) == {"name": "leaf1"}
+
+    def test_keeps_scalar_and_scalar_list_verbatim(self):
+        """Scalars and lists of scalars pass through unchanged."""
+        data = {"name": "leaf1", "interface_names": ["Eth1/1", "Eth1/2"]}
+        spec = {"name": {"type": "str"}, "interface_names": {"type": "list", "elements": "str"}}
+        assert prune_to_spec(data, spec) == data
+
+    def test_recurses_into_modeled_dict(self):
+        """A dict suboption with options is pruned recursively."""
+        data = {"config_data": {"policy_type": "numbered", "server_only": "x"}}
+        spec = {"config_data": {"type": "dict", "options": {"policy_type": {"type": "str"}}}}
+        assert prune_to_spec(data, spec) == {"config_data": {"policy_type": "numbered"}}
+
+    def test_recurses_into_list_of_modeled_dicts(self):
+        """A list of dicts with options is pruned element by element."""
+        data = {"links": [{"name": "a", "extra": 1}, {"name": "b", "extra": 2}]}
+        spec = {"links": {"type": "list", "elements": "dict", "options": {"name": {"type": "str"}}}}
+        assert prune_to_spec(data, spec) == {"links": [{"name": "a"}, {"name": "b"}]}
+
+    def test_free_form_dict_left_untouched(self):
+        """A dict suboption without options is free-form and preserved verbatim."""
+        data = {"template_inputs": {"anyKey": 1, "nested": {"deep": True}}}
+        spec = {"template_inputs": {"type": "dict"}}
+        assert prune_to_spec(data, spec) == data
+
+    def test_deeply_nested_recursion(self):
+        """Recursion follows options through several levels."""
+        data = {"config_data": {"network_os": {"policy": {"mtu": "9216", "server_only": "x"}}}}
+        spec = {
+            "config_data": {
+                "type": "dict",
+                "options": {
+                    "network_os": {
+                        "type": "dict",
+                        "options": {"policy": {"type": "dict", "options": {"mtu": {"type": "str"}}}},
+                    }
+                },
+            }
+        }
+        assert prune_to_spec(data, spec) == {"config_data": {"network_os": {"policy": {"mtu": "9216"}}}}
+
+    def test_drops_no_log_keys(self):
+        """no_log suboptions are dropped so gathered never surfaces a secret."""
+        data = {"name": "leaf1", "password": "hunter2"}
+        spec = {"name": {"type": "str"}, "password": {"type": "str", "no_log": True}}
+        assert prune_to_spec(data, spec) == {"name": "leaf1"}
+
+    def test_drops_nested_no_log_keys(self):
+        """no_log suboptions nested inside a modeled dict are also dropped."""
+        data = {"config_data": {"policy_type": "numbered", "password": "hunter2"}}
+        spec = {
+            "config_data": {
+                "type": "dict",
+                "options": {"policy_type": {"type": "str"}, "password": {"type": "str", "no_log": True}},
+            }
+        }
+        assert prune_to_spec(data, spec) == {"config_data": {"policy_type": "numbered"}}
+
+    def test_non_dict_data_returned_as_is(self):
+        """Non-dict input is returned unchanged."""
+        assert prune_to_spec("leaf1", {"name": {"type": "str"}}) == "leaf1"
+
+    def test_mismatched_type_values_kept(self):
+        """If data shape does not match the spec's declared type, value is kept as-is."""
+        # spec says dict, but data has a scalar -> keep verbatim rather than crash
+        data = {"config_data": "unexpected"}
+        spec = {"config_data": {"type": "dict", "options": {"policy_type": {"type": "str"}}}}
+        assert prune_to_spec(data, spec) == {"config_data": "unexpected"}


### PR DESCRIPTION
## Related Issue(s)

Related to [#340](https://github.com/CiscoDevNet/ansible-nd/issues/340).

This PR builds on the foundational framework established in
[#312](https://github.com/CiscoDevNet/ansible-nd/pull/312) 
including the state machine, base model infrastructure, orchestrator pattern,
and secrets handling. 

## Proposed Changes

This PR introduces an opt-in gathered-state filtering framework for modules
using `NDStateMachine` and enables it for:

- `cisco.nd.nd_interface_loopback`
- `cisco.nd.nd_local_user`

### Shared gathered-filtering framework

The shared implementation:

- runs filtering only when `state: gathered`;
- requires each model to opt in using `supports_gathered_filtering`;
- treats `config` as partial filter criteria for supported gathered operations;
- uses AND semantics between fields within one filter item;
- uses OR semantics between separate filter items;
- converts API responses into normalized Ansible configuration before final matching;
- allows models to declare supported filter properties through `gathered_filter_properties` and rejects unsupported properties before any API request;
- allows models to normalize filter values through `normalize_gathered_filter`;
- allows models to customize matching through `matches_gathered_filter`;
- removes duplicate matches using the model identifier;
- keeps gathered filters out of `proposed` configuration;
- prevents gathered filters from entering create, update, or delete diff processing;
- preserves existing behavior for non-gathered states;
- preserves existing behavior for models that have not opted in.

The generic local filter remains the final correctness layer. Endpoint-specific filtering is used only to reduce the number of API candidates where the endpoint safely supports it.

### Loopback-interface filtering

The loopback module supports gather-all and partial gathered filters across switches in a fabric.

Gathered loopback queries use the interface-list endpoint and its Lucene `filter` query parameter:

- every query includes `interfaceType:loopback` and `policyType:loopback`;
- `switch_ip` is resolved to a switch serial number and limits the query to that switch;
- omitting `switch_ip` queries all switches in the fabric;
- `interface_name` is translated into an exact-match Lucene term;
- separate filter items are queried independently to preserve OR semantics;
- an unfiltered loopback query for a switch supersedes narrower interface-name queries for that switch;
- pagination uses `max` and `offset` until the API reports no remaining results;
- responses from multiple switches, filter items, and pages are combined and deduplicated.

Lucene expressions are built only from structured module input. Raw Lucene expressions are not accepted from users.

The module continues to enforce its resource-ownership boundary:

- `interfaceType` must be `loopback`;
- `policyType` must be `loopback`;
- system-managed `underlayLoopback` interfaces are excluded;
- non-standard `ipfmLoopback` and `userDefined` policies are excluded.

Nested criteria such as IP address, administrative state, IPv6 address, and VRF are evaluated by the generic final local filter.

Interface names supplied as filters are normalized to lowercase to match the existing model and Nexus Dashboard API behavior.

### Local-user filtering

The local-user endpoint does not expose documented server-side Lucene filtering. Gather-all retrieves the available local users, and optional filter criteria are evaluated through the shared final local-matching layer.

Supported gathered filter properties for local users are `login_id`, `email`, `first_name`, and `last_name`. Other configuration fields (such as `user_password`, `reuse_limitation`, or `security_domains`) are rejected with a validation error before any API request.

Multiple filter items use OR semantics. String matching is case-sensitive.

Local-user passwords are not returned by Nexus Dashboard and remain excluded from gathered output. Gathered output for an existing user can be reused as configuration, but recreating a deleted user still requires a new password.

### Argument validation and gathered output

For both modules:

- `config` can be omitted for gather-all operations;
- `config` remains required for write states through `required_if`;
- the underlying Pydantic resource identifiers remain required for complete resources;
- gathered output is pruned to the module argument specification so it can be reused as `config`;
- gathered operations remain read-only and return `changed: false`.

For loopback gathered operations, `switch_ip`, `interface_name`, and nested policy fields (`admin_state`, `ip`, `ipv6`, `vrf`) can be supplied as partial filtering criteria.

For local-user gathered operations, `login_id`, `email`, `first_name`, and `last_name` can be supplied as partial filtering criteria.

### Compatibility and rollout

- Gathered filtering is disabled by default in the base model.
- Existing modules are unaffected until they explicitly opt in.
- Lucene filtering is disabled by default in the base orchestrator.
- Existing orchestrators are unaffected until they explicitly opt in.
- Custom modules using specialized runners are unaffected.
- Non-gathered state behavior remains unchanged.
- Gathered filters do not enter write-state processing.
- Gathered operations do not modify Nexus Dashboard resources.

## Test Notes

Unit coverage includes Lucene expression construction and escaping, query planning, pagination, deduplication, local matching, gathered/write-state isolation, local-user filtering, property validation, and password secrecy.

Integration coverage was added for gather-all, exact and multiple filters, OR semantics, no-match behavior, unsupported filter rejection, empty filter rejection, password secrecy, and gathered-output reuse.

## Cisco Nexus Dashboard Version

Cisco Nexus Dashboard 4.2 lab environment.

## Related ND API Resource Category

- manage
- infra

The loopback-interface module uses the Manage API, while the local-user module uses the Infra AAA API.

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] New or updated documentation has been added
- [ ] Assigned the proper reviewers