### PR TITLE
ND Manage Networks | Parity with VRF Changes

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 __metaclass__ = type
 
-from typing import ClassVar, Literal, Optional
+from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
@@ -100,7 +100,7 @@ class FabricsTicketEndpointParams(FabricsEndpointParams):
     Endpoint-specific query parameters for fabric membership mutation endpoints.
     """
 
-    ticket_id: Optional[str] = Field(
+    ticket_id: str | None = Field(
         default=None,
         min_length=1,
         description="Change control ticket ID",
@@ -643,7 +643,7 @@ class EpManageFabricsDeploymentFreezeGet(_EpManageFabricsBase):
         default="EpManageFabricsDeploymentFreezeGet", frozen=True, description="Class name for backward compatibility"
     )
 
-    _path_suffix: ClassVar[Optional[str]] = "deploymentFreeze"
+    _path_suffix: ClassVar[str | None] = "deploymentFreeze"
 
     endpoint_params: FabricsEndpointParams = Field(default_factory=FabricsEndpointParams, description="Endpoint-specific query parameters")
 
@@ -662,7 +662,7 @@ class EpManageFabricsMembersGet(_EpManageFabricsBase):
         description="Class name for backward compatibility",
     )
 
-    _path_suffix: ClassVar[Optional[str]] = "members"
+    _path_suffix: ClassVar[str | None] = "members"
 
     endpoint_params: FabricsEndpointParams = Field(default_factory=FabricsEndpointParams, description="Endpoint-specific query parameters")
 
@@ -681,7 +681,7 @@ class EpManageFabricsMemberCandidatesGet(_EpManageFabricsBase):
         description="Class name for backward compatibility",
     )
 
-    _path_suffix: ClassVar[Optional[str]] = "memberCandidates"
+    _path_suffix: ClassVar[str | None] = "memberCandidates"
 
     endpoint_params: FabricsEndpointParams = Field(default_factory=FabricsEndpointParams, description="Endpoint-specific query parameters")
 
@@ -700,7 +700,7 @@ class EpManageFabricsMembersAddPost(_EpManageFabricsBase):
         description="Class name for backward compatibility",
     )
 
-    _path_suffix: ClassVar[Optional[str]] = "actions/addMembers"
+    _path_suffix: ClassVar[str | None] = "actions/addMembers"
 
     endpoint_params: FabricsTicketEndpointParams = Field(default_factory=FabricsTicketEndpointParams, description="Endpoint-specific query parameters")
 
@@ -719,7 +719,7 @@ class EpManageFabricsMembersRemovePost(_EpManageFabricsBase):
         description="Class name for backward compatibility",
     )
 
-    _path_suffix: ClassVar[Optional[str]] = "actions/removeMembers"
+    _path_suffix: ClassVar[str | None] = "actions/removeMembers"
 
     endpoint_params: FabricsTicketEndpointParams = Field(default_factory=FabricsTicketEndpointParams, description="Endpoint-specific query parameters")
 

--- a/plugins/module_utils/orchestrators/fabric_resolver.py
+++ b/plugins/module_utils/orchestrators/fabric_resolver.py
@@ -58,6 +58,14 @@ def _response_message(data: Any) -> str:
     return str(data)
 
 
+class FabricResolverNotFound(Exception):
+    """Raised when a resolver lookup receives an explicit controller 404."""
+
+
+class FabricResolverRequestError(Exception):
+    """Raised when a required resolver request fails for a non-404 reason."""
+
+
 def _is_error_response(response: Any) -> bool:
     """Return True when a wrapped ND response represents an HTTP/API error."""
     if not isinstance(response, dict):
@@ -180,12 +188,18 @@ class FabricResolverBase:
         """Send a resolver request through RestSend."""
         self._rest_send.path = path
         self._rest_send.verb = HttpVerbEnum(method.upper())
-        self._rest_send.commit()
+        try:
+            self._rest_send.commit()
+        except Exception as exc:
+            raise FabricResolverRequestError(f"{method.upper()} {path} failed before controller response: {exc}") from exc
 
         if ignore_not_found_error and self._rest_send.return_code == 404:
             return {}
+        if self._rest_send.return_code == 404:
+            raise FabricResolverNotFound(f"{method.upper()} {path} returned 404: {self._rest_send.error_summary}")
         if not self._rest_send.success:
-            raise Exception(f"Request failed {self._rest_send.error_summary}")
+            detail = _response_message(_response_data(self._rest_send.response_current))
+            raise FabricResolverRequestError(f"{method.upper()} {path} failed: {self._rest_send.error_summary}: {detail}")
         return self._rest_send.response_current
 
     def _controller_version(self) -> str:
@@ -388,7 +402,7 @@ class FabricResolverBase:
         enriched = dict(fabric_data or {})
         try:
             details = self._fetch_manage_fabric_details(self.fabric_name, enriched.get("clusterName"))
-        except Exception:
+        except FabricResolverNotFound:
             details = {}
 
         management = details.get("management") if isinstance(details, dict) else {}
@@ -416,7 +430,7 @@ class FabricResolverBase:
         """Resolve fabric topology with Manage endpoints and OneManage MCFG probe."""
         try:
             fabric_details = self._fetch_manage_fabric_details(self.fabric_name)
-        except Exception:
+        except FabricResolverNotFound:
             fabric_details = {}
 
         if fabric_details and fabric_details.get("category") != "fabricGroup":

--- a/plugins/module_utils/orchestrators/fabric_resolver.py
+++ b/plugins/module_utils/orchestrators/fabric_resolver.py
@@ -7,6 +7,7 @@ import time
 
 from typing import Any
 
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import (
     EpManageFabricsGet,
     EpManageFabricsListGet,
@@ -37,7 +38,7 @@ def _nd_onemanage_proxy(_version_str: str) -> str:
 
 
 def _response_data(response: Any) -> Any:
-    """Return the data payload from direct NDModule or wrapped RestSend responses."""
+    """Return the data payload from direct dict or wrapped RestSend responses."""
     if isinstance(response, dict) and "DATA" in response:
         return response.get("DATA")
     return response
@@ -154,11 +155,12 @@ class FabricResolverBase:
     multicluster_parent_strategy_cls: type[Any] | None = None
     child_strategy_cls: type[Any] | None = None
 
-    def __init__(self, nd_module: Any, fabric_name: str):
-        self._nd = nd_module
+    def __init__(self, fabric_name: str, rest_send: Any):
+        self._rest_send = rest_send
         self.fabric_name = fabric_name
         self._workflow_trace: list[dict[str, Any]] = []
         self._trace_started_at = time.monotonic()
+        self._manage_fabric_details_cache: dict[tuple[str, str | None], dict[str, Any]] = {}
 
     @property
     def workflow_trace(self) -> list[dict[str, Any]]:
@@ -173,6 +175,22 @@ class FabricResolverBase:
         }
         entry.update(details)
         self._workflow_trace.append(entry)
+
+    def _request(self, path: str, method: str = "GET", ignore_not_found_error: bool = False) -> Any:
+        """Send a resolver request through RestSend."""
+        self._rest_send.path = path
+        self._rest_send.verb = HttpVerbEnum(method.upper())
+        self._rest_send.commit()
+
+        if ignore_not_found_error and self._rest_send.return_code == 404:
+            return {}
+        if not self._rest_send.success:
+            raise Exception(f"Request failed {self._rest_send.error_summary}")
+        return self._rest_send.response_current
+
+    def _controller_version(self) -> str:
+        """Return the controller version when provided by the request runtime."""
+        return getattr(self._rest_send, "version", "") or ""
 
     def resolve(self) -> Any:
         """Resolve and instantiate the strategy for ``fabric_name``."""
@@ -233,51 +251,42 @@ class FabricResolverBase:
 
     def _request_onemanage_probe(self, path: str, method: str) -> Any:
         """Call a OneManage probe without letting HTTP errors abort detection."""
-        connection = getattr(self._nd, "connection", None)
-        if connection is None:
-            try:
-                response = self._nd.request(path, method=method, ignore_not_found_error=True)
-            except Exception as exc:
-                self._trace("fabric_resolver_onemanage_probe_error", path=path, method=method, error=repr(exc))
-                return {}
-            if _is_error_response(response):
-                self._trace("fabric_resolver_onemanage_probe_error_response", path=path, method=method, message=_response_message(_response_data(response)))
-                return {}
-            return response
-
         try:
-            info = connection.send_request(method, path)
-            if hasattr(self._nd, "httpapi_logs") and hasattr(connection, "pop_messages"):
-                self._nd.httpapi_logs.extend(connection.pop_messages())
+            response = self._request(path, method=method, ignore_not_found_error=True)
         except Exception as exc:
             self._trace("fabric_resolver_onemanage_probe_error", path=path, method=method, error=repr(exc))
             return {}
-
-        status = info.get("status", -1) if isinstance(info, dict) else -1
-        body = info.get("body") if isinstance(info, dict) else None
-        if status in (200, 201, 202, 204):
-            return body
-        if status == 404:
+        if _is_error_response(response):
+            self._trace("fabric_resolver_onemanage_probe_error_response", path=path, method=method, message=_response_message(_response_data(response)))
             return {}
-        if status >= 400:
-            message = _response_message(body)
-            if message in _FEDERATION_MANAGER_NOT_FOUND_ERRORS or "this API is allowed only for remote user" in message:
-                return {}
-            return {}
-        return body
+        return response
 
     def _fetch_manage_fabric_details(self, fabric_name: str, cluster_name: str | None = None) -> dict[str, Any]:
         """GET ND Manage fabric details for the target fabric."""
+        cache_key = (fabric_name, cluster_name)
+        if cache_key in self._manage_fabric_details_cache:
+            cached = self._manage_fabric_details_cache[cache_key]
+            self._trace(
+                "fabric_resolver_manage_fabric_cache_hit",
+                fabric_name=fabric_name,
+                cluster_name=cluster_name,
+                found=bool(cached),
+                category=cached.get("category"),
+                fabric_type=cached.get("fabricType") or cached.get("type"),
+            )
+            return dict(cached)
+
         endpoint = EpManageFabricsGet(fabric_name=fabric_name)
         endpoint.endpoint_params.cluster_name = cluster_name
         self._trace("fabric_resolver_manage_fabric_start", fabric_name=fabric_name, cluster_name=cluster_name, path=endpoint.path)
-        response = self._nd.request(
+        response = self._request(
             endpoint.path,
             method=endpoint.verb.value,
             ignore_not_found_error=True,
         )
         data = _response_data(response)
         result = data if isinstance(data, dict) else {}
+        self._manage_fabric_details_cache[cache_key] = dict(result)
         self._trace(
             "fabric_resolver_manage_fabric_end",
             fabric_name=fabric_name,
@@ -292,7 +301,7 @@ class FabricResolverBase:
         endpoint = EpManageFabricsMembersGet(fabric_name=fabric_name)
         endpoint.endpoint_params.cluster_name = cluster_name
         self._trace("fabric_resolver_manage_members_fetch_start", fabric_name=fabric_name, cluster_name=cluster_name, path=endpoint.path)
-        response = self._nd.request(
+        response = self._request(
             endpoint.path,
             method=endpoint.verb.value,
             ignore_not_found_error=True,
@@ -309,7 +318,7 @@ class FabricResolverBase:
         endpoint.endpoint_params.category = "fabricGroup"
         endpoint.endpoint_params.max = 10000
         self._trace("fabric_resolver_manage_fabric_groups_start", path=endpoint.path)
-        response = self._nd.request(
+        response = self._request(
             endpoint.path,
             method=endpoint.verb.value,
             ignore_not_found_error=True,
@@ -333,7 +342,7 @@ class FabricResolverBase:
         """GET OneManage member fabrics for a multicluster parent fabric."""
         endpoint = EpOneManageFabricsMembersGet(fabric_name=fabric_name)
         self._trace("fabric_resolver_onemanage_members_fetch_start", fabric_name=fabric_name, path=endpoint.path)
-        response = self._nd.request(
+        response = self._request(
             endpoint.path,
             method=endpoint.verb.value,
             ignore_not_found_error=True,
@@ -391,7 +400,7 @@ class FabricResolverBase:
         if details:
             enriched["manageFabricDetails"] = details
         if enriched.get("fabricType") == "MFD":
-            enriched["onemanageProxyPath"] = _nd_onemanage_proxy(self._nd.version or "")
+            enriched["onemanageProxyPath"] = _nd_onemanage_proxy(self._controller_version())
             members = enriched.get("members")
             if not members:
                 try:

--- a/plugins/module_utils/orchestrators/network_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/network_attachment_manager.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import time
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from ansible_collections.cisco.nd.plugins.module_utils.enums import OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_network_attachments import (
@@ -91,9 +91,9 @@ class NetworkAttachmentManager:
         module_args: dict,
         strategy: BaseNetworkStrategy,
         phase: str,
-        desired: Optional[dict[tuple[str, str], dict[str, Any]]] = None,
-        current_network_names: Optional[list[str]] = None,
-        current: Optional[dict[tuple[str, str], dict[str, Any]]] = None,
+        desired: dict[tuple[str, str], dict[str, Any]] | None = None,
+        current_network_names: list[str] | None = None,
+        current: dict[tuple[str, str], dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         state = module_args.get("state", "merged")
         config = module_args.get("config") or []
@@ -147,8 +147,8 @@ class NetworkAttachmentManager:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]] = None,
-        attachment_details: Optional[list[dict[str, Any]]] = None,
+        network_names: list[str] | None = None,
+        attachment_details: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         network_names = network_names if network_names is not None else configured_network_names(module_args.get("config") or [])
         self._trace("network_deleted_attachment_phase_start", network_names=network_names)
@@ -260,7 +260,7 @@ class NetworkAttachmentManager:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]] = None,
+        network_names: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         attachments: list[dict[str, Any]] = []
         offset = 0
@@ -281,7 +281,7 @@ class NetworkAttachmentManager:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]],
+        network_names: list[str] | None,
         offset: int,
     ) -> Any:
         orchestrator, _results = self.coordinator._new_network_orchestrator(module_args, strategy)
@@ -336,7 +336,7 @@ class NetworkAttachmentManager:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]] = None,
+        network_names: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         if network_names and len(network_names) > self.wait_chunk_size:
             attachments: list[dict[str, Any]] = []
@@ -353,14 +353,8 @@ class NetworkAttachmentManager:
         if not network_names or len(network_names) <= 1:
             return []
 
-        attachments: list[dict[str, Any]] = []
-        for network_name in network_names:
-            try:
-                attachments.extend(self.current_attachment_details(module_args, strategy, [network_name]))
-            except Exception as exc:
-                if not self._attachment_query_missing_network(exc):
-                    raise
-        return attachments
+        all_attachments = self.current_attachment_details(module_args, strategy, None)
+        return self.filter_attachment_details_by_network(all_attachments, network_names)
 
     @staticmethod
     def _attachment_query_missing_network(error: Exception) -> bool:
@@ -371,14 +365,14 @@ class NetworkAttachmentManager:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]] = None,
+        network_names: list[str] | None = None,
     ) -> dict[tuple[str, str], dict[str, Any]]:
         return self.attachment_map_from_details(self.current_attachment_details(module_args, strategy, network_names), network_names)
 
     @staticmethod
     def attachment_map_from_details(
         attachments: list[dict[str, Any]],
-        network_names: Optional[Union[list[str], set[str]]] = None,
+        network_names: list[str] | set[str] | None = None,
     ) -> dict[tuple[str, str], dict[str, Any]]:
         filter_set = set(network_names or [])
         result: dict[tuple[str, str], dict[str, Any]] = {}
@@ -720,7 +714,7 @@ class NetworkAttachmentManager:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]] = None,
+        network_names: list[str] | None = None,
     ) -> None:
         pending = set(network_names if network_names is not None else configured_network_names(module_args.get("config") or []))
         if not pending:
@@ -763,7 +757,7 @@ class NetworkAttachmentManager:
             msg=f"Timed out waiting for network attachments to become deletable on fabric '{strategy.fabric_name}': {last_blockers}"
         )
 
-    def wait_for_networks_delete_ready(self, module_args: dict, strategy: BaseNetworkStrategy, network_names: Optional[list[str]] = None) -> None:
+    def wait_for_networks_delete_ready(self, module_args: dict, strategy: BaseNetworkStrategy, network_names: list[str] | None = None) -> None:
         pending = set(network_names if network_names is not None else configured_network_names(module_args.get("config") or []))
         if not pending:
             return
@@ -817,7 +811,7 @@ class NetworkAttachmentManager:
         return attachments
 
     @staticmethod
-    def filter_attachment_details_by_network(attachments: list[dict[str, Any]], network_names: Union[list[str], set[str]]) -> list[dict[str, Any]]:
+    def filter_attachment_details_by_network(attachments: list[dict[str, Any]], network_names: list[str] | set[str]) -> list[dict[str, Any]]:
         names = set(network_names)
         return [attachment for attachment in attachments if attachment.get("networkName") in names]
 

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -20,7 +20,7 @@ coordinator helpers instead of changing the shared state-machine contract.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.strategies.base_network import (
     BaseNetworkStrategy,
@@ -49,7 +49,7 @@ class NetworkStateMachine:
         """Return True when the owning Ansible module is running in check mode."""
         return bool(getattr(getattr(self.coordinator, "module", None), "check_mode", False))
 
-    def run_basic(self, module_args: dict, strategy: Optional[BaseNetworkStrategy] = None) -> dict[str, Any]:
+    def run_basic(self, module_args: dict, strategy: BaseNetworkStrategy | None = None) -> dict[str, Any]:
         """
         Run only the generic NDStateMachine-backed Network CRUD/gathered flow.
         """
@@ -68,7 +68,7 @@ class NetworkStateMachine:
     def run(
         self,
         module_args: dict,
-        strategy: Optional[BaseNetworkStrategy] = None,
+        strategy: BaseNetworkStrategy | None = None,
         defer_deploy: bool = False,
     ) -> dict[str, Any]:
         """
@@ -222,7 +222,7 @@ class NetworkStateMachine:
         self,
         pre_attach: dict[str, Any],
         empty_when_absent: bool = False,
-    ) -> Optional[dict[tuple[str, str], dict[str, Any]]]:
+    ) -> dict[tuple[str, str], dict[str, Any]] | None:
         """Return cached attachments after applying pre-detach payloads."""
         current = pre_attach.get("current")
         if current is None:
@@ -320,7 +320,7 @@ class NetworkStateMachine:
         module_args: dict,
         strategy: BaseNetworkStrategy,
         omitted_network_names: list[str],
-        current_attachment_details: Optional[list[dict[str, Any]]] = None,
+        current_attachment_details: list[dict[str, Any]] | None = None,
     ) -> list[dict[str, Any]]:
         """Detach/deploy omitted Networks before overridden deletes them."""
         if not omitted_network_names:
@@ -453,7 +453,7 @@ class NetworkStateMachine:
         strategy: BaseNetworkStrategy,
         config: list[dict],
         detach_trace: dict[str, Any],
-        wait_network_names: Optional[list[str]] = None,
+        wait_network_names: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """Return detach trace plus delete undeploy traces, then wait for readiness."""
         traces = [detach_trace] if detach_trace else []

--- a/plugins/module_utils/orchestrators/network_workflow_coordinator.py
+++ b/plugins/module_utils/orchestrators/network_workflow_coordinator.py
@@ -145,7 +145,7 @@ class NetworkWorkflowCoordinator:
         timeout: int | None = None,
         send_interval: int | None = None,
     ) -> RestSend:
-        """Build the Gen-3 REST runtime used by resolver and orchestrators."""
+        """Build a Gen-3 REST runtime for resolver or state-machine calls."""
         sender = Sender()
         sender.ansible_module = self.module
 
@@ -161,7 +161,13 @@ class NetworkWorkflowCoordinator:
         return rest_send
 
     def _resolve_strategy(self, module_args: dict) -> BaseNetworkStrategy:
-        """Resolve fabric topology using the same Gen-3 REST runtime as the workflow."""
+        """Resolve fabric topology with a short-timeout Gen-3 REST probe.
+
+        Topology detection intentionally uses a non-check-mode, single-attempt
+        RestSend variant so expected probe misses do not enter the workflow
+        retry loop. State-machine operations build their own RestSend instances
+        with the module's check mode and default timeout settings.
+        """
         rest_send = self._new_rest_send(params=module_args, check_mode=False, timeout=1, send_interval=1)
         resolver = NetworkFabricResolver(
             rest_send=rest_send,

--- a/plugins/module_utils/orchestrators/network_workflow_coordinator.py
+++ b/plugins/module_utils/orchestrators/network_workflow_coordinator.py
@@ -5,14 +5,15 @@
 """
 NetworkWorkflowCoordinator — Parent / child Network workflow orchestration.
 
-The coordinator is constructed inside nd_manage_networks.py after the strategy is
-resolved. For standalone and child fabrics it runs the state machine
-directly. For parent fabrics it:
-  1. Parses and validates the requested Network config.
-  2. Splits child_fabric_config into per-child in-process tasks.
-  3. Runs the parent task via the Network state machine.
-  4. Runs each child task with the child's resolved strategy.
-  5. Deploys deferred parent attachment changes, then aggregates results.
+The coordinator is constructed inside nd_manage_networks.py and resolves the
+target fabric strategy through the Gen-3 REST runtime. For standalone and child
+fabrics it runs the state machine directly. For parent fabrics it:
+  1. Resolves fabric topology and selects the strategy.
+  2. Parses and validates the requested Network config.
+  3. Splits child_fabric_config into per-child in-process tasks.
+  4. Runs the parent task via the Network state machine.
+  5. Runs each child task with the child's resolved strategy.
+  6. Deploys deferred parent attachment changes, then aggregates results.
 """
 
 from __future__ import annotations
@@ -20,7 +21,7 @@ from __future__ import annotations
 import copy
 import time
 
-from typing import Any, Optional, Union
+from typing import Any
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -70,8 +71,8 @@ class NetworkWorkflowCoordinator:
     def __init__(
         self,
         module: AnsibleModule,
-        strategy: BaseNetworkStrategy,
-        initial_workflow_trace: Optional[list[dict[str, Any]]] = None,
+        strategy: BaseNetworkStrategy | None = None,
+        initial_workflow_trace: list[dict[str, Any]] | None = None,
     ):
         self.module = module
         self.strategy = strategy
@@ -79,6 +80,11 @@ class NetworkWorkflowCoordinator:
         self._workflow_trace: list[dict[str, Any]] = []
         if initial_workflow_trace:
             self._workflow_trace.extend(dict(entry) for entry in initial_workflow_trace)
+
+    @property
+    def workflow_trace(self) -> list[dict[str, Any]]:
+        """Return workflow trace entries collected by the coordinator."""
+        return list(self._workflow_trace)
 
     @property
     def attachments(self) -> NetworkAttachmentManager:
@@ -103,6 +109,8 @@ class NetworkWorkflowCoordinator:
         Returns a result dict suitable for module.exit_json(**result).
         """
         module_args: dict = dict(self.module.params)
+        if self.strategy is None:
+            self.strategy = self._resolve_strategy(module_args)
         self._trace(
             "workflow_start",
             fabric_name=module_args.get("fabric_name"),
@@ -129,6 +137,41 @@ class NetworkWorkflowCoordinator:
 
         self._trace("workflow_end", changed=result.get("changed"), failed=result.get("failed"))
         return self._attach_workflow_trace(result)
+
+    def _new_rest_send(
+        self,
+        params: dict[str, Any] | None = None,
+        check_mode: bool | None = None,
+        timeout: int | None = None,
+        send_interval: int | None = None,
+    ) -> RestSend:
+        """Build the Gen-3 REST runtime used by resolver and orchestrators."""
+        sender = Sender()
+        sender.ansible_module = self.module
+
+        rest_send_params = dict(params if params is not None else self.module.params)
+        rest_send_params["check_mode"] = self.module.check_mode if check_mode is None else check_mode
+        rest_send = RestSend(rest_send_params)
+        rest_send.sender = sender
+        rest_send.response_handler = ResponseHandler()
+        if timeout is not None:
+            rest_send.timeout = timeout
+        if send_interval is not None:
+            rest_send.send_interval = send_interval
+        return rest_send
+
+    def _resolve_strategy(self, module_args: dict) -> BaseNetworkStrategy:
+        """Resolve fabric topology using the same Gen-3 REST runtime as the workflow."""
+        rest_send = self._new_rest_send(params=module_args, check_mode=False, timeout=1, send_interval=1)
+        resolver = NetworkFabricResolver(
+            rest_send=rest_send,
+            fabric_name=module_args["fabric_name"],
+        )
+        strategy = resolver.resolve()
+        resolver_trace = getattr(resolver, "workflow_trace", None)
+        if resolver_trace:
+            self._workflow_trace.extend(dict(entry) for entry in resolver_trace)
+        return strategy
 
     def _trace_enabled(self) -> bool:
         verbosity = self.module._verbosity if hasattr(self.module, "_verbosity") else 0
@@ -445,7 +488,7 @@ class NetworkWorkflowCoordinator:
 
     # ── State machine runner ──────────────────────────────────────
 
-    def _run_state_machine(self, module_args: dict, strategy: Optional[BaseNetworkStrategy] = None) -> dict[str, Any]:
+    def _run_state_machine(self, module_args: dict, strategy: BaseNetworkStrategy | None = None) -> dict[str, Any]:
         """
         Run NDStateMachine for the given module_args and return the result dict.
 
@@ -478,7 +521,7 @@ class NetworkWorkflowCoordinator:
             self._network_state_machine_instance = NetworkStateMachine(self)
         return self._network_state_machine_instance
 
-    def _new_state_machine(self, module_args: dict, strategy: Optional[BaseNetworkStrategy] = None) -> tuple[NDStateMachine, Any, Any]:
+    def _new_state_machine(self, module_args: dict, strategy: BaseNetworkStrategy | None = None) -> tuple[NDStateMachine, Any, Any]:
         """
         Build a Network state machine after applying Network config transformation.
 
@@ -546,7 +589,7 @@ class NetworkWorkflowCoordinator:
     def _run_state_machine_with_attachments(
         self,
         module_args: dict,
-        strategy: Optional[BaseNetworkStrategy] = None,
+        strategy: BaseNetworkStrategy | None = None,
         defer_deploy: bool = False,
     ) -> dict[str, Any]:
         """
@@ -655,7 +698,7 @@ class NetworkWorkflowCoordinator:
     def _finalize_api_trace(
         self,
         results: Results,
-        deploy_targets: Optional[dict[str, set[str]]] = None,
+        deploy_targets: dict[str, set[str]] | None = None,
     ) -> dict[str, Any]:
         """Convert collected API calls into a compact mergeable structure."""
         results.build_final_result()
@@ -728,9 +771,9 @@ class NetworkWorkflowCoordinator:
         module_args: dict,
         strategy: BaseNetworkStrategy,
         phase: str,
-        desired: Optional[dict[tuple[str, str], dict[str, Any]]] = None,
-        current_network_names: Optional[list[str]] = None,
-        current: Optional[dict[tuple[str, str], dict[str, Any]]] = None,
+        desired: dict[tuple[str, str], dict[str, Any]] | None = None,
+        current_network_names: list[str] | None = None,
+        current: dict[tuple[str, str], dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Attach or detach Networks according to state and phase."""
         return self.attachments.apply_phase(module_args, strategy, phase, desired, current_network_names, current)
@@ -754,8 +797,8 @@ class NetworkWorkflowCoordinator:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]] = None,
-        attachment_details: Optional[list[dict[str, Any]]] = None,
+        network_names: list[str] | None = None,
+        attachment_details: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """
         Detach all current attachments for deleted Networks, independent of config.
@@ -769,7 +812,7 @@ class NetworkWorkflowCoordinator:
     def _filter_attachment_details_by_network(
         self,
         attachments: list[dict[str, Any]],
-        network_names: Union[list[str], set[str]],
+        network_names: list[str] | set[str],
     ) -> list[dict[str, Any]]:
         """Return attachment rows for the requested Network names."""
         return self.attachments.filter_attachment_details_by_network(attachments, network_names)
@@ -819,7 +862,7 @@ class NetworkWorkflowCoordinator:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]],
+        network_names: list[str] | None,
     ) -> dict[tuple[str, str], dict[str, Any]]:
         """Gathered ND and key attached Network attachments by (networkName, switchId)."""
         return self.attachments.current_attachment_map(module_args, strategy, network_names)
@@ -827,7 +870,7 @@ class NetworkWorkflowCoordinator:
     def _attachment_map_from_details(
         self,
         attachments: list[dict[str, Any]],
-        network_names: Optional[Union[list[str], set[str]]] = None,
+        network_names: list[str] | set[str] | None = None,
     ) -> dict[tuple[str, str], dict[str, Any]]:
         """Key attached Network attachment rows by (networkName, switchId)."""
         return self.attachments.attachment_map_from_details(attachments, network_names)
@@ -836,7 +879,7 @@ class NetworkWorkflowCoordinator:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]],
+        network_names: list[str] | None,
     ) -> list[dict[str, Any]]:
         """Gathered all attachment details, including pending detach entries."""
         return self.attachments.current_attachment_details(module_args, strategy, network_names)
@@ -845,7 +888,7 @@ class NetworkWorkflowCoordinator:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]],
+        network_names: list[str] | None,
     ) -> list[dict[str, Any]]:
         """Gathered attachment details while treating absent deleted Networks as empty."""
         return self.attachments.current_attachment_details_ignore_missing(module_args, strategy, network_names)
@@ -935,8 +978,8 @@ class NetworkWorkflowCoordinator:
     def _record_deploy_target(
         self,
         deploy_targets: dict[str, set[str]],
-        network_name: Optional[str],
-        switch_id: Optional[str],
+        network_name: str | None,
+        switch_id: str | None,
     ) -> None:
         """Record one Network/switch pair for a later Network deployment request."""
         self.attachments.record_deploy_target(deploy_targets, network_name, switch_id)
@@ -996,7 +1039,7 @@ class NetworkWorkflowCoordinator:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]] = None,
+        network_names: list[str] | None = None,
     ) -> None:
         """Wait until configured Networks are absent or in notApplicable state."""
         if self.module.check_mode:
@@ -1007,7 +1050,7 @@ class NetworkWorkflowCoordinator:
         self,
         module_args: dict,
         strategy: BaseNetworkStrategy,
-        network_names: Optional[list[str]] = None,
+        network_names: list[str] | None = None,
     ) -> None:
         """Wait until configured Network attachments no longer block deletion."""
         if self.module.check_mode:

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -558,46 +558,15 @@ api_metadata:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec, NDModule
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_fabric_resolver import (
-    NetworkFabricResolver,
-)
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_workflow_coordinator import (
     NetworkWorkflowCoordinator,
 )
-
-# ---------------------------------------------------------------------------
-# Argument-spec helpers
-# ---------------------------------------------------------------------------
-
-
-def network_base_argument_spec():
-    """Re-exported for backward compatibility. Defined in network_argument_specs."""
-    from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_argument_specs import (
-        network_base_argument_spec as _impl,
-    )
-
-    return _impl()
-
-
-def _child_fabric_config_element_spec():
-    from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_argument_specs import (
-        _child_fabric_config_element_spec as _impl,
-    )
-
-    return _impl()
-
-
-def network_parent_argument_spec():
-    """Re-exported for backward compatibility. Defined in network_argument_specs."""
-    from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_argument_specs import (
-        network_parent_argument_spec as _impl,
-    )
-
-    return _impl()
-
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_argument_specs import (
+    network_parent_argument_spec,
+)
 
 # ---------------------------------------------------------------------------
 # Module entry point
@@ -629,25 +598,7 @@ def main():
     require_pydantic(module)
 
     try:
-        fabric_name: str = module.params["fabric_name"]
-
-        # Resolve the Network strategy from the ND API
-        nd_module = NDModule(module)
-        resolver = NetworkFabricResolver(
-            nd_module=nd_module,
-            fabric_name=fabric_name,
-        )
-        strategy = resolver.resolve()
-
-        # Run the workflow coordinator for the resolved strategy
-        coordinator_args = {
-            "module": module,
-            "strategy": strategy,
-        }
-        resolver_trace = getattr(resolver, "workflow_trace", None)
-        if resolver_trace:
-            coordinator_args["initial_workflow_trace"] = resolver_trace
-        coordinator = NetworkWorkflowCoordinator(**coordinator_args)
+        coordinator = NetworkWorkflowCoordinator(module=module)
         result = coordinator.run()
 
         module.exit_json(**result)

--- a/tests/unit/module_utils/orchestrators/test_network_fabric_resolver.py
+++ b/tests/unit/module_utils/orchestrators/test_network_fabric_resolver.py
@@ -67,8 +67,7 @@ def _controller_response(status: int, message: str, data: dict | None = None) ->
 
 def _real_rest_send_resolver(fabric_name: str, responses: list[dict], sender_exception: Exception | None = None) -> NetworkFabricResolver:
     def generated_responses():
-        for response in responses:
-            yield response
+        yield from responses
 
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()

--- a/tests/unit/module_utils/orchestrators/test_network_fabric_resolver.py
+++ b/tests/unit/module_utils/orchestrators/test_network_fabric_resolver.py
@@ -9,118 +9,64 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_fab
 )
 
 
-class _ND:
+class _RestSend:
     version = "3.2.1"
 
-    def __init__(self):
-        self.calls = []
-
-    def request(self, path, method="GET", **kwargs):
-        self.calls.append({"path": path, "method": method, "kwargs": kwargs})
-        if path == "/api/v1/manage/fabrics/fab1":
-            return {"management": {"type": "vxlanIbgp"}}
-        if path == "/api/v1/manage/fabrics?category=fabricGroup&max=10000":
-            return {"fabrics": []}
-        if path == "/api/v1/manage/fabrics/MCFG_C":
-            return {"name": "MCFG_C", "category": "fabricGroup", "management": {"type": "vxlan"}}
-        if path == "/api/v1/oneManage/manage/fabrics/MCFG_C/networks?max=1":
-            return {"networks": [], "meta": {"total": 0, "remaining": 0}}
-        if path == "/api/v1/oneManage/manage/fabrics/MCFG_C/members":
-            return {"fabrics": [{"name": "nacfab", "clusterName": "ND42-REL", "type": "vxlanIbgp"}]}
-        if path == "/api/v1/manage/fabrics/mfd1?clusterName=cluster1":
-            return {"management": {"type": "vxlanEbgp"}}
-        if path == "/api/v1/oneManage/manage/fabrics/mfd1/members":
-            return {"fabrics": [{"name": "child1", "clusterName": "cluster2", "type": "vxlanIbgp"}]}
-        return {}
-
-
-class _Connection:
-    def __init__(self, responses, options=None):
+    def __init__(self, responses):
         self.responses = responses
-        self.options = options or {}
         self.calls = []
+        self.path = None
+        self.verb = None
+        self.return_code = 200
+        self.success = True
+        self.error_summary = ""
+        self.response_current = {}
 
-    def send_request(self, method, path):
-        self.calls.append({"path": path, "method": method})
-        return self.responses.get(path, {"status": 404, "body": {}})
-
-    def get_option(self, name):
-        return self.options.get(name)
-
-    def pop_messages(self):
-        return []
-
-
-class _MSDND(_ND):
-    def __init__(self):
-        super().__init__()
-        self.httpapi_logs = []
-        self.connection = _Connection(
-            {
-                "/api/v1/oneManage/manage/fabrics/msd_p/networks?max=1": {
-                    "status": 500,
-                    "body": {"code": 500, "message": "this API is allowed only for remote user"},
-                }
-            }
-        )
-
-    def request(self, path, method="GET", **kwargs):
-        self.calls.append({"path": path, "method": method, "kwargs": kwargs})
-        if path == "/api/v1/manage/fabrics/msd_p":
-            return {"name": "msd_p", "category": "fabricGroup", "management": {"type": "vxlan"}}
-        if path == "/api/v1/manage/fabrics/msd_p/members":
-            return {"fabrics": [{"name": "nacfab", "type": "VXLAN"}]}
-        return {}
+    def commit(self):
+        method = self.verb.value if hasattr(self.verb, "value") else self.verb
+        self.calls.append({"path": self.path, "method": method})
+        response = self.responses.get(self.path, {})
+        if isinstance(response, Exception):
+            raise response
+        if isinstance(response, dict) and "RETURN_CODE" in response:
+            self.return_code = response.get("RETURN_CODE", 200)
+            self.success = self.return_code < 400
+            self.response_current = response
+            self.error_summary = f"({self.return_code})"
+            return
+        self.return_code = 200
+        self.success = True
+        self.error_summary = ""
+        self.response_current = {"DATA": response}
 
 
-class _WrappedOneManageErrorMSDND(_ND):
-    def request(self, path, method="GET", **kwargs):
-        self.calls.append({"path": path, "method": method, "kwargs": kwargs})
-        if path == "/api/v1/manage/fabrics/msd_p":
-            return {"name": "msd_p", "category": "fabricGroup", "management": {"type": "vxlan"}}
-        if path == "/api/v1/oneManage/manage/fabrics/msd_p/networks?max=1":
-            return {"RETURN_CODE": 400, "DATA": {"code": 400, "message": "fabric not found"}}
-        if path == "/api/v1/manage/fabrics/msd_p/members":
-            return {"fabrics": [{"name": "nacfab", "type": "VXLAN"}]}
-        return {}
-
-
-class _ChildND(_ND):
-    def __init__(self, member_parent, member_name, member_probe_body):
-        super().__init__()
-        self.member_parent = member_parent
-        self.member_name = member_name
-        self.httpapi_logs = []
-        self.connection = _Connection(
-            {
-                f"/api/v1/oneManage/manage/fabrics/{member_parent}/members": member_probe_body,
-            }
-        )
-
-    def request(self, path, method="GET", **kwargs):
-        self.calls.append({"path": path, "method": method, "kwargs": kwargs})
-        if path == f"/api/v1/manage/fabrics/{self.member_name}":
-            return {"name": self.member_name, "category": "fabric", "management": {"type": "vxlanIbgp"}}
-        if path == "/api/v1/manage/fabrics?category=fabricGroup&max=10000":
-            return {"fabrics": [{"name": self.member_parent, "category": "fabricGroup", "management": {"type": "vxlan"}}]}
-        if path == f"/api/v1/manage/fabrics/{self.member_parent}/members":
-            return {"fabrics": [{"name": self.member_name, "type": "Switch_Fabric"}]}
-        return {}
+def _resolver(fabric_name, responses):
+    rest_send = _RestSend(responses)
+    return NetworkFabricResolver(rest_send=rest_send, fabric_name=fabric_name), rest_send
 
 
 def test_network_fabric_resolver_00010_standalone_enrichment_does_not_fetch_members():
-    nd = _ND()
-    resolver = NetworkFabricResolver(nd_module=nd, fabric_name="fab1")
+    resolver, rest_send = _resolver(
+        "fab1",
+        {
+            "/api/v1/manage/fabrics/fab1": {"management": {"type": "vxlanIbgp"}},
+        },
+    )
 
     enriched = resolver._enrich_with_manage_fabric_details({"fabricName": "fab1", "fabricType": "VXLAN"})
 
     assert enriched["networkType"] == "vxlanIbgp"
-    assert [call["path"] for call in nd.calls] == ["/api/v1/manage/fabrics/fab1"]
+    assert [call["path"] for call in rest_send.calls] == ["/api/v1/manage/fabrics/fab1"]
 
 
 def test_network_fabric_resolver_00020_mcfg_enrichment_fetches_members_with_cluster_name():
-    nd = _ND()
-    resolver = NetworkFabricResolver(nd_module=nd, fabric_name="mfd1")
+    resolver, rest_send = _resolver(
+        "mfd1",
+        {
+            "/api/v1/manage/fabrics/mfd1?clusterName=cluster1": {"management": {"type": "vxlanEbgp"}},
+            "/api/v1/oneManage/manage/fabrics/mfd1/members": {"fabrics": [{"name": "child1", "clusterName": "cluster2", "type": "vxlanIbgp"}]},
+        },
+    )
 
     enriched = resolver._enrich_with_manage_fabric_details({"fabricName": "mfd1", "fabricType": "MFD", "clusterName": "cluster1"})
 
@@ -128,15 +74,21 @@ def test_network_fabric_resolver_00020_mcfg_enrichment_fetches_members_with_clus
     assert enriched["manageFabricMembers"] == [
         {"name": "child1", "clusterName": "cluster2", "type": "vxlanIbgp", "fabricName": "child1", "fabricState": "member", "fabricType": "vxlanIbgp"}
     ]
-    assert [call["path"] for call in nd.calls] == [
+    assert [call["path"] for call in rest_send.calls] == [
         "/api/v1/manage/fabrics/mfd1?clusterName=cluster1",
         "/api/v1/oneManage/manage/fabrics/mfd1/members",
     ]
 
 
 def test_network_fabric_resolver_00030_mcfg_detection_uses_schema_backed_onemanage_resource_path():
-    nd = _ND()
-    resolver = NetworkFabricResolver(nd_module=nd, fabric_name="MCFG_C")
+    resolver, rest_send = _resolver(
+        "MCFG_C",
+        {
+            "/api/v1/manage/fabrics/MCFG_C": {"name": "MCFG_C", "category": "fabricGroup", "management": {"type": "vxlan"}},
+            "/api/v1/oneManage/manage/fabrics/MCFG_C/networks?max=1": {"networks": [], "meta": {"total": 0, "remaining": 0}},
+            "/api/v1/oneManage/manage/fabrics/MCFG_C/members": {"fabrics": [{"name": "nacfab", "clusterName": "ND42-REL", "type": "vxlanIbgp"}]},
+        },
+    )
 
     fabric_type, fabric_data = resolver._resolve_fabric_type()
 
@@ -156,57 +108,64 @@ def test_network_fabric_resolver_00030_mcfg_detection_uses_schema_backed_onemana
             }
         ],
     }
-    assert [call["path"] for call in nd.calls] == [
+    assert [call["path"] for call in rest_send.calls] == [
         "/api/v1/manage/fabrics/MCFG_C",
         "/api/v1/oneManage/manage/fabrics/MCFG_C/networks?max=1",
         "/api/v1/oneManage/manage/fabrics/MCFG_C/members",
     ]
 
 
-def test_network_fabric_resolver_00031_mcfg_detection_uses_httpapi_connection_probe():
-    nd = _ND()
-    nd.httpapi_logs = []
-    nd.connection = _Connection(
+def test_network_fabric_resolver_00040_standalone_detection_does_not_probe_onemanage():
+    resolver, rest_send = _resolver(
+        "fab1",
         {
-            "/api/v1/oneManage/manage/fabrics/MCFG_C/networks?max=1": {
-                "status": 200,
-                "body": {"networks": [], "meta": {"total": 0, "remaining": 0}},
-            },
-            "/api/v1/oneManage/manage/fabrics/MCFG_C/members": {
-                "status": 200,
-                "body": {"fabrics": [{"name": "nacfab", "clusterName": "ND42-REL", "type": "vxlanIbgp"}]},
-            },
+            "/api/v1/manage/fabrics/fab1": {"management": {"type": "vxlanIbgp"}},
+            "/api/v1/manage/fabrics?category=fabricGroup&max=10000": {"fabrics": []},
         },
     )
-    resolver = NetworkFabricResolver(nd_module=nd, fabric_name="MCFG_C")
-
-    fabric_type, fabric_data = resolver._resolve_fabric_type()
-
-    assert fabric_type == "multicluster_parent"
-    assert fabric_data["fabricType"] == "MFD"
-    assert [call["path"] for call in nd.connection.calls] == [
-        "/api/v1/oneManage/manage/fabrics/MCFG_C/networks?max=1",
-        "/api/v1/oneManage/manage/fabrics/MCFG_C/members",
-    ]
-
-
-def test_network_fabric_resolver_00040_standalone_detection_does_not_probe_onemanage():
-    nd = _ND()
-    resolver = NetworkFabricResolver(nd_module=nd, fabric_name="fab1")
 
     fabric_type, fabric_data = resolver._resolve_fabric_type()
 
     assert fabric_type == "standalone"
     assert fabric_data == {"fabricName": "fab1", "fabricType": None, "fabricState": "active"}
-    assert [call["path"] for call in nd.calls] == [
+    assert [call["path"] for call in rest_send.calls] == [
+        "/api/v1/manage/fabrics/fab1",
+        "/api/v1/manage/fabrics?category=fabricGroup&max=10000",
+    ]
+
+
+def test_network_fabric_resolver_00041_resolve_reuses_manage_fabric_details_for_enrichment():
+    resolver, rest_send = _resolver(
+        "fab1",
+        {
+            "/api/v1/manage/fabrics/fab1": {"management": {"type": "vxlanIbgp"}},
+            "/api/v1/manage/fabrics?category=fabricGroup&max=10000": {"fabrics": []},
+        },
+    )
+
+    strategy = resolver.resolve()
+
+    assert strategy.fabric_type == "standalone"
+    assert strategy.fabric_data["networkType"] == "vxlanIbgp"
+    assert [call["path"] for call in rest_send.calls].count("/api/v1/manage/fabrics/fab1") == 1
+    assert [call["path"] for call in rest_send.calls] == [
         "/api/v1/manage/fabrics/fab1",
         "/api/v1/manage/fabrics?category=fabricGroup&max=10000",
     ]
 
 
 def test_network_fabric_resolver_00050_msd_detection_falls_back_when_onemanage_unavailable():
-    nd = _MSDND()
-    resolver = NetworkFabricResolver(nd_module=nd, fabric_name="msd_p")
+    resolver, rest_send = _resolver(
+        "msd_p",
+        {
+            "/api/v1/manage/fabrics/msd_p": {"name": "msd_p", "category": "fabricGroup", "management": {"type": "vxlan"}},
+            "/api/v1/oneManage/manage/fabrics/msd_p/networks?max=1": {
+                "RETURN_CODE": 500,
+                "DATA": {"code": 500, "message": "this API is allowed only for remote user"},
+            },
+            "/api/v1/manage/fabrics/msd_p/members": {"fabrics": [{"name": "nacfab", "type": "VXLAN"}]},
+        },
+    )
 
     fabric_type, fabric_data = resolver._resolve_fabric_type()
 
@@ -226,25 +185,29 @@ def test_network_fabric_resolver_00050_msd_detection_falls_back_when_onemanage_u
             }
         ],
     }
-    assert [call["path"] for call in nd.calls] == [
+    assert [call["path"] for call in rest_send.calls] == [
         "/api/v1/manage/fabrics/msd_p",
-        "/api/v1/manage/fabrics/msd_p/members",
-    ]
-    assert [call["path"] for call in nd.connection.calls] == [
         "/api/v1/oneManage/manage/fabrics/msd_p/networks?max=1",
+        "/api/v1/manage/fabrics/msd_p/members",
     ]
 
 
 def test_network_fabric_resolver_00051_msd_detection_ignores_wrapped_onemanage_error_response():
-    nd = _WrappedOneManageErrorMSDND()
-    resolver = NetworkFabricResolver(nd_module=nd, fabric_name="msd_p")
+    resolver, rest_send = _resolver(
+        "msd_p",
+        {
+            "/api/v1/manage/fabrics/msd_p": {"name": "msd_p", "category": "fabricGroup", "management": {"type": "vxlan"}},
+            "/api/v1/oneManage/manage/fabrics/msd_p/networks?max=1": {"RETURN_CODE": 400, "DATA": {"code": 400, "message": "fabric not found"}},
+            "/api/v1/manage/fabrics/msd_p/members": {"fabrics": [{"name": "nacfab", "type": "VXLAN"}]},
+        },
+    )
 
     fabric_type, fabric_data = resolver._resolve_fabric_type()
 
     assert fabric_type == "multisite_parent"
     assert fabric_data["fabricType"] == "MSD"
     assert fabric_data["members"][0]["fabricName"] == "nacfab"
-    assert [call["path"] for call in nd.calls] == [
+    assert [call["path"] for call in rest_send.calls] == [
         "/api/v1/manage/fabrics/msd_p",
         "/api/v1/oneManage/manage/fabrics/msd_p/networks?max=1",
         "/api/v1/manage/fabrics/msd_p/members",
@@ -252,15 +215,19 @@ def test_network_fabric_resolver_00051_msd_detection_ignores_wrapped_onemanage_e
 
 
 def test_network_fabric_resolver_00060_mcfg_child_uses_parent_onemanage_members_cluster():
-    nd = _ChildND(
-        "MCFG_C",
+    resolver, rest_send = _resolver(
         "nacfab",
         {
-            "status": 200,
-            "body": {"fabrics": [{"name": "nacfab", "clusterName": "ND42-REL", "fabricGroupName": "MCFG_C", "type": "vxlanIbgp"}]},
+            "/api/v1/manage/fabrics/nacfab": {"name": "nacfab", "category": "fabric", "management": {"type": "vxlanIbgp"}},
+            "/api/v1/manage/fabrics?category=fabricGroup&max=10000": {
+                "fabrics": [{"name": "MCFG_C", "category": "fabricGroup", "management": {"type": "vxlan"}}]
+            },
+            "/api/v1/manage/fabrics/MCFG_C/members": {"fabrics": [{"name": "nacfab", "type": "Switch_Fabric"}]},
+            "/api/v1/oneManage/manage/fabrics/MCFG_C/members": {
+                "fabrics": [{"name": "nacfab", "clusterName": "ND42-REL", "fabricGroupName": "MCFG_C", "type": "vxlanIbgp"}]
+            },
         },
     )
-    resolver = NetworkFabricResolver(nd_module=nd, fabric_name="nacfab")
 
     fabric_type, fabric_data = resolver._resolve_fabric_type()
 
@@ -268,19 +235,29 @@ def test_network_fabric_resolver_00060_mcfg_child_uses_parent_onemanage_members_
     assert fabric_data["fabricName"] == "nacfab"
     assert fabric_data["fabricParent"] == "MCFG_C"
     assert fabric_data["clusterName"] == "ND42-REL"
-    assert [call["path"] for call in nd.connection.calls] == ["/api/v1/oneManage/manage/fabrics/MCFG_C/members"]
+    assert [call["path"] for call in rest_send.calls] == [
+        "/api/v1/manage/fabrics/nacfab",
+        "/api/v1/manage/fabrics?category=fabricGroup&max=10000",
+        "/api/v1/manage/fabrics/MCFG_C/members",
+        "/api/v1/oneManage/manage/fabrics/MCFG_C/members",
+    ]
 
 
 def test_network_fabric_resolver_00070_msd_child_falls_back_when_parent_onemanage_unavailable():
-    nd = _ChildND(
-        "msd_p",
+    resolver, rest_send = _resolver(
         "AK-VXLAN",
         {
-            "status": 500,
-            "body": {"code": 500, "message": "this API is allowed only for remote user"},
+            "/api/v1/manage/fabrics/AK-VXLAN": {"name": "AK-VXLAN", "category": "fabric", "management": {"type": "vxlanIbgp"}},
+            "/api/v1/manage/fabrics?category=fabricGroup&max=10000": {
+                "fabrics": [{"name": "msd_p", "category": "fabricGroup", "management": {"type": "vxlan"}}]
+            },
+            "/api/v1/manage/fabrics/msd_p/members": {"fabrics": [{"name": "AK-VXLAN", "type": "Switch_Fabric"}]},
+            "/api/v1/oneManage/manage/fabrics/msd_p/members": {
+                "RETURN_CODE": 500,
+                "DATA": {"code": 500, "message": "this API is allowed only for remote user"},
+            },
         },
     )
-    resolver = NetworkFabricResolver(nd_module=nd, fabric_name="AK-VXLAN")
 
     fabric_type, fabric_data = resolver._resolve_fabric_type()
 
@@ -293,4 +270,9 @@ def test_network_fabric_resolver_00070_msd_child_falls_back_when_parent_onemanag
         "fabricState": "member",
         "fabricParent": "msd_p",
     }
-    assert [call["path"] for call in nd.connection.calls] == ["/api/v1/oneManage/manage/fabrics/msd_p/members"]
+    assert [call["path"] for call in rest_send.calls] == [
+        "/api/v1/manage/fabrics/AK-VXLAN",
+        "/api/v1/manage/fabrics?category=fabricGroup&max=10000",
+        "/api/v1/manage/fabrics/msd_p/members",
+        "/api/v1/oneManage/manage/fabrics/msd_p/members",
+    ]

--- a/tests/unit/module_utils/orchestrators/test_network_fabric_resolver.py
+++ b/tests/unit/module_utils/orchestrators/test_network_fabric_resolver.py
@@ -4,9 +4,19 @@
 
 from __future__ import annotations
 
+import pytest
+
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.fabric_resolver import (
+    FabricResolverRequestError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_fabric_resolver import (
     NetworkFabricResolver,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
 
 class _RestSend:
@@ -43,6 +53,84 @@ class _RestSend:
 def _resolver(fabric_name, responses):
     rest_send = _RestSend(responses)
     return NetworkFabricResolver(rest_send=rest_send, fabric_name=fabric_name), rest_send
+
+
+def _controller_response(status: int, message: str, data: dict | None = None) -> dict:
+    return {
+        "RETURN_CODE": status,
+        "MESSAGE": message,
+        "DATA": data or {},
+        "METHOD": "GET",
+        "REQUEST_PATH": "https://controller.example/api/v1/manage/fabrics/fab1",
+    }
+
+
+def _real_rest_send_resolver(fabric_name: str, responses: list[dict], sender_exception: Exception | None = None) -> NetworkFabricResolver:
+    def generated_responses():
+        for response in responses:
+            yield response
+
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = ResponseGenerator(generated_responses())
+    if sender_exception is not None:
+        sender.raise_method = "commit"
+        sender.raise_exception = sender_exception
+
+    rest_send = RestSend({"check_mode": False, "fabric_name": fabric_name})
+    rest_send.sender = sender
+    rest_send.response_handler = ResponseHandler()
+    rest_send.unit_test = True
+    rest_send.timeout = 1
+    rest_send.send_interval = 1
+
+    return NetworkFabricResolver(rest_send=rest_send, fabric_name=fabric_name)
+
+
+@pytest.mark.parametrize(
+    ("status", "message"),
+    [
+        (401, "Unauthorized"),
+        (403, "Forbidden"),
+        (500, "Internal Server Error"),
+    ],
+)
+def test_network_fabric_resolver_00001_initial_manage_failure_preserves_controller_error(status, message):
+    resolver = _real_rest_send_resolver(
+        "fab1",
+        [
+            _controller_response(status, message, {"code": status, "message": "controller unavailable"}),
+        ],
+    )
+
+    with pytest.raises(FabricResolverRequestError, match="controller unavailable") as exc_info:
+        resolver.resolve()
+
+    assert "GET /api/v1/manage/fabrics/fab1 failed" in str(exc_info.value)
+    assert "could not be resolved from ND Manage fabric topology" not in str(exc_info.value)
+
+
+def test_network_fabric_resolver_00002_initial_manage_transport_failure_preserves_error():
+    resolver = _real_rest_send_resolver("fab1", [], sender_exception=ValueError("socket closed"))
+
+    with pytest.raises(FabricResolverRequestError, match="socket closed") as exc_info:
+        resolver.resolve()
+
+    assert "GET /api/v1/manage/fabrics/fab1 failed before controller response" in str(exc_info.value)
+    assert "could not be resolved from ND Manage fabric topology" not in str(exc_info.value)
+
+
+def test_network_fabric_resolver_00003_initial_manage_404_uses_topology_resolution_error():
+    resolver = _real_rest_send_resolver(
+        "fab1",
+        [
+            _controller_response(404, "Not Found", {"code": 404, "message": "fabric not found"}),
+            _controller_response(200, "OK", {"fabrics": []}),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Fabric 'fab1' could not be resolved from ND Manage fabric topology"):
+        resolver.resolve()
 
 
 def test_network_fabric_resolver_00010_standalone_enrichment_does_not_fetch_members():

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import pytest
 
+from unittest.mock import patch
+
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.config_models import (
     NetworkConfigModel,
@@ -26,6 +28,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.networks im
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_workflow_coordinator import (
     NetworkWorkflowCoordinator,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators import network_workflow_coordinator as coordinator_mod
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_state_machine import (
     NetworkStateMachine,
 )
@@ -92,6 +95,33 @@ def _orchestrator():
         rest_send=RestSend({"state": "merged", "config": [], "check_mode": False}),
         strategy=strategy,
     )
+
+
+def test_network_workflow_coordinator_resolves_strategy_with_gen3_restsend():
+    events = []
+    module = _Module({"fabric_name": "fab1", "state": "gathered", "config": []})
+    module.check_mode = True
+
+    class FakeResolver:
+        def __init__(self, rest_send, fabric_name):
+            events.append(("NetworkFabricResolver", rest_send, fabric_name))
+            self.workflow_trace = [{"event": "fabric_resolver_start"}]
+
+        def resolve(self):
+            events.append(("resolve",))
+            return StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"})
+
+    with patch.object(coordinator_mod, "NetworkFabricResolver", FakeResolver):
+        coordinator = NetworkWorkflowCoordinator(module=module)
+        strategy = coordinator._resolve_strategy(dict(module.params))
+
+    resolver_rest_send = events[0][1]
+    assert strategy.fabric_type == "standalone"
+    assert resolver_rest_send.params["check_mode"] is False
+    assert resolver_rest_send.timeout == 1
+    assert resolver_rest_send.send_interval == 1
+    assert events == [("NetworkFabricResolver", resolver_rest_send, "fab1"), ("resolve",)]
+    assert coordinator.workflow_trace[0]["event"] == "fabric_resolver_start"
 
 
 def _mcfg_parent_orchestrator():
@@ -1165,7 +1195,7 @@ def test_network_attachment_query_chunks_large_network_name_sets():
     assert manager.queried_chunks == [["net-0", "net-1"], ["net-2", "net-3"], ["net-4"]]
 
 
-def test_network_attachment_query_missing_network_falls_back_per_name():
+def test_network_attachment_query_missing_network_falls_back_to_unscoped_read():
     class RecordingManager(NetworkAttachmentManager):
         def __init__(self):
             super().__init__(coordinator=None)
@@ -1175,16 +1205,17 @@ def test_network_attachment_query_missing_network_falls_back_per_name():
             self.queried_names.append(network_names)
             if network_names == ["BLUE_NET", "MISSING_NET"]:
                 raise RuntimeError("Network(s) [MISSING_NET] not found in fabric")
-            if network_names == ["BLUE_NET"]:
-                return [{"networkName": "BLUE_NET", "switchId": "SW1"}]
-            raise RuntimeError("Network(s) [MISSING_NET] not found in fabric")
+            return [
+                {"networkName": "BLUE_NET", "switchId": "SW1"},
+                {"networkName": "GREEN_NET", "switchId": "SW2"},
+            ]
 
     manager = RecordingManager()
 
     assert manager.current_attachment_details_ignore_missing({}, _orchestrator().strategy, ["BLUE_NET", "MISSING_NET"]) == [
         {"networkName": "BLUE_NET", "switchId": "SW1"}
     ]
-    assert manager.queried_names == [["BLUE_NET", "MISSING_NET"], ["BLUE_NET"], ["MISSING_NET"]]
+    assert manager.queried_names == [["BLUE_NET", "MISSING_NET"], None]
 
 
 def test_tor_is_modeled_as_normal_attachment_payload():

--- a/tests/unit/modules/test_nd_manage_networks.py
+++ b/tests/unit/modules/test_nd_manage_networks.py
@@ -39,21 +39,9 @@ def test_nd_manage_networks_requires_pydantic_immediately_after_module_creation(
         def fail_json(self, **kwargs):
             raise AssertionError(f"fail_json called unexpectedly: {kwargs}")
 
-    class FakeNDModule:
-        def __init__(self, module):
-            events.append(("NDModule", module))
-
-    class FakeResolver:
-        def __init__(self, nd_module, fabric_name):
-            events.append(("NetworkFabricResolver", nd_module, fabric_name))
-
-        def resolve(self):
-            events.append(("resolve",))
-            return object()
-
     class FakeCoordinator:
-        def __init__(self, module, strategy):
-            events.append(("NetworkWorkflowCoordinator", module, strategy))
+        def __init__(self, module):
+            events.append(("NetworkWorkflowCoordinator", module))
 
         def run(self):
             events.append(("run",))
@@ -64,17 +52,12 @@ def test_nd_manage_networks_requires_pydantic_immediately_after_module_creation(
 
     with patch.object(nd_manage_networks, "AnsibleModule", FakeAnsibleModule), patch.object(
         nd_manage_networks, "require_pydantic", fake_require_pydantic
-    ), patch.object(nd_manage_networks, "NDModule", FakeNDModule), patch.object(nd_manage_networks, "NetworkFabricResolver", FakeResolver), patch.object(
-        nd_manage_networks, "NetworkWorkflowCoordinator", FakeCoordinator
-    ):
+    ), patch.object(nd_manage_networks, "NetworkWorkflowCoordinator", FakeCoordinator):
         nd_manage_networks.main()
 
     assert [event[0] for event in events] == [
         "AnsibleModule",
         "require_pydantic",
-        "NDModule",
-        "NetworkFabricResolver",
-        "resolve",
         "NetworkWorkflowCoordinator",
         "run",
         "exit_json",


### PR DESCRIPTION
- Removed old NDModule runtime usage from Networks.
- Moved Network fabric resolution into NetworkWorkflowCoordinator, matching VRF.
- Updated Network resolver/tests to use Gen3 RestSend.
- Removed stale argspec wrapper helpers from nd_manage_networks.py.
- Cleaned legacy Optional / Union typing in Network orchestrator files.
- Fixed Network attachment missing-resource fallback to avoid per-network retry calls.
- Updated tests to enforce the new Gen3 wrapper/resolver flow.