### PR TITLE
FabricContext: expose platform_type, retain switch records, fail closed (#399, #400)

### DIFF
--- a/plugins/module_utils/fabric_context.py
+++ b/plugins/module_utils/fabric_context.py
@@ -145,7 +145,9 @@ class FabricContext:
 
         ## Raises
 
-        None
+        ### RuntimeError
+
+        - If the summary payload carries an embedded `code` error key instead of a fabric summary (via `fabric_summary`).
         """
         return self.fabric_summary is not None
 
@@ -164,7 +166,9 @@ class FabricContext:
 
         ## Raises
 
-        None
+        ### RuntimeError
+
+        - If the summary payload carries an embedded `code` error key instead of a fabric summary (via `fabric_summary`).
         """
         summary = self.fabric_summary
         if summary is None:
@@ -186,7 +190,9 @@ class FabricContext:
 
         ## Raises
 
-        None
+        ### RuntimeError
+
+        - If the summary payload carries an embedded `code` error key instead of a fabric summary (via `fabric_summary`).
         """
         summary = self.fabric_summary
         if summary is None:
@@ -283,6 +289,7 @@ class FabricContext:
         ### RuntimeError
 
         - If the switches API query fails.
+        - If the fabric does not exist.
         """
         self._load_switch_maps()
         if self._switch_map is None:
@@ -303,6 +310,7 @@ class FabricContext:
         ### RuntimeError
 
         - If the switches API query fails.
+        - If the fabric does not exist.
         """
         self._load_switch_maps()
         if self._switch_map_by_id is None:

--- a/plugins/module_utils/fabric_context.py
+++ b/plugins/module_utils/fabric_context.py
@@ -254,6 +254,9 @@ class FabricContext:
         Fetches the switch inventory on first access and caches it. Retaining the full records (rather than only the
         derived lookup maps) lets callers read per-switch attributes such as `platformType` without a second API call.
 
+        A shallow copy of the cached list is returned so a caller appending to or removing from it cannot corrupt the
+        cache or desync it from `switch_map` / `switch_map_by_id` (the per-record dicts are still shared references).
+
         ## Raises
 
         ### RuntimeError
@@ -264,7 +267,7 @@ class FabricContext:
         self._load_switch_maps()
         if self._switches is None:
             raise AssertionError("switches is None after _load_switch_maps()")
-        return self._switches
+        return list(self._switches)
 
     @property
     def switch_map(self) -> dict[str, str]:
@@ -361,7 +364,11 @@ class FabricContext:
         for switch in self.switches:
             if switch.get("fabricManagementIp") == switch_ip:
                 raw = (switch.get("additionalData") or {}).get("platformType")
-                return PlatformTypeEnum(raw) if raw in PlatformTypeEnum.values() else None
+                try:
+                    return PlatformTypeEnum(raw)
+                except ValueError:
+                    # Absent (None) or a value newer than PlatformTypeEnum -> no recognizable platform type.
+                    return None
         return None
 
     def validate_for_mutation(self) -> None:

--- a/plugins/module_utils/fabric_context.py
+++ b/plugins/module_utils/fabric_context.py
@@ -14,10 +14,34 @@ the `local` and `fabricStatus` fields used by the pre-flight checks.
 
 from __future__ import annotations
 
+from enum import Enum
+from typing import Literal
+
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import EpManageFabricsSummaryGet
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_switches import EpManageSwitchesListGet
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, PlatformTypeEnum
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+
+
+class _Sentinel(Enum):
+    """
+    # Summary
+
+    Single-member enum used as a typed "not yet fetched" sentinel for lazily-cached values whose fetched value may
+    legitimately be `None`.
+
+    A plain `object()` sentinel cannot be narrowed by a type checker, which forces the cached attribute to be typed
+    `object` and leaks that type into every read. Declaring the sentinel as a single-member `Enum` lets it be spelled
+    `Literal[_Sentinel.UNSET]` in a union, so `is _Sentinel.UNSET` narrows the attribute to its real type.
+
+    Kept module-private: promote to a shared module if a second consumer needs it.
+
+    ## Raises
+
+    None
+    """
+
+    UNSET = 0
 
 
 class FabricContext:
@@ -54,9 +78,8 @@ class FabricContext:
         """
         self._rest_send = rest_send
         self._fabric_name = fabric_name
-        # `_fabric_summary_fetched` distinguishes "not yet fetched" from "fetched but the fabric does not exist" (None).
-        self._fabric_summary: dict | None = None
-        self._fabric_summary_fetched = False
+        # `_Sentinel.UNSET` distinguishes "not yet fetched" from "fetched but the fabric does not exist" (None).
+        self._fabric_summary: dict | None | Literal[_Sentinel.UNSET] = _Sentinel.UNSET
         self._switches: list[dict] | None = None
         self._switch_map: dict[str, str] | None = None
         self._switch_map_by_id: dict[str, str] | None = None
@@ -127,14 +150,13 @@ class FabricContext:
 
         - If the summary payload carries an embedded `code` error key instead of a fabric summary.
         """
-        if not self._fabric_summary_fetched:
+        if self._fabric_summary is _Sentinel.UNSET:
             ep = EpManageFabricsSummaryGet()
             ep.fabric_name = self._fabric_name
             result = self._query_get(ep.path)
             if result and "code" in result:
                 raise RuntimeError(f"GET {ep.path} returned an embedded error instead of a fabric summary: {result.get('message', result)}")
             self._fabric_summary = result if result else None
-            self._fabric_summary_fetched = True
         return self._fabric_summary
 
     def fabric_exists(self) -> bool:
@@ -210,8 +232,7 @@ class FabricContext:
 
         None
         """
-        self._fabric_summary = None
-        self._fabric_summary_fetched = False
+        self._fabric_summary = _Sentinel.UNSET
         self._switches = None
         self._switch_map = None
         self._switch_map_by_id = None

--- a/plugins/module_utils/fabric_context.py
+++ b/plugins/module_utils/fabric_context.py
@@ -19,7 +19,7 @@ from typing import Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import EpManageFabricsSummaryGet
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_switches import EpManageSwitchesListGet
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, PlatformTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, PlatformType
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 
 
@@ -372,15 +372,15 @@ class FabricContext:
         except KeyError as e:
             raise RuntimeError(f"No switch found with switchId '{switch_id}' in fabric '{self._fabric_name}'.") from e
 
-    def get_platform_type(self, switch_ip: str) -> PlatformTypeEnum | None:
+    def get_platform_type(self, switch_ip: str) -> PlatformType | None:
         """
         # Summary
 
-        Resolve a switch management IP address to its `platformType` (as a `PlatformTypeEnum`) via the cached switch
+        Resolve a switch management IP address to its `platformType` (as a `PlatformType`) via the cached switch
         inventory. Callers use this to select the platform-appropriate feature model (e.g. `loopback` vs `iosXeLoopback`).
 
         Returns `None` when the switch exists in the fabric but reports no recognizable `platformType` (the field is
-        nested under a `oneOf` variant and may be absent, or ND may report a value newer than `PlatformTypeEnum`).
+        nested under a `oneOf` variant and may be absent, or ND may report a value newer than `PlatformType`).
 
         ## Raises
 
@@ -397,9 +397,9 @@ class FabricContext:
             if switch.get("fabricManagementIp") == switch_ip:
                 raw = (switch.get("additionalData") or {}).get("platformType")
                 try:
-                    return PlatformTypeEnum(raw)
+                    return PlatformType(raw)
                 except ValueError:
-                    # Absent (None) or a value newer than PlatformTypeEnum -> no recognizable platform type.
+                    # Absent (None) or a value newer than PlatformType -> no recognizable platform type.
                     return None
         return None
 

--- a/plugins/module_utils/fabric_context.py
+++ b/plugins/module_utils/fabric_context.py
@@ -16,11 +16,8 @@ from __future__ import annotations
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import EpManageFabricsSummaryGet
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_switches import EpManageSwitchesListGet
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, PlatformTypeEnum
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-
-# Sentinel to distinguish "not yet fetched" from "fetched but not found"
-_NOT_FETCHED = object()
 
 
 class FabricContext:
@@ -40,6 +37,9 @@ class FabricContext:
     - Via `validate_for_mutation` if the fabric does not exist on any ND node.
     - Via `get_switch_id` if no switch matches the given management IP.
     - Via `get_switch_ip` if no switch matches the given switch ID.
+    - Via `get_platform_type` if no switch matches the given management IP.
+    - Via `fabric_summary` if the summary payload carries an embedded `code` error key.
+    - Via the `switches` / `switch_map` accessors if the fabric does not exist.
     """
 
     def __init__(self, rest_send: RestSend, fabric_name: str):
@@ -54,9 +54,25 @@ class FabricContext:
         """
         self._rest_send = rest_send
         self._fabric_name = fabric_name
-        self._fabric_summary = _NOT_FETCHED
+        # `_fabric_summary_fetched` distinguishes "not yet fetched" from "fetched but the fabric does not exist" (None).
+        self._fabric_summary: dict | None = None
+        self._fabric_summary_fetched = False
+        self._switches: list[dict] | None = None
         self._switch_map: dict[str, str] | None = None
         self._switch_map_by_id: dict[str, str] | None = None
+
+    def _fabric_not_found_message(self) -> str:
+        """
+        # Summary
+
+        Return the standard user-facing "fabric not found" message for this context's fabric name. Shared by
+        `validate_for_mutation` and `_load_switch_maps` so both surface identical wording.
+
+        ## Raises
+
+        None
+        """
+        return f"Fabric '{self._fabric_name}' not found. Verify the fabric name and ensure you are targeting the correct ND node."
 
     def _query_get(self, path: str) -> dict:
         """
@@ -101,15 +117,24 @@ class FabricContext:
 
         Returns `None` if the fabric does not exist.
 
+        Fails closed: ND signals some errors by embedding `{"code": <N>, "message": "<reason>"}` in an otherwise-successful
+        response body. Rather than accept such a payload as a valid summary (which would let every `validate_for_mutation`
+        check default open), a payload carrying a `code` key is rejected with `RuntimeError`.
+
         ## Raises
 
-        None
+        ### RuntimeError
+
+        - If the summary payload carries an embedded `code` error key instead of a fabric summary.
         """
-        if self._fabric_summary is _NOT_FETCHED:
+        if not self._fabric_summary_fetched:
             ep = EpManageFabricsSummaryGet()
             ep.fabric_name = self._fabric_name
             result = self._query_get(ep.path)
+            if result and "code" in result:
+                raise RuntimeError(f"GET {ep.path} returned an embedded error instead of a fabric summary: {result.get('message', result)}")
             self._fabric_summary = result if result else None
+            self._fabric_summary_fetched = True
         return self._fabric_summary
 
     def fabric_exists(self) -> bool:
@@ -172,14 +197,16 @@ class FabricContext:
         """
         # Summary
 
-        Drop all cached state so the next access to `fabric_summary`, `switch_map`, or `switch_map_by_id` re-fetches from the API.
-        Useful after a mutation that should be reflected on subsequent reads.
+        Drop all cached state so the next access to `fabric_summary`, `switches`, `switch_map`, `switch_map_by_id`, or the
+        `platformType` lookup re-fetches from the API. Useful after a mutation that should be reflected on subsequent reads.
 
         ## Raises
 
         None
         """
-        self._fabric_summary = _NOT_FETCHED
+        self._fabric_summary = None
+        self._fabric_summary_fetched = False
+        self._switches = None
         self._switch_map = None
         self._switch_map_by_id = None
 
@@ -187,22 +214,57 @@ class FabricContext:
         """
         # Summary
 
-        Fetch the fabric switch inventory once and populate both the IP-keyed and ID-keyed lookup maps.
+        Fetch the fabric switch inventory once, retain the raw switch records, and populate the IP-keyed and ID-keyed
+        lookup maps. Per-switch `platformType` is read on demand from the retained records by `get_platform_type`.
+
+        Fails closed on a nonexistent fabric: the switches endpoint returns HTTP 404 when the parent fabric is absent.
+        `_query_get` maps that 404 to an empty dict, which would otherwise yield empty maps and surface a misleading
+        "switch not found" error downstream. Instead, a 404 here is confirmed against `fabric_summary` and re-raised as a
+        clear "fabric not found" error, matching `validate_for_mutation`.
 
         ## Raises
 
         ### RuntimeError
 
         - If the switches API query fails.
+        - If the fabric does not exist (switches GET 404 confirmed by an absent `fabric_summary`).
         """
         if self._switch_map is not None:
             return
         ep = EpManageSwitchesListGet()
         ep.fabric_name = self._fabric_name
         result = self._query_get(ep.path)
+        # Not an ND deviation (no TODO/vault note): ND correctly returns 404 for a missing fabric. `_query_get` swallows
+        # that 404 into `{}`, so we confirm against `fabric_summary` and raise the fabric-level error here rather than
+        # letting an empty switch map surface a misleading "switch not found" downstream (issue #399).
+        if self._rest_send.return_code == 404 and not self.fabric_exists():
+            raise RuntimeError(self._fabric_not_found_message())
         switches = (result.get("switches") or []) if result else []
+        self._switches = switches
         self._switch_map = {sw["fabricManagementIp"]: sw["switchId"] for sw in switches if sw.get("fabricManagementIp") and sw.get("switchId")}
         self._switch_map_by_id = {sw["switchId"]: sw["fabricManagementIp"] for sw in switches if sw.get("switchId") and sw.get("fabricManagementIp")}
+
+    @property
+    def switches(self) -> list[dict]:
+        """
+        # Summary
+
+        Return the raw switch records as returned by the ND Manage Switches API for this fabric.
+
+        Fetches the switch inventory on first access and caches it. Retaining the full records (rather than only the
+        derived lookup maps) lets callers read per-switch attributes such as `platformType` without a second API call.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the switches API query fails.
+        - If the fabric does not exist.
+        """
+        self._load_switch_maps()
+        if self._switches is None:
+            raise AssertionError("switches is None after _load_switch_maps()")
+        return self._switches
 
     @property
     def switch_map(self) -> dict[str, str]:
@@ -278,6 +340,30 @@ class FabricContext:
         except KeyError as e:
             raise RuntimeError(f"No switch found with switchId '{switch_id}' in fabric '{self._fabric_name}'.") from e
 
+    def get_platform_type(self, switch_ip: str) -> PlatformTypeEnum | None:
+        """
+        # Summary
+
+        Resolve a switch management IP address to its `platformType` (as a `PlatformTypeEnum`) via the cached switch
+        inventory. Callers use this to select the platform-appropriate feature model (e.g. `loopback` vs `iosXeLoopback`).
+
+        Returns `None` when the switch exists in the fabric but reports no recognizable `platformType` (the field is
+        nested under a `oneOf` variant and may be absent, or ND may report a value newer than `PlatformTypeEnum`).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If no switch matches the given IP in the fabric.
+        """
+        if switch_ip not in self.switch_map:
+            raise RuntimeError(f"No switch found with fabricManagementIp '{switch_ip}' in fabric '{self._fabric_name}'.")
+        for switch in self.switches:
+            if switch.get("fabricManagementIp") == switch_ip:
+                raw = (switch.get("additionalData") or {}).get("platformType")
+                return PlatformTypeEnum(raw) if raw in PlatformTypeEnum.values() else None
+        return None
+
     def validate_for_mutation(self) -> None:
         """
         # Summary
@@ -300,7 +386,7 @@ class FabricContext:
         - If the fabric is in deployment freeze mode.
         """
         if not self.fabric_exists():
-            raise RuntimeError(f"Fabric '{self._fabric_name}' not found. Verify the fabric name and ensure you are targeting the correct ND node.")
+            raise RuntimeError(self._fabric_not_found_message())
         if not self.fabric_is_local():
             raise RuntimeError(
                 f"Fabric '{self._fabric_name}' is owned by a different controller in this cluster. "

--- a/plugins/module_utils/fabric_context.py
+++ b/plugins/module_utils/fabric_context.py
@@ -359,9 +359,12 @@ class FabricContext:
 
         - If no switch matches the given IP in the fabric.
         """
-        if switch_ip not in self.switch_map:
+        self._load_switch_maps()
+        if self._switch_map is None or self._switches is None:
+            raise AssertionError("switch records are None after _load_switch_maps()")
+        if switch_ip not in self._switch_map:
             raise RuntimeError(f"No switch found with fabricManagementIp '{switch_ip}' in fabric '{self._fabric_name}'.")
-        for switch in self.switches:
+        for switch in self._switches:
             if switch.get("fabricManagementIp") == switch_ip:
                 raw = (switch.get("additionalData") or {}).get("platformType")
                 try:

--- a/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
@@ -82,6 +82,17 @@
             "ownerCluster": "cluster_a"
         }
     },
+    "test_fabric_context_00170a": {
+        "TEST_NOTES": ["#400: summary returns HTTP 200 but the body carries an embedded 'code' error key; fabric_summary must fail closed and raise"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "code": 404,
+            "message": "Fabric fabric_1 not found"
+        }
+    },
     "test_fabric_context_00200a": {
         "TEST_NOTES": ["Switch list: two switches in fabric"],
         "RETURN_CODE": 200,
@@ -153,6 +164,50 @@
                 }
             ]
         }
+    },
+    "test_fabric_context_00230a": {
+        "TEST_NOTES": [
+            "Switch list with additionalData.platformType for get_platform_type / switches.",
+            "sw1: nx-os, sw2: ios-xe, sw3: no additionalData (platform_type -> None)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.12.151",
+                    "switchId": "FDO12345ABC",
+                    "additionalData": {"platformType": "nx-os"}
+                },
+                {
+                    "fabricManagementIp": "192.168.12.152",
+                    "switchId": "FDO12345ABD",
+                    "additionalData": {"platformType": "ios-xe"}
+                },
+                {
+                    "fabricManagementIp": "192.168.12.153",
+                    "switchId": "FDO12345ABE"
+                }
+            ]
+        }
+    },
+    "test_fabric_context_00250a": {
+        "TEST_NOTES": ["#399: switches endpoint 404 (parent fabric missing). First call in _load_switch_maps."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/switches",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_fabric_context_00250b": {
+        "TEST_NOTES": ["#399: summary endpoint 404, consulted by fabric_exists() to confirm the fabric is absent."],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
     },
     "test_fabric_context_00300a": {
         "TEST_NOTES": ["Fabric summary: fabric exists, local=true, fabricStatus=default (validate_for_mutation success)"],

--- a/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
@@ -199,7 +199,9 @@
     "test_fabric_context_00230a": {
         "TEST_NOTES": [
             "Switch list with additionalData.platformType for get_platform_type / switches.",
-            "sw1: nx-os, sw2: ios-xe, sw3: no additionalData (platform_type -> None)."
+            "sw1: nx-os, sw2: ios-xe, sw3: no additionalData (platform_type -> None), sw4: sonic.",
+            "sw4 guards the SONIC member: PlatformTypeEnum originally omitted it, so get_platform_type resolved a",
+            "SONiC switch to None (the try/except ValueError fall-through) instead of its platform."
         ],
         "RETURN_CODE": 200,
         "METHOD": "GET",
@@ -220,6 +222,13 @@
                 {
                     "fabricManagementIp": "192.168.12.153",
                     "switchId": "FDO12345ABE"
+                },
+                {
+                    "fabricManagementIp": "192.168.12.154",
+                    "switchId": "FDO12345ABF",
+                    "additionalData": {
+                        "platformType": "sonic"
+                    }
                 }
             ]
         }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
@@ -23,6 +23,37 @@
         "MESSAGE": "Not Found",
         "DATA": {}
     },
+    "test_fabric_context_00180a": {
+        "TEST_NOTES": [
+            "Fabric summary: 404 not found.",
+            "Single response for the whole test: the fetched-but-absent (None) summary must be cached, so only one GET is issued",
+            "across repeated fabric_summary / fabric_exists reads. A second GET exhausts the generator and fails the test."
+        ],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_fabric_context_00190a": {
+        "TEST_NOTES": ["Fabric summary: 404 not found (pre-invalidate read for the invalidate-refetch test)"],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_fabric_context_00190b": {
+        "TEST_NOTES": ["Fabric summary: 200 after the fabric is created; proves invalidate() cleared the cached None rather than pinning it"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "missing_fabric",
+            "ownerCluster": "cluster_a"
+        }
+    },
     "test_fabric_context_00120a": {
         "TEST_NOTES": ["Deployment freeze: enabled (fabricStatus=frozen in summary)"],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
@@ -200,7 +200,7 @@
         "TEST_NOTES": [
             "Switch list with additionalData.platformType for get_platform_type / switches.",
             "sw1: nx-os, sw2: ios-xe, sw3: no additionalData (platform_type -> None), sw4: sonic.",
-            "sw4 guards the SONIC member: PlatformTypeEnum originally omitted it, so get_platform_type resolved a",
+            "sw4 guards the SONIC member: the read-side enum this PR originally added omitted it, so get_platform_type resolved a",
             "SONiC switch to None (the try/except ValueError fall-through) instead of its platform."
         ],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/test_fabric_context.py
+++ b/tests/unit/module_utils/test_fabric_context.py
@@ -23,7 +23,7 @@ import inspect
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, PlatformTypeEnum
-from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext, _Sentinel
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
@@ -201,6 +201,93 @@ def test_fabric_context_00170() -> None:
     match = r"returned an embedded error instead of a fabric summary"
     with pytest.raises(RuntimeError, match=match):
         result = instance.fabric_summary  # pylint: disable=unused-variable
+
+
+def test_fabric_context_00180() -> None:
+    """
+    # Summary
+
+    Verify a fetched-but-absent (`None`) fabric summary is cached, so repeated reads do not re-issue the GET.
+
+    `None` is a legitimate fetched value here ("the fabric does not exist"), so `_fabric_summary` cannot use `None` to
+    mean "not yet fetched" — it is initialized to the `_Sentinel.UNSET` sentinel instead. Without that sentinel every
+    `fabric_exists()` call against a nonexistent fabric re-queries the controller.
+
+    ## Test
+
+    - GET (summary) returns 404 exactly once; the fixture supplies a single response
+    - `fabric_summary` and `fabric_exists` are read repeatedly
+    - Every read is served from cache; a second GET would exhaust the response generator and fail the test
+
+    ## Classes and Methods
+
+    - FabricContext.fabric_summary
+    - FabricContext.fabric_exists
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_fabric_context(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = FabricContext(rest_send=rest_send, fabric_name="missing_fabric")
+        assert instance._fabric_summary is _Sentinel.UNSET  # pylint: disable=protected-access
+        first = instance.fabric_summary
+        # The cached value is now None (fetched, absent) -- these reads must not re-query.
+        second = instance.fabric_summary
+        exists_first = instance.fabric_exists()
+        exists_second = instance.fabric_exists()
+
+    assert first is None
+    assert second is None
+    assert exists_first is False
+    assert exists_second is False
+    assert instance._fabric_summary is None  # pylint: disable=protected-access
+
+
+def test_fabric_context_00190() -> None:
+    """
+    # Summary
+
+    Verify `invalidate` clears a cached-absent (`None`) fabric summary rather than pinning it, so a fabric created
+    after the first read is observed on the next access.
+
+    Guards the sentinel's reset path: `invalidate` must restore `_Sentinel.UNSET`, not `None`, or the summary would be
+    treated as already-fetched-and-absent forever.
+
+    ## Test
+
+    - GET (summary) returns 404; `fabric_summary` caches `None`
+    - `invalidate` is called
+    - GET (summary) returns 200; `fabric_summary` re-fetches and returns the new summary
+
+    ## Classes and Methods
+
+    - FabricContext.fabric_summary
+    - FabricContext.invalidate
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_fabric_context(f"{method_name}a")
+        yield responses_fabric_context(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = FabricContext(rest_send=rest_send, fabric_name="missing_fabric")
+        before = instance.fabric_summary
+        instance.invalidate()
+        assert instance._fabric_summary is _Sentinel.UNSET  # pylint: disable=protected-access
+        after = instance.fabric_summary
+
+    assert before is None
+    assert after is not None
+    assert after.get("name") == "missing_fabric"
 
 
 # =============================================================================

--- a/tests/unit/module_utils/test_fabric_context.py
+++ b/tests/unit/module_utils/test_fabric_context.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import inspect
 
 import pytest
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, PlatformTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, PlatformType
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext, _Sentinel
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
@@ -595,15 +595,15 @@ def test_fabric_context_00230() -> None:
     # Summary
 
     Verify `switches` retains the raw switch records and `get_platform_type` resolves each switch's `platformType`
-    (nested under `additionalData`) to a `PlatformTypeEnum`.
+    (nested under `additionalData`) to a `PlatformType`.
 
     ## Test
 
     - GET (switches) returns four switches: nx-os, ios-xe, one with no `additionalData`, and sonic
     - `switches` returns the raw four-record list
-    - `get_platform_type` returns `PlatformTypeEnum.NX_OS` / `PlatformTypeEnum.IOS_XE` for the first two
+    - `get_platform_type` returns `PlatformType.NX_OS` / `PlatformType.IOS_XE` for the first two
     - `get_platform_type` returns `None` for the switch that reports no `platformType`
-    - `get_platform_type` returns `PlatformTypeEnum.SONIC` for the sonic switch (guards the omitted-member defect:
+    - `get_platform_type` returns `PlatformType.SONIC` for the sonic switch (guards the omitted-member defect:
       an unrecognized value falls through `try/except ValueError` to `None`, silently hiding the platform)
     - `get_platform_type` raises `RuntimeError` for an IP not in the fabric
 
@@ -631,12 +631,12 @@ def test_fabric_context_00230() -> None:
     # `switches` returns a shallow copy: mutating it must not corrupt the cache.
     switches.append({"fabricManagementIp": "10.0.0.9", "switchId": "BOGUS"})
     assert len(instance.switches) == 4
-    assert instance.get_platform_type("192.168.12.151") == PlatformTypeEnum.NX_OS
-    assert instance.get_platform_type("192.168.12.152") == PlatformTypeEnum.IOS_XE
+    assert instance.get_platform_type("192.168.12.151") == PlatformType.NX_OS
+    assert instance.get_platform_type("192.168.12.152") == PlatformType.IOS_XE
     # Switch exists but reports no platformType -> None (not a raise).
     assert instance.get_platform_type("192.168.12.153") is None
     # SONIC must resolve rather than falling through to None (omitted-member defect).
-    assert instance.get_platform_type("192.168.12.154") == PlatformTypeEnum.SONIC
+    assert instance.get_platform_type("192.168.12.154") == PlatformType.SONIC
 
     match = r"No switch found with fabricManagementIp '10\.0\.0\.1' in fabric 'fabric_1'"
     with pytest.raises(RuntimeError, match=match):

--- a/tests/unit/module_utils/test_fabric_context.py
+++ b/tests/unit/module_utils/test_fabric_context.py
@@ -541,6 +541,9 @@ def test_fabric_context_00230() -> None:
 
     assert len(switches) == 3
     assert switches[0]["switchId"] == "FDO12345ABC"
+    # `switches` returns a shallow copy: mutating it must not corrupt the cache.
+    switches.append({"fabricManagementIp": "10.0.0.9", "switchId": "BOGUS"})
+    assert len(instance.switches) == 3
     assert instance.get_platform_type("192.168.12.151") == PlatformTypeEnum.NX_OS
     assert instance.get_platform_type("192.168.12.152") == PlatformTypeEnum.IOS_XE
     # Switch exists but reports no platformType -> None (not a raise).

--- a/tests/unit/module_utils/test_fabric_context.py
+++ b/tests/unit/module_utils/test_fabric_context.py
@@ -599,10 +599,12 @@ def test_fabric_context_00230() -> None:
 
     ## Test
 
-    - GET (switches) returns three switches: nx-os, ios-xe, and one with no `additionalData`
-    - `switches` returns the raw three-record list
+    - GET (switches) returns four switches: nx-os, ios-xe, one with no `additionalData`, and sonic
+    - `switches` returns the raw four-record list
     - `get_platform_type` returns `PlatformTypeEnum.NX_OS` / `PlatformTypeEnum.IOS_XE` for the first two
     - `get_platform_type` returns `None` for the switch that reports no `platformType`
+    - `get_platform_type` returns `PlatformTypeEnum.SONIC` for the sonic switch (guards the omitted-member defect:
+      an unrecognized value falls through `try/except ValueError` to `None`, silently hiding the platform)
     - `get_platform_type` raises `RuntimeError` for an IP not in the fabric
 
     ## Classes and Methods
@@ -624,15 +626,17 @@ def test_fabric_context_00230() -> None:
         instance = FabricContext(rest_send=rest_send, fabric_name="fabric_1")
         switches = instance.switches
 
-    assert len(switches) == 3
+    assert len(switches) == 4
     assert switches[0]["switchId"] == "FDO12345ABC"
     # `switches` returns a shallow copy: mutating it must not corrupt the cache.
     switches.append({"fabricManagementIp": "10.0.0.9", "switchId": "BOGUS"})
-    assert len(instance.switches) == 3
+    assert len(instance.switches) == 4
     assert instance.get_platform_type("192.168.12.151") == PlatformTypeEnum.NX_OS
     assert instance.get_platform_type("192.168.12.152") == PlatformTypeEnum.IOS_XE
     # Switch exists but reports no platformType -> None (not a raise).
     assert instance.get_platform_type("192.168.12.153") is None
+    # SONIC must resolve rather than falling through to None (omitted-member defect).
+    assert instance.get_platform_type("192.168.12.154") == PlatformTypeEnum.SONIC
 
     match = r"No switch found with fabricManagementIp '10\.0\.0\.1' in fabric 'fabric_1'"
     with pytest.raises(RuntimeError, match=match):

--- a/tests/unit/module_utils/test_fabric_context.py
+++ b/tests/unit/module_utils/test_fabric_context.py
@@ -15,9 +15,7 @@ and switches list endpoints, surfaces 404s as "fabric not found", parses the
 
 # pylint: disable=disallowed-name,protected-access,redefined-outer-name,too-many-lines
 
-from __future__ import absolute_import, annotations, division, print_function
-
-__metaclass__ = type  # pylint: disable=invalid-name
+from __future__ import annotations
 
 import inspect
 

--- a/tests/unit/module_utils/test_fabric_context.py
+++ b/tests/unit/module_utils/test_fabric_context.py
@@ -22,7 +22,7 @@ __metaclass__ = type  # pylint: disable=invalid-name
 import inspect
 
 import pytest
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, PlatformTypeEnum
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
@@ -172,6 +172,35 @@ def test_fabric_context_00110() -> None:
 
     assert summary is None
     assert exists is False
+
+
+def test_fabric_context_00170() -> None:
+    """
+    # Summary
+
+    Verify `fabric_summary` fails closed when a 200 response body carries an embedded `code` error key (issue #400).
+
+    ## Test
+
+    - GET (summary) returns 200 with DATA `{"code": 404, "message": "..."}`
+    - `fabric_summary` raises `RuntimeError` rather than accepting the payload as a valid summary
+
+    ## Classes and Methods
+
+    - FabricContext.fabric_summary
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_fabric_context(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    instance = FabricContext(rest_send=rest_send, fabric_name="fabric_1")
+    match = r"returned an embedded error instead of a fabric summary"
+    with pytest.raises(RuntimeError, match=match):
+        result = instance.fabric_summary  # pylint: disable=unused-variable
 
 
 # =============================================================================
@@ -474,6 +503,86 @@ def test_fabric_context_00220() -> None:
         "FDO12345ABC": "192.168.12.151",
         "FDO12345ABD": "192.168.12.152",
     }
+
+
+def test_fabric_context_00230() -> None:
+    """
+    # Summary
+
+    Verify `switches` retains the raw switch records and `get_platform_type` resolves each switch's `platformType`
+    (nested under `additionalData`) to a `PlatformTypeEnum`.
+
+    ## Test
+
+    - GET (switches) returns three switches: nx-os, ios-xe, and one with no `additionalData`
+    - `switches` returns the raw three-record list
+    - `get_platform_type` returns `PlatformTypeEnum.NX_OS` / `PlatformTypeEnum.IOS_XE` for the first two
+    - `get_platform_type` returns `None` for the switch that reports no `platformType`
+    - `get_platform_type` raises `RuntimeError` for an IP not in the fabric
+
+    ## Classes and Methods
+
+    - FabricContext.switches
+    - FabricContext.get_platform_type
+    - FabricContext._load_switch_maps
+    """
+    method_name = inspect.stack()[0][3]
+    key = f"{method_name}a"
+
+    def responses():
+        yield responses_fabric_context(key)
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    with does_not_raise():
+        instance = FabricContext(rest_send=rest_send, fabric_name="fabric_1")
+        switches = instance.switches
+
+    assert len(switches) == 3
+    assert switches[0]["switchId"] == "FDO12345ABC"
+    assert instance.get_platform_type("192.168.12.151") == PlatformTypeEnum.NX_OS
+    assert instance.get_platform_type("192.168.12.152") == PlatformTypeEnum.IOS_XE
+    # Switch exists but reports no platformType -> None (not a raise).
+    assert instance.get_platform_type("192.168.12.153") is None
+
+    match = r"No switch found with fabricManagementIp '10\.0\.0\.1' in fabric 'fabric_1'"
+    with pytest.raises(RuntimeError, match=match):
+        instance.get_platform_type("10.0.0.1")
+
+
+def test_fabric_context_00250() -> None:
+    """
+    # Summary
+
+    Verify a switches-endpoint 404 for a nonexistent fabric raises "fabric not found" rather than a misleading
+    "switch not found" (issue #399). The 404 is confirmed against `fabric_summary` before raising.
+
+    ## Test
+
+    - GET (switches) returns 404
+    - `_load_switch_maps` consults `fabric_summary` (also 404) and raises the fabric-level error
+    - The message matches `validate_for_mutation`'s "fabric not found" wording
+
+    ## Classes and Methods
+
+    - FabricContext.switch_map
+    - FabricContext._load_switch_maps
+    - FabricContext.fabric_exists
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_fabric_context(f"{method_name}a")  # switches 404
+        yield responses_fabric_context(f"{method_name}b")  # summary 404 (fabric_exists confirmation)
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    instance = FabricContext(rest_send=rest_send, fabric_name="missing_fabric")
+    match = r"Fabric 'missing_fabric' not found"
+    with pytest.raises(RuntimeError, match=match):
+        result = instance.switch_map  # pylint: disable=unused-variable
 
 
 # =============================================================================


### PR DESCRIPTION
## Rebased onto develop after #405 (2026-08-27) — hold lifted

This PR was labeled `Postponed` on 2026-07-16 because the `PlatformTypeEnum` it introduced duplicated the existing `PlatformType`
(then in `models/manage_switches/enums.py`), and its copy also omitted `SONIC`, so `FabricContext.get_platform_type()` silently
returned `None` for a SONiC switch. The design discussion on #405 settled on promoting `PlatformType` to `plugins/module_utils/enums.py`,
which #405 did (merged 2026-08-25).

Done on this rebase:

- [x] Dropped this PR's `PlatformTypeEnum` from `enums.py`; `FabricContext.get_platform_type()` now returns the promoted
  `PlatformType` (which includes `SONIC`, closing the silent-`None` defect) — commit "FabricContext: use the promoted PlatformType,
  drop PlatformTypeEnum". `PlatformType.normalize()` is deliberately not used on the read path: its `None -> NX_OS` default would
  mask a switch that reports no `platformType`, which must stay `None`.
- [x] Removed the `Postponed` label.

`enums.py` is no longer touched by this PR. Everything else (`#399` fidelity fix, `#400` fail-closed hardening, `_Sentinel` tri-state)
is unchanged since @akinross's approval.

Sequencing note for reviewers: this PR should land **before** the upcoming IOS-XE interface union wave (ethernet, port-channel, SVI,
sub-interface — following the #403 loopback pattern). Those PRs plan to make `network_os_type` optional via the
`FabricContext.get_platform_type()` fallback added here.

## Related Issue(s)

Closes #399
Closes #400

## Proposed Changes

Three related changes to `FabricContext` (`plugins/module_utils/fabric_context.py`):

- **feat — expose switch platform type.** Retain the raw switch records from `GET /api/v1/manage/fabrics/{fabric}/switches` and add `get_platform_type(switch_ip) -> PlatformType | None` (reads the nested `additionalData.platformType`), plus a `switches` property exposing the retained records. Uses the `PlatformType` enum #405 promoted to `plugins/module_utils/enums.py`. This lets callers select a platform-appropriate feature model (e.g. `loopback` vs `iosXeLoopback`) without exposing the value to users — the switch-derived `networkOSType` the interface-granularity design calls for.
- **fix #399 — fabric-not-found fidelity.** The switches endpoint returns `404` when the parent fabric is absent; `_query_get` swallowed that into an empty map, so `get_switch_id` surfaced a misleading "switch not found". `_load_switch_maps` now confirms a `404` against `fabric_summary` and raises the fabric-level "fabric not found" message (shared with `validate_for_mutation` via `_fabric_not_found_message`). Not an ND deviation, so no `TODO(X.Y.Z)`/vault marker.
- **hardening #400 — fail closed.** `fabric_summary` now rejects a `200` body carrying an embedded `{"code": N, ...}` error key instead of accepting it as a valid summary (which would let every `validate_for_mutation` check default open). Kept narrow (summary only; not pushed into `_query_get`) to avoid changing behavior for all 13 `FabricContext` consumers.

Incidentally replaces the `_NOT_FETCHED = object()` sentinel on `_fabric_summary` with a typed one — a module-private single-member `_Sentinel` enum, spelled `Literal[_Sentinel.UNSET]` in the union — so the property is correctly typed `dict | None` (clears a pre-existing mypy/Pylance `object`-return smell on the touched code). `_fabric_summary` needs a tri-state because `None` is a load-bearing value meaning "the fabric does not exist"; `object()` couldn't be narrowed by a type checker, whereas the enum can. Keeps the state in one field rather than two that must be kept in sync, so `invalidate()` is a single assignment. Per @akinross review. No behavior change.

## Test Notes

- Unit: +5 tests (embedded-`code` hardening, `platform_type`/`switches`, switches-`404` → fabric-not-found, plus two for the `_Sentinel` tri-state: a fetched-but-absent `None` summary is cached so `fabric_exists()` doesn't re-query, and `invalidate()` clears the cached `None` rather than pinning it), new fixtures for each.
- The two `_Sentinel` tests were verified to fail against a deliberately mutated implementation (`invalidate()` resetting to `None`; sentinel dropped for None-means-unset), confirming they guard the invariant rather than passing vacuously.
- Full `module_utils` unit suite green: **3036 passed** via `ndpytest`.
- `black`, `isort`, `pylint`, `mypy` clean on the changed files (nd-dev container).
- Post-rebase (2026-08-27, onto develop @ #454): `test_fabric_context.py` 20 passed; `black`, `isort`, `pylint`, `mypy` clean on `fabric_context.py` / `test_fabric_context.py` (nd-dev container).
- ND behavior (`404` on both fabric endpoints for a missing fabric; `platformType` enum values) verified against a live ND 4.2.1 lab, as documented in #399/#400.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers




