### PR TITLE
Pair-scoped vPC interface identity: support same vPC id on two pairs

### DIFF
--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -387,15 +387,17 @@ class AccessVpcHostInterfaceModel(NDBaseModel):
     """
 
     # --- Identifier Configuration ---
+    # --- Identifier Configuration ---
     # TODO(4.2.1) vpc-interface-dual-peer-duplicate
     # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in the per-switch
-    # `/interfaces` GET (with identical `configData` and only `switchId` / `peerSwitchId` swapping). Using a composite
-    # (switch_ip, interface_name) identifier caused `_manage_override_deletions` to delete the peer-side duplicate. The
-    # identifier is therefore `interface_name` only; `switch_ip` is kept as a field for routing (URL-path resolution +
-    # peer-resolution) but is excluded from diff and dedup'd in `query_all`.
+    # `/interfaces` GET (identical `configData`; only `switchId` / `peerSwitchId` swap). That echo is deduped in
+    # `VpcInterfaceBaseOrchestrator.query_all`, keyed on `interfaceName` + the unordered `{switchId, peerSwitchId}` pair
+    # set, so the composite identifier below stays safe: two vPC pairs in one fabric may legally reuse the same vPC id
+    # (ND's `vpcId` resource pool is devicePair-scoped; issue #356), which a name-only identity cannot represent.
+    # `switch_ip` remains excluded from payload and diff (routing-only on the wire).
 
-    identifiers: ClassVar[list[str] | None] = ["interface_name"]
-    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
 
     # --- Serialization Configuration ---
 

--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -387,7 +387,6 @@ class AccessVpcHostInterfaceModel(NDBaseModel):
     """
 
     # --- Identifier Configuration ---
-    # --- Identifier Configuration ---
     # TODO(4.2.1) vpc-interface-dual-peer-duplicate
     # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in the per-switch
     # `/interfaces` GET (identical `configData`; only `switchId` / `peerSwitchId` swap). That echo is deduped in

--- a/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
@@ -542,10 +542,11 @@ class TrunkVpcHostInterfaceModel(NDBaseModel):
 
     vPC `trunkVpcHost` interface configuration for Nexus Dashboard.
 
-    The nested model structure mirrors the ND Manage Interfaces API payload, so `to_payload()` and `from_response()`
-    work via standard Pydantic serialization. The `interface_name` is the vPC's own name (e.g. `vpc100`), not a member
-    interface. Member interfaces are listed per-peer in `config_data.network_os.policy.peer1_member_ports` and
-    `peer2_member_ports`.
+    Uses a composite identifier (`switch_ip`, `interface_name`). The nested model structure mirrors the ND Manage
+    Interfaces API payload, so `to_payload()` and `from_response()` work via standard Pydantic serialization.
+
+    The `interface_name` is the vPC's own name (e.g. `vpc100`), not a member interface. Member interfaces are listed
+    per-peer in `config_data.network_os.policy.peer1_member_ports` and `peer2_member_ports`.
 
     ## Raises
 
@@ -554,14 +555,15 @@ class TrunkVpcHostInterfaceModel(NDBaseModel):
 
     # --- Identifier Configuration ---
     # TODO(4.2.1) vpc-interface-dual-peer-duplicate
-    # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in
-    # the per-switch `/interfaces` GET (with identical `configData` and only `switchId` / `peerSwitchId` swapping).
-    # Using a composite (switch_ip, interface_name) identifier caused `_manage_override_deletions` to delete the
-    # peer-side duplicate. The identifier is therefore `interface_name` only; `switch_ip` is kept as a field for
-    # routing (URL-path resolution + peer-resolution) but is excluded from diff and dedup'd in `query_all`.
+    # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in the per-switch
+    # `/interfaces` GET (identical `configData`; only `switchId` / `peerSwitchId` swap). That echo is deduped in
+    # `VpcInterfaceBaseOrchestrator.query_all`, keyed on `interfaceName` + the unordered `{switchId, peerSwitchId}` pair
+    # set, so the composite identifier below stays safe: two vPC pairs in one fabric may legally reuse the same vPC id
+    # (ND's `vpcId` resource pool is devicePair-scoped; issue #356), which a name-only identity cannot represent.
+    # `switch_ip` remains excluded from payload and diff (routing-only on the wire).
 
-    identifiers: ClassVar[list[str] | None] = ["interface_name"]
-    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
 
     # --- Serialization Configuration ---
 

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -410,7 +410,9 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         Return the unordered vPC pair discriminator for an interface record: `frozenset({switchId, peerSwitchId})`. The two peer copies
         of one vPC interface carry the same set (only the orientation swaps), while same-name interfaces on different pairs carry
         disjoint sets (issue #356). Falls back to `frozenset({switch_id})` when `peerSwitchId` is absent so a malformed record degrades
-        to per-switch identity instead of raising.
+        to per-switch identity instead of raising. Note: if BOTH peer copies of one interface ever lacked `peerSwitchId`, they would get
+        disjoint keys, both would survive dedup, and `state: overridden` could queue a spurious delete of the unconfigured copy —
+        acceptable only because the wire always carries the field (lab-verified 2026-07-20).
 
         ## Raises
 

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -324,25 +324,25 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
-    def _configured_switch_ip_by_interface_name(self) -> dict[str, str]:
+    def _configured_switch_ips_by_interface_name(self) -> dict[str, set[str]]:
         """
         # Summary
 
-        Map each config `interface_name` to the user-supplied `switch_ip`. A vPC interface spans two peers and ND
-        returns it on both; this lets `query_all` pick the peer whose IP the user actually configured so the existing
-        state's composite identifier `(switch_ip, interface_name)` matches the proposed identifier and the run stays
-        idempotent regardless of which peer the user names.
+        Map each config `interface_name` to the set of user-supplied `switch_ip` values. A vPC interface spans two peers and ND returns
+        it on both; `query_all` uses this to keep the peer copy whose IP the user actually configured, so the existing state's composite
+        identifier `(switch_ip, interface_name)` matches the proposed identifier and the run stays idempotent regardless of which peer
+        the user names. A set (not a single IP) because the same name may legally appear on multiple pairs (issue #356).
 
         ## Raises
 
         None
         """
-        mapping: dict[str, str] = {}
+        mapping: dict[str, set[str]] = {}
         for item in self.rest_send.params.get("config") or []:
             name = item.get("interface_name")
             switch_ip = item.get("switch_ip")
             if name and switch_ip:
-                mapping[name] = switch_ip
+                mapping.setdefault(name, set()).add(switch_ip)
         return mapping
 
     @staticmethod
@@ -361,6 +361,28 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         network_os = config_data.get("networkOS") or {}
         policy = network_os.get("policy") or {}
         return policy.get("policyType")
+
+    @staticmethod
+    def _pair_key(iface: dict, switch_id: str) -> frozenset[str]:
+        """
+        # Summary
+
+        Return the unordered vPC pair discriminator for an interface record: `frozenset({switchId, peerSwitchId})`. The two peer copies
+        of one vPC interface carry the same set (only the orientation swaps), while same-name interfaces on different pairs carry
+        disjoint sets (issue #356). Falls back to `frozenset({switch_id})` when `peerSwitchId` is absent so a malformed record degrades
+        to per-switch identity instead of raising.
+
+        ## Raises
+
+        None
+        """
+        config_data = iface.get("configData") or {}
+        network_os = config_data.get("networkOS") or {}
+        policy = network_os.get("policy") or {}
+        peer_switch_id = policy.get("peerSwitchId")
+        if peer_switch_id:
+            return frozenset({switch_id, peer_switch_id})
+        return frozenset({switch_id})
 
     def _managed_vpc_interfaces(self, switch_ip: str, switch_id: str, managed_types: set[str]) -> list[dict]:
         """
@@ -399,6 +421,9 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         Each returned interface dict is enriched with a `switchIp` field so that the model can be constructed with the
         composite identifier `(switch_ip, interface_name)`.
 
+        Dedup is keyed on `(interfaceName, frozenset({switchId, peerSwitchId}))`, not `interfaceName` alone, so that two vPC pairs in
+        the same fabric may legally reuse the same vPC interface name (issue #356).
+
         ## Raises
 
         ### RuntimeError
@@ -410,23 +435,27 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         managed_types = self._managed_policy_types()
         try:
             self.validate_prerequisites()
-            configured_ip_by_name = self._configured_switch_ip_by_interface_name()
+            configured_ips_by_name = self._configured_switch_ips_by_interface_name()
             # TODO(4.2.1) vpc-interface-dual-peer-duplicate
-            # ND returns each vPC interface TWICE — once per peer switch — with identical configData. Dedupe by
-            # interfaceName. When the interface is in the user config, keep the peer whose switchIp the user supplied so
-            # idempotency holds regardless of which peer they name; otherwise keep the alphabetically-lower switchId for
-            # a stable representative. Without this dedupe, `_manage_override_deletions` would see the peer-side copy as
-            # "not in proposed" and queue a spurious delete.
-            interfaces_by_name: dict[str, tuple[str, dict]] = {}
+            # ND returns each vPC interface TWICE — once per peer switch — with identical configData. Dedupe on
+            # (interfaceName, frozenset({switchId, peerSwitchId})): one pair's two copies share the unordered set and
+            # collapse, while same-name interfaces on DIFFERENT pairs have disjoint sets and stay distinct (two pairs
+            # may legally reuse a vPC id — the vpcId pool is devicePair-scoped; issue #356). When the interface is in
+            # the user config, keep the peer whose switchIp the user supplied so idempotency holds regardless of which
+            # peer they name; otherwise keep the alphabetically-lower switchId for a stable representative. Without
+            # this dedupe, `_manage_override_deletions` would see the peer-side copy as "not in proposed" and queue a
+            # spurious delete.
+            interfaces_by_key: dict[tuple[str, frozenset[str]], tuple[str, dict]] = {}
             for switch_ip, switch_id in self._switches_to_query().items():
                 for iface in self._managed_vpc_interfaces(switch_ip, switch_id, managed_types):
                     name = iface.get("interfaceName")
                     if name is None:
                         continue
-                    existing = interfaces_by_name.get(name)
-                    if self._prefers_candidate(name, switch_id, switch_ip, existing, configured_ip_by_name):
-                        interfaces_by_name[name] = (switch_id, iface)
-            return [entry[1] for entry in interfaces_by_name.values()]
+                    key = (name, self._pair_key(iface, switch_id))
+                    existing = interfaces_by_key.get(key)
+                    if self._prefers_candidate(name, switch_id, switch_ip, existing, configured_ips_by_name):
+                        interfaces_by_key[key] = (switch_id, iface)
+            return [entry[1] for entry in interfaces_by_key.values()]
         except Exception as e:
             raise RuntimeError(f"Query all failed: {e}") from e
 
@@ -436,15 +465,15 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         switch_id: str,
         switch_ip: str,
         existing: tuple[str, dict] | None,
-        configured_ip_by_name: dict[str, str],
+        configured_ips_by_name: dict[str, set[str]],
     ) -> bool:
         """
         # Summary
 
-        Decide whether a newly-seen per-peer copy of a vPC interface should replace the one already kept for `name`.
-        Prefer the peer whose `switch_ip` the user configured (idempotency); when neither peer is the configured one
-        (or the interface is not in config, e.g. an `overridden` deletion candidate), prefer the alphabetically-lower
-        `switch_id` for a stable representative.
+        Decide whether a newly-seen per-peer copy of a vPC interface should replace the one already kept for its dedup key. Prefer the
+        peer whose `switch_ip` the user configured (idempotency); when neither peer is the configured one (or the interface is not in
+        config, e.g. an `overridden` deletion candidate), prefer the alphabetically-lower `switch_id` for a stable representative. The
+        two candidates for one key are always the two peers of one pair (issue #356 keys dedup on the unordered pair set).
 
         ## Raises
 
@@ -452,10 +481,10 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         """
         if existing is None:
             return True
-        configured_ip = configured_ip_by_name.get(name)
-        if configured_ip is not None:
-            if switch_ip == configured_ip:
+        configured_ips = configured_ips_by_name.get(name, set())
+        if configured_ips:
+            if switch_ip in configured_ips:
                 return True
-            if existing[1].get("switchIp") == configured_ip:
+            if existing[1].get("switchIp") in configured_ips:
                 return False
         return switch_id < existing[0]

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -371,7 +371,8 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         Map each config `interface_name` to the set of user-supplied `switch_ip` values. A vPC interface spans two peers and ND returns
         it on both; `query_all` uses this to keep the peer copy whose IP the user actually configured, so the existing state's composite
         identifier `(switch_ip, interface_name)` matches the proposed identifier and the run stays idempotent regardless of which peer
-        the user names. A set (not a single IP) because the same name may legally appear on multiple pairs (issue #356).
+        the user names. A set (not a single IP) because the same name may legally appear on multiple pairs (issue #356). Keys are
+        canonical (lowercase) names — see `_canonical_interface_name`.
 
         ## Raises
 
@@ -382,8 +383,24 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
             name = item.get("interface_name")
             switch_ip = item.get("switch_ip")
             if name and switch_ip:
-                mapping.setdefault(name, set()).add(switch_ip)
+                mapping.setdefault(self._canonical_interface_name(name), set()).add(switch_ip)
         return mapping
+
+    @staticmethod
+    def _canonical_interface_name(name: str) -> str:
+        """
+        # Summary
+
+        Return the canonical (lowercase) form of a vPC interface name. The vPC models lowercase `interface_name` on validation
+        (`VPC501` -> `vpc501`, matching what ND echoes), but `query_all` reads the user config raw from `rest_send.params`, so both
+        the configured names and the response names must pass through this one canonicalizer before they are compared; otherwise a
+        mixed-case config never matches its own echo and the dedup falls back to the wrong peer (PR #411 review).
+
+        ## Raises
+
+        None
+        """
+        return name.lower()
 
     @staticmethod
     def _policy_type(iface: dict) -> str | None:
@@ -402,29 +419,33 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         policy = network_os.get("policy") or {}
         return policy.get("policyType")
 
-    @staticmethod
-    def _pair_key(iface: dict, switch_id: str) -> frozenset[str]:
+    def _pair_key(self, iface: dict, switch_ip: str, switch_id: str) -> frozenset[str]:
         """
         # Summary
 
         Return the unordered vPC pair discriminator for an interface record: `frozenset({switchId, peerSwitchId})`. The two peer copies
         of one vPC interface carry the same set (only the orientation swaps), while same-name interfaces on different pairs carry
-        disjoint sets (issue #356). Falls back to `frozenset({switch_id})` when `peerSwitchId` is absent so a malformed record degrades
-        to per-switch identity instead of raising. Note: if BOTH peer copies of one interface ever lacked `peerSwitchId`, they would get
-        disjoint keys, both would survive dedup, and `state: overridden` could queue a spurious delete of the unconfigured copy —
-        acceptable only because the wire always carries the field (lab-verified 2026-07-20).
+        disjoint sets (issue #356).
+
+        When the echo omits `peerSwitchId` (the OpenAPI schema does not mark it required, so this is a schema-valid shape) the peer is
+        resolved from the authoritative `vpcPair` endpoint via `_resolve_peer_switch_id` (cached per switch, so the degraded path costs
+        at most one extra GET per switch). A per-switch singleton key is NOT an acceptable fallback: if even one of the two peer echoes
+        lacked the field, the copies would key on `{A}` vs `{A, B}`, both would survive dedup, and `state: overridden` would delete the
+        pair-wide interface through the "unconfigured" peer (PR #411 review). If the pair cannot be resolved, this raises and
+        `query_all` fails closed before any override deletion can be computed.
 
         ## Raises
 
-        None
+        ### RuntimeError
+
+        - Propagated from `_resolve_peer_switch_id` when `peerSwitchId` is absent and the switch is not in a vPC pair (or the
+          `vpcPair` record itself omits `peerSwitchId`).
         """
         config_data = iface.get("configData") or {}
         network_os = config_data.get("networkOS") or {}
         policy = network_os.get("policy") or {}
-        peer_switch_id = policy.get("peerSwitchId")
-        if peer_switch_id:
-            return frozenset({switch_id, peer_switch_id})
-        return frozenset({switch_id})
+        peer_switch_id = policy.get("peerSwitchId") or self._resolve_peer_switch_id(switch_ip, switch_id)
+        return frozenset({switch_id, peer_switch_id})
 
     def _managed_vpc_interfaces(self, switch_ip: str, switch_id: str, managed_types: set[str]) -> list[dict]:
         """
@@ -464,7 +485,8 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         composite identifier `(switch_ip, interface_name)`.
 
         Dedup is keyed on `(interfaceName, frozenset({switchId, peerSwitchId}))`, not `interfaceName` alone, so that two vPC pairs in
-        the same fabric may legally reuse the same vPC interface name (issue #356).
+        the same fabric may legally reuse the same vPC interface name (issue #356). An echo that omits `peerSwitchId` has its pair
+        resolved from the `vpcPair` endpoint; if that fails the whole query fails closed (see `_pair_key`).
 
         ## Raises
 
@@ -473,6 +495,7 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         - If the fabric does not exist on the target ND node.
         - If the fabric is in deployment-freeze mode.
         - If the query API request fails.
+        - If an interface echo omits `peerSwitchId` and its switch's vPC pair cannot be resolved.
         """
         managed_types = self._managed_policy_types()
         try:
@@ -484,16 +507,18 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
             # collapse, while same-name interfaces on DIFFERENT pairs have disjoint sets and stay distinct (two pairs
             # may legally reuse a vPC id — the vpcId pool is devicePair-scoped; issue #356). When the interface is in
             # the user config, keep the peer whose switchIp the user supplied so idempotency holds regardless of which
-            # peer they name; otherwise keep the alphabetically-lower switchId for a stable representative. Without
-            # this dedupe, `_manage_override_deletions` would see the peer-side copy as "not in proposed" and queue a
+            # peer they name; otherwise keep the alphabetically-lower switchId for a stable representative. Names are
+            # canonicalized (lowercase) on both sides so a mixed-case config still matches its echo. Without this
+            # dedupe, `_manage_override_deletions` would see the peer-side copy as "not in proposed" and queue a
             # spurious delete.
             interfaces_by_key: dict[tuple[str, frozenset[str]], tuple[str, dict]] = {}
             for switch_ip, switch_id in self._switches_to_query().items():
                 for iface in self._managed_vpc_interfaces(switch_ip, switch_id, managed_types):
-                    name = iface.get("interfaceName")
-                    if name is None:
+                    raw_name = iface.get("interfaceName")
+                    if raw_name is None:
                         continue
-                    key = (name, self._pair_key(iface, switch_id))
+                    name = self._canonical_interface_name(raw_name)
+                    key = (name, self._pair_key(iface, switch_ip, switch_id))
                     existing = interfaces_by_key.get(key)
                     if self._prefers_candidate(name, switch_id, switch_ip, existing, configured_ips_by_name):
                         interfaces_by_key[key] = (switch_id, iface)

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -31,6 +31,7 @@ user to create the pair first via `nd_manage_vpc_pair`.
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
@@ -112,6 +113,45 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         """
         super().model_post_init(__context)
         self._peer_serial_cache: dict[str, str] = {}
+
+    def preflight(self, model_instances: Sequence[ModelType]) -> None:
+        """
+        # Summary
+
+        Run the shared interface preflight, then reject a config that lists the same `interface_name` under both peers of one vPC
+        pair. With the composite `(switch_ip, interface_name)` identity (issue #356) such a config parses as two proposed items that
+        target a single ND resource; failing fast here (the state machine runs `preflight` before any mutation, in check mode too)
+        prevents a double-write against one interface. Pair resolution runs ONLY for names that appear more than once, so runs with
+        unique names — the common case — issue no additional requests; the duplicate path costs one cached `vpcPair` GET per distinct
+        primary switch, reused later by create/update.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If two (or more) proposed items share an `interface_name` and resolve to the same vPC pair.
+        - Propagated from `super().preflight` / `_resolve_switch_id` / `_resolve_peer_switch_id` (unresolvable switch, missing pair).
+        """
+        super().preflight(model_instances)
+        items_by_name: dict[str, list[ModelType]] = {}
+        for model_instance in model_instances:
+            items_by_name.setdefault(model_instance.interface_name, []).append(model_instance)
+        offenders: list[str] = []
+        for name, items in items_by_name.items():
+            if len(items) < 2:
+                continue
+            switch_ips_by_pair: dict[frozenset[str], list[str]] = {}
+            for item in items:
+                switch_id = self._resolve_switch_id(item.switch_ip)
+                peer_serial = self._resolve_peer_switch_id(item.switch_ip, switch_id)
+                switch_ips_by_pair.setdefault(frozenset({switch_id, peer_serial}), []).append(item.switch_ip)
+            for switch_ips in switch_ips_by_pair.values():
+                if len(switch_ips) > 1:
+                    offenders.append(
+                        f"{name} is listed for multiple peers ({', '.join(sorted(switch_ips))}) of the same vPC pair; list it once, under either peer"
+                    )
+        if offenders:
+            raise RuntimeError(f"Invalid vPC config in fabric '{self.fabric_name}': " + "; ".join(sorted(offenders)))
 
     def _managed_policy_types(self) -> set[str]:
         """

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -310,6 +310,11 @@ notes:
 - The primary switch supplied in O(config[].switch_ip) must already be in a vPC pair (managed by
   M(cisco.nd.nd_manage_vpc_pair)). The peer serial is auto-resolved from the pair record.
 - C(peer1) refers to the switch supplied in O(config[].switch_ip); C(peer2) refers to the auto-resolved peer.
+- A vPC interface is identified by the combination of O(config[].switch_ip) and O(config[].interface_name). Two different vPC
+  pairs in the same fabric may reuse the same vPC id (for example C(vpc100) on two pairs); list each under its own pair's
+  O(config[].switch_ip).
+- Listing the same O(config[].interface_name) under both peers of the same vPC pair is rejected; list each vPC interface once,
+  under either peer.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -313,8 +313,9 @@ notes:
 - A vPC interface is identified by the combination of O(config[].switch_ip) and O(config[].interface_name). Two different vPC
   pairs in the same fabric may reuse the same vPC id (for example C(vpc100) on two pairs); list each under its own pair's
   O(config[].switch_ip).
-- Listing the same O(config[].interface_name) under both peers of the same vPC pair is rejected; list each vPC interface once,
-  under either peer.
+- For states C(merged), C(replaced), and C(overridden), listing the same O(config[].interface_name) under both peers of the same
+  vPC pair is rejected; list each vPC interface once, under either peer. For state C(deleted) this guard does not run; duplicate
+  entries simply resolve to the same vPC interface.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_interface_vpc_trunk_host.py
+++ b/plugins/modules/nd_interface_vpc_trunk_host.py
@@ -353,6 +353,11 @@ notes:
 - The primary switch supplied in O(config[].switch_ip) must already be in a vPC pair (managed by
   M(cisco.nd.nd_manage_vpc_pair)). The peer serial is auto-resolved from the pair record.
 - C(peer1) refers to the switch supplied in O(config[].switch_ip); C(peer2) refers to the auto-resolved peer.
+- A vPC interface is identified by the combination of O(config[].switch_ip) and O(config[].interface_name). Two different vPC
+  pairs in the same fabric may reuse the same vPC id (for example C(vpc100) on two pairs); list each under its own pair's
+  O(config[].switch_ip).
+- Listing the same O(config[].interface_name) under both peers of the same vPC pair is rejected; list each vPC interface once,
+  under either peer.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/nd_interface_vpc_trunk_host.py
+++ b/plugins/modules/nd_interface_vpc_trunk_host.py
@@ -356,8 +356,9 @@ notes:
 - A vPC interface is identified by the combination of O(config[].switch_ip) and O(config[].interface_name). Two different vPC
   pairs in the same fabric may reuse the same vPC id (for example C(vpc100) on two pairs); list each under its own pair's
   O(config[].switch_ip).
-- Listing the same O(config[].interface_name) under both peers of the same vPC pair is rejected; list each vPC interface once,
-  under either peer.
+- For states C(merged), C(replaced), and C(overridden), listing the same O(config[].interface_name) under both peers of the same
+  vPC pair is rejected; list each vPC interface once, under either peer. For state C(deleted) this guard does not run; duplicate
+  entries simply resolve to the same vPC interface.
 """
 
 EXAMPLES = r"""

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
@@ -42,11 +42,11 @@
     - name: Run nd_interface_vpc_access overridden state tests
       ansible.builtin.include_tasks: overridden.yaml
 
-    - name: Include multi-pair same-vPC-id tests (issue 356)
-      ansible.builtin.include_tasks: multi_pair.yaml
-
     - name: Run nd_interface_vpc_access deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
+
+    - name: Include multi-pair same-vPC-id tests (issue 356)
+      ansible.builtin.include_tasks: multi_pair.yaml
   always:
     - name: Teardown (unpair vPC, cascades to remove any remaining vPC interfaces)
       cisco.nd.nd_manage_vpc_pair:

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
@@ -42,6 +42,9 @@
     - name: Run nd_interface_vpc_access overridden state tests
       ansible.builtin.include_tasks: overridden.yaml
 
+    - name: Include multi-pair same-vPC-id tests (issue 356)
+      ansible.builtin.include_tasks: multi_pair.yaml
+
     - name: Run nd_interface_vpc_access deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
   always:

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
@@ -16,7 +16,9 @@
 #   - vPC pair uses a virtual peer-link (no physical peer-link cable required); see vars/main.yaml
 #
 # Setup creates the vPC pair if missing; teardown unpairs it (which cascades and removes all
-# member vPC interfaces, so we don't need an explicit vPC-interface teardown).
+# member vPC interfaces, so we don't need an explicit vPC-interface teardown). Set
+# nd_test_manage_vpc_pairs=false to treat the pair as pre-existing lab substrate (setup/teardown
+# then leave it untouched).
 
 - name: Test that we have a Nexus Dashboard host, username and password
   ansible.builtin.fail:
@@ -57,6 +59,7 @@
             peer2_switch_id: "{{ test_switch_ip_peer2 }}"
         state: deleted
       ignore_errors: true
+      when: test_manage_vpc_pairs
   vars:
     ansible_command_timeout: 300
   environment:

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/main.yaml
@@ -14,6 +14,7 @@
 #   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.152) reachable
 #   - Ethernet1/5, Ethernet1/6, Ethernet1/7 free on both peers for vPC member testing
 #   - vPC pair uses a virtual peer-link (no physical peer-link cable required); see vars/main.yaml
+#   - Multi-pair scenario additionally requires Ethernet1/10 free on all four leaves and a second vPC pair present
 #
 # Setup creates the vPC pair if missing; teardown unpairs it (which cascades and removes all
 # member vPC interfaces, so we don't need an explicit vPC-interface teardown). Set

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/multi_pair.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/multi_pair.yaml
@@ -139,3 +139,16 @@
   ansible.builtin.assert:
     that:
       - mp_cleanup is changed
+
+# Pair 2's copy is normally removed by the OVERRIDDEN step above; this best-effort delete (no changed
+# assert, failures ignored) keeps the fabric clean if a prior run aborted between the MERGED create
+# and the OVERRIDDEN step.
+- name: "MULTI-PAIR CLEANUP: Delete pair 2's {{ vpc_multi_pair_name }} (best effort)"
+  cisco.nd.nd_interface_vpc_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip_pair2_peer1 }}"
+        interface_name: "{{ vpc_multi_pair_name }}"
+    state: deleted
+  failed_when: false

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/multi_pair.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/multi_pair.yaml
@@ -1,0 +1,141 @@
+---
+# Multi-pair same-vPC-id tests for nd_interface_vpc_access (issue #356)
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- PRECONDITION: second vPC pair must exist (never created here) ---
+#
+# nd_manage_vpc_pair has no `query` state; its read-only mode is `state: gathered`. The module's
+# top-level fabric key is `fabric_name` (not `fabric`), and config.peer1_switch_id / peer2_switch_id
+# are BOTH required (see plugins/modules/nd_manage_vpc_pair.py DOCUMENTATION + vpc_pair_model.py
+# VpcPairPlaybookItemModel) — a peer1-only filter fails Pydantic validation before the request is
+# even sent. Gathered output is `gathered.vpc_pairs` / `gathered.pending_delete_vpc_pairs`
+# (plugins/module_utils/manage_vpc_pair/runner.py), not `response` or `current`.
+
+- name: "MULTI-PAIR PRECONDITION: Gather vPC pair state for pair-2 (peer1/peer2)"
+  cisco.nd.nd_manage_vpc_pair:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - peer1_switch_id: "{{ test_switch_ip_pair2_peer1 }}"
+        peer2_switch_id: "{{ test_switch_ip_pair2_peer2 }}"
+    state: gathered
+  register: pair2_query
+  failed_when: false
+
+- name: "MULTI-PAIR PRECONDITION: Assert the second vPC pair exists"
+  ansible.builtin.assert:
+    that:
+      - pair2_query is not failed
+      - pair2_query.gathered is defined
+      - pair2_query.gathered.vpc_pairs | default([]) | length > 0
+    fail_msg: >-
+      The multi-pair scenario requires a second vPC pair ({{ test_switch_ip_pair2_peer1 }}/{{ test_switch_ip_pair2_peer2 }})
+      in fabric {{ test_fabric_name }}. Create it first (nd_manage_vpc_pair) or override nd_test_vpc_pair2_peer*_ip.
+
+# --- MERGED: same name + id on both pairs in ONE task (the #356 CONFIRMED failure) ---
+
+- name: "MULTI-PAIR MERGED: Create {{ vpc_multi_pair_name }} on both pairs (check mode)"
+  cisco.nd.nd_interface_vpc_access: &multi_pair_merge
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_multi_pair_pair1 }}"
+      - "{{ vpc_multi_pair_pair2 }}"
+    state: merged
+  check_mode: true
+  register: cm_mp_merged
+
+- name: "MULTI-PAIR MERGED: Create {{ vpc_multi_pair_name }} on both pairs (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *multi_pair_merge
+  register: nm_mp_merged
+
+- name: "MULTI-PAIR MERGED: Verify both creations produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_mp_merged is changed
+      - nm_mp_merged is changed
+
+- name: "MULTI-PAIR IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "MULTI-PAIR IDEMPOTENT: Re-apply both (normal mode)"
+  cisco.nd.nd_interface_vpc_access: *multi_pair_merge
+  register: nm_mp_idem
+
+- name: "MULTI-PAIR IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_mp_idem is not changed
+
+# --- GUARD: same name under both peers of ONE pair must fail fast ---
+
+- name: "MULTI-PAIR GUARD: Same name under both peers of pair 1 (must fail)"
+  cisco.nd.nd_interface_vpc_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_multi_pair_pair1 }}"
+      - "{{ vpc_multi_pair_pair1 | combine({'switch_ip': test_switch_ip_peer2}) }}"
+    state: merged
+  register: mp_guard
+  failed_when: false
+
+- name: "MULTI-PAIR GUARD: Verify the fail-fast error names the pair"
+  ansible.builtin.assert:
+    that:
+      - mp_guard is failed or (mp_guard.msg is defined and 'same vPC pair' in mp_guard.msg | string)
+      - "'same vPC pair' in (mp_guard.msg | default(mp_guard) | string)"
+
+# --- OVERRIDDEN: config holds only pair 1's interface -> pair 2's must be deleted (the #356 override gap) ---
+
+- name: "MULTI-PAIR OVERRIDDEN: Keep only pair 1's {{ vpc_multi_pair_name }} (normal mode)"
+  cisco.nd.nd_interface_vpc_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_multi_pair_pair1 }}"
+    state: overridden
+  register: nm_mp_overridden
+
+- name: "MULTI-PAIR OVERRIDDEN: Verify pair 2's copy was removed (a change occurred)"
+  ansible.builtin.assert:
+    that:
+      - nm_mp_overridden is changed
+
+- name: "MULTI-PAIR OVERRIDDEN IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "MULTI-PAIR OVERRIDDEN IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_interface_vpc_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_multi_pair_pair1 }}"
+    state: overridden
+  register: nm_mp_overridden_idem
+
+- name: "MULTI-PAIR OVERRIDDEN IDEMPOTENT: Verify stable (pair 1 untouched, nothing re-deleted)"
+  ansible.builtin.assert:
+    that:
+      - nm_mp_overridden_idem is not changed
+
+# --- CLEANUP ---
+
+- name: "MULTI-PAIR CLEANUP: Delete pair 1's {{ vpc_multi_pair_name }}"
+  cisco.nd.nd_interface_vpc_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip_peer1 }}"
+        interface_name: "{{ vpc_multi_pair_name }}"
+    state: deleted
+  register: mp_cleanup
+
+- name: "MULTI-PAIR CLEANUP: Verify deletion"
+  ansible.builtin.assert:
+    that:
+      - mp_cleanup is changed

--- a/tests/integration/targets/nd_interface_vpc_access/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/tasks/setup.yaml
@@ -18,11 +18,13 @@
         peer2_switch_id: "{{ test_switch_ip_peer2 }}"
     state: deleted
   ignore_errors: true
+  when: test_manage_vpc_pairs
   tags: always
 
 - name: "SETUP: Pause for unpair convergence"
   ansible.builtin.pause:
     seconds: 30
+  when: test_manage_vpc_pairs
   tags: always
 
 - name: "SETUP: Create vPC pair"
@@ -32,9 +34,11 @@
     config:
       - "{{ vpc_pair_setup }}"
     state: merged
+  when: test_manage_vpc_pairs
   tags: always
 
 - name: "SETUP: Pause for pair-establishment convergence"
   ansible.builtin.pause:
     seconds: 30
+  when: test_manage_vpc_pairs
   tags: always

--- a/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
@@ -26,6 +26,9 @@ test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.152') }}"
 # Revert to a physical peer-link once ND fixes physical peer-link config generation, i.e. restore
 # use_virtual_peer_link: false plus switch_po_id / peer_switch_po_id / switch_member_interfaces /
 # peer_switch_member_interfaces (Ethernet1/2 on both peers) under vpc_pair_details.
+#
+# Set nd_test_manage_vpc_pairs=false to treat this pair as pre-existing lab substrate (see
+# test_manage_vpc_pairs below); the config above is then only used for peer-serial resolution.
 vpc_pair_setup:
   peer1_switch_id: "{{ test_switch_ip_peer1 }}"
   peer2_switch_id: "{{ test_switch_ip_peer2 }}"
@@ -36,6 +39,11 @@ vpc_pair_setup:
     keep_alive_vrf: management
     switch_keep_alive_local_ip: "{{ test_switch_ip_peer1 }}"
     peer_switch_keep_alive_local_ip: "{{ test_switch_ip_peer2 }}"
+
+# When false, the test run treats the vPC pair as pre-existing lab substrate: setup does not
+# create/modify the pair and teardown does not unpair it. Default true preserves the original
+# self-contained behavior (setup creates the pair, teardown unpairs it).
+test_manage_vpc_pairs: "{{ nd_test_manage_vpc_pairs | default(true) | bool }}"
 
 # Baseline vPC access interface used by merged + idempotency tests.
 vpc_access_baseline:

--- a/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_access/vars/main.yaml
@@ -90,3 +90,44 @@ vpc_access_overridden:
         peer2_member_ports:
           - Ethernet1/7
         port_channel_mode: active
+
+# --- Multi-pair scenario (#356): second vPC pair + same-name interfaces on both pairs ---
+# Requires a SECOND vPC pair in the fabric (SITE1: S1_LE3/S1_LE4, added 2026-07-20). The scenario asserts the
+# pair exists and fails with a clear message if not — it never creates or mutates vPC pairs.
+test_switch_ip_pair2_peer1: "{{ nd_test_vpc_pair2_peer1_ip | default('192.168.12.154') }}"
+test_switch_ip_pair2_peer2: "{{ nd_test_vpc_pair2_peer2_ip | default('192.168.12.155') }}"
+
+# Same interface name and id on BOTH pairs — legal on ND (devicePair-scoped vpcId pool, issue #356).
+# Uses vpc211 / Ethernet1/10 (distinct from the trunk_host target's vpc210 / Ethernet1/9) so the two
+# targets' multi-pair scenarios never collide if run back-to-back against the same pair-2 switches.
+vpc_multi_pair_name: vpc211
+vpc_multi_pair_pair1:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: "{{ vpc_multi_pair_name }}"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 10
+        peer1_port_channel_id: 211
+        peer1_member_ports:
+          - Ethernet1/10
+        peer2_port_channel_id: 211
+        peer2_member_ports:
+          - Ethernet1/10
+        port_channel_mode: active
+vpc_multi_pair_pair2:
+  switch_ip: "{{ test_switch_ip_pair2_peer1 }}"
+  interface_name: "{{ vpc_multi_pair_name }}"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        access_vlan: 10
+        peer1_port_channel_id: 211
+        peer1_member_ports:
+          - Ethernet1/10
+        peer2_port_channel_id: 211
+        peer2_member_ports:
+          - Ethernet1/10
+        port_channel_mode: active

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
@@ -16,7 +16,9 @@
 #   - vPC pair uses a virtual peer-link (no physical peer-link cable required); see vars/main.yaml
 #
 # Setup creates the vPC pair if missing; teardown unpairs it (which cascades and removes all
-# member vPC interfaces, so we don't need an explicit vPC-interface teardown).
+# member vPC interfaces, so we don't need an explicit vPC-interface teardown). Set
+# nd_test_manage_vpc_pairs=false to treat the pair as pre-existing lab substrate (setup/teardown
+# then leave it untouched).
 
 - name: Test that we have a Nexus Dashboard host, username and password
   ansible.builtin.fail:
@@ -57,6 +59,7 @@
             peer2_switch_id: "{{ test_switch_ip_peer2 }}"
         state: deleted
       ignore_errors: true
+      when: test_manage_vpc_pairs
   vars:
     ansible_command_timeout: 300
   environment:

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
@@ -42,11 +42,11 @@
     - name: Run nd_interface_vpc_trunk_host overridden state tests
       ansible.builtin.include_tasks: overridden.yaml
 
-    - name: Include multi-pair same-vPC-id tests (issue 356)
-      ansible.builtin.include_tasks: multi_pair.yaml
-
     - name: Run nd_interface_vpc_trunk_host deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
+
+    - name: Include multi-pair same-vPC-id tests (issue 356)
+      ansible.builtin.include_tasks: multi_pair.yaml
   always:
     - name: Teardown (unpair vPC, cascades to remove any remaining vPC interfaces)
       cisco.nd.nd_manage_vpc_pair:

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
@@ -14,6 +14,7 @@
 #   - SITE1 fabric with peer1 (192.168.12.151) and peer2 (192.168.12.152) reachable
 #   - Ethernet1/8, Ethernet1/9, Ethernet1/10 free on both peers for vPC member testing
 #   - vPC pair uses a virtual peer-link (no physical peer-link cable required); see vars/main.yaml
+#   - Multi-pair scenario additionally requires Ethernet1/9 free on the second pair's leaves (S1_LE3/S1_LE4) and a second vPC pair present
 #
 # Setup creates the vPC pair if missing; teardown unpairs it (which cascades and removes all
 # member vPC interfaces, so we don't need an explicit vPC-interface teardown). Set

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/main.yaml
@@ -42,6 +42,9 @@
     - name: Run nd_interface_vpc_trunk_host overridden state tests
       ansible.builtin.include_tasks: overridden.yaml
 
+    - name: Include multi-pair same-vPC-id tests (issue 356)
+      ansible.builtin.include_tasks: multi_pair.yaml
+
     - name: Run nd_interface_vpc_trunk_host deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
   always:

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/multi_pair.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/multi_pair.yaml
@@ -1,0 +1,141 @@
+---
+# Multi-pair same-vPC-id tests for nd_interface_vpc_trunk_host (issue #356)
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# --- PRECONDITION: second vPC pair must exist (never created here) ---
+#
+# nd_manage_vpc_pair has no `query` state; its read-only mode is `state: gathered`. The module's
+# top-level fabric key is `fabric_name` (not `fabric`), and config.peer1_switch_id / peer2_switch_id
+# are BOTH required (see plugins/modules/nd_manage_vpc_pair.py DOCUMENTATION + vpc_pair_model.py
+# VpcPairPlaybookItemModel) — a peer1-only filter fails Pydantic validation before the request is
+# even sent. Gathered output is `gathered.vpc_pairs` / `gathered.pending_delete_vpc_pairs`
+# (plugins/module_utils/manage_vpc_pair/runner.py), not `response` or `current`.
+
+- name: "MULTI-PAIR PRECONDITION: Gather vPC pair state for pair-2 (peer1/peer2)"
+  cisco.nd.nd_manage_vpc_pair:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - peer1_switch_id: "{{ test_switch_ip_pair2_peer1 }}"
+        peer2_switch_id: "{{ test_switch_ip_pair2_peer2 }}"
+    state: gathered
+  register: pair2_query
+  failed_when: false
+
+- name: "MULTI-PAIR PRECONDITION: Assert the second vPC pair exists"
+  ansible.builtin.assert:
+    that:
+      - pair2_query is not failed
+      - pair2_query.gathered is defined
+      - pair2_query.gathered.vpc_pairs | default([]) | length > 0
+    fail_msg: >-
+      The multi-pair scenario requires a second vPC pair ({{ test_switch_ip_pair2_peer1 }}/{{ test_switch_ip_pair2_peer2 }})
+      in fabric {{ test_fabric_name }}. Create it first (nd_manage_vpc_pair) or override nd_test_vpc_pair2_peer*_ip.
+
+# --- MERGED: same name + id on both pairs in ONE task (the #356 CONFIRMED failure) ---
+
+- name: "MULTI-PAIR MERGED: Create {{ vpc_multi_pair_name }} on both pairs (check mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: &multi_pair_merge
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_multi_pair_pair1 }}"
+      - "{{ vpc_multi_pair_pair2 }}"
+    state: merged
+  check_mode: true
+  register: cm_mp_merged
+
+- name: "MULTI-PAIR MERGED: Create {{ vpc_multi_pair_name }} on both pairs (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *multi_pair_merge
+  register: nm_mp_merged
+
+- name: "MULTI-PAIR MERGED: Verify both creations produced a change"
+  ansible.builtin.assert:
+    that:
+      - cm_mp_merged is changed
+      - nm_mp_merged is changed
+
+- name: "MULTI-PAIR IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "MULTI-PAIR IDEMPOTENT: Re-apply both (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host: *multi_pair_merge
+  register: nm_mp_idem
+
+- name: "MULTI-PAIR IDEMPOTENT: Verify no change on second run"
+  ansible.builtin.assert:
+    that:
+      - nm_mp_idem is not changed
+
+# --- GUARD: same name under both peers of ONE pair must fail fast ---
+
+- name: "MULTI-PAIR GUARD: Same name under both peers of pair 1 (must fail)"
+  cisco.nd.nd_interface_vpc_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_multi_pair_pair1 }}"
+      - "{{ vpc_multi_pair_pair1 | combine({'switch_ip': test_switch_ip_peer2}) }}"
+    state: merged
+  register: mp_guard
+  failed_when: false
+
+- name: "MULTI-PAIR GUARD: Verify the fail-fast error names the pair"
+  ansible.builtin.assert:
+    that:
+      - mp_guard is failed or (mp_guard.msg is defined and 'same vPC pair' in mp_guard.msg | string)
+      - "'same vPC pair' in (mp_guard.msg | default(mp_guard) | string)"
+
+# --- OVERRIDDEN: config holds only pair 1's interface -> pair 2's must be deleted (the #356 override gap) ---
+
+- name: "MULTI-PAIR OVERRIDDEN: Keep only pair 1's {{ vpc_multi_pair_name }} (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_multi_pair_pair1 }}"
+    state: overridden
+  register: nm_mp_overridden
+
+- name: "MULTI-PAIR OVERRIDDEN: Verify pair 2's copy was removed (a change occurred)"
+  ansible.builtin.assert:
+    that:
+      - nm_mp_overridden is changed
+
+- name: "MULTI-PAIR OVERRIDDEN IDEMPOTENT: Pause for convergence"
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: "MULTI-PAIR OVERRIDDEN IDEMPOTENT: Re-apply (normal mode)"
+  cisco.nd.nd_interface_vpc_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - "{{ vpc_multi_pair_pair1 }}"
+    state: overridden
+  register: nm_mp_overridden_idem
+
+- name: "MULTI-PAIR OVERRIDDEN IDEMPOTENT: Verify stable (pair 1 untouched, nothing re-deleted)"
+  ansible.builtin.assert:
+    that:
+      - nm_mp_overridden_idem is not changed
+
+# --- CLEANUP ---
+
+- name: "MULTI-PAIR CLEANUP: Delete pair 1's {{ vpc_multi_pair_name }}"
+  cisco.nd.nd_interface_vpc_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip_peer1 }}"
+        interface_name: "{{ vpc_multi_pair_name }}"
+    state: deleted
+  register: mp_cleanup
+
+- name: "MULTI-PAIR CLEANUP: Verify deletion"
+  ansible.builtin.assert:
+    that:
+      - mp_cleanup is changed

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/multi_pair.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/multi_pair.yaml
@@ -139,3 +139,16 @@
   ansible.builtin.assert:
     that:
       - mp_cleanup is changed
+
+# Pair 2's copy is normally removed by the OVERRIDDEN step above; this best-effort delete (no changed
+# assert, failures ignored) keeps the fabric clean if a prior run aborted between the MERGED create
+# and the OVERRIDDEN step.
+- name: "MULTI-PAIR CLEANUP: Delete pair 2's {{ vpc_multi_pair_name }} (best effort)"
+  cisco.nd.nd_interface_vpc_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - switch_ip: "{{ test_switch_ip_pair2_peer1 }}"
+        interface_name: "{{ vpc_multi_pair_name }}"
+    state: deleted
+  failed_when: false

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/tasks/setup.yaml
@@ -18,11 +18,13 @@
         peer2_switch_id: "{{ test_switch_ip_peer2 }}"
     state: deleted
   ignore_errors: true
+  when: test_manage_vpc_pairs
   tags: always
 
 - name: "SETUP: Pause for unpair convergence"
   ansible.builtin.pause:
     seconds: 30
+  when: test_manage_vpc_pairs
   tags: always
 
 - name: "SETUP: Create vPC pair"
@@ -32,9 +34,11 @@
     config:
       - "{{ vpc_pair_setup }}"
     state: merged
+  when: test_manage_vpc_pairs
   tags: always
 
 - name: "SETUP: Pause for pair-establishment convergence"
   ansible.builtin.pause:
     seconds: 30
+  when: test_manage_vpc_pairs
   tags: always

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/vars/main.yaml
@@ -128,3 +128,44 @@ vpc_trunk_host_with_vlan_mapping:
             customer_inner_vlan_id: 510
             provider_vlan_id: 1010
             dot1q_tunnel: true
+
+# --- Multi-pair scenario (#356): second vPC pair + same-name interfaces on both pairs ---
+# Requires a SECOND vPC pair in the fabric (SITE1: S1_LE3/S1_LE4, added 2026-07-20). The scenario asserts the
+# pair exists and fails with a clear message if not — it never creates or mutates vPC pairs.
+test_switch_ip_pair2_peer1: "{{ nd_test_vpc_pair2_peer1_ip | default('192.168.12.154') }}"
+test_switch_ip_pair2_peer2: "{{ nd_test_vpc_pair2_peer2_ip | default('192.168.12.155') }}"
+
+# Same interface name and id on BOTH pairs — legal on ND (devicePair-scoped vpcId pool, issue #356).
+vpc_multi_pair_name: vpc210
+vpc_multi_pair_pair1:
+  switch_ip: "{{ test_switch_ip_peer1 }}"
+  interface_name: "{{ vpc_multi_pair_name }}"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-200"
+        native_vlan: 99
+        peer1_port_channel_id: 210
+        peer1_member_ports:
+          - Ethernet1/9
+        peer2_port_channel_id: 210
+        peer2_member_ports:
+          - Ethernet1/9
+        port_channel_mode: active
+vpc_multi_pair_pair2:
+  switch_ip: "{{ test_switch_ip_pair2_peer1 }}"
+  interface_name: "{{ vpc_multi_pair_name }}"
+  config_data:
+    network_os:
+      policy:
+        admin_state: true
+        allowed_vlans: "100-200"
+        native_vlan: 99
+        peer1_port_channel_id: 210
+        peer1_member_ports:
+          - Ethernet1/9
+        peer2_port_channel_id: 210
+        peer2_member_ports:
+          - Ethernet1/9
+        port_channel_mode: active

--- a/tests/integration/targets/nd_interface_vpc_trunk_host/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_vpc_trunk_host/vars/main.yaml
@@ -26,6 +26,9 @@ test_switch_ip_peer2: "{{ nd_test_vpc_peer2_ip | default('192.168.12.152') }}"
 # Revert to a physical peer-link once ND fixes physical peer-link config generation, i.e. restore
 # use_virtual_peer_link: false plus switch_po_id / peer_switch_po_id / switch_member_interfaces /
 # peer_switch_member_interfaces (Ethernet1/2 on both peers) under vpc_pair_details.
+#
+# Set nd_test_manage_vpc_pairs=false to treat this pair as pre-existing lab substrate (see
+# test_manage_vpc_pairs below); the config above is then only used for peer-serial resolution.
 vpc_pair_setup:
   peer1_switch_id: "{{ test_switch_ip_peer1 }}"
   peer2_switch_id: "{{ test_switch_ip_peer2 }}"
@@ -36,6 +39,11 @@ vpc_pair_setup:
     keep_alive_vrf: management
     switch_keep_alive_local_ip: "{{ test_switch_ip_peer1 }}"
     peer_switch_keep_alive_local_ip: "{{ test_switch_ip_peer2 }}"
+
+# When false, the test run treats the vPC pair as pre-existing lab substrate: setup does not
+# create/modify the pair and teardown does not unpair it. Default true preserves the original
+# self-contained behavior (setup creates the pair, teardown unpairs it).
+test_manage_vpc_pairs: "{{ nd_test_manage_vpc_pairs | default(true) | bool }}"
 
 # Baseline vPC trunk-host interface used by merged + idempotency tests.
 # ND requires per-peer peer1AllowedVlans/peer2AllowedVlans and peer1NativeVlan/peer2NativeVlan

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_access_interface_orchestrator.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_access_interface_orchestrator.json
@@ -352,5 +352,465 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
         "MESSAGE": "Not Found",
         "DATA": {}
+    },
+    "test_overridden_mixed_case_00440a": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (normal mode, #411 review): fabric summary (fabric exists)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_overridden_mixed_case_00440b": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (normal mode, #411 review): switch list, two switches in one vPC pair."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00440c": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (normal mode, #411 review): S1 echoes canonical lowercase vpc100 (peerSwitchId=FDOBBBBBBBB); deduped away in favor of the configured peer S2."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDOBBBBBBBB",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00440d": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (normal mode, #411 review): S2 echoes canonical lowercase vpc100 (peerSwitchId=FDOAAAAAAAA); the user configured it as VPC100 on S2, so this copy is kept."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDOAAAAAAAA",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00445a": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (check mode, #411 review): fabric summary (fabric exists)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_overridden_mixed_case_00445b": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (check mode, #411 review): switch list, two switches in one vPC pair."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00445c": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (check mode, #411 review): S1 echoes canonical lowercase vpc100 (peerSwitchId=FDOBBBBBBBB); deduped away in favor of the configured peer S2."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDOBBBBBBBB",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00445d": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (check mode, #411 review): S2 echoes canonical lowercase vpc100 (peerSwitchId=FDOAAAAAAAA); the user configured it as VPC100 on S2, so this copy is kept."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDOAAAAAAAA",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_one_peer_missing_00450a": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): fabric summary (fabric exists)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_overridden_one_peer_missing_00450b": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): switch list, two switches in one vPC pair."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_overridden_one_peer_missing_00450c": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): S1 echoes vpc100 WITH peerSwitchId=FDOBBBBBBBB."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "peerSwitchId": "FDOBBBBBBBB",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_one_peer_missing_00450d": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): S2 echoes vpc100 WITHOUT peerSwitchId; must collapse into S1's entry, never become an override-delete candidate. S2 is queried second so positional replay feeds both echoes to pre-fix code too, which then plans the destructive delete."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_one_peer_missing_00450e": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): vpcPair for FDOBBBBBBBB — peer is FDOAAAAAAAA."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDOBBBBBBBB",
+            "peerSwitchId": "FDOAAAAAAAA"
+        }
+    },
+    "test_overridden_both_peers_missing_00455a": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): fabric summary (fabric exists)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_overridden_both_peers_missing_00455b": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): switch list, two switches in one vPC pair."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_overridden_both_peers_missing_00455c": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): S1 echoes vpc100 WITHOUT peerSwitchId."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_both_peers_missing_00455d": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): vpcPair for FDOAAAAAAAA — peer is FDOBBBBBBBB."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDOAAAAAAAA",
+            "peerSwitchId": "FDOBBBBBBBB"
+        }
+    },
+    "test_overridden_both_peers_missing_00455e": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): S2 echoes vpc100 WITHOUT peerSwitchId."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc100",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "accessVlan": 10,
+                                "peer1PortChannelId": 100,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 100,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_both_peers_missing_00455f": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): vpcPair for FDOBBBBBBBB — peer is FDOAAAAAAAA."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDOBBBBBBBB",
+            "peerSwitchId": "FDOAAAAAAAA"
+        }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
@@ -646,6 +646,41 @@
         "DATA": [{"interfaceName": "junk", "interfaceType": "vpc"}]
     },
 
+    "test_vpc_interface_base_00970a": {
+        "TEST_NOTES": ["query_all mixed-case config name (#411 review): fabric summary."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_00970b": {
+        "TEST_NOTES": ["query_all mixed-case config name (#411 review): switches list (two vPC peers)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": [{"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}, {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}]}
+    },
+    "test_vpc_interface_base_00970c": {
+        "TEST_NOTES": ["query_all mixed-case config name (#411 review): switch A (lower switchId) echoes canonical lowercase vpc501; deduped away in favor of the configured peer."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc501", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO22222BBB"}}}}
+        ]}
+    },
+    "test_vpc_interface_base_00970d": {
+        "TEST_NOTES": ["query_all mixed-case config name (#411 review): switch B (higher switchId, configured as VPC501 in mixed case) echoes canonical lowercase vpc501; kept."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc501", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO11111AAA"}}}}
+        ]}
+    },
+
     "test_vpc_interface_base_01000a": {
         "TEST_NOTES": ["Multi-pair dedup (#356): fabric summary (validate_prerequisites)."],
         "RETURN_CODE": 200, "METHOD": "GET",
@@ -720,7 +755,7 @@
         "DATA": {"switches": [{"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}]}
     },
     "test_vpc_interface_base_01010c": {
-        "TEST_NOTES": ["peerSwitchId-missing fallback (#356): vpc record WITHOUT peerSwitchId — keyed on frozenset({switchId}), kept, not raised on."],
+        "TEST_NOTES": ["peerSwitchId-missing fallback (#356 / #411 review): vpc300 echo WITHOUT peerSwitchId — pair identity must be resolved from the vpcPair endpoint, not guessed from switchId alone."],
         "RETURN_CODE": 200, "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
         "MESSAGE": "OK",
@@ -728,6 +763,133 @@
             {"interfaceName": "vpc300", "interfaceType": "vpc",
              "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 30}}}}
         ]}
+    },
+    "test_vpc_interface_base_01010d": {
+        "TEST_NOTES": ["peerSwitchId-missing fallback (#356 / #411 review): vpcPair for FDO11111AAA — peer is FDO22222BBB; completes the dedup key {FDO11111AAA, FDO22222BBB}."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"switchId": "FDO11111AAA", "peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_01020a": {
+        "TEST_NOTES": ["one peer echo omits peerSwitchId (#411 review): fabric summary."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_01020b": {
+        "TEST_NOTES": ["one peer echo omits peerSwitchId (#411 review): switches list (two vPC peers)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": [{"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}, {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}]}
+    },
+    "test_vpc_interface_base_01020c": {
+        "TEST_NOTES": ["one peer echo omits peerSwitchId (#411 review): switch A echoes vpc300 WITH peerSwitchId."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc300", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 30, "peerSwitchId": "FDO22222BBB"}}}}
+        ]}
+    },
+    "test_vpc_interface_base_01020d": {
+        "TEST_NOTES": ["one peer echo omits peerSwitchId (#411 review): switch B echoes vpc300 WITHOUT peerSwitchId; must collapse into A's entry, not survive as a second resource."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc300", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 30}}}}
+        ]}
+    },
+    "test_vpc_interface_base_01020e": {
+        "TEST_NOTES": ["one peer echo omits peerSwitchId (#411 review): vpcPair for FDO22222BBB fills in the missing peer so B's copy keys on {FDO11111AAA, FDO22222BBB}."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"switchId": "FDO22222BBB", "peerSwitchId": "FDO11111AAA"}
+    },
+    "test_vpc_interface_base_01030a": {
+        "TEST_NOTES": ["both peer echoes omit peerSwitchId (#411 review): fabric summary."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_01030b": {
+        "TEST_NOTES": ["both peer echoes omit peerSwitchId (#411 review): switches list (two vPC peers)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": [{"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}, {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}]}
+    },
+    "test_vpc_interface_base_01030c": {
+        "TEST_NOTES": ["both peer echoes omit peerSwitchId (#411 review): switch A echoes vpc300 WITHOUT peerSwitchId."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc300", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 30}}}}
+        ]}
+    },
+    "test_vpc_interface_base_01030d": {
+        "TEST_NOTES": ["both peer echoes omit peerSwitchId (#411 review): vpcPair for FDO11111AAA."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"switchId": "FDO11111AAA", "peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_01030e": {
+        "TEST_NOTES": ["both peer echoes omit peerSwitchId (#411 review): switch B echoes vpc300 WITHOUT peerSwitchId."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc300", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 30}}}}
+        ]}
+    },
+    "test_vpc_interface_base_01030f": {
+        "TEST_NOTES": ["both peer echoes omit peerSwitchId (#411 review): vpcPair for FDO22222BBB."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"switchId": "FDO22222BBB", "peerSwitchId": "FDO11111AAA"}
+    },
+    "test_vpc_interface_base_01040a": {
+        "TEST_NOTES": ["peerSwitchId missing and vpcPair 404 (#411 review): fabric summary."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_01040b": {
+        "TEST_NOTES": ["peerSwitchId missing and vpcPair 404 (#411 review): switches list (one switch)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": [{"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}]}
+    },
+    "test_vpc_interface_base_01040c": {
+        "TEST_NOTES": ["peerSwitchId missing and vpcPair 404 (#411 review): switch A echoes vpc300 WITHOUT peerSwitchId."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc300", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 30}}}}
+        ]}
+    },
+    "test_vpc_interface_base_01040d": {
+        "TEST_NOTES": ["peerSwitchId missing and vpcPair 404 (#411 review): vpcPair GET returns 404 — pair identity cannot be established; query_all must fail closed rather than key on switchId alone."],
+        "RETURN_CODE": 404, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "Not Found",
+        "DATA": {}
     },
     "test_vpc_interface_base_01100a": {
         "TEST_NOTES": ["Same-pair-dupe guard (#356): switches list for _resolve_switch_id (two peers of one pair)."],

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
@@ -369,7 +369,8 @@
         "TEST_NOTES": [
             "query_all dedupe: switch A (FDO11111AAA) interfaces.",
             "Contains the managed accessVpcHost vpc501, an other-policy trunkVpcHost vpc502 (filtered out),",
-            "and a non-vPC ethernet (filtered out). vpc501 also appears on switch B (peer copy)."
+            "and a non-vPC ethernet (filtered out). vpc501 also appears on switch B (peer copy).",
+            "peerSwitchId mirrors the real wire (issue #356)."
         ],
         "RETURN_CODE": 200,
         "METHOD": "GET",
@@ -380,12 +381,12 @@
                 {
                     "interfaceName": "vpc501",
                     "interfaceType": "vpc",
-                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO22222BBB"}}}
                 },
                 {
                     "interfaceName": "vpc502",
                     "interfaceType": "vpc",
-                    "configData": {"networkOS": {"policy": {"policyType": "trunkVpcHost", "allowedVlans": "1-10"}}}
+                    "configData": {"networkOS": {"policy": {"policyType": "trunkVpcHost", "allowedVlans": "1-10", "peerSwitchId": "FDO22222BBB"}}}
                 },
                 {
                     "interfaceName": "Ethernet1/5",
@@ -399,7 +400,8 @@
         "TEST_NOTES": [
             "query_all dedupe: switch B (FDO22222BBB) interfaces.",
             "Returns the peer-side copy of vpc501 (same interfaceName) which must be deduped away,",
-            "keeping the alphabetically-lower switchId (FDO11111AAA) representative."
+            "keeping the alphabetically-lower switchId (FDO11111AAA) representative.",
+            "peerSwitchId mirrors the real wire (issue #356)."
         ],
         "RETURN_CODE": 200,
         "METHOD": "GET",
@@ -410,7 +412,7 @@
                 {
                     "interfaceName": "vpc501",
                     "interfaceType": "vpc",
-                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO11111AAA"}}}
                 }
             ]
         }
@@ -517,7 +519,10 @@
     },
 
     "test_vpc_interface_base_00920c": {
-        "TEST_NOTES": ["query_all config-scoped: config switch (FDO11111AAA) interfaces; switch B is never fetched."],
+        "TEST_NOTES": [
+            "query_all config-scoped: config switch (FDO11111AAA) interfaces; switch B is never fetched.",
+            "peerSwitchId mirrors the real wire (issue #356)."
+        ],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
@@ -527,7 +532,7 @@
                 {
                     "interfaceName": "vpc501",
                     "interfaceType": "vpc",
-                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO22222BBB"}}}
                 }
             ]
         }
@@ -557,7 +562,10 @@
     },
 
     "test_vpc_interface_base_00950c": {
-        "TEST_NOTES": ["query_all peer-preference: switch A (lower switchId) returns vpc501; deduped away in favor of the configured peer."],
+        "TEST_NOTES": [
+            "query_all peer-preference: switch A (lower switchId) returns vpc501; deduped away in favor of the configured peer.",
+            "peerSwitchId mirrors the real wire (issue #356)."
+        ],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
@@ -567,14 +575,17 @@
                 {
                     "interfaceName": "vpc501",
                     "interfaceType": "vpc",
-                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO22222BBB"}}}
                 }
             ]
         }
     },
 
     "test_vpc_interface_base_00950d": {
-        "TEST_NOTES": ["query_all peer-preference: switch B (higher switchId, the configured peer 192.168.1.2) returns vpc501; kept because the user configured it."],
+        "TEST_NOTES": [
+            "query_all peer-preference: switch B (higher switchId, the configured peer 192.168.1.2) returns vpc501; kept because the user configured it.",
+            "peerSwitchId mirrors the real wire (issue #356)."
+        ],
         "RETURN_CODE": 200,
         "METHOD": "GET",
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
@@ -584,7 +595,7 @@
                 {
                     "interfaceName": "vpc501",
                     "interfaceType": "vpc",
-                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100}}}
+                    "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO11111AAA"}}}
                 }
             ]
         }
@@ -633,5 +644,89 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
         "MESSAGE": "OK",
         "DATA": [{"interfaceName": "junk", "interfaceType": "vpc"}]
+    },
+
+    "test_vpc_interface_base_01000a": {
+        "TEST_NOTES": ["Multi-pair dedup (#356): fabric summary (validate_prerequisites)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_01000b": {
+        "TEST_NOTES": ["Multi-pair dedup (#356): switches list — two vPC pairs (four leaves)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": [
+            {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+            {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"},
+            {"fabricManagementIp": "192.168.1.3", "switchId": "FDO33333CCC"},
+            {"fabricManagementIp": "192.168.1.4", "switchId": "FDO44444DDD"}
+        ]}
+    },
+    "test_vpc_interface_base_01000c": {
+        "TEST_NOTES": ["Multi-pair dedup (#356): pair-1 peer A echoes vpc210 with pair-1's peerSwitchId."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc210", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO22222BBB"}}}}
+        ]}
+    },
+    "test_vpc_interface_base_01000d": {
+        "TEST_NOTES": ["Multi-pair dedup (#356): pair-1 peer B echoes the same vpc210 (peer copy — must collapse with 01000c)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc210", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 100, "peerSwitchId": "FDO11111AAA"}}}}
+        ]}
+    },
+    "test_vpc_interface_base_01000e": {
+        "TEST_NOTES": ["Multi-pair dedup (#356): pair-2 peer A echoes its OWN vpc210 (same name, different pair — must stay distinct)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO33333CCC/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc210", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 200, "peerSwitchId": "FDO44444DDD"}}}}
+        ]}
+    },
+    "test_vpc_interface_base_01000f": {
+        "TEST_NOTES": ["Multi-pair dedup (#356): pair-2 peer B echoes the pair-2 vpc210 (peer copy — collapses with 01000e)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO44444DDD/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc210", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 200, "peerSwitchId": "FDO33333CCC"}}}}
+        ]}
+    },
+    "test_vpc_interface_base_01010a": {
+        "TEST_NOTES": ["peerSwitchId-missing fallback (#356): fabric summary."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {"name": "fabric_1", "ownerCluster": "cluster_a"}
+    },
+    "test_vpc_interface_base_01010b": {
+        "TEST_NOTES": ["peerSwitchId-missing fallback (#356): switches list (one switch)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": [{"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"}]}
+    },
+    "test_vpc_interface_base_01010c": {
+        "TEST_NOTES": ["peerSwitchId-missing fallback (#356): vpc record WITHOUT peerSwitchId — keyed on frozenset({switchId}), kept, not raised on."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {"interfaces": [
+            {"interfaceName": "vpc300", "interfaceType": "vpc",
+             "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 30}}}}
+        ]}
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_interface_base.json
@@ -728,5 +728,55 @@
             {"interfaceName": "vpc300", "interfaceType": "vpc",
              "configData": {"networkOS": {"policy": {"policyType": "accessVpcHost", "accessVlan": 30}}}}
         ]}
+    },
+    "test_vpc_interface_base_01100a": {
+        "TEST_NOTES": ["Same-pair-dupe guard (#356): switches list for _resolve_switch_id (two peers of one pair)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": [
+            {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+            {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"}
+        ]}
+    },
+    "test_vpc_interface_base_01100b": {
+        "TEST_NOTES": ["Same-pair-dupe guard (#356): vpcPair for FDO11111AAA — peer is FDO22222BBB."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"switchId": "FDO11111AAA", "peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_01100c": {
+        "TEST_NOTES": ["Same-pair-dupe guard (#356): vpcPair for FDO22222BBB — peer is FDO11111AAA (same pair -> guard fires)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"switchId": "FDO22222BBB", "peerSwitchId": "FDO11111AAA"}
+    },
+    "test_vpc_interface_base_01110a": {
+        "TEST_NOTES": ["Same-pair-dupe guard pass (#356): switches list — four leaves, two pairs."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {"switches": [
+            {"fabricManagementIp": "192.168.1.1", "switchId": "FDO11111AAA"},
+            {"fabricManagementIp": "192.168.1.2", "switchId": "FDO22222BBB"},
+            {"fabricManagementIp": "192.168.1.3", "switchId": "FDO33333CCC"},
+            {"fabricManagementIp": "192.168.1.4", "switchId": "FDO44444DDD"}
+        ]}
+    },
+    "test_vpc_interface_base_01110b": {
+        "TEST_NOTES": ["Same-pair-dupe guard pass (#356): vpcPair for FDO11111AAA — pair 1."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"switchId": "FDO11111AAA", "peerSwitchId": "FDO22222BBB"}
+    },
+    "test_vpc_interface_base_01110c": {
+        "TEST_NOTES": ["Same-pair-dupe guard pass (#356): vpcPair for FDO33333CCC — pair 2 (different pair -> no error)."],
+        "RETURN_CODE": 200, "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO33333CCC/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {"switchId": "FDO33333CCC", "peerSwitchId": "FDO44444DDD"}
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_vpc_trunk_host_interface_orchestrator.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_vpc_trunk_host_interface_orchestrator.json
@@ -356,5 +356,473 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
         "MESSAGE": "Not Found",
         "DATA": {}
+    },
+    "test_overridden_mixed_case_00440a": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (normal mode, #411 review): fabric summary (fabric exists)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_overridden_mixed_case_00440b": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (normal mode, #411 review): switch list, two switches in one vPC pair."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00440c": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (normal mode, #411 review): S1 echoes canonical lowercase vpc500 (peerSwitchId=FDOBBBBBBBB); deduped away in favor of the configured peer S2."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDOBBBBBBBB",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00440d": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (normal mode, #411 review): S2 echoes canonical lowercase vpc500 (peerSwitchId=FDOAAAAAAAA); the user configured it as VPC500 on S2, so this copy is kept."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDOAAAAAAAA",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00445a": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (check mode, #411 review): fabric summary (fabric exists)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_overridden_mixed_case_00445b": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (check mode, #411 review): switch list, two switches in one vPC pair."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00445c": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (check mode, #411 review): S1 echoes canonical lowercase vpc500 (peerSwitchId=FDOBBBBBBBB); deduped away in favor of the configured peer S2."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDOBBBBBBBB",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_mixed_case_00445d": {
+        "TEST_NOTES": [
+            "Overridden mixed-case idempotency (check mode, #411 review): S2 echoes canonical lowercase vpc500 (peerSwitchId=FDOAAAAAAAA); the user configured it as VPC500 on S2, so this copy is kept."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDOAAAAAAAA",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_one_peer_missing_00450a": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): fabric summary (fabric exists)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_overridden_one_peer_missing_00450b": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): switch list, two switches in one vPC pair."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_overridden_one_peer_missing_00450c": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): S1 echoes vpc500 WITH peerSwitchId=FDOBBBBBBBB."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "peerSwitchId": "FDOBBBBBBBB",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_one_peer_missing_00450d": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): S2 echoes vpc500 WITHOUT peerSwitchId; must collapse into S1's entry, never become an override-delete candidate. S2 is queried second so positional replay feeds both echoes to pre-fix code too, which then plans the destructive delete."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_one_peer_missing_00450e": {
+        "TEST_NOTES": [
+            "Overridden, one peer echo omits peerSwitchId (#411 review): vpcPair for FDOBBBBBBBB — peer is FDOAAAAAAAA."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDOBBBBBBBB",
+            "peerSwitchId": "FDOAAAAAAAA"
+        }
+    },
+    "test_overridden_both_peers_missing_00455a": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): fabric summary (fabric exists)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a"
+        }
+    },
+    "test_overridden_both_peers_missing_00455b": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): switch list, two switches in one vPC pair."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDOAAAAAAAA"
+                },
+                {
+                    "fabricManagementIp": "192.168.1.2",
+                    "switchId": "FDOBBBBBBBB"
+                }
+            ]
+        }
+    },
+    "test_overridden_both_peers_missing_00455c": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): S1 echoes vpc500 WITHOUT peerSwitchId."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_both_peers_missing_00455d": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): vpcPair for FDOAAAAAAAA — peer is FDOBBBBBBBB."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDOAAAAAAAA",
+            "peerSwitchId": "FDOBBBBBBBB"
+        }
+    },
+    "test_overridden_both_peers_missing_00455e": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): S2 echoes vpc500 WITHOUT peerSwitchId."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc500",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkVpcHost",
+                                "allowedVlans": "100-200",
+                                "nativeVlan": 99,
+                                "peer1PortChannelId": 500,
+                                "peer1MemberPorts": [
+                                    "Ethernet1/1"
+                                ],
+                                "peer2PortChannelId": 500,
+                                "peer2MemberPorts": [
+                                    "Ethernet1/1"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "test_overridden_both_peers_missing_00455f": {
+        "TEST_NOTES": [
+            "Overridden, both peer echoes omit peerSwitchId (#411 review): vpcPair for FDOBBBBBBBB — peer is FDOAAAAAAAA."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/vpcPair",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switchId": "FDOBBBBBBBB",
+            "peerSwitchId": "FDOAAAAAAAA"
+        }
     }
 }

--- a/tests/unit/module_utils/models/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_access_interface.py
@@ -376,27 +376,24 @@ def test_vpc_access_interface_00300_identifier():
     """
     # Summary
 
-    Verify the identifier is `interface_name` only (single strategy). A vPC interface is one fabric-level resource;
-    ND echoes it from both peers but it must collapse to one identity for diff/override-deletion correctness.
+    Verify the identifier is the composite (`switch_ip`, `interface_name`), matching the other interface modules. Two vPC pairs in one
+    fabric may legally reuse the same vPC id (ND's `vpcId` resource pool is devicePair-scoped; issue #356), so name-only identity cannot
+    represent them. The dual-peer GET echo is deduped in `VpcInterfaceBaseOrchestrator.query_all` (pair-set key), not via the identity.
 
     ## Test
 
-    - Identifier is `["interface_name"]`
-    - Identifier strategy is `"single"`
-    - get_identifier_value returns the interface name string
-    - `switch_ip` is excluded from the diff dict (routing-only field)
+    - identifiers is ["switch_ip", "interface_name"]
+    - identifier_strategy is "composite"
+    - get_identifier_value returns the (switch_ip, interface_name) tuple
 
     ## Classes and Methods
 
     - AccessVpcHostInterfaceModel.get_identifier_value()
-    - AccessVpcHostInterfaceModel.to_diff_dict()
     """
     instance = AccessVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc100")
-    assert instance.identifiers == ["interface_name"]
-    assert instance.identifier_strategy == "single"
-    assert instance.get_identifier_value() == "vpc100"
-    # switch_ip is for routing only; it must not appear in the diff dict so two peers' echoes diff-equal.
-    assert "switchIp" not in instance.to_diff_dict()
+    assert instance.identifiers == ["switch_ip", "interface_name"]
+    assert instance.identifier_strategy == "composite"
+    assert instance.get_identifier_value() == (instance.switch_ip, "vpc100")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/module_utils/models/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_access_interface.py
@@ -385,6 +385,7 @@ def test_vpc_access_interface_00300_identifier():
     - identifiers is ["switch_ip", "interface_name"]
     - identifier_strategy is "composite"
     - get_identifier_value returns the (switch_ip, interface_name) tuple
+    - switchIp stays excluded from the diff (exclude_from_diff)
 
     ## Classes and Methods
 
@@ -394,6 +395,7 @@ def test_vpc_access_interface_00300_identifier():
     assert instance.identifiers == ["switch_ip", "interface_name"]
     assert instance.identifier_strategy == "composite"
     assert instance.get_identifier_value() == (instance.switch_ip, "vpc100")
+    assert "switchIp" not in instance.to_diff_dict()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/module_utils/models/test_vpc_trunk_host_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_trunk_host_interface.py
@@ -551,27 +551,24 @@ def test_vpc_trunk_host_interface_00300_identifier():
     """
     # Summary
 
-    Verify the identifier is `interface_name` only (single strategy). A vPC interface is one fabric-level resource;
-    ND echoes it from both peers but it must collapse to one identity for diff/override-deletion correctness.
+    Verify the identifier is the composite (`switch_ip`, `interface_name`), matching the other interface modules. Two vPC pairs in one
+    fabric may legally reuse the same vPC id (ND's `vpcId` resource pool is devicePair-scoped; issue #356), so name-only identity cannot
+    represent them. The dual-peer GET echo is deduped in `VpcInterfaceBaseOrchestrator.query_all` (pair-set key), not via the identity.
 
     ## Test
 
-    - Identifier is `["interface_name"]`
-    - Identifier strategy is `"single"`
-    - get_identifier_value returns the interface name string
-    - `switch_ip` is excluded from the diff dict (routing-only field)
+    - identifiers is ["switch_ip", "interface_name"]
+    - identifier_strategy is "composite"
+    - get_identifier_value returns the (switch_ip, interface_name) tuple
 
     ## Classes and Methods
 
     - TrunkVpcHostInterfaceModel.get_identifier_value()
-    - TrunkVpcHostInterfaceModel.to_diff_dict()
     """
     instance = TrunkVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc500")
-    assert instance.identifiers == ["interface_name"]
-    assert instance.identifier_strategy == "single"
-    assert instance.get_identifier_value() == "vpc500"
-    # switch_ip is for routing only; it must not appear in the diff dict so two peers' echoes diff-equal.
-    assert "switchIp" not in instance.to_diff_dict()
+    assert instance.identifiers == ["switch_ip", "interface_name"]
+    assert instance.identifier_strategy == "composite"
+    assert instance.get_identifier_value() == (instance.switch_ip, "vpc500")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/module_utils/models/test_vpc_trunk_host_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_trunk_host_interface.py
@@ -560,6 +560,7 @@ def test_vpc_trunk_host_interface_00300_identifier():
     - identifiers is ["switch_ip", "interface_name"]
     - identifier_strategy is "composite"
     - get_identifier_value returns the (switch_ip, interface_name) tuple
+    - switchIp stays excluded from the diff (exclude_from_diff)
 
     ## Classes and Methods
 
@@ -569,6 +570,7 @@ def test_vpc_trunk_host_interface_00300_identifier():
     assert instance.identifiers == ["switch_ip", "interface_name"]
     assert instance.identifier_strategy == "composite"
     assert instance.get_identifier_value() == (instance.switch_ip, "vpc500")
+    assert "switchIp" not in instance.to_diff_dict()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/module_utils/orchestrators/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_access_interface.py
@@ -26,14 +26,19 @@ Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as th
 # pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
 # pylint: disable=too-many-lines
+# pylint: disable=unused-argument
 
 from __future__ import annotations
+
+from typing import Any
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import (
     AccessVpcHostInterfaceModel,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_access_interface import (
     AccessVpcHostInterfaceOrchestrator,
 )
@@ -517,3 +522,240 @@ def test_vpc_access_orchestrator_00420_query_all_fabric_not_found() -> None:
 
     with pytest.raises(RuntimeError, match=r"Query all failed.*missing_fabric"):
         orchestrator.query_all()
+
+
+# =============================================================================
+# Test: overridden through NDStateMachine — dedup correctness under real diff/override logic (#411 review)
+# =============================================================================
+
+
+class _SpyAccessVpcHostInterfaceOrchestrator(AccessVpcHostInterfaceOrchestrator):
+    """Real `query_all` / `preflight` (file-based REST), but every mutation entry point records itself on `self._calls` instead of
+    sending, so a test can assert exactly which creates/updates/deletes `NDStateMachine.manage_state` planned."""
+
+    def model_post_init(self, __context) -> None:
+        """Initialize the recorded-call list after Pydantic construction."""
+        super().model_post_init(__context)
+        self._calls: list[tuple] = []  # pylint: disable=attribute-defined-outside-init
+
+    def create(self, model_instance, **kwargs) -> ResponseType:
+        """Record a single create instead of sending it."""
+        self._calls.append(("create", model_instance.get_identifier_value()))
+        return {}
+
+    def create_bulk(self, model_instances, **kwargs) -> ResponseType:
+        """Record a bulk create instead of sending it."""
+        self._calls.append(("create_bulk", [item.get_identifier_value() for item in model_instances]))
+        return {}
+
+    def update(self, model_instance, **kwargs) -> ResponseType:
+        """Record an update instead of sending it."""
+        self._calls.append(("update", model_instance.get_identifier_value()))
+        return {}
+
+    def delete(self, model_instance, **kwargs) -> None:
+        """Record a single delete instead of sending it."""
+        self._calls.append(("delete", model_instance.get_identifier_value()))
+
+    def delete_bulk(self, model_instances, **kwargs) -> None:
+        """Record a bulk delete instead of sending it."""
+        self._calls.append(("delete_bulk", [item.get_identifier_value() for item in model_instances]))
+
+
+def _build_state_machine(
+    gen_responses: ResponseGenerator, state: str, check_mode: bool, config: list[dict]
+) -> tuple[NDStateMachine, _SpyAccessVpcHostInterfaceOrchestrator]:
+    """Wire a `_SpyAccessVpcHostInterfaceOrchestrator` (file-based `RestSend` carrying `state`/`config`) into a real `NDStateMachine`."""
+    spy = _SpyAccessVpcHostInterfaceOrchestrator(rest_send=_build_rest_send(gen_responses, state=state, config=config))
+    module = MockAnsibleModule()
+    module.check_mode = check_mode
+    params: dict[str, Any] = {"state": state, "config": config, "output_level": "normal", "ignore_errors": False, "fabric_name": "fabric_1"}
+    module.params = params
+    return NDStateMachine(module=module, model_orchestrator=spy), spy
+
+
+# Mirrors the vpc100 echo in the 00440/00445/00450/00455 fixtures so the proposed item is a subset of the existing one (no_diff).
+_OVERRIDDEN_POLICY = {
+    "access_vlan": 10,
+    "peer1_port_channel_id": 100,
+    "peer1_member_ports": ["Ethernet1/1"],
+    "peer2_port_channel_id": 100,
+    "peer2_member_ports": ["Ethernet1/1"],
+}
+
+
+def _assert_idempotent(state_machine: NDStateMachine, spy: _SpyAccessVpcHostInterfaceOrchestrator, expected_switch_ip: str, expected_paths: list[str]) -> None:
+    """Shared assertions: one existing `vpc100` on `expected_switch_ip`, the exact orchestrator request sequence (`Results.path`; the
+    file-based Sender replays positionally, so this proves each `vpcPair` lookup happened where expected), no planned mutation, and
+    `changed` False."""
+    before = list(state_machine.before)
+    assert [(item.switch_ip, item.interface_name) for item in before] == [(expected_switch_ip, "vpc100")]
+    assert state_machine.results.path == expected_paths
+    state_machine.manage_state()
+    assert spy._calls == []
+    assert state_machine.output.format()["changed"] is False
+
+
+def test_vpc_access_orchestrator_00440_overridden_mixed_case_idempotent() -> None:
+    """
+    # Summary
+
+    Verify `state: overridden` is idempotent when the user names the higher-serial peer with a mixed-case `interface_name`
+    (`VPC100`). The model canonicalizes the proposed identifier to `(192.168.1.2, vpc100)`; the orchestrator's configured-peer
+    preference must key on the same canonical name, otherwise the dedup keeps peer S1 and the state machine plans a spurious
+    CREATE `(192.168.1.2, vpc100)` + override DELETE `(192.168.1.1, vpc100)` for an interface that is already correct (PR #411 review).
+
+    ## Test
+
+    - Both peers echo `vpc100`; config lists `VPC100` on 192.168.1.2 with a policy mirroring the echo
+    - `before` holds exactly `(192.168.1.2, vpc100)`
+    - `manage_state` plans no create/update/delete; `changed` is False
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._configured_switch_ips_by_interface_name()
+    """
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_access(f"test_overridden_mixed_case_00440{suffix}")
+
+    config = [{"switch_ip": "192.168.1.2", "interface_name": "VPC100", "config_data": {"network_os": {"policy": _OVERRIDDEN_POLICY}}}]
+
+    with does_not_raise():
+        state_machine, spy = _build_state_machine(ResponseGenerator(responses()), state="overridden", check_mode=False, config=config)
+        _assert_idempotent(
+            state_machine,
+            spy,
+            expected_switch_ip="192.168.1.2",
+            expected_paths=[
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+            ],
+        )
+
+
+def test_vpc_access_orchestrator_00445_overridden_mixed_case_idempotent_check_mode() -> None:
+    """
+    # Summary
+
+    Same scenario as 00440 under `--check`: the dry-run must preview no create/delete for a mixed-case name on the higher-serial
+    peer. Check mode skips the mutation calls but still runs the diff/override planning, so a wrong dedup representative would
+    surface as `changed: True` here (PR #411 review).
+
+    ## Test
+
+    - `check_mode=True`; both peers echo `vpc100`; config lists `VPC100` on 192.168.1.2
+    - `before` holds exactly `(192.168.1.2, vpc100)`; no planned mutation; `changed` is False
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_access(f"test_overridden_mixed_case_00445{suffix}")
+
+    config = [{"switch_ip": "192.168.1.2", "interface_name": "VPC100", "config_data": {"network_os": {"policy": _OVERRIDDEN_POLICY}}}]
+
+    with does_not_raise():
+        state_machine, spy = _build_state_machine(ResponseGenerator(responses()), state="overridden", check_mode=True, config=config)
+        _assert_idempotent(
+            state_machine,
+            spy,
+            expected_switch_ip="192.168.1.2",
+            expected_paths=[
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+            ],
+        )
+
+
+def test_vpc_access_orchestrator_00450_overridden_one_peer_missing_peer_switch_id() -> None:
+    """
+    # Summary
+
+    Verify `state: overridden` does not queue a delete of the desired vPC when ONE peer echo omits `peerSwitchId`. The missing
+    peer is resolved from the `vpcPair` endpoint so both copies share one dedup key; with a per-switch singleton fallback the S2
+    copy would survive as `(192.168.1.2, vpc100)` and be deleted — removing the pair-wide interface the playbook meant to keep
+    (PR #411 review).
+
+    ## Test
+
+    - S1 echoes `vpc100` with `peerSwitchId`, S2 without it; one `vpcPair` GET for S2 (queried second, so the positional replay
+      also feeds both echoes to pre-fix code — which then plans DELETE `(192.168.1.2, vpc100)`, the destructive symptom pinned here)
+    - Config lists `vpc100` on 192.168.1.1 with a policy mirroring the echo
+    - `before` holds exactly `(192.168.1.1, vpc100)`; no planned mutation (in particular no delete); `changed` is False
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_override_deletions()
+    - VpcInterfaceBaseOrchestrator._pair_key()
+    """
+
+    def responses():
+        for suffix in ("a", "b", "c", "d", "e"):
+            yield responses_vpc_access(f"test_overridden_one_peer_missing_00450{suffix}")
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "vpc100", "config_data": {"network_os": {"policy": _OVERRIDDEN_POLICY}}}]
+
+    with does_not_raise():
+        state_machine, spy = _build_state_machine(ResponseGenerator(responses()), state="overridden", check_mode=False, config=config)
+        _assert_idempotent(
+            state_machine,
+            spy,
+            expected_switch_ip="192.168.1.1",
+            expected_paths=[
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/vpcPair",
+            ],
+        )
+
+
+def test_vpc_access_orchestrator_00455_overridden_both_peers_missing_peer_switch_id() -> None:
+    """
+    # Summary
+
+    Verify `state: overridden` does not queue a delete of the desired vPC when BOTH peer echoes omit `peerSwitchId`: each switch's
+    pair is resolved from its `vpcPair` record, the two copies collapse, and nothing is left over for override deletion
+    (PR #411 review).
+
+    ## Test
+
+    - Both `vpc100` echoes omit `peerSwitchId`; one `vpcPair` GET per switch (positional replay cannot also feed pre-fix code both
+      echoes here, so the pinned request sequence is what proves the pair resolution ran for each switch)
+    - Config lists `vpc100` on 192.168.1.1 with a policy mirroring the echo
+    - `before` holds exactly `(192.168.1.1, vpc100)`; no planned mutation; `changed` is False
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_override_deletions()
+    - VpcInterfaceBaseOrchestrator._pair_key()
+    """
+
+    def responses():
+        for suffix in ("a", "b", "c", "d", "e", "f"):
+            yield responses_vpc_access(f"test_overridden_both_peers_missing_00455{suffix}")
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "vpc100", "config_data": {"network_os": {"policy": _OVERRIDDEN_POLICY}}}]
+
+    with does_not_raise():
+        state_machine, spy = _build_state_machine(ResponseGenerator(responses()), state="overridden", check_mode=False, config=config)
+        _assert_idempotent(
+            state_machine,
+            spy,
+            expected_switch_ip="192.168.1.1",
+            expected_paths=[
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/vpcPair",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/vpcPair",
+            ],
+        )

--- a/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
@@ -54,6 +54,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNe
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import VpcInterfaceBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
 from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
 from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
@@ -158,10 +159,15 @@ def _build_orchestrator(
     fabric_name: str = "fabric_1",
     state: str | None = None,
     config: list[dict] | None = None,
+    results: Results | None = None,
 ) -> _StubVpcOrchestrator:
-    """Construct a `_StubVpcOrchestrator` with the file-based `RestSend` injected."""
+    """Construct a `_StubVpcOrchestrator` with the file-based `RestSend` injected.
+
+    Pass `results` when a test needs to assert on the orchestrator's request sequence (`Results.path`); without it the base
+    orchestrator registers nothing.
+    """
     rest_send = _build_rest_send(gen_responses, fabric_name=fabric_name, state=state, config=config)
-    return _StubVpcOrchestrator(rest_send=rest_send)
+    return _StubVpcOrchestrator(rest_send=rest_send, results=results)
 
 
 def _build_model(
@@ -1176,6 +1182,46 @@ def test_vpc_interface_base_00960() -> None:
     assert result == []
 
 
+def test_vpc_interface_base_00970() -> None:
+    """
+    # Summary
+
+    Verify the configured-peer preference survives a mixed-case `interface_name` in the user config. The vPC models lowercase
+    `interface_name` (`VPC501` -> `vpc501`) and ND echoes the canonical lowercase name, so the preference map must be keyed on the
+    same canonical form; keyed on the raw input it never matches, the dedup silently falls back to the alphabetically-lower peer, and
+    `state: overridden` plans a spurious create + delete for an interface that is already in the desired state (PR #411 review).
+
+    ## Test
+
+    - `state=overridden` so both peers are scanned (192.168.1.1 / FDO11111AAA and 192.168.1.2 / FDO22222BBB)
+    - Config names `VPC501` (mixed case) on the higher-`switchId` peer 192.168.1.2; both echoes carry `vpc501`
+    - The deduped entry carries `switchIp` 192.168.1.2 (the configured peer), not the lower-`switchId` default
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._configured_switch_ips_by_interface_name()
+    - VpcInterfaceBaseOrchestrator._prefers_candidate()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    config = [{"switch_ip": "192.168.1.2", "interface_name": "VPC501"}]
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden", config=config)
+        result = instance.query_all()
+
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc501"
+    assert result[0]["switchIp"] == "192.168.1.2"
+
+
 # =============================================================================
 # Test: query_all multi-pair dedup (#356)
 # =============================================================================
@@ -1224,13 +1270,67 @@ def test_vpc_interface_base_01010() -> None:
     """
     # Summary
 
-    Verify a managed vPC record with no `peerSwitchId` is still returned (dedup key falls back to `frozenset({switchId})`) rather than
-    raising. The real wire always carries `peerSwitchId` (2026-07-20 captures); this pins the tolerant fallback for issue #356.
+    Verify a managed vPC record with no `peerSwitchId` has its pair identity resolved from the authoritative `vpcPair` endpoint
+    (cached per primary switch) rather than keyed on `frozenset({switchId})` alone. A singleton key is unsafe: if the other peer's
+    echo does carry `peerSwitchId`, the two copies get disjoint keys, both survive dedup, and `state: overridden` deletes the
+    "unconfigured" copy — which removes the pair-wide interface from both peers (PR #411 review).
 
     ## Test
 
     - `state=overridden`, one switch, one managed vPC record without `peerSwitchId`
+    - A `vpcPair` GET for that switch supplies the peer serial
     - `query_all` returns exactly that record, `switchIp` stamped
+    - Request sequence (via `Results.path`) is: interfaces(A), vpcPair(A)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._pair_key()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        results = Results()
+        instance = _build_orchestrator(gen_responses, state="overridden", results=results)
+        result = instance.query_all()
+
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc300"
+    assert result[0]["switchIp"] == "192.168.1.1"
+
+    # The file-based Sender replays responses positionally, so pin the request sequence: this proves the vpcPair lookup
+    # actually happens (and where), rather than a later interfaces GET silently consuming the vpcPair fixture.
+    assert results.path == [
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+    ]
+
+
+def test_vpc_interface_base_01020() -> None:
+    """
+    # Summary
+
+    Verify the two peer copies of one vPC interface collapse to a single entry when only ONE echo omits `peerSwitchId`. The
+    OpenAPI schema does not mark `peerSwitchId` required, so this is a schema-valid response; with a singleton fallback key
+    peer A would key on `{A}` and peer B on `{A, B}`, both would survive, and an `overridden` run naming only peer A would
+    delete the interface through peer B (PR #411 review).
+
+    ## Test
+
+    - `state=overridden`, two peers; switch A's `vpc300` echo carries `peerSwitchId`, switch B's omits it
+    - One `vpcPair` GET (for switch B) supplies B's peer; no lookup is needed for A
+    - `query_all` returns exactly ONE `vpc300`, stamped with the lower-`switchId` peer 192.168.1.1
+    - Request sequence (via `Results.path`) is: interfaces(A), interfaces(B), vpcPair(B) — no vpcPair(A)
+
+    Switch B (queried second) is the one that omits the field so the file-based Sender's positional replay feeds both echoes to the
+    pre-fix code as well — a singleton-key fallback then yields TWO entries, which is the real symptom this test pins.
 
     ## Classes and Methods
 
@@ -1240,18 +1340,106 @@ def test_vpc_interface_base_01010() -> None:
     method_name = inspect.stack()[0][3]
 
     def responses():
-        for suffix in ("a", "b", "c"):
+        for suffix in ("a", "b", "c", "d", "e"):
             yield responses_vpc_base(f"{method_name}{suffix}")
 
     gen_responses = ResponseGenerator(responses())
 
     with does_not_raise():
-        instance = _build_orchestrator(gen_responses, state="overridden")
+        results = Results()
+        instance = _build_orchestrator(gen_responses, state="overridden", results=results)
         result = instance.query_all()
 
     assert len(result) == 1
     assert result[0]["interfaceName"] == "vpc300"
     assert result[0]["switchIp"] == "192.168.1.1"
+
+    # The file-based Sender replays responses positionally, so pin the request sequence: this proves the vpcPair lookup
+    # actually happens (and where), rather than a later interfaces GET silently consuming the vpcPair fixture.
+    assert results.path == [
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/vpcPair",
+    ]
+
+
+def test_vpc_interface_base_01030() -> None:
+    """
+    # Summary
+
+    Verify the two peer copies of one vPC interface collapse to a single entry when BOTH echoes omit `peerSwitchId`: each
+    switch's pair is resolved from its `vpcPair` record and the two resolved keys are the same unordered set (PR #411 review).
+
+    ## Test
+
+    - `state=overridden`, two peers; both `vpc300` echoes omit `peerSwitchId`
+    - One `vpcPair` GET per switch supplies the peer serials
+    - `query_all` returns exactly ONE `vpc300`, stamped with the lower-`switchId` peer 192.168.1.1
+    - Request sequence (via `Results.path`) is: interfaces(A), vpcPair(A), interfaces(B), vpcPair(B)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._pair_key()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d", "e", "f"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        results = Results()
+        instance = _build_orchestrator(gen_responses, state="overridden", results=results)
+        result = instance.query_all()
+
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc300"
+    assert result[0]["switchIp"] == "192.168.1.1"
+
+    # The file-based Sender replays responses positionally, so pin the request sequence: this proves the vpcPair lookup
+    # actually happens (and where), rather than a later interfaces GET silently consuming the vpcPair fixture.
+    assert results.path == [
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/vpcPair",
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/interfaces",
+        "/api/v1/manage/fabrics/fabric_1/switches/FDO22222BBB/vpcPair",
+    ]
+
+
+def test_vpc_interface_base_01040() -> None:
+    """
+    # Summary
+
+    Verify `query_all` fails closed when a vPC record omits `peerSwitchId` AND the switch's `vpcPair` lookup returns 404: the
+    pair identity cannot be established, so the run aborts before any override deletion can be computed against a guessed
+    per-switch key (PR #411 review).
+
+    ## Test
+
+    - `state=overridden`, one switch, one managed vPC record without `peerSwitchId`
+    - The `vpcPair` GET returns 404
+    - `query_all` raises `RuntimeError` matching `Query all failed.*not in a vPC pair`
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._pair_key()
+    - VpcInterfaceBaseOrchestrator._resolve_peer_switch_id()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses, state="overridden")
+
+    with pytest.raises(RuntimeError, match=r"Query all failed.*192\.168\.1\.1.*not in a vPC pair"):
+        instance.query_all()
 
 
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
@@ -1174,3 +1174,81 @@ def test_vpc_interface_base_00960() -> None:
         result = instance.query_all()
 
     assert result == []
+
+
+# =============================================================================
+# Test: query_all multi-pair dedup (#356)
+# =============================================================================
+
+
+def test_vpc_interface_base_01000() -> None:
+    """
+    # Summary
+
+    Verify the dedup key is `(interfaceName, frozenset({switchId, peerSwitchId}))`, not `interfaceName` alone: two vPC pairs in one
+    fabric can legally own the same vPC id (ND's `vpcId` pool is devicePair-scoped, lab-confirmed 2026-07-20 — issue #356). One pair's
+    two peer copies must collapse to a single entry while the second pair's same-name interface stays distinct.
+
+    ## Test
+
+    - `state=overridden`, four switches forming two vPC pairs, every peer echoes a `vpc210`
+    - Pair 1 copies carry pair-1 serials in `{switchId, peerSwitchId}`; pair 2 copies carry pair-2 serials
+    - Result has exactly TWO entries named `vpc210` — one per pair
+    - Each entry's `switchIp` is its pair's alphabetically-lower peer (192.168.1.1 and 192.168.1.3; nothing configured)
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._pair_key()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c", "d", "e", "f"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden")
+        result = instance.query_all()
+
+    assert len(result) == 2
+    assert {entry["interfaceName"] for entry in result} == {"vpc210"}
+    assert {entry["switchIp"] for entry in result} == {"192.168.1.1", "192.168.1.3"}
+    vlans = {((entry.get("configData") or {}).get("networkOS") or {}).get("policy", {}).get("accessVlan") for entry in result}
+    assert vlans == {100, 200}
+
+
+def test_vpc_interface_base_01010() -> None:
+    """
+    # Summary
+
+    Verify a managed vPC record with no `peerSwitchId` is still returned (dedup key falls back to `frozenset({switchId})`) rather than
+    raising. The real wire always carries `peerSwitchId` (2026-07-20 captures); this pins the tolerant fallback for issue #356.
+
+    ## Test
+
+    - `state=overridden`, one switch, one managed vPC record without `peerSwitchId`
+    - `query_all` returns exactly that record, `switchIp` stamped
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._pair_key()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+
+    with does_not_raise():
+        instance = _build_orchestrator(gen_responses, state="overridden")
+        result = instance.query_all()
+
+    assert len(result) == 1
+    assert result[0]["interfaceName"] == "vpc300"
+    assert result[0]["switchIp"] == "192.168.1.1"

--- a/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_interface_base.py
@@ -1252,3 +1252,106 @@ def test_vpc_interface_base_01010() -> None:
     assert len(result) == 1
     assert result[0]["interfaceName"] == "vpc300"
     assert result[0]["switchIp"] == "192.168.1.1"
+
+
+# =============================================================================
+# Test: preflight same-pair-duplicate guard (#356)
+# =============================================================================
+
+
+def test_vpc_interface_base_01100() -> None:
+    """
+    # Summary
+
+    Verify `preflight` raises when one config lists the same `interface_name` under both peers of the SAME vPC pair. With composite
+    identity (issue #356) such a config parses as two items that target one ND resource; the guard fails fast (before any mutation,
+    check mode included via the state machine's existing preflight wiring) instead of double-writing.
+
+    ## Test
+
+    - Two proposed items: vpc100@192.168.1.1 and vpc100@192.168.1.2 — peers of one pair (vpcPair fixtures)
+    - `preflight` raises `RuntimeError` naming vpc100 and both IPs
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.preflight()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+    items = [
+        _build_model(switch_ip="192.168.1.1", interface_name="vpc100"),
+        _build_model(switch_ip="192.168.1.2", interface_name="vpc100"),
+    ]
+
+    with pytest.raises(RuntimeError, match=r"vpc100.*192\.168\.1\.1, 192\.168\.1\.2.*same vPC pair"):
+        instance.preflight(items)
+
+
+def test_vpc_interface_base_01110() -> None:
+    """
+    # Summary
+
+    Verify `preflight` accepts the same `interface_name` on two DIFFERENT vPC pairs — the multi-pair vPC-id reuse that issue #356
+    exists to support (lab-confirmed legal on ND 4.2.1, devicePair-scoped vpcId pool).
+
+    ## Test
+
+    - Two proposed items: vpc100@192.168.1.1 (pair 1) and vpc100@192.168.1.3 (pair 2)
+    - `preflight` does not raise
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.preflight()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        for suffix in ("a", "b", "c"):
+            yield responses_vpc_base(f"{method_name}{suffix}")
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+    items = [
+        _build_model(switch_ip="192.168.1.1", interface_name="vpc100"),
+        _build_model(switch_ip="192.168.1.3", interface_name="vpc100"),
+    ]
+
+    with does_not_raise():
+        instance.preflight(items)
+
+
+def test_vpc_interface_base_01120() -> None:
+    """
+    # Summary
+
+    Verify `preflight` issues ZERO requests when every proposed `interface_name` is unique (the overwhelmingly common case): pair
+    resolution only runs for duplicated names, so idempotent runs pay no extra API cost (CLAUDE.md performance rule, issue #356).
+
+    ## Test
+
+    - Two proposed items with distinct names
+    - The response generator yields nothing — any API request would raise StopIteration and fail the test
+
+    ## Classes and Methods
+
+    - VpcInterfaceBaseOrchestrator.preflight()
+    """
+
+    def responses():
+        yield from ()
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+    items = [
+        _build_model(switch_ip="192.168.1.1", interface_name="vpc100"),
+        _build_model(switch_ip="192.168.1.1", interface_name="vpc101"),
+    ]
+
+    with does_not_raise():
+        instance.preflight(items)

--- a/tests/unit/module_utils/orchestrators/test_vpc_trunk_host_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_vpc_trunk_host_interface.py
@@ -28,14 +28,19 @@ Uses the file-based `Sender` from `tests/unit/module_utils/sender_file.py` as th
 # pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
 # pylint: disable=too-many-lines
+# pylint: disable=unused-argument
 
 from __future__ import annotations
+
+from typing import Any
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import (
     TrunkVpcHostInterfaceModel,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_trunk_host_interface import (
     TrunkVpcHostInterfaceOrchestrator,
 )
@@ -514,3 +519,241 @@ def test_vpc_trunk_host_orchestrator_00600_delete_uses_per_interface_endpoint() 
     assert orchestrator._pending_deploys == [("vpc500", "FDOAAAAAAAA")]
     # Bulk-remove queue stays untouched because we use per-interface DELETE.
     assert orchestrator._pending_removes == []
+
+
+# =============================================================================
+# Test: overridden through NDStateMachine — dedup correctness under real diff/override logic (#411 review)
+# =============================================================================
+
+
+class _SpyTrunkVpcHostInterfaceOrchestrator(TrunkVpcHostInterfaceOrchestrator):
+    """Real `query_all` / `preflight` (file-based REST), but every mutation entry point records itself on `self._calls` instead of
+    sending, so a test can assert exactly which creates/updates/deletes `NDStateMachine.manage_state` planned."""
+
+    def model_post_init(self, __context) -> None:
+        """Initialize the recorded-call list after Pydantic construction."""
+        super().model_post_init(__context)
+        self._calls: list[tuple] = []  # pylint: disable=attribute-defined-outside-init
+
+    def create(self, model_instance, **kwargs) -> ResponseType:
+        """Record a single create instead of sending it."""
+        self._calls.append(("create", model_instance.get_identifier_value()))
+        return {}
+
+    def create_bulk(self, model_instances, **kwargs) -> ResponseType:
+        """Record a bulk create instead of sending it."""
+        self._calls.append(("create_bulk", [item.get_identifier_value() for item in model_instances]))
+        return {}
+
+    def update(self, model_instance, **kwargs) -> ResponseType:
+        """Record an update instead of sending it."""
+        self._calls.append(("update", model_instance.get_identifier_value()))
+        return {}
+
+    def delete(self, model_instance, **kwargs) -> None:
+        """Record a single delete instead of sending it."""
+        self._calls.append(("delete", model_instance.get_identifier_value()))
+
+    def delete_bulk(self, model_instances, **kwargs) -> None:
+        """Record a bulk delete instead of sending it."""
+        self._calls.append(("delete_bulk", [item.get_identifier_value() for item in model_instances]))
+
+
+def _build_state_machine(
+    gen_responses: ResponseGenerator, state: str, check_mode: bool, config: list[dict]
+) -> tuple[NDStateMachine, _SpyTrunkVpcHostInterfaceOrchestrator]:
+    """Wire a `_SpyTrunkVpcHostInterfaceOrchestrator` (file-based `RestSend` carrying `state`/`config`) into a real `NDStateMachine`."""
+    spy = _SpyTrunkVpcHostInterfaceOrchestrator(rest_send=_build_rest_send(gen_responses, state=state, config=config))
+    module = MockAnsibleModule()
+    module.check_mode = check_mode
+    params: dict[str, Any] = {"state": state, "config": config, "output_level": "normal", "ignore_errors": False, "fabric_name": "fabric_1"}
+    module.params = params
+    return NDStateMachine(module=module, model_orchestrator=spy), spy
+
+
+# Mirrors the vpc500 echo in the 00440/00445/00450/00455 fixtures so the proposed item is a subset of the existing one (no_diff).
+_OVERRIDDEN_POLICY = {
+    "allowed_vlans": "100-200",
+    "native_vlan": 99,
+    "peer1_port_channel_id": 500,
+    "peer1_member_ports": ["Ethernet1/1"],
+    "peer2_port_channel_id": 500,
+    "peer2_member_ports": ["Ethernet1/1"],
+}
+
+
+def _assert_idempotent(state_machine: NDStateMachine, spy: _SpyTrunkVpcHostInterfaceOrchestrator, expected_switch_ip: str, expected_paths: list[str]) -> None:
+    """Shared assertions: one existing `vpc500` on `expected_switch_ip`, the exact orchestrator request sequence (`Results.path`; the
+    file-based Sender replays positionally, so this proves each `vpcPair` lookup happened where expected), no planned mutation, and
+    `changed` False."""
+    before = list(state_machine.before)
+    assert [(item.switch_ip, item.interface_name) for item in before] == [(expected_switch_ip, "vpc500")]
+    assert state_machine.results.path == expected_paths
+    state_machine.manage_state()
+    assert spy._calls == []
+    assert state_machine.output.format()["changed"] is False
+
+
+def test_vpc_trunk_host_orchestrator_00440_overridden_mixed_case_idempotent() -> None:
+    """
+    # Summary
+
+    Verify `state: overridden` is idempotent when the user names the higher-serial peer with a mixed-case `interface_name`
+    (`VPC500`). The model canonicalizes the proposed identifier to `(192.168.1.2, vpc500)`; the orchestrator's configured-peer
+    preference must key on the same canonical name, otherwise the dedup keeps peer S1 and the state machine plans a spurious
+    CREATE `(192.168.1.2, vpc500)` + override DELETE `(192.168.1.1, vpc500)` for an interface that is already correct (PR #411 review).
+
+    ## Test
+
+    - Both peers echo `vpc500`; config lists `VPC500` on 192.168.1.2 with a policy mirroring the echo
+    - `before` holds exactly `(192.168.1.2, vpc500)`
+    - `manage_state` plans no create/update/delete; `changed` is False
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    - VpcInterfaceBaseOrchestrator._configured_switch_ips_by_interface_name()
+    """
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_trunk_host(f"test_overridden_mixed_case_00440{suffix}")
+
+    config = [{"switch_ip": "192.168.1.2", "interface_name": "VPC500", "config_data": {"network_os": {"policy": _OVERRIDDEN_POLICY}}}]
+
+    with does_not_raise():
+        state_machine, spy = _build_state_machine(ResponseGenerator(responses()), state="overridden", check_mode=False, config=config)
+        _assert_idempotent(
+            state_machine,
+            spy,
+            expected_switch_ip="192.168.1.2",
+            expected_paths=[
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+            ],
+        )
+
+
+def test_vpc_trunk_host_orchestrator_00445_overridden_mixed_case_idempotent_check_mode() -> None:
+    """
+    # Summary
+
+    Same scenario as 00440 under `--check`: the dry-run must preview no create/delete for a mixed-case name on the higher-serial
+    peer. Check mode skips the mutation calls but still runs the diff/override planning, so a wrong dedup representative would
+    surface as `changed: True` here (PR #411 review).
+
+    ## Test
+
+    - `check_mode=True`; both peers echo `vpc500`; config lists `VPC500` on 192.168.1.2
+    - `before` holds exactly `(192.168.1.2, vpc500)`; no planned mutation; `changed` is False
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - VpcInterfaceBaseOrchestrator.query_all()
+    """
+
+    def responses():
+        for suffix in ("a", "b", "c", "d"):
+            yield responses_vpc_trunk_host(f"test_overridden_mixed_case_00445{suffix}")
+
+    config = [{"switch_ip": "192.168.1.2", "interface_name": "VPC500", "config_data": {"network_os": {"policy": _OVERRIDDEN_POLICY}}}]
+
+    with does_not_raise():
+        state_machine, spy = _build_state_machine(ResponseGenerator(responses()), state="overridden", check_mode=True, config=config)
+        _assert_idempotent(
+            state_machine,
+            spy,
+            expected_switch_ip="192.168.1.2",
+            expected_paths=[
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+            ],
+        )
+
+
+def test_vpc_trunk_host_orchestrator_00450_overridden_one_peer_missing_peer_switch_id() -> None:
+    """
+    # Summary
+
+    Verify `state: overridden` does not queue a delete of the desired vPC when ONE peer echo omits `peerSwitchId`. The missing
+    peer is resolved from the `vpcPair` endpoint so both copies share one dedup key; with a per-switch singleton fallback the S2
+    copy would survive as `(192.168.1.2, vpc500)` and be deleted — removing the pair-wide interface the playbook meant to keep
+    (PR #411 review).
+
+    ## Test
+
+    - S1 echoes `vpc500` with `peerSwitchId`, S2 without it; one `vpcPair` GET for S2 (queried second, so the positional replay
+      also feeds both echoes to pre-fix code — which then plans DELETE `(192.168.1.2, vpc500)`, the destructive symptom pinned here)
+    - Config lists `vpc500` on 192.168.1.1 with a policy mirroring the echo
+    - `before` holds exactly `(192.168.1.1, vpc500)`; no planned mutation (in particular no delete); `changed` is False
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_override_deletions()
+    - VpcInterfaceBaseOrchestrator._pair_key()
+    """
+
+    def responses():
+        for suffix in ("a", "b", "c", "d", "e"):
+            yield responses_vpc_trunk_host(f"test_overridden_one_peer_missing_00450{suffix}")
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "vpc500", "config_data": {"network_os": {"policy": _OVERRIDDEN_POLICY}}}]
+
+    with does_not_raise():
+        state_machine, spy = _build_state_machine(ResponseGenerator(responses()), state="overridden", check_mode=False, config=config)
+        _assert_idempotent(
+            state_machine,
+            spy,
+            expected_switch_ip="192.168.1.1",
+            expected_paths=[
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/vpcPair",
+            ],
+        )
+
+
+def test_vpc_trunk_host_orchestrator_00455_overridden_both_peers_missing_peer_switch_id() -> None:
+    """
+    # Summary
+
+    Verify `state: overridden` does not queue a delete of the desired vPC when BOTH peer echoes omit `peerSwitchId`: each switch's
+    pair is resolved from its `vpcPair` record, the two copies collapse, and nothing is left over for override deletion
+    (PR #411 review).
+
+    ## Test
+
+    - Both `vpc500` echoes omit `peerSwitchId`; one `vpcPair` GET per switch (positional replay cannot also feed pre-fix code both
+      echoes here, so the pinned request sequence is what proves the pair resolution ran for each switch)
+    - Config lists `vpc500` on 192.168.1.1 with a policy mirroring the echo
+    - `before` holds exactly `(192.168.1.1, vpc500)`; no planned mutation; `changed` is False
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_override_deletions()
+    - VpcInterfaceBaseOrchestrator._pair_key()
+    """
+
+    def responses():
+        for suffix in ("a", "b", "c", "d", "e", "f"):
+            yield responses_vpc_trunk_host(f"test_overridden_both_peers_missing_00455{suffix}")
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "vpc500", "config_data": {"network_os": {"policy": _OVERRIDDEN_POLICY}}}]
+
+    with does_not_raise():
+        state_machine, spy = _build_state_machine(ResponseGenerator(responses()), state="overridden", check_mode=False, config=config)
+        _assert_idempotent(
+            state_machine,
+            spy,
+            expected_switch_ip="192.168.1.1",
+            expected_paths=[
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOAAAAAAAA/vpcPair",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/interfaces",
+                "/api/v1/manage/fabrics/fabric_1/switches/FDOBBBBBBBB/vpcPair",
+            ],
+        )


### PR DESCRIPTION
## Merge Ordering — #422 merged 2026-08-28; rebased and lab-verified

#422 merged into `develop` on 2026-08-28 and this branch is rebased on it (clean replay, no conflicts). The replaced/overridden re-run it called for is done — see the 2026-08-28 entry under Test Notes. Original reasoning kept for the record:

~~**Prefer merging #422 (replaced/overridden field-removal detection) before this PR.**~~ Not a textual concern — the two
branches touch different regions of the vPC model files (identifier block here vs. policy-model defaults tables there)
and auto-merge cleanly. The coupling is semantic:

- Review of #422 surfaced a vPC-specific replaced/overridden idempotency bug in its reverse diff pass: ND echoes the
  orchestrator-injected `peerSwitchId` inside the policy block, which the proposed config can never express, so the
  reverse pass reports a removal on every run (permanent `changed=true` + re-PUT). The fix lands in #422 and will touch
  the same vPC model files this PR modifies.
- This PR changes vPC identity and `query_all` dedup — exactly the machinery that produces the `before[]` set #422's
  reverse pass classifies against.

**After #422 merges:** rebase this branch and re-run the vPC `replaced`/`overridden` integration scenarios (including
the new `multi_pair.yaml`) against the live lab before merging, to confirm idempotency holds with the reverse pass
active on the rebased code.

## Related Issue(s)

Fixes #356

Added NaC-CapSet1 since Issue #356 also contains this label.

## Proposed Changes

- Restore the composite (`switch_ip`, `interface_name`) identifier on both vPC interface models
  (`accessVpcHost`, `trunkVpcHost`), matching every other interface module. Two vPC pairs in one fabric
  can now legally own the same vPC id (e.g. `vpc100` on two pairs) in a single task `config` — previously
  this collided at parse time ("Item with identifier `vpc100` already exists").
- Move the `vpc-interface-dual-peer-duplicate` workaround from the model identity into
  `VpcInterfaceBaseOrchestrator.query_all`: dedup is now keyed on `interfaceName` + the unordered
  `{switchId, peerSwitchId}` pair set, so one pair's two peer echoes collapse while same-name interfaces
  on different pairs stay distinct (fixes the `state: overridden` silent-collapse gap).
- Add a `preflight()` guard that fails fast when one config lists the same `interface_name` under both
  peers of the same vPC pair (two items targeting one ND resource). Pair resolution only runs for
  duplicated names, so runs with unique names issue zero extra requests.
- Document the pair-scoped identity and the same-pair-duplicate rejection in both modules' `notes:`.
- Integration: new `multi_pair.yaml` scenario in both vPC targets (same name + id created on both lab
  pairs in one task, idempotency, fail-fast guard, `overridden` reconciliation, cleanup), plus a
  backward-compatible `nd_test_manage_vpc_pairs` gate (default `true`) so test runs can treat hand-built
  lab vPC pairs as substrate instead of creating/unpairing them. The multi-pair scenario deliberately
  runs after `deleted.yaml`: its `state: overridden` step is fabric-wide, so running it earlier would
  delete the `vpc201`/`vpc101` artifacts the deleted-state tests assert against.

Design/spec: `docs/superpowers/specs/2026-07-20-vpc-multi-pair-identity-design.md`. Lab premise directly
confirmed on ND 4.2.1: the `vpcId` resource pool is `devicePair`-scoped, and creating the same-name/same-id
vPC interface intent on two pairs succeeds (findings recorded in the team bug-tracker vault note
`vpc-interface-dual-peer-duplicate`).

## Test Notes

- **2026-08-28 (post-#422 rebase):** rebased onto `develop` @ `bb985d74`; full unit suite **4146 passed**; CI green. Live integration against the rebuilt ND 4.2.1.10 lab (SITE1, pair S1_LE1/S1_LE2, `nd_test_manage_vpc_pairs=false`): the `setup` → `merged` → `replaced` → `overridden` → `deleted` scenarios of both `nd_interface_vpc_trunk_host` and `nd_interface_vpc_access` are **green** (each `ok=30 changed=8 failed=0`), and every `REPLACED IDEMPOTENT` / `OVERRIDDEN IDEMPOTENT` re-apply reports no change — confirming replaced/overridden idempotency holds with #422's reverse pass (`peerSwitchId` exclusion) active on this branch's pair-scoped identity and dedup. Then, after rebuilding the second lab pair (S1_LE3/S1_LE4, domain 2, physical peer link — the rebuilt lab had left them unpaired), **`multi_pair.yaml` re-run green on both targets** (each `ok=20 changed=4 failed=0`): same-name/same-id create on both pairs, idempotent re-apply, the same-pair fail-fast guard, cross-pair `overridden` reconciliation plus its idempotent re-apply, and cleanup. Post-run raw-API check: no vPC interfaces left on any of the four leafs, both pairs intact.
- Unit: full suite green via `ndpytest tests/unit/` (3184 passed), including new multi-pair dedup,
  missing-`peerSwitchId` fallback, and preflight-guard tests (TDD; fixtures modeled on captured live wire
  data from both lab pairs).
- Sanity: `ndtest` — all checks relevant to the changed files pass; 2 pre-existing failures on develop
  (`action-plugin-docs`, `pylint` on `manage_fabric_base.py`) are in files untouched by this branch.
- Live integration (ND 4.2.1, SITE1, two vPC pairs — S1_LE1/S1_LE2 domain 1, S1_LE3/S1_LE4 domain 2, both
  physical peer link): `ansible-test network-integration` for `nd_interface_vpc_trunk_host` and
  `nd_interface_vpc_access`, run with `nd_test_manage_vpc_pairs=false`. Both targets green end-to-end
  (each `ok=49 changed=12 failed=0`), including the new multi-pair blocks; post-run raw-API check
  confirmed no leftover `vpcId` pool entries and both lab pairs intact.
- validate-modules pass for both modules.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHGFDqqU37PRqNHhKw1FCQ



