### PR TITLE
Detect field removals in replaced/overridden states (one-way subset diff)

### DIFF
--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -332,7 +332,16 @@ class NDBaseModel(BaseModel, ABC):
                 difference. Empty existing values (``""``, ``[]``, ``{}``) are
                 normalized to absent so ND-echoed empty markers keep runs
                 idempotent.
+
+        Raises:
+            TypeError: If ``other`` is not an instance of this model's type
+                (same contract as ``merge``). The reverse pass applies
+                ``other``'s own ``reverse_diff_*`` declarations, so a
+                cross-type comparison is a programming error, not a diff.
         """
+        if not isinstance(other, type(self)):
+            raise TypeError(f"Cannot diff {type(other).__name__} against {type(self).__name__}. Both must be the same type.")
+
         self_data = self.to_diff_dict()
         other_data = other.to_diff_dict(exclude_unset=exclude_unset)
         is_subset = issubset(other_data, self_data)

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -248,19 +248,34 @@ class NDBaseModel(BaseModel, ABC):
         config and must not count as removals). Like `to_diff_dict`, the top-level exclusion sets apply at the top
         level only; nested exclusions are declared on the nested model via `reverse_diff_exclude`.
 
+        Derived from `to_diff_dict` (one dump, then in-place scoping) rather than a second `model_dump`, so subclass
+        `to_diff_dict` overrides scope the reverse pass too, and `get_diff` can reuse its forward dumps instead of
+        re-dumping both models.
+
         ## Raises
 
         None
         """
-        data = self.model_dump(
-            by_alias=True,
-            exclude_none=True,
-            exclude=(self.exclude_from_diff | self.payload_exclude_fields) or None,
-            mode="json",
-            **kwargs,
-        )
-        self._scrub_reverse_diff_dict(data)
+        data = self.to_diff_dict(**kwargs)
+        self._apply_reverse_diff_scope(data)
         return data
+
+    def _apply_reverse_diff_scope(self, data: Dict[str, Any]) -> None:
+        """
+        # Summary
+
+        Convert a `to_diff_dict` export into the reverse-pass shape, in place: pop the aliases of top-level
+        `payload_exclude_fields` (already absent when a field is also in `exclude_from_diff`), then run
+        `_scrub_reverse_diff_dict` so each nested model applies its own exclusions/extras/defaults declarations.
+
+        ## Raises
+
+        None
+        """
+        for field_name in self.payload_exclude_fields:
+            field_info = type(self).model_fields.get(field_name)
+            data.pop(field_info.alias if field_info is not None and field_info.alias else field_name, None)
+        self._scrub_reverse_diff_dict(data)
 
     def _scrub_reverse_diff_dict(self, data: Dict[str, Any]) -> None:
         """
@@ -320,8 +335,14 @@ class NDBaseModel(BaseModel, ABC):
         is_subset = issubset(other_data, self_data)
         if is_subset and exclude_unset and self.merge_would_change(other):
             return False
-        if is_subset and not exclude_unset and has_removals(self.to_reverse_diff_dict(), other.to_reverse_diff_dict()):
-            return False
+        if is_subset and not exclude_unset:
+            # Reuse the forward dumps for the reverse pass (they are not read again): scoping them in place
+            # avoids a second full model_dump per side (PR #422 review, efficiency finding).
+            self._apply_reverse_diff_scope(self_data)
+            # Same-class access; pylint cannot infer `other` shares this NDBaseModel API.
+            other._apply_reverse_diff_scope(other_data)  # pylint: disable=protected-access
+            if has_removals(self_data, other_data):
+                return False
         return is_subset
 
     def merge_would_change(self, other: "NDBaseModel") -> bool:

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -77,6 +77,9 @@ class NDBaseModel(BaseModel, ABC):
     # value equal to its declared default is normalized to absent during removal detection -- omitting it from
     # proposed config is not a pending reset. Source the values from the ND OpenAPI template schema for the
     # model's policyType (see the `nd-openapi` MCP); a wrong value here breaks replaced/overridden idempotency.
+    # Values MUST be in the model's DUMPED form, not the schema-declared form: when a validator coerces a field
+    # on read (e.g. loopback `routeMapTag` schema integer 12345 stored as string "12345"), the table must hold
+    # the coerced value or the default never matches and the field silently reopens issue #410 for that model.
     reverse_diff_defaults: ClassVar[Dict[str, Any]] = {}
 
     # Keys (field ALIASES / wire keys) stripped from this model's level of the reverse-pass dump regardless of

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -8,7 +8,7 @@ from abc import ABC
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Set, Tuple, Union
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict
-from ansible_collections.cisco.nd.plugins.module_utils.utils import issubset
+from ansible_collections.cisco.nd.plugins.module_utils.utils import has_removals, issubset
 
 
 def _strip_none_values(data):
@@ -71,6 +71,13 @@ class NDBaseModel(BaseModel, ABC):
     # Fields to explicitly exclude per mode
     payload_exclude_fields: ClassVar[Set[str]] = set()
     config_exclude_fields: ClassVar[Set[str]] = set()
+
+    # ND template defaults for the reverse pass of `get_diff` (issue #410), keyed by field ALIAS (wire key).
+    # ND echoes the schema-declared template default for every field the user never set, so an existing-side
+    # value equal to its declared default is normalized to absent during removal detection -- omitting it from
+    # proposed config is not a pending reset. Source the values from the ND OpenAPI template schema for the
+    # model's policyType (see the `nd-openapi` MCP); a wrong value here breaks replaced/overridden idempotency.
+    reverse_diff_defaults: ClassVar[Dict[str, Any]] = {}
 
     # --- Subclass Validation ---
 
@@ -221,6 +228,53 @@ class NDBaseModel(BaseModel, ABC):
             **kwargs,
         )
 
+    def to_reverse_diff_dict(self, **kwargs) -> Dict[str, Any]:
+        """
+        # Summary
+
+        Export for the reverse pass of `get_diff` (issue #410), scoped to payload shape: fields in `exclude_from_diff` or
+        `payload_exclude_fields` are excluded, so only fields the PUT body can express participate in removal detection.
+        Existing-side values equal to their `reverse_diff_defaults` entry are stripped (recursively, each nested model
+        applying its own table) because ND echoes template defaults for unset fields. Like `to_diff_dict`, the exclusion
+        sets apply at the top level only; models needing nested exclusions override `get_diff`.
+
+        ## Raises
+
+        None
+        """
+        data = self.model_dump(
+            by_alias=True,
+            exclude_none=True,
+            exclude=(self.exclude_from_diff | self.payload_exclude_fields) or None,
+            mode="json",
+            **kwargs,
+        )
+        self._strip_reverse_diff_defaults(data)
+        return data
+
+    def _strip_reverse_diff_defaults(self, data: Dict[str, Any]) -> None:
+        """
+        # Summary
+
+        Remove keys from `data` (an aliased dump of `self`) whose value equals the model's declared `reverse_diff_defaults`
+        entry, then recurse into nested `NDBaseModel` fields so each nested model applies its own table.
+
+        ## Raises
+
+        None
+        """
+        for alias, default in self.reverse_diff_defaults.items():
+            if alias in data and data[alias] == default:
+                del data[alias]
+        for field_name, field_info in type(self).model_fields.items():
+            value = getattr(self, field_name, None)
+            if isinstance(value, NDBaseModel):
+                alias = field_info.alias or field_name
+                nested = data.get(alias)
+                if isinstance(nested, dict):
+                    # Same-class recursion; pylint cannot infer `value` is an NDBaseModel from getattr.
+                    value._strip_reverse_diff_defaults(nested)  # pylint: disable=protected-access
+
     def get_diff(self, other: "NDBaseModel", exclude_unset: bool = False) -> bool:
         """Diff comparison.
 
@@ -234,11 +288,22 @@ class NDBaseModel(BaseModel, ABC):
                 to catch merge side effects the one-way subset test cannot see
                 (e.g. mutually exclusive counterpart fields that the merge
                 would clear).
+
+                When False (the ``replaced``/``overridden`` path), a subset
+                match is additionally cross-checked with ``has_removals`` over
+                the payload-scoped dumps (issue #410): a field present on
+                ``self`` (device) but absent from ``other`` (proposed) means
+                the full-payload PUT would reset it, so it must classify as a
+                difference. Empty existing values (``""``, ``[]``, ``{}``) are
+                normalized to absent so ND-echoed empty markers keep runs
+                idempotent.
         """
         self_data = self.to_diff_dict()
         other_data = other.to_diff_dict(exclude_unset=exclude_unset)
         is_subset = issubset(other_data, self_data)
         if is_subset and exclude_unset and self.merge_would_change(other):
+            return False
+        if is_subset and not exclude_unset and has_removals(self.to_reverse_diff_dict(), other.to_reverse_diff_dict()):
             return False
         return is_subset
 

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -79,6 +79,13 @@ class NDBaseModel(BaseModel, ABC):
     # model's policyType (see the `nd-openapi` MCP); a wrong value here breaks replaced/overridden idempotency.
     reverse_diff_defaults: ClassVar[Dict[str, Any]] = {}
 
+    # Keys (field ALIASES / wire keys) stripped from this model's level of the reverse-pass dump regardless of
+    # value. For server-populated fields the proposed config can never express (e.g. the orchestrator-injected
+    # `peerSwitchId` on vPC policy models): their presence on the existing side is not a pending reset, and
+    # unlike `reverse_diff_defaults` they have no single constant value to match against. Applies at the
+    # declaring model's own nesting level, so nested models scope their own exclusions.
+    reverse_diff_exclude: ClassVar[Set[str]] = set()
+
     # --- Subclass Validation ---
 
     def __init_subclass__(cls, **kwargs):
@@ -234,9 +241,12 @@ class NDBaseModel(BaseModel, ABC):
 
         Export for the reverse pass of `get_diff` (issue #410), scoped to payload shape: fields in `exclude_from_diff` or
         `payload_exclude_fields` are excluded, so only fields the PUT body can express participate in removal detection.
-        Existing-side values equal to their `reverse_diff_defaults` entry are stripped (recursively, each nested model
-        applying its own table) because ND echoes template defaults for unset fields. Like `to_diff_dict`, the exclusion
-        sets apply at the top level only; models needing nested exclusions override `get_diff`.
+        The dump is then scrubbed recursively, each nested model applying its own declarations: values equal to their
+        `reverse_diff_defaults` entry are stripped (ND echoes template defaults for unset fields), keys in
+        `reverse_diff_exclude` are stripped unconditionally (server-populated fields the proposed config can never
+        express), and keys retained by `extra="allow"` are stripped (undeclared server keys are not expressible in
+        config and must not count as removals). Like `to_diff_dict`, the top-level exclusion sets apply at the top
+        level only; nested exclusions are declared on the nested model via `reverse_diff_exclude`.
 
         ## Raises
 
@@ -249,20 +259,27 @@ class NDBaseModel(BaseModel, ABC):
             mode="json",
             **kwargs,
         )
-        self._strip_reverse_diff_defaults(data)
+        self._scrub_reverse_diff_dict(data)
         return data
 
-    def _strip_reverse_diff_defaults(self, data: Dict[str, Any]) -> None:
+    def _scrub_reverse_diff_dict(self, data: Dict[str, Any]) -> None:
         """
         # Summary
 
-        Remove keys from `data` (an aliased dump of `self`) whose value equals the model's declared `reverse_diff_defaults`
-        entry, then recurse into nested `NDBaseModel` fields so each nested model applies its own table.
+        Scrub `data` (an aliased dump of `self`) for removal detection: drop keys listed in `reverse_diff_exclude`, keys
+        retained only via `extra="allow"` (undeclared server keys), and keys whose value equals the model's declared
+        `reverse_diff_defaults` entry, then recurse into nested `NDBaseModel` fields so each nested model applies its own
+        declarations.
 
         ## Raises
 
         None
         """
+        for alias in self.reverse_diff_exclude:
+            data.pop(alias, None)
+        # `model_extra` keys are stored under their wire spelling, matching the aliased dump.
+        for extra_key in getattr(self, "model_extra", None) or {}:
+            data.pop(extra_key, None)
         for alias, default in self.reverse_diff_defaults.items():
             if alias in data and data[alias] == default:
                 del data[alias]
@@ -273,7 +290,7 @@ class NDBaseModel(BaseModel, ABC):
                 nested = data.get(alias)
                 if isinstance(nested, dict):
                     # Same-class recursion; pylint cannot infer `value` is an NDBaseModel from getattr.
-                    value._strip_reverse_diff_defaults(nested)  # pylint: disable=protected-access
+                    value._scrub_reverse_diff_dict(nested)  # pylint: disable=protected-access
 
     def get_diff(self, other: "NDBaseModel", exclude_unset: bool = False) -> bool:
         """Diff comparison.

--- a/plugins/module_utils/models/interfaces/ethernet_access_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_access_interface.py
@@ -26,7 +26,7 @@ wrapping or flattening.
 from __future__ import annotations
 
 import re
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
@@ -70,6 +70,32 @@ class EthernetAccessPolicyModel(StormControlMutexMixin):
 
     None
     """
+
+    # ND 4.2.1 `int_access_host` template defaults (schema-sourced via nd-openapi `intAccessHostTemplate`). ND echoes these
+    # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
+    # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
+    reverse_diff_defaults: ClassVar[dict[str, Any]] = {
+        "adminState": True,
+        "bpduFilter": "default",
+        "bpduGuard": "enable",
+        "cdp": True,
+        "debounceTimer": 100,
+        "duplexMode": "auto",
+        "errorDetectionAcl": True,
+        "fec": "auto",
+        "linkType": "auto",
+        "monitor": False,
+        "mtu": "jumbo",
+        "negotiateAuto": True,
+        "netflow": False,
+        "orphanPort": False,
+        "pfc": False,
+        "portTypeEdgeTrunk": True,
+        "qos": False,
+        "speed": "auto",
+        "stormControl": False,
+        "stormControlAction": "default",
+    }
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     access_vlan: int | None = Field(default=None, alias="accessVlan", ge=1, le=4094, description="VLAN for this access port")

--- a/plugins/module_utils/models/interfaces/ethernet_access_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_access_interface.py
@@ -71,6 +71,7 @@ class EthernetAccessPolicyModel(StormControlMutexMixin):
     None
     """
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND 4.2.1 `int_access_host` template defaults (schema-sourced via nd-openapi `intAccessHostTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/ethernet_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_trunk_host_interface.py
@@ -221,6 +221,7 @@ class EthernetTrunkHostPolicyModel(StormControlMutexMixin):
     - If both the percentage and pps level are set for the same storm-control class in a non-response context (via `StormControlMutexMixin`)
     """
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND 4.2.1 `int_trunk_host` template defaults (schema-sourced via nd-openapi `intTrunkHostTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/ethernet_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_trunk_host_interface.py
@@ -28,7 +28,7 @@ wrapping or flattening.
 from __future__ import annotations
 
 import re
-from typing import Annotated, ClassVar, Literal, Optional  # Optional needed for Annotated runtime expr (see types.py)
+from typing import Annotated, Any, ClassVar, Literal, Optional  # Optional needed for Annotated runtime expr (see types.py)
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     BeforeValidator,
@@ -220,6 +220,34 @@ class EthernetTrunkHostPolicyModel(StormControlMutexMixin):
     - If `allowed_vlans` is not `none`, `all`, or a comma-separated list of VLAN ids / ranges
     - If both the percentage and pps level are set for the same storm-control class in a non-response context (via `StormControlMutexMixin`)
     """
+
+    # ND 4.2.1 `int_trunk_host` template defaults (schema-sourced via nd-openapi `intTrunkHostTemplate`). ND echoes these
+    # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
+    # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
+    reverse_diff_defaults: ClassVar[dict[str, Any]] = {
+        "adminState": True,
+        "allowedVlans": "none",
+        "bpduFilter": "default",
+        "bpduGuard": "default",
+        "cdp": True,
+        "debounceTimer": 100,
+        "duplexMode": "auto",
+        "errorDetectionAcl": True,
+        "fec": "auto",
+        "linkType": "auto",
+        "monitor": False,
+        "mtu": "jumbo",
+        "negotiateAuto": True,
+        "netflow": False,
+        "orphanPort": False,
+        "pfc": False,
+        "portTypeEdgeTrunk": True,
+        "qos": False,
+        "speed": "auto",
+        "stormControl": False,
+        "stormControlAction": "default",
+        "vlanMapping": False,
+    }
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     allowed_vlans: AllowedVlans = Field(

--- a/plugins/module_utils/models/interfaces/loopback_interface.py
+++ b/plugins/module_utils/models/interfaces/loopback_interface.py
@@ -48,6 +48,7 @@ class LoopbackPolicyModel(NDNestedModel):
     None
     """
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND 4.2.1 `int_loopback` template defaults (schema-sourced via nd-openapi `intLoopbackTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/loopback_interface.py
+++ b/plugins/module_utils/models/interfaces/loopback_interface.py
@@ -26,7 +26,7 @@ work via standard Pydantic serialization with no custom wrapping or flattening.
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
@@ -47,6 +47,16 @@ class LoopbackPolicyModel(NDNestedModel):
 
     None
     """
+
+    # ND 4.2.1 `int_loopback` template defaults (schema-sourced via nd-openapi `intLoopbackTemplate`). ND echoes these
+    # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
+    # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
+    # Values must be in the model's DUMPED form: the schema declares routeMapTag as integer 12345, but
+    # `coerce_route_map_tag` stores it as a string (ND 4.2.1 GET-side type drift), so the table holds "12345".
+    reverse_diff_defaults: ClassVar[dict[str, Any]] = {
+        "adminState": True,
+        "routeMapTag": "12345",
+    }
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     ip: IPv4Host = Field(default=None, alias="ip", description="Loopback IPv4 address (bare host form, e.g. 10.1.1.1; CIDR input is accepted and normalized)")

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -81,6 +81,7 @@ class PortChannelAccessPolicyModel(StormControlMutexMixin):
     None
     """
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND 4.2.1 `int_port_channel_access_host` template defaults (schema-sourced via nd-openapi `intPortChannelAccessHostTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -31,7 +31,7 @@ interfaces inherit access-mode settings from the port-channel; users do not pre-
 from __future__ import annotations
 
 import re
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
@@ -80,6 +80,29 @@ class PortChannelAccessPolicyModel(StormControlMutexMixin):
 
     None
     """
+
+    # ND 4.2.1 `int_port_channel_access_host` template defaults (schema-sourced via nd-openapi `intPortChannelAccessHostTemplate`). ND echoes these
+    # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
+    # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
+    reverse_diff_defaults: ClassVar[dict[str, Any]] = {
+        "adminState": True,
+        "bpduFilter": "default",
+        "bpduGuard": "enable",
+        "cdp": True,
+        "copyDescription": False,
+        "duplexMode": "auto",
+        "lacpPortPriority": 32768,
+        "lacpRate": "normal",
+        "lacpSuspend": False,
+        "monitor": False,
+        "mtu": "jumbo",
+        "netflow": False,
+        "portChannelMode": "active",
+        "qos": False,
+        "speed": "auto",
+        "stormControl": False,
+        "stormControlAction": "default",
+    }
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     access_vlan: int | None = Field(default=None, alias="accessVlan", ge=1, le=4094, description="VLAN for this access port-channel")

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -32,7 +32,7 @@ interfaces inherit trunk-mode settings from the port-channel; users do not pre-c
 from __future__ import annotations
 
 import re
-from typing import Annotated, ClassVar, Literal, Optional  # Optional needed for Annotated runtime expr (see types.py)
+from typing import Annotated, Any, ClassVar, Literal, Optional  # Optional needed for Annotated runtime expr (see types.py)
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     BeforeValidator,
@@ -230,6 +230,36 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
 
     - If the wrapped model serializer receives a non-`dict` from the handler (see `_strip_policy_type_in_config`).
     """
+
+    # ND 4.2.1 `int_port_channel_trunk_host` template defaults (schema-sourced via nd-openapi `intPortChannelTrunkHostTemplate`). ND echoes these
+    # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
+    # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
+    reverse_diff_defaults: ClassVar[dict[str, Any]] = {
+        "adminState": True,
+        "allowedVlans": "none",
+        "bpduFilter": "default",
+        "bpduGuard": "enable",
+        "cdp": True,
+        "copyDescription": False,
+        "duplexMode": "auto",
+        "lacpPortPriority": 32768,
+        "lacpRate": "normal",
+        "lacpSuspend": False,
+        "linkType": "auto",
+        "monitor": False,
+        "mtu": "jumbo",
+        "negotiateAuto": True,
+        "netflow": False,
+        "orphanPort": False,
+        "pfc": False,
+        "portChannelMode": "active",
+        "portTypeEdgeTrunk": True,
+        "qos": False,
+        "speed": "auto",
+        "stormControl": False,
+        "stormControlAction": "default",
+        "vlanMapping": False,
+    }
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     allowed_vlans: AllowedVlans = Field(

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -231,6 +231,7 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
     - If the wrapped model serializer receives a non-`dict` from the handler (see `_strip_policy_type_in_config`).
     """
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND 4.2.1 `int_port_channel_trunk_host` template defaults (schema-sourced via nd-openapi `intPortChannelTrunkHostTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -264,12 +264,14 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
 
     # `ptp` is deliberately NOT modeled (deviation: interface-get-undocumented-ptp-field). ND injects a `ptp`
     # boolean into every port-channel policy GET even though intPortChannelTrunkHostTemplate declares no such
-    # property. A lab probe (2026-08-12, SITE1, ND 4.2.1.10, fabric PTP disabled) proved a client-sent `ptp` is
-    # persist-but-inert there: ND stores and echoes it but generates zero pending CLI. On a PTP-enabled fabric the
-    # fabric-level deploy rewrites the stored value fabric-wide regardless of per-interface intent (vault note,
-    # 2026-06-10), so the field is fabric-owned in both regimes and exposing it would fake per-interface control.
-    # The injected echo is dropped at parse time by `extra="ignore"`, same as the sibling ethernet/vPC models.
-    # Do not re-add the field from wire observation alone; it belongs only if a future template declares it.
+    # property. Lab probes (2026-08-12, SITE1, ND 4.2.1.10) covered all three fabric-PTP regimes — disabled,
+    # enabled-not-deployed, and fully deployed — and in every regime a client-sent `ptp` is persist-but-inert:
+    # ND stores and echoes it but generates zero pending CLI. ND's own PTP CLI lands only on physical interfaces
+    # (never under port-channels, matching NX-OS's per-physical-port PTP model), and the fabric-PTP deploy
+    # rewrites the stored value fabric-wide regardless of per-interface intent, so exposing the field would fake
+    # per-interface control. The injected echo is dropped at parse time by `extra="ignore"`, same as the sibling
+    # ethernet/vPC models. Do not re-add the field from wire observation alone; it belongs only if a future
+    # template declares it.
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     allowed_vlans: AllowedVlans = Field(

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -264,10 +264,12 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
 
     # `ptp` is deliberately NOT modeled (deviation: interface-get-undocumented-ptp-field). ND injects a `ptp`
     # boolean into every port-channel policy GET even though intPortChannelTrunkHostTemplate declares no such
-    # property, and a lab probe (2026-08-12, SITE1, ND 4.2.1.10) proved a client-sent `ptp` is persist-but-inert:
-    # ND stores and echoes it but generates zero pending CLI, so exposing it would be a silent no-op that fakes
-    # success. The injected echo is dropped at parse time by `extra="ignore"`, same as the sibling ethernet/vPC
-    # models. Do not re-add the field from wire observation alone; it belongs only if a future template declares it.
+    # property. A lab probe (2026-08-12, SITE1, ND 4.2.1.10, fabric PTP disabled) proved a client-sent `ptp` is
+    # persist-but-inert there: ND stores and echoes it but generates zero pending CLI. On a PTP-enabled fabric the
+    # fabric-level deploy rewrites the stored value fabric-wide regardless of per-interface intent (vault note,
+    # 2026-06-10), so the field is fabric-owned in both regimes and exposing it would fake per-interface control.
+    # The injected echo is dropped at parse time by `extra="ignore"`, same as the sibling ethernet/vPC models.
+    # Do not re-add the field from wire observation alone; it belongs only if a future template declares it.
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     allowed_vlans: AllowedVlans = Field(

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -262,13 +262,12 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
         "vlanMapping": False,
     }
 
-    # TODO(4.2.1) interface-get-undocumented-ptp-field
-    # ND injects a `ptp` boolean into every port-channel policy GET even though intPortChannelTrunkHostTemplate
-    # declares no such property. The value is not interface state: it reads false until a fabric-PTP deploy, after
-    # which ND rewrites ALL physical/port-channel records to true fabric-wide. Because `ptp` is a declared field on
-    # this model, the echo survives from_response and would count as a pending removal in the reverse pass, so it is
-    # stripped unconditionally (a defaults-table entry of False would re-break after the fabric-wide true rewrite).
-    reverse_diff_exclude: ClassVar[set[str]] = {"ptp"}
+    # `ptp` is deliberately NOT modeled (deviation: interface-get-undocumented-ptp-field). ND injects a `ptp`
+    # boolean into every port-channel policy GET even though intPortChannelTrunkHostTemplate declares no such
+    # property, and a lab probe (2026-08-12, SITE1, ND 4.2.1.10) proved a client-sent `ptp` is persist-but-inert:
+    # ND stores and echoes it but generates zero pending CLI, so exposing it would be a silent no-op that fakes
+    # success. The injected echo is dropped at parse time by `extra="ignore"`, same as the sibling ethernet/vPC
+    # models. Do not re-add the field from wire observation alone; it belongs only if a future template declares it.
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     allowed_vlans: AllowedVlans = Field(
@@ -308,7 +307,6 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
     port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode (on/active/passive)")
     port_type_edge_trunk: bool | None = Field(default=None, alias="portTypeEdgeTrunk", description="Configure as edge trunk port (PortFast on trunk)")
     ports: list[str] | None = Field(default=None, alias="ports", description="Member interface names (e.g. ['Ethernet1/1', 'Ethernet1/2'])")
-    ptp: bool | None = Field(default=None, alias="ptp", description="Enable Precision Time Protocol on the interface")
     qos: bool | None = Field(default=None, alias="qos", description="Enable QoS configuration for this interface")
     qos_policy: str | None = Field(default=None, alias="qosPolicy", description="Custom QoS policy name")
     queuing_policy: str | None = Field(default=None, alias="queuingPolicy", description="Custom queuing policy name")
@@ -611,7 +609,6 @@ class PortChannelTrunkHostInterfaceModel(NDBaseModel):
                                             port_channel_mode=dict(type="str", choices=[e.value for e in PortChannelModeEnum]),
                                             port_type_edge_trunk=dict(type="bool"),
                                             ports=dict(type="list", elements="str"),
-                                            ptp=dict(type="bool"),
                                             qos=dict(type="bool"),
                                             qos_policy=dict(type="str"),
                                             queuing_policy=dict(type="str"),

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -262,6 +262,14 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
         "vlanMapping": False,
     }
 
+    # TODO(4.2.1) interface-get-undocumented-ptp-field
+    # ND injects a `ptp` boolean into every port-channel policy GET even though intPortChannelTrunkHostTemplate
+    # declares no such property. The value is not interface state: it reads false until a fabric-PTP deploy, after
+    # which ND rewrites ALL physical/port-channel records to true fabric-wide. Because `ptp` is a declared field on
+    # this model, the echo survives from_response and would count as a pending removal in the reverse pass, so it is
+    # stripped unconditionally (a defaults-table entry of False would re-break after the fabric-wide true rewrite).
+    reverse_diff_exclude: ClassVar[set[str]] = {"ptp"}
+
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
     allowed_vlans: AllowedVlans = Field(
         default=None,

--- a/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
+++ b/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
@@ -38,7 +38,7 @@ routing tag, MTU, PIM, ip-redirects, admin-state, and netflow. The "unmanaged" s
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
@@ -65,6 +65,18 @@ class SubinterfaceManagedPolicyModel(NDNestedModel):
 
     None
     """
+
+    # ND 4.2.1 `int_subif` template defaults (schema-sourced via nd-openapi `intSubifTemplate`). ND echoes these
+    # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
+    # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
+    reverse_diff_defaults: ClassVar[dict[str, Any]] = {
+        "adminState": True,
+        "ipRedirects": False,
+        "mtu": 9216,
+        "netflow": False,
+        "pimDrPriority": 1,
+        "pimSparse": False,
+    }
 
     policy_type: SubinterfaceManagedPolicyTypeEnum = Field(
         default=SubinterfaceManagedPolicyTypeEnum.SUBINTERFACE,

--- a/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
+++ b/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
@@ -66,6 +66,7 @@ class SubinterfaceManagedPolicyModel(NDNestedModel):
     None
     """
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND 4.2.1 `int_subif` template defaults (schema-sourced via nd-openapi `intSubifTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -33,7 +33,7 @@ ND GUI exposes for managed SVIs on Nexus. OSPF / ISIS / BFD / replication-mode f
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
@@ -59,6 +59,21 @@ class SviPolicyModel(NDNestedModel):
 
     None
     """
+
+    # ND 4.2.1 `int_vlan` template defaults (schema-sourced via nd-openapi `intVlanTemplate`). ND echoes these
+    # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
+    # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
+    reverse_diff_defaults: ClassVar[dict[str, Any]] = {
+        "adminState": True,
+        "advertiseSubnetInUnderlay": False,
+        "hsrpGroup": 1,
+        "hsrpVersion": 1,
+        "ipRedirects": True,
+        "netflow": False,
+        "pimDrPriority": 1,
+        "pimSparse": False,
+        "preempt": False,
+    }
 
     policy_type: SviPolicyTypeEnum = Field(
         default=SviPolicyTypeEnum.SVI, alias="policyType", frozen=True, description="Interface policy type (hardcoded for this module)"

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -60,6 +60,7 @@ class SviPolicyModel(NDNestedModel):
     None
     """
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND 4.2.1 `int_vlan` template defaults (schema-sourced via nd-openapi `intVlanTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -36,7 +36,7 @@ use the ND-native `peer1_*` / `peer2_*` naming where `peer1` corresponds to `swi
 from __future__ import annotations
 
 import re
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
@@ -85,6 +85,34 @@ class AccessVpcHostPolicyModel(StormControlMutexMixin):
 
     None
     """
+
+    # ND 4.2.1 `int_vpc_access_host` template defaults (schema-sourced via nd-openapi `intVpcAccessHostTemplate`). ND echoes these
+    # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
+    # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
+    reverse_diff_defaults: ClassVar[dict[str, Any]] = {
+        "adminState": True,
+        "bpduFilter": "default",
+        "bpduGuard": "enable",
+        "cdp": True,
+        "copyDescription": False,
+        "duplexMode": "auto",
+        "lacpPortPriority": 32768,
+        "lacpRate": "normal",
+        "lacpSuspend": False,
+        "lacpVpcConvergence": False,
+        "linkType": "auto",
+        "mirrorConfig": False,
+        "mtu": "jumbo",
+        "negotiateAuto": True,
+        "netflow": False,
+        "pfc": False,
+        "portChannelMode": "active",
+        "portTypeEdgeTrunk": True,
+        "qos": False,
+        "speed": "auto",
+        "stormControl": False,
+        "stormControlAction": "default",
+    }
 
     # --- Policy Discriminator ---
 

--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -86,6 +86,11 @@ class AccessVpcHostPolicyModel(StormControlMutexMixin):
     None
     """
 
+    # `peerSwitchId` is orchestrator-injected (resolved from the vPC pair record; not in the argspec), so the
+    # proposed config can never express it. ND echoes it on reads; without this exclusion the reverse pass of
+    # `get_diff` would count it as a removal on every replaced/overridden run, breaking idempotency.
+    reverse_diff_exclude: ClassVar[set[str]] = {"peerSwitchId"}
+
     # ND 4.2.1 `int_vpc_access_host` template defaults (schema-sourced via nd-openapi `intVpcAccessHostTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -91,6 +91,7 @@ class AccessVpcHostPolicyModel(StormControlMutexMixin):
     # `get_diff` would count it as a removal on every replaced/overridden run, breaking idempotency.
     reverse_diff_exclude: ClassVar[set[str]] = {"peerSwitchId"}
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND 4.2.1 `int_vpc_access_host` template defaults (schema-sourced via nd-openapi `intVpcAccessHostTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
@@ -228,6 +228,7 @@ class TrunkVpcHostPolicyModel(StormControlMutexMixin):
     # `get_diff` would count it as a removal on every replaced/overridden run, breaking idempotency.
     reverse_diff_exclude: ClassVar[set[str]] = {"peerSwitchId"}
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND 4.2.1 `int_vpc_trunk_host` template defaults (schema-sourced via nd-openapi `intVpcTrunkHostTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
@@ -38,7 +38,7 @@ use the ND-native `peer1_*` / `peer2_*` naming where `peer1` corresponds to `swi
 from __future__ import annotations
 
 import re
-from typing import Annotated, ClassVar, Literal, Optional  # Optional needed for Annotated runtime expr (see types.py)
+from typing import Annotated, Any, ClassVar, Literal, Optional  # Optional needed for Annotated runtime expr (see types.py)
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     BeforeValidator,
@@ -222,6 +222,35 @@ class TrunkVpcHostPolicyModel(StormControlMutexMixin):
 
     - If `allowed_vlans` is set and does not match `none`, `all`, or comma-separated VLAN ranges.
     """
+
+    # ND 4.2.1 `int_vpc_trunk_host` template defaults (schema-sourced via nd-openapi `intVpcTrunkHostTemplate`). ND echoes these
+    # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
+    # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
+    reverse_diff_defaults: ClassVar[dict[str, Any]] = {
+        "adminState": True,
+        "bpduFilter": "default",
+        "bpduGuard": "enable",
+        "cdp": True,
+        "copyDescription": False,
+        "duplexMode": "auto",
+        "lacpPortPriority": 32768,
+        "lacpRate": "normal",
+        "lacpSuspend": False,
+        "lacpVpcConvergence": False,
+        "linkType": "auto",
+        "mirrorConfig": False,
+        "mtu": "jumbo",
+        "negotiateAuto": True,
+        "netflow": False,
+        "pfc": False,
+        "portChannelMode": "active",
+        "portTypeEdgeTrunk": True,
+        "qos": False,
+        "speed": "auto",
+        "stormControl": False,
+        "stormControlAction": "default",
+        "vlanMapping": False,
+    }
 
     # --- Policy Discriminator ---
 

--- a/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
@@ -223,6 +223,11 @@ class TrunkVpcHostPolicyModel(StormControlMutexMixin):
     - If `allowed_vlans` is set and does not match `none`, `all`, or comma-separated VLAN ranges.
     """
 
+    # `peerSwitchId` is orchestrator-injected (resolved from the vPC pair record; not in the argspec), so the
+    # proposed config can never express it. ND echoes it on reads; without this exclusion the reverse pass of
+    # `get_diff` would count it as a removal on every replaced/overridden run, breaking idempotency.
+    reverse_diff_exclude: ClassVar[set[str]] = {"peerSwitchId"}
+
     # ND 4.2.1 `int_vpc_trunk_host` template defaults (schema-sourced via nd-openapi `intVpcTrunkHostTemplate`). ND echoes these
     # for every field the user never set; the reverse pass of `get_diff` normalizes existing-side matches to absent
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.

--- a/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
@@ -234,6 +234,11 @@ class TrunkVpcHostPolicyModel(StormControlMutexMixin):
     # so replaced/overridden removal detection (issue #410) stays idempotent against default echoes.
     reverse_diff_defaults: ClassVar[dict[str, Any]] = {
         "adminState": True,
+        # Dumped-form keys: the write-side dump fans the single user-facing `allowed_vlans` out to the per-peer
+        # wire keys (vpc-interface-peer-vlan-collapse), so the reverse pass sees peer1/peer2AllowedVlans, never
+        # the collapsed `allowedVlans` that ND echoes on GET.
+        "peer1AllowedVlans": "none",
+        "peer2AllowedVlans": "none",
         "bpduFilter": "default",
         "bpduGuard": "enable",
         "cdp": True,

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -4,20 +4,21 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import List, Dict, Any, Optional, ClassVar, Literal
+from typing import Any, ClassVar, Dict, List, Literal, Optional
+
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
+    FieldSerializationInfo,
     SecretStr,
-    model_serializer,
+    SerializationInfo,
     field_serializer,
     field_validator,
+    model_serializer,
     model_validator,
-    FieldSerializationInfo,
-    SerializationInfo,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.constants import NDConstantMapping
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
-from ansible_collections.cisco.nd.plugins.module_utils.constants import NDConstantMapping
 
 USER_ROLES_MAPPING = NDConstantMapping(
     {
@@ -80,6 +81,16 @@ class LocalUserModel(NDBaseModel):
     # --- Serialization Configuration ---
 
     exclude_from_diff: ClassVar[set] = {"user_password"}
+
+    # ND echoes these falsy defaults for a user created without the corresponding options set (lab-verified on
+    # 4.2.1; the module's integration tests assert exactly these `before` values). `False`/`0` are not "effectively
+    # empty", so without this table the reverse pass of `get_diff` (issue #410) would count each echo as a removal
+    # on every replaced run, breaking idempotency for playbooks that omit these options.
+    reverse_diff_defaults: ClassVar[Dict[str, Any]] = {
+        "xLaunch": False,
+        "reuseLimitation": 0,
+        "timeIntervalLimitation": 0,
+    }
     unwanted_keys: ClassVar[List] = [
         ["passwordPolicy", "passwordChangeTime"],
         ["userID"],

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -82,6 +82,7 @@ class LocalUserModel(NDBaseModel):
 
     exclude_from_diff: ClassVar[set] = {"user_password"}
 
+    # TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields
     # ND echoes these falsy defaults for a user created without the corresponding options set (lab-verified on
     # 4.2.1; the module's integration tests assert exactly these `before` values). `False`/`0` are not "effectively
     # empty", so without this table the reverse pass of `get_diff` (issue #410) would count each echo as a removal

--- a/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
+++ b/plugins/module_utils/models/manage_prefix_list/manage_prefix_list.py
@@ -61,12 +61,12 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
     model_validator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_prefix_list.enums import (
     IpVersionEnum,
     PrefixListActionEnum,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
 # Allowed characters for prefix list / tenant names (from OpenAPI pattern)
 _NAME_RE = re.compile(r"^[a-zA-Z0-9~_-]+$")
@@ -356,21 +356,6 @@ class PrefixListModel(NDBaseModel):
     def get_identifier_value(self) -> tuple[str, str | None, str]:
         """Return the tenant-aware composite identifier."""
         return (str(self.ip_version), self.tenant_name, self.name)
-
-    def get_diff(self, other: NDBaseModel, exclude_unset: bool = False) -> bool:
-        """
-        Compare prefix-list config, treating omitted description as empty in replace-style states.
-
-        ``NDStateMachine`` calls this with ``exclude_unset=True`` for ``merged``,
-        where omitted fields must be left untouched. For ``replaced`` and
-        ``overridden`` it passes ``exclude_unset=False``; in that path an omitted
-        description means the desired value is empty/absent, so a stale controller
-        description must trigger an update.
-        """
-        if not exclude_unset and isinstance(other, PrefixListModel):
-            if other.description is None and self.description not in (None, ""):
-                return False
-        return super().get_diff(other, exclude_unset=exclude_unset)
 
     @classmethod
     def validate_config_for_state(cls, config: list[dict[str, Any]], state: str) -> None:

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -86,6 +86,9 @@ def _is_effectively_empty(value: Any) -> bool:
 
     None
     """
+    # Lists are only empty-normalized when literally `[]` -- a list of empty markers ([""], [{}]) is NOT collapsed,
+    # unlike the dict branch below. ND has only been observed echoing literal `[]` for never-configured list fields;
+    # collapsing non-empty lists without lab evidence could mask a real pending removal.
     if value is None or value == "" or value == [] or value == {}:
         return True
     if isinstance(value, dict):
@@ -116,6 +119,10 @@ def has_removals(existing_data: Any, proposed_data: Any) -> bool:
             continue
         if key not in proposed_data:
             return True
+        # Recurse into dicts only -- lists are deliberately not descended into. A removal inside a list element
+        # (e.g. a nested dict that loses a key) is already caught by the forward `issubset` pass, which matches
+        # list elements bidirectionally, so any element divergence classifies as changed there; a wholly-omitted
+        # list key is caught by the key-presence check above.
         if isinstance(value, dict) and has_removals(value, proposed_data[key]):
             return True
 

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -75,6 +75,53 @@ def issubset(subset: Any, superset: Any) -> bool:
     return True
 
 
+def _is_effectively_empty(value: Any) -> bool:
+    """
+    # Summary
+
+    Return `True` when `value` carries no user-visible content: `None`, `""`, `[]`, `{}`, or a dict whose values are all themselves effectively empty.
+    ND echoes such empty markers for fields the user never configured, so `has_removals` must not treat them as removable values.
+
+    ## Raises
+
+    None
+    """
+    if value is None or value == "" or value == [] or value == {}:
+        return True
+    if isinstance(value, dict):
+        return all(_is_effectively_empty(item) for item in value.values())
+    return False
+
+
+def has_removals(existing_data: Any, proposed_data: Any) -> bool:
+    """
+    # Summary
+
+    Return `True` when `existing_data` carries a non-empty key that is absent from `proposed_data` (issue #410: the reverse pass for
+    `replaced`/`overridden` diff classification). Only key *presence* is examined -- value differences between keys present on both
+    sides are the forward `issubset` pass's job. Keys whose existing value is effectively empty (`None`, `""`, `[]`, `{}`, or a dict
+    of only such values) are normalized to absent, so ND-echoed empty markers for never-configured fields do not break idempotency.
+    Recurses into dicts present on both sides; non-dict inputs (including a dict/non-dict type conflict, which the forward pass
+    already classifies as changed) report no removals.
+
+    ## Raises
+
+    None
+    """
+    if not isinstance(existing_data, dict) or not isinstance(proposed_data, dict):
+        return False
+
+    for key, value in existing_data.items():
+        if _is_effectively_empty(value):
+            continue
+        if key not in proposed_data:
+            return True
+        if isinstance(value, dict) and has_removals(value, proposed_data[key]):
+            return True
+
+    return False
+
+
 def remove_unwanted_keys(data: dict, unwanted_keys: list[str | list[str]]) -> dict:
     """Remove unwanted keys from dict (supports nested paths)."""
     data = deepcopy(data)

--- a/plugins/modules/nd_interface_port_channel_trunk_host.py
+++ b/plugins/modules/nd_interface_port_channel_trunk_host.py
@@ -193,10 +193,6 @@ options:
                       interfaces inherit trunk-mode settings from this policy.
                     type: list
                     elements: str
-                  ptp:
-                    description:
-                    - Whether Precision Time Protocol is enabled on the port-channel.
-                    type: bool
                   qos:
                     description:
                     - Whether a QoS policy is applied to the port-channel.

--- a/tests/unit/module_utils/models/test_base_model_reverse_diff.py
+++ b/tests/unit/module_utils/models/test_base_model_reverse_diff.py
@@ -661,3 +661,68 @@ def test_base_model_reverse_diff_00550() -> None:
     existing = LocalUserModel.from_response({"loginID": "jdoe", "xLaunch": True})
     proposed = LocalUserModel.from_config({"login_id": "jdoe"})
     assert existing.get_diff(proposed, exclude_unset=False) is False
+
+
+# --- 006xx: efficiency contract -- the reverse pass reuses the forward dumps ---
+
+
+def test_base_model_reverse_diff_00600(monkeypatch) -> None:
+    """
+    # Summary
+
+    The replaced/overridden no-diff path performs exactly one `model_dump` per side: the reverse pass derives its
+    payload-scoped dicts from the already-computed forward dumps instead of re-dumping both models. Guards the
+    PR #422 review's efficiency finding against regression -- a second dump per side doubles classification cost
+    for every no-diff item in a `query_all` inventory.
+
+    ## Test
+
+    - `NDBaseModel.model_dump` is wrapped with a call counter.
+    - `get_diff(proposed, exclude_unset=False)` runs on an idempotent loopback pair (the reverse pass executes).
+    - `no_diff` is reported and exactly 2 dumps are observed (one per side).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_diff_dict()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = LoopbackInterfaceModel.from_response(nd_loopback_response({"adminState": True, "description": "kept"}))
+    proposed = LoopbackInterfaceModel.from_config(loopback_config({"admin_state": True, "description": "kept"}))
+
+    calls = {"count": 0}
+    original_model_dump = NDBaseModel.model_dump
+
+    def counting_model_dump(self, *args, **kwargs):
+        calls["count"] += 1
+        return original_model_dump(self, *args, **kwargs)
+
+    monkeypatch.setattr(NDBaseModel, "model_dump", counting_model_dump)
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+    assert calls["count"] == 2, f"expected 2 model dumps (one per side), observed {calls['count']}"
+
+
+def test_base_model_reverse_diff_00610() -> None:
+    """
+    # Summary
+
+    `to_reverse_diff_dict` called standalone still yields the payload-scoped, scrubbed dict: top-level
+    `payload_exclude_fields` are absent (by alias), and `reverse_diff_defaults` matches are stripped, identical to
+    the dict `get_diff` derives internally.
+
+    ## Test
+
+    - A loopback model built from a response carrying `switchIp` (payload-excluded) and default-echo fields.
+    - `to_reverse_diff_dict()` omits `switchIp`, omits table-default matches, keeps non-default values.
+
+    ## Classes and Methods
+
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = LoopbackInterfaceModel.from_response(nd_loopback_response({"adminState": True, "description": "kept", "routeMapTag": 12345}))
+    data = existing.to_reverse_diff_dict()
+    assert "switchIp" not in data
+    policy = data["configData"]["networkOS"]["policy"]
+    assert "adminState" not in policy  # reverse_diff_defaults: adminState True stripped
+    assert "routeMapTag" not in policy  # reverse_diff_defaults: "12345" (dumped form) stripped
+    assert policy["description"] == "kept"

--- a/tests/unit/module_utils/models/test_base_model_reverse_diff.py
+++ b/tests/unit/module_utils/models/test_base_model_reverse_diff.py
@@ -753,6 +753,52 @@ def test_base_model_reverse_diff_00580() -> None:
     assert existing.get_diff(proposed, exclude_unset=False) is False
 
 
+def test_base_model_reverse_diff_00590() -> None:
+    """
+    # Summary
+
+    ND 4.2.1 echoes a collapsed `allowedVlans: "none"` on trunkVpcHost GETs when the user never set it (lab-verified
+    2026-08-07 on SITE1), but the write-side dump fans the field out to per-peer `peer1AllowedVlans`/`peer2AllowedVlans`
+    (deviation: vpc-interface-peer-vlan-collapse). The `reverse_diff_defaults` entries must therefore use the dumped-form
+    per-peer keys -- a collapsed-form `allowedVlans` entry never matches and replaced/overridden loops forever.
+
+    ## Test
+
+    - An existing `TrunkVpcHostPolicyModel` built from a response carrying the collapsed `allowedVlans: "none"` echo.
+    - A proposed model re-stating the configured fields but omitting `allowed_vlans`: `get_diff` is `True` (no difference).
+    - A proposed model explicitly setting `allowed_vlans: "100-200"`: `get_diff` is `False` (difference detected).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = TrunkVpcHostPolicyModel.from_response(
+        {
+            "policyType": "trunkVpcHost",
+            "peerSwitchId": "FDOPEER0001",
+            "adminState": True,
+            "allowedVlans": "none",
+            "peer1PortChannelId": 20,
+            "peer1MemberPorts": ["Ethernet1/6"],
+            "peer2PortChannelId": 20,
+            "peer2MemberPorts": ["Ethernet1/6"],
+        }
+    )
+    trunk_config = {
+        "admin_state": True,
+        "peer1_port_channel_id": 20,
+        "peer1_member_ports": ["Ethernet1/6"],
+        "peer2_port_channel_id": 20,
+        "peer2_member_ports": ["Ethernet1/6"],
+    }
+    proposed = TrunkVpcHostPolicyModel.from_config(dict(trunk_config))
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+    proposed_explicit = TrunkVpcHostPolicyModel.from_config({**trunk_config, "allowed_vlans": "100-200"})
+    assert existing.get_diff(proposed_explicit, exclude_unset=False) is False
+
+
 # --- 006xx: efficiency contract -- the reverse pass reuses the forward dumps ---
 
 

--- a/tests/unit/module_utils/models/test_base_model_reverse_diff.py
+++ b/tests/unit/module_utils/models/test_base_model_reverse_diff.py
@@ -665,9 +665,10 @@ def test_base_model_reverse_diff_00550() -> None:
 
 # The ND-injected `ptp` echo observed on port-channel policy GETs (deviation: interface-get-undocumented-ptp-field).
 # `ptp` is deliberately NOT a field on PortChannelTrunkHostPolicyModel: intPortChannelTrunkHostTemplate declares no
-# such property, and a lab probe (2026-08-12, SITE1, ND 4.2.1.10) proved ND persists and echoes a client-sent `ptp`
-# but generates ZERO pending CLI from it (persist-but-inert). Like the sibling ethernet/vPC models, the injected key
-# is dropped at parse time by `extra="ignore"`, so no reverse-pass exclusion is needed.
+# such property, and a lab probe (2026-08-12, SITE1, ND 4.2.1.10, fabric PTP disabled) proved ND persists and echoes
+# a client-sent `ptp` but generates ZERO pending CLI from it there; on a PTP-enabled fabric the fabric-level deploy
+# owns the stored value fabric-wide regardless of per-interface intent. Like the sibling ethernet/vPC models, the
+# injected key is dropped at parse time by `extra="ignore"`, so no reverse-pass exclusion is needed.
 PORT_CHANNEL_TRUNK_HOST_PTP_ECHO = {
     "policyType": "trunkPoHost",
     "adminState": True,
@@ -738,8 +739,9 @@ def test_base_model_reverse_diff_00580() -> None:
 
     `ptp` is not part of the model's writable surface: it is not a declared field, and a response-injected value is
     dropped entirely at parse time (no attribute, absent from every dump) rather than retained as an extra. A lab
-    probe (2026-08-12, SITE1, ND 4.2.1.10) proved a client-sent `ptp` is persist-but-inert — ND stores and echoes
-    it but generates no pending CLI — so exposing it would be a silent no-op that fakes success.
+    probe (2026-08-12, SITE1, ND 4.2.1.10, fabric PTP disabled) proved a client-sent `ptp` is persist-but-inert
+    there — ND stores and echoes it but generates no pending CLI — and on a PTP-enabled fabric the fabric-level
+    deploy owns the stored value fabric-wide, so exposing it would fake per-interface control in both regimes.
 
     ## Test
 

--- a/tests/unit/module_utils/models/test_base_model_reverse_diff.py
+++ b/tests/unit/module_utils/models/test_base_model_reverse_diff.py
@@ -32,8 +32,10 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_ch
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import PortChannelTrunkHostPolicyModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import SubinterfaceManagedPolicyModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.svi_interface import SviPolicyModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import AccessVpcHostPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import AccessVpcHostInterfaceModel, AccessVpcHostPolicyModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import TrunkVpcHostPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ebgp_vxlan import FabricEbgpModel, VxlanEbgpManagementModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 
 SWITCH_IP = "192.0.2.10"
@@ -458,3 +460,204 @@ def test_base_model_reverse_diff_00430(policy_cls) -> None:
     existing = policy_cls.from_response(echo)
     proposed = policy_cls.from_config({"admin_state": True})
     assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+# --- 005xx: server-populated existing-side data the proposed config can never express ---
+
+
+VPC_ACCESS_RESPONSE = {
+    "switchIp": "192.168.1.1",
+    "interfaceName": "vpc100",
+    "interfaceType": "vpc",
+    "configData": {
+        "mode": "access",
+        "networkOS": {
+            "networkOSType": "nx-os",
+            "policy": {
+                "policyType": "accessVpcHost",
+                "peerSwitchId": "FDOPEER0001",
+                "adminState": True,
+                "accessVlan": 10,
+                "peer1PortChannelId": 100,
+                "peer2PortChannelId": 100,
+                "lacpRate": "fast",
+            },
+        },
+    },
+}
+
+VPC_ACCESS_CONFIG = {
+    "switch_ip": "192.168.1.1",
+    "interface_name": "vpc100",
+    "config_data": {
+        "network_os": {
+            "policy": {
+                "admin_state": True,
+                "access_vlan": 10,
+                "peer1_port_channel_id": 100,
+                "peer2_port_channel_id": 100,
+                "lacp_rate": "fast",
+            },
+        },
+    },
+}
+
+
+def test_base_model_reverse_diff_00500() -> None:
+    """
+    # Summary
+
+    ND echoes the orchestrator-injected `peerSwitchId` inside the vPC policy block; a proposed config restating every
+    user-settable field identically must stay `no_diff` on the replaced/overridden path even though it can never
+    express `peer_switch_id` (not in the argspec; injected only at payload-build time).
+
+    ## Test
+
+    - An existing `AccessVpcHostInterfaceModel` built from a 4.2.1-wire-shaped response carrying `peerSwitchId`.
+    - A proposed model built from config restating every user-settable field with identical values.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = AccessVpcHostInterfaceModel.from_response(VPC_ACCESS_RESPONSE)
+    proposed = AccessVpcHostInterfaceModel.from_config(VPC_ACCESS_CONFIG)
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00510() -> None:
+    """
+    # Summary
+
+    The trunk vPC policy model carries the same orchestrator-injected `peerSwitchId` echo as the access variant and
+    must likewise stay `no_diff` when the proposed config restates all user-settable fields.
+
+    ## Test
+
+    - An existing `TrunkVpcHostPolicyModel` built from an echo carrying `peerSwitchId` and `adminState`.
+    - A proposed model built from config carrying only `admin_state`.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = TrunkVpcHostPolicyModel.from_response({"policyType": "trunkVpcHost", "peerSwitchId": "FDOPEER0001", "adminState": True})
+    proposed = TrunkVpcHostPolicyModel.from_config({"admin_state": True})
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00520() -> None:
+    """
+    # Summary
+
+    A genuine removal must still be detected on vPC models once `peerSwitchId` is excluded: existing carries a
+    user-settable field (`accessVlan`) the proposed config omits, so the reverse pass must report a difference.
+
+    ## Test
+
+    - The existing model from `test_base_model_reverse_diff_00500` (carries `accessVlan` and `peerSwitchId`).
+    - A proposed model built from the same config minus `access_vlan`.
+    - `get_diff(proposed, exclude_unset=False)` is `False` (difference detected).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - utils.has_removals()
+    """
+    existing = AccessVpcHostInterfaceModel.from_response(VPC_ACCESS_RESPONSE)
+    config = {
+        "switch_ip": "192.168.1.1",
+        "interface_name": "vpc100",
+        "config_data": {
+            "network_os": {
+                "policy": {
+                    "admin_state": True,
+                    "peer1_port_channel_id": 100,
+                    "peer2_port_channel_id": 100,
+                    "lacp_rate": "fast",
+                },
+            },
+        },
+    }
+    proposed = AccessVpcHostInterfaceModel.from_config(config)
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+
+def test_base_model_reverse_diff_00530() -> None:
+    """
+    # Summary
+
+    Fabric models use `extra="allow"`, so ND GET responses populate undeclared keys on the existing side; those extras
+    can never appear in proposed config (argspec-validated) and must not count as removals on the replaced path.
+
+    ## Test
+
+    - An existing `FabricEbgpModel` carrying a top-level extra key (`metadata`) and a nested management extra key.
+    - A proposed model built from the same declared fields with no extras.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = FabricEbgpModel(
+        fabric_name="F1",
+        management=VxlanEbgpManagementModel(bgp_asn="65001", **{"someServerField": "x"}),
+        **{"metadata": {"uuid": "abc-123"}},
+    )
+    proposed = FabricEbgpModel(fabric_name="F1", management=VxlanEbgpManagementModel(bgp_asn="65001"))
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00540() -> None:
+    """
+    # Summary
+
+    ND echoes `xLaunch=false`, `reuseLimitation=0`, and `timeIntervalLimitation=0` for a local user created without
+    those options (lab-verified; the module's integration tests assert these `before` values). A proposed config
+    omitting them must stay `no_diff` on the replaced path -- `False`/`0` are not "effectively empty", so this
+    normalization must come from the model's `reverse_diff_defaults` table.
+
+    ## Test
+
+    - An existing `LocalUserModel` built from a response echoing the three falsy defaults.
+    - A proposed model built from config carrying only `login_id`.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = LocalUserModel.from_response({"loginID": "jdoe", "xLaunch": False, "reuseLimitation": 0, "timeIntervalLimitation": 0})
+    proposed = LocalUserModel.from_config({"login_id": "jdoe"})
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00550() -> None:
+    """
+    # Summary
+
+    A genuine pending reset must still be detected for local users: existing has `xLaunch=true` (non-default), the
+    proposed config omits `remote_user_authorization`, so the full-payload PUT would reset it and the reverse pass
+    must report a difference.
+
+    ## Test
+
+    - An existing `LocalUserModel` built from a response echoing `xLaunch=true`.
+    - A proposed model built from config carrying only `login_id`.
+    - `get_diff(proposed, exclude_unset=False)` is `False` (difference detected).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - utils.has_removals()
+    """
+    existing = LocalUserModel.from_response({"loginID": "jdoe", "xLaunch": True})
+    proposed = LocalUserModel.from_config({"login_id": "jdoe"})
+    assert existing.get_diff(proposed, exclude_unset=False) is False

--- a/tests/unit/module_utils/models/test_base_model_reverse_diff.py
+++ b/tests/unit/module_utils/models/test_base_model_reverse_diff.py
@@ -869,3 +869,27 @@ def test_base_model_reverse_diff_00610() -> None:
     assert "adminState" not in policy  # reverse_diff_defaults: adminState True stripped
     assert "routeMapTag" not in policy  # reverse_diff_defaults: "12345" (dumped form) stripped
     assert policy["description"] == "kept"
+
+
+@pytest.mark.parametrize("exclude_unset", [False, True])
+def test_base_model_reverse_diff_00620(exclude_unset: bool) -> None:
+    """
+    # Summary
+
+    `get_diff` rejects a model of a different type with `TypeError`, mirroring `merge` (PR #422 review). The reverse
+    pass calls `other._apply_reverse_diff_scope`, which assumes `other` carries this model's `reverse_diff_*`
+    declarations, so a cross-type comparison is a programming error rather than a "changed" classification.
+
+    ## Test
+
+    - A loopback policy model compared against an SVI policy model, on both the merged and replaced/overridden paths.
+    - `TypeError` is raised naming both types; a same-type comparison still returns a bool.
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    """
+    existing = LoopbackPolicyModel(description="kept")
+    with pytest.raises(TypeError, match=r"Cannot diff SviPolicyModel against LoopbackPolicyModel"):
+        existing.get_diff(SviPolicyModel(), exclude_unset=exclude_unset)
+    assert existing.get_diff(LoopbackPolicyModel(description="kept"), exclude_unset=exclude_unset) is True

--- a/tests/unit/module_utils/models/test_base_model_reverse_diff.py
+++ b/tests/unit/module_utils/models/test_base_model_reverse_diff.py
@@ -663,6 +663,96 @@ def test_base_model_reverse_diff_00550() -> None:
     assert existing.get_diff(proposed, exclude_unset=False) is False
 
 
+# The ND-injected `ptp` echo observed on port-channel policy GETs (deviation: interface-get-undocumented-ptp-field).
+# `ptp` is a declared field on PortChannelTrunkHostPolicyModel, so unlike the sibling models (where the injected key
+# lands in `model_extra` and is scrubbed as an extra) it survives `from_response` and must be stripped explicitly.
+PORT_CHANNEL_TRUNK_HOST_PTP_ECHO = {
+    "policyType": "trunkPoHost",
+    "adminState": True,
+    "allowedVlans": "100-110",
+    "ports": ["Ethernet1/1", "Ethernet1/2"],
+}
+
+PORT_CHANNEL_TRUNK_HOST_PTP_CONFIG = {
+    "admin_state": True,
+    "allowed_vlans": "100-110",
+    "ports": ["Ethernet1/1", "Ethernet1/2"],
+}
+
+
+def test_base_model_reverse_diff_00560() -> None:
+    """
+    # Summary
+
+    ND injects `ptp: false` into port-channel trunkPoHost policy GETs even though `intPortChannelTrunkHostTemplate`
+    declares no `ptp` property (deviation: interface-get-undocumented-ptp-field). Because `ptp` is a declared field
+    on `PortChannelTrunkHostPolicyModel`, the echo survives `from_response`; a proposed config omitting `ptp` must
+    still be `no_diff` on the replaced/overridden path (PR #422 review finding).
+
+    ## Test
+
+    - An existing `PortChannelTrunkHostPolicyModel` built from a response carrying the injected `ptp: false`.
+    - A proposed model re-stating the configured fields but omitting `ptp`.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = PortChannelTrunkHostPolicyModel.from_response({**PORT_CHANNEL_TRUNK_HOST_PTP_ECHO, "ptp": False})
+    proposed = PortChannelTrunkHostPolicyModel.from_config(dict(PORT_CHANNEL_TRUNK_HOST_PTP_CONFIG))
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00570() -> None:
+    """
+    # Summary
+
+    After a fabric-PTP deploy, ND rewrites the injected `ptp` to `true` fabric-wide on ALL existing physical and
+    port-channel records, even on interfaces with no PTP configuration (deviation:
+    interface-get-undocumented-ptp-field). The strip must therefore be value-independent (`reverse_diff_exclude`,
+    not a `reverse_diff_defaults` entry of `False`) so idempotency also holds against the `true` rewrite.
+
+    ## Test
+
+    - An existing `PortChannelTrunkHostPolicyModel` built from a response carrying the rewritten `ptp: true`.
+    - A proposed model re-stating the configured fields but omitting `ptp`.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = PortChannelTrunkHostPolicyModel.from_response({**PORT_CHANNEL_TRUNK_HOST_PTP_ECHO, "ptp": True})
+    proposed = PortChannelTrunkHostPolicyModel.from_config(dict(PORT_CHANNEL_TRUNK_HOST_PTP_CONFIG))
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00580() -> None:
+    """
+    # Summary
+
+    The `ptp` strip is reverse-pass-only: a user-set `ptp` that differs from the existing-side echo must still be
+    detected by the forward diff, so explicit PTP configuration keeps working.
+
+    ## Test
+
+    - An existing `PortChannelTrunkHostPolicyModel` built from a response carrying `ptp: false`.
+    - A proposed model explicitly setting `ptp: true`.
+    - `get_diff(proposed, exclude_unset=False)` is `False` (difference detected).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_diff_dict()
+    """
+    existing = PortChannelTrunkHostPolicyModel.from_response({**PORT_CHANNEL_TRUNK_HOST_PTP_ECHO, "ptp": False})
+    proposed = PortChannelTrunkHostPolicyModel.from_config({**PORT_CHANNEL_TRUNK_HOST_PTP_CONFIG, "ptp": True})
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+
 # --- 006xx: efficiency contract -- the reverse pass reuses the forward dumps ---
 
 

--- a/tests/unit/module_utils/models/test_base_model_reverse_diff.py
+++ b/tests/unit/module_utils/models/test_base_model_reverse_diff.py
@@ -665,10 +665,11 @@ def test_base_model_reverse_diff_00550() -> None:
 
 # The ND-injected `ptp` echo observed on port-channel policy GETs (deviation: interface-get-undocumented-ptp-field).
 # `ptp` is deliberately NOT a field on PortChannelTrunkHostPolicyModel: intPortChannelTrunkHostTemplate declares no
-# such property, and a lab probe (2026-08-12, SITE1, ND 4.2.1.10, fabric PTP disabled) proved ND persists and echoes
-# a client-sent `ptp` but generates ZERO pending CLI from it there; on a PTP-enabled fabric the fabric-level deploy
-# owns the stored value fabric-wide regardless of per-interface intent. Like the sibling ethernet/vPC models, the
-# injected key is dropped at parse time by `extra="ignore"`, so no reverse-pass exclusion is needed.
+# such property, and lab probes (2026-08-12, SITE1, ND 4.2.1.10, all three fabric-PTP regimes: disabled,
+# enabled-not-deployed, deployed) proved ND persists and echoes a client-sent `ptp` but generates ZERO pending CLI
+# from it in every regime; ND's own PTP CLI lands only on physical interfaces, never under port-channels. Like the
+# sibling ethernet/vPC models, the injected key is dropped at parse time by `extra="ignore"`, so no reverse-pass
+# exclusion is needed.
 PORT_CHANNEL_TRUNK_HOST_PTP_ECHO = {
     "policyType": "trunkPoHost",
     "adminState": True,
@@ -738,10 +739,10 @@ def test_base_model_reverse_diff_00580() -> None:
     # Summary
 
     `ptp` is not part of the model's writable surface: it is not a declared field, and a response-injected value is
-    dropped entirely at parse time (no attribute, absent from every dump) rather than retained as an extra. A lab
-    probe (2026-08-12, SITE1, ND 4.2.1.10, fabric PTP disabled) proved a client-sent `ptp` is persist-but-inert
-    there — ND stores and echoes it but generates no pending CLI — and on a PTP-enabled fabric the fabric-level
-    deploy owns the stored value fabric-wide, so exposing it would fake per-interface control in both regimes.
+    dropped entirely at parse time (no attribute, absent from every dump) rather than retained as an extra. Lab
+    probes (2026-08-12, SITE1, ND 4.2.1.10) covered all three fabric-PTP regimes — disabled, enabled-not-deployed,
+    and deployed — and in every one a client-sent `ptp` is persist-but-inert: ND stores and echoes it but generates
+    no pending CLI, so exposing the field would fake per-interface control unconditionally.
 
     ## Test
 

--- a/tests/unit/module_utils/models/test_base_model_reverse_diff.py
+++ b/tests/unit/module_utils/models/test_base_model_reverse_diff.py
@@ -1,0 +1,460 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the `NDBaseModel.get_diff` reverse pass (issue #410).
+
+For `replaced`/`overridden` states the state machine calls `get_diff(..., exclude_unset=False)`; a proposed
+item that merely *removed* a field relative to existing device config must classify as a difference so the
+full-payload PUT (which clears omitted fields on ND 4.2.1) is issued. The reverse pass is scoped to payload
+shape -- fields in `exclude_from_diff` or `payload_exclude_fields` never count as removals -- and normalizes
+ND-echoed empty markers (`""`, `[]`, `{}`) to absent so idempotent runs stay idempotent.
+
+The `merged` path (`exclude_unset=True`) is unaffected: omitted fields mean "leave untouched" there.
+"""
+
+# pylint: disable=line-too-long
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import EthernetAccessPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import EthernetTrunkHostPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel, LoopbackPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import PortChannelAccessPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import PortChannelTrunkHostPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import SubinterfaceManagedPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.svi_interface import SviPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_access_interface import AccessVpcHostPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_trunk_host_interface import TrunkVpcHostPolicyModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+
+SWITCH_IP = "192.0.2.10"
+INTERFACE_NAME = "loopback10"
+
+
+def nd_loopback_response(policy_fields: dict) -> dict:
+    """Build an ND-shaped loopback GET response dict carrying the given aliased policy fields."""
+    policy = {"policyType": "loopback"}
+    policy.update(policy_fields)
+    return {"switchIp": SWITCH_IP, "interfaceName": INTERFACE_NAME, "configData": {"networkOS": {"policy": policy}}}
+
+
+def loopback_config(policy_fields: dict) -> dict:
+    """Build an Ansible-shaped proposed loopback config dict carrying the given snake_case policy fields."""
+    return {"switch_ip": SWITCH_IP, "interface_name": INTERFACE_NAME, "config_data": {"network_os": {"policy": policy_fields}}}
+
+
+def test_base_model_reverse_diff_00100() -> None:
+    """
+    # Summary
+
+    A removal-only proposed item is a difference on the replaced/overridden path: existing carries a nested policy
+    field the proposed config omits, so `get_diff(exclude_unset=False)` must report a change (issue #410).
+
+    ## Test
+
+    - An existing model is built from an ND response whose policy carries `adminState` and `description`.
+    - A proposed model is built from config carrying only `admin_state` (description intentionally omitted).
+    - `get_diff(proposed, exclude_unset=False)` is `False` (difference detected).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    - utils.has_removals()
+    """
+    existing = LoopbackInterfaceModel.from_response(nd_loopback_response({"adminState": True, "description": "stale description"}))
+    proposed = LoopbackInterfaceModel.from_config(loopback_config({"admin_state": True}))
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+
+def test_base_model_reverse_diff_00110() -> None:
+    """
+    # Summary
+
+    The same removal-only proposed item is NOT a difference on the merged path: omitted fields mean "leave
+    untouched" under `merged`, so the reverse pass must not run when `exclude_unset=True`.
+
+    ## Test
+
+    - The identical existing/proposed pair from `test_base_model_reverse_diff_00100`.
+    - `get_diff(proposed, exclude_unset=True)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    """
+    existing = LoopbackInterfaceModel.from_response(nd_loopback_response({"adminState": True, "description": "stale description"}))
+    proposed = LoopbackInterfaceModel.from_config(loopback_config({"admin_state": True}))
+    assert existing.get_diff(proposed, exclude_unset=True) is True
+
+
+def test_base_model_reverse_diff_00120() -> None:
+    """
+    # Summary
+
+    No false positives: proposed config re-stating the full existing device state remains `no_diff` on the
+    replaced/overridden path, so idempotent runs stay idempotent.
+
+    ## Test
+
+    - An existing model is built from an ND response whose policy carries `adminState` and `description`.
+    - A proposed model is built from config re-stating both fields with the same values.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    """
+    existing = LoopbackInterfaceModel.from_response(nd_loopback_response({"adminState": True, "description": "kept"}))
+    proposed = LoopbackInterfaceModel.from_config(loopback_config({"admin_state": True, "description": "kept"}))
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00130() -> None:
+    """
+    # Summary
+
+    ND-echoed empty markers normalize to absent: an existing policy field echoed as `""` does not force a
+    difference when the proposed config omits it (generalizes the PrefixListModel description precedent).
+
+    ## Test
+
+    - An existing model is built from an ND response whose policy carries `adminState` and `extraConfig: ""`.
+    - A proposed model is built from config carrying only `admin_state`.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - utils.has_removals()
+    """
+    existing = LoopbackInterfaceModel.from_response(nd_loopback_response({"adminState": True, "extraConfig": ""}))
+    proposed = LoopbackInterfaceModel.from_config(loopback_config({"admin_state": True}))
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+class _ScopedModel(NDBaseModel):
+    """Minimal model exercising the reverse-pass scoping metadata (`exclude_from_diff`, `payload_exclude_fields`)."""
+
+    identifiers: ClassVar[list[str] | None] = ["name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+
+    exclude_from_diff: ClassVar[set[str]] = {"oper_status"}
+    payload_exclude_fields: ClassVar[set[str]] = {"serial"}
+
+    name: str = Field(alias="name")
+    serial: str | None = Field(default=None, alias="serial")
+    oper_status: str | None = Field(default=None, alias="operStatus")
+    description: str | None = Field(default=None, alias="description")
+
+
+def test_base_model_reverse_diff_00200() -> None:
+    """
+    # Summary
+
+    Server-populated fields are outside the reverse pass: existing-side values in `exclude_from_diff` or
+    `payload_exclude_fields` absent from proposed do NOT count as removals (they are not expressible in the
+    PUT payload, so their presence cannot mean a pending reset).
+
+    ## Test
+
+    - An existing model carries `serial` (payload-excluded) and `oper_status` (diff-excluded) but no user field.
+    - A proposed model carries only the identifier.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = _ScopedModel.from_response({"name": "item1", "serial": "FDO12345", "operStatus": "up"})
+    proposed = _ScopedModel.from_config({"name": "item1"})
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00210() -> None:
+    """
+    # Summary
+
+    A user-settable payload field on the same model DOES trigger the reverse pass, proving the scoping in
+    `test_base_model_reverse_diff_00200` is the exclusion sets and not an accidental no-op.
+
+    ## Test
+
+    - The existing model additionally carries `description`, which is in neither exclusion set.
+    - The proposed model still carries only the identifier.
+    - `get_diff(proposed, exclude_unset=False)` is `False` (difference detected).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = _ScopedModel.from_response({"name": "item1", "serial": "FDO12345", "operStatus": "up", "description": "stale"})
+    proposed = _ScopedModel.from_config({"name": "item1"})
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+
+class _DefaultsPolicyModel(NDNestedModel):
+    """Nested policy model declaring ND-template defaults for the reverse pass (issue #410 default-echo normalization)."""
+
+    reverse_diff_defaults: ClassVar[dict] = {"mtu": "jumbo", "cdp": True}
+
+    admin_state: bool | None = Field(default=None, alias="adminState")
+    mtu: str | None = Field(default=None, alias="mtu")
+    cdp: bool | None = Field(default=None, alias="cdp")
+    description: str | None = Field(default=None, alias="description")
+
+
+class _DefaultsModel(NDBaseModel):
+    """Top-level model carrying a nested policy, exercising recursive reverse-pass default normalization."""
+
+    identifiers: ClassVar[list[str] | None] = ["name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+
+    reverse_diff_defaults: ClassVar[dict] = {"tier": "gold"}
+
+    name: str = Field(alias="name")
+    tier: str | None = Field(default=None, alias="tier")
+    policy: _DefaultsPolicyModel | None = Field(default=None, alias="policy")
+
+
+def test_base_model_reverse_diff_00300() -> None:
+    """
+    # Summary
+
+    An existing-side value equal to its declared `reverse_diff_defaults` entry normalizes to absent: ND echoes
+    template defaults for every unset field (lab-verified on 4.2.1), so a default-valued echo omitted from the
+    proposed config must NOT count as a removal, keeping replaced/overridden runs idempotent.
+
+    ## Test
+
+    - The existing model carries top-level `tier: "gold"` (the declared default) and nothing else the proposed omits.
+    - The proposed model carries only the identifier.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = _DefaultsModel.from_response({"name": "item1", "tier": "gold"})
+    proposed = _DefaultsModel.from_config({"name": "item1"})
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00310() -> None:
+    """
+    # Summary
+
+    An existing-side value that DIFFERS from its declared default still counts as a removal: the full-payload PUT
+    would revert it to the template default, which is a real device change.
+
+    ## Test
+
+    - The existing model carries top-level `tier: "silver"` (not the declared `"gold"` default).
+    - The proposed model carries only the identifier.
+    - `get_diff(proposed, exclude_unset=False)` is `False` (difference detected).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = _DefaultsModel.from_response({"name": "item1", "tier": "silver"})
+    proposed = _DefaultsModel.from_config({"name": "item1"})
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+
+def test_base_model_reverse_diff_00320() -> None:
+    """
+    # Summary
+
+    Default normalization recurses into nested models using each nested model's own `reverse_diff_defaults`:
+    a nested policy echoing only template defaults does not force a difference, while a non-default nested value
+    (or a default-less field like `description`) still does.
+
+    ## Test
+
+    - Existing carries a nested policy `{adminState: true, mtu: "jumbo", cdp: true}`; proposed re-states only
+      `admin_state`. Both declared defaults normalize away -> no difference.
+    - Existing with nested `mtu: "default"` (non-default) -> difference.
+    - Existing with nested `description` (no declared default) -> difference.
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    proposed = _DefaultsModel.from_config({"name": "item1", "policy": {"admin_state": True}})
+
+    existing = _DefaultsModel.from_response({"name": "item1", "policy": {"adminState": True, "mtu": "jumbo", "cdp": True}})
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+    existing = _DefaultsModel.from_response({"name": "item1", "policy": {"adminState": True, "mtu": "default"}})
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+    existing = _DefaultsModel.from_response({"name": "item1", "policy": {"adminState": True, "description": "stale"}})
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+
+# The full trunkHost policy echo observed on ND 4.2.1 (SITE1, S1_TOR1 Ethernet1/10) after an admin_state-only PUT:
+# ND echoes the schema-declared int_trunk_host template default for every unset field. Hard-coded (not derived from
+# the model's table) so an accidental table edit fails this test.
+ND_421_TRUNK_HOST_DEFAULT_ECHO = {
+    "adminState": True,
+    "allowedVlans": "none",
+    "bpduFilter": "default",
+    "bpduGuard": "default",
+    "cdp": True,
+    "debounceTimer": 100,
+    "duplexMode": "auto",
+    "errorDetectionAcl": True,
+    "fec": "auto",
+    "linkType": "auto",
+    "monitor": False,
+    "mtu": "jumbo",
+    "negotiateAuto": True,
+    "netflow": False,
+    "orphanPort": False,
+    "pfc": False,
+    "policyType": "trunkHost",
+    "portTypeEdgeTrunk": True,
+    "ptp": False,
+    "qos": False,
+    "speed": "auto",
+    "stormControl": False,
+    "stormControlAction": "default",
+    "vlanMapping": False,
+}
+
+
+def test_base_model_reverse_diff_00400() -> None:
+    """
+    # Summary
+
+    The lab-observed ND 4.2.1 trunkHost default echo does not break replaced/overridden idempotency: an existing
+    policy carrying the full template-default echo, against proposed config re-stating only `admin_state`, is
+    `no_diff` (issue #410 lab verification, S1_TOR1 Ethernet1/10).
+
+    ## Test
+
+    - An existing `EthernetTrunkHostPolicyModel` is built from the verbatim ND echo captured in the lab.
+    - A proposed model is built from config carrying only `admin_state: true`.
+    - `get_diff(proposed, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    existing = EthernetTrunkHostPolicyModel.from_response(ND_421_TRUNK_HOST_DEFAULT_ECHO)
+    proposed = EthernetTrunkHostPolicyModel.from_config({"admin_state": True})
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_base_model_reverse_diff_00410() -> None:
+    """
+    # Summary
+
+    A non-default value inside the same echo still triggers the reverse pass: existing `mtu: "default"` (the
+    template default is `"jumbo"`) omitted from proposed config means the full-payload PUT would revert it.
+
+    ## Test
+
+    - The lab echo with `mtu` flipped to `"default"`.
+    - The same admin_state-only proposed model.
+    - `get_diff(proposed, exclude_unset=False)` is `False` (difference detected).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    echo = dict(ND_421_TRUNK_HOST_DEFAULT_ECHO)
+    echo["mtu"] = "default"
+    existing = EthernetTrunkHostPolicyModel.from_response(echo)
+    proposed = EthernetTrunkHostPolicyModel.from_config({"admin_state": True})
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+
+def test_base_model_reverse_diff_00420() -> None:
+    """
+    # Summary
+
+    A user-created loopback echoes ND-injected `routeMapTag: 12345` (the intLoopbackTemplate default, lab-verified
+    on 4.2.1) even though the user never sent it -- it must not break replaced/overridden idempotency, while a
+    non-default `routeMapTag` must still trigger the reverse pass.
+
+    ## Test
+
+    - An existing `LoopbackPolicyModel` built from the lab-observed echo (adminState/description/ip/routeMapTag).
+    - Proposed config re-stating admin_state/description/ip but omitting `route_map_tag`: `no_diff`.
+    - The same echo with `routeMapTag: 54321`: difference detected.
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    echo = {"adminState": True, "description": "issue-410 probe", "ip": "10.99.205.1", "policyType": "loopback", "routeMapTag": 12345}
+    proposed = LoopbackPolicyModel.from_config({"admin_state": True, "description": "issue-410 probe", "ip": "10.99.205.1"})
+    existing = LoopbackPolicyModel.from_response(echo)
+    assert existing.get_diff(proposed, exclude_unset=False) is True
+
+    echo["routeMapTag"] = 54321
+    existing = LoopbackPolicyModel.from_response(echo)
+    assert existing.get_diff(proposed, exclude_unset=False) is False
+
+
+# Every Gen-3 interface policy model carrying a schema-sourced reverse_diff_defaults table. The echo for each is
+# derived from the model's own table (the invariant under test: echo == declared defaults -> normalized), with the
+# non-empty assertion preventing a trivially passing empty table.
+POLICY_MODELS_WITH_DEFAULTS = [
+    LoopbackPolicyModel,
+    EthernetAccessPolicyModel,
+    EthernetTrunkHostPolicyModel,
+    PortChannelAccessPolicyModel,
+    PortChannelTrunkHostPolicyModel,
+    AccessVpcHostPolicyModel,
+    TrunkVpcHostPolicyModel,
+    SviPolicyModel,
+    SubinterfaceManagedPolicyModel,
+]
+
+
+@pytest.mark.parametrize("policy_cls", POLICY_MODELS_WITH_DEFAULTS)
+def test_base_model_reverse_diff_00430(policy_cls) -> None:
+    """
+    # Summary
+
+    Every interface policy model declares a non-empty schema-sourced `reverse_diff_defaults` table, and an existing
+    policy echoing exactly those defaults diffs clean against an admin_state-only proposed config on the
+    replaced/overridden path.
+
+    ## Test
+
+    - The model's `reverse_diff_defaults` is non-empty (schema-sourced from the ND 4.2.1 OpenAPI template).
+    - An existing model built from an echo of exactly those defaults (plus the policyType discriminator).
+    - `get_diff(proposed_admin_state_only, exclude_unset=False)` is `True` (no difference).
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    """
+    assert policy_cls.reverse_diff_defaults, f"{policy_cls.__name__} must declare a schema-sourced reverse_diff_defaults table"
+    policy_type = policy_cls.model_fields["policy_type"].default
+    echo = {"policyType": getattr(policy_type, "value", policy_type), **policy_cls.reverse_diff_defaults}
+    existing = policy_cls.from_response(echo)
+    proposed = policy_cls.from_config({"admin_state": True})
+    assert existing.get_diff(proposed, exclude_unset=False) is True

--- a/tests/unit/module_utils/models/test_base_model_reverse_diff.py
+++ b/tests/unit/module_utils/models/test_base_model_reverse_diff.py
@@ -664,8 +664,10 @@ def test_base_model_reverse_diff_00550() -> None:
 
 
 # The ND-injected `ptp` echo observed on port-channel policy GETs (deviation: interface-get-undocumented-ptp-field).
-# `ptp` is a declared field on PortChannelTrunkHostPolicyModel, so unlike the sibling models (where the injected key
-# lands in `model_extra` and is scrubbed as an extra) it survives `from_response` and must be stripped explicitly.
+# `ptp` is deliberately NOT a field on PortChannelTrunkHostPolicyModel: intPortChannelTrunkHostTemplate declares no
+# such property, and a lab probe (2026-08-12, SITE1, ND 4.2.1.10) proved ND persists and echoes a client-sent `ptp`
+# but generates ZERO pending CLI from it (persist-but-inert). Like the sibling ethernet/vPC models, the injected key
+# is dropped at parse time by `extra="ignore"`, so no reverse-pass exclusion is needed.
 PORT_CHANNEL_TRUNK_HOST_PTP_ECHO = {
     "policyType": "trunkPoHost",
     "adminState": True,
@@ -685,9 +687,9 @@ def test_base_model_reverse_diff_00560() -> None:
     # Summary
 
     ND injects `ptp: false` into port-channel trunkPoHost policy GETs even though `intPortChannelTrunkHostTemplate`
-    declares no `ptp` property (deviation: interface-get-undocumented-ptp-field). Because `ptp` is a declared field
-    on `PortChannelTrunkHostPolicyModel`, the echo survives `from_response`; a proposed config omitting `ptp` must
-    still be `no_diff` on the replaced/overridden path (PR #422 review finding).
+    declares no `ptp` property (deviation: interface-get-undocumented-ptp-field). `ptp` is deliberately not modeled,
+    so the echo is dropped at parse time by `extra="ignore"` and a proposed config omitting `ptp` is `no_diff` on the
+    replaced/overridden path (PR #422 review finding).
 
     ## Test
 
@@ -697,8 +699,8 @@ def test_base_model_reverse_diff_00560() -> None:
 
     ## Classes and Methods
 
+    - NDBaseModel.from_response()
     - NDBaseModel.get_diff()
-    - NDBaseModel.to_reverse_diff_dict()
     """
     existing = PortChannelTrunkHostPolicyModel.from_response({**PORT_CHANNEL_TRUNK_HOST_PTP_ECHO, "ptp": False})
     proposed = PortChannelTrunkHostPolicyModel.from_config(dict(PORT_CHANNEL_TRUNK_HOST_PTP_CONFIG))
@@ -711,8 +713,8 @@ def test_base_model_reverse_diff_00570() -> None:
 
     After a fabric-PTP deploy, ND rewrites the injected `ptp` to `true` fabric-wide on ALL existing physical and
     port-channel records, even on interfaces with no PTP configuration (deviation:
-    interface-get-undocumented-ptp-field). The strip must therefore be value-independent (`reverse_diff_exclude`,
-    not a `reverse_diff_defaults` entry of `False`) so idempotency also holds against the `true` rewrite.
+    interface-get-undocumented-ptp-field). The parse-time drop is value-independent, so idempotency also holds
+    against the `true` rewrite.
 
     ## Test
 
@@ -722,8 +724,8 @@ def test_base_model_reverse_diff_00570() -> None:
 
     ## Classes and Methods
 
+    - NDBaseModel.from_response()
     - NDBaseModel.get_diff()
-    - NDBaseModel.to_reverse_diff_dict()
     """
     existing = PortChannelTrunkHostPolicyModel.from_response({**PORT_CHANNEL_TRUNK_HOST_PTP_ECHO, "ptp": True})
     proposed = PortChannelTrunkHostPolicyModel.from_config(dict(PORT_CHANNEL_TRUNK_HOST_PTP_CONFIG))
@@ -734,23 +736,25 @@ def test_base_model_reverse_diff_00580() -> None:
     """
     # Summary
 
-    The `ptp` strip is reverse-pass-only: a user-set `ptp` that differs from the existing-side echo must still be
-    detected by the forward diff, so explicit PTP configuration keeps working.
+    `ptp` is not part of the model's writable surface: it is not a declared field, and a response-injected value is
+    dropped entirely at parse time (no attribute, absent from every dump) rather than retained as an extra. A lab
+    probe (2026-08-12, SITE1, ND 4.2.1.10) proved a client-sent `ptp` is persist-but-inert — ND stores and echoes
+    it but generates no pending CLI — so exposing it would be a silent no-op that fakes success.
 
     ## Test
 
-    - An existing `PortChannelTrunkHostPolicyModel` built from a response carrying `ptp: false`.
-    - A proposed model explicitly setting `ptp: true`.
-    - `get_diff(proposed, exclude_unset=False)` is `False` (difference detected).
+    - `ptp` is not in `PortChannelTrunkHostPolicyModel.model_fields`.
+    - `from_response` with an injected `ptp` yields a model without the key in `to_diff_dict()` or `model_extra`.
 
     ## Classes and Methods
 
-    - NDBaseModel.get_diff()
+    - NDBaseModel.from_response()
     - NDBaseModel.to_diff_dict()
     """
-    existing = PortChannelTrunkHostPolicyModel.from_response({**PORT_CHANNEL_TRUNK_HOST_PTP_ECHO, "ptp": False})
-    proposed = PortChannelTrunkHostPolicyModel.from_config({**PORT_CHANNEL_TRUNK_HOST_PTP_CONFIG, "ptp": True})
-    assert existing.get_diff(proposed, exclude_unset=False) is False
+    assert "ptp" not in list(PortChannelTrunkHostPolicyModel.model_fields)
+    existing = PortChannelTrunkHostPolicyModel.from_response({**PORT_CHANNEL_TRUNK_HOST_PTP_ECHO, "ptp": True})
+    assert "ptp" not in existing.to_diff_dict()
+    assert not getattr(existing, "model_extra", None)
 
 
 def test_base_model_reverse_diff_00590() -> None:

--- a/tests/unit/module_utils/models/test_loopback_interface.py
+++ b/tests/unit/module_utils/models/test_loopback_interface.py
@@ -1404,12 +1404,15 @@ def test_loopback_interface_00620():
     """
     # Summary
 
-    Verify other with fewer fields (None excluded) -> True (subset).
+    Verify other with fewer fields (None excluded) is a difference on the default `exclude_unset=False`
+    (replaced/overridden) path -- the reverse pass detects the removed fields (issue #410) -- while the
+    `exclude_unset=True` (merged) path still treats the subset as no difference.
 
     ## Test
 
     - other has fewer fields than self
-    - get_diff returns True (other is subset of self)
+    - get_diff returns False by default (removals must trigger the resetting update)
+    - get_diff with exclude_unset=True returns True (merged leaves omitted fields untouched)
 
     ## Classes and Methods
 
@@ -1417,7 +1420,8 @@ def test_loopback_interface_00620():
     """
     instance_full = LoopbackInterfaceModel.from_config(copy.deepcopy(SAMPLE_ANSIBLE_CONFIG))
     instance_minimal = LoopbackInterfaceModel(switch_ip="192.168.1.1", interface_name="loopback0")
-    assert instance_full.get_diff(instance_minimal) is True
+    assert instance_full.get_diff(instance_minimal) is False
+    assert instance_full.get_diff(instance_minimal, exclude_unset=True) is True
 
 
 # =============================================================================

--- a/tests/unit/module_utils/models/test_port_channel_trunk_host_interface.py
+++ b/tests/unit/module_utils/models/test_port_channel_trunk_host_interface.py
@@ -168,7 +168,6 @@ def test_port_channel_trunk_host_interface_00100():
     assert instance.port_channel_mode is None
     assert instance.port_type_edge_trunk is None
     assert instance.ports is None
-    assert instance.ptp is None
     assert instance.qos is None
     assert instance.qos_policy is None
     assert instance.queuing_policy is None
@@ -1548,14 +1547,15 @@ def test_port_channel_trunk_host_interface_00840():
     # Summary
 
     Verify `from_response` accepts the wire-format response shape with `portChannelId` and `ptp` fields that
-    ND auto-fills. These fields are present in actual API responses but not always in the OpenAPI spec.
+    ND auto-fills. These fields are present in actual API responses but not in `intPortChannelTrunkHostTemplate`.
 
     ## Test
 
     - Response with portChannelId and ptp fields constructs valid model
     - `portChannelId` is a response-only echo of interface_name and is silently ignored (extra="ignore"), so it
       never leaks into config-shaped output
-    - `ptp` is a modeled field and is stored
+    - `ptp` is deliberately not modeled (ND persists a client-sent value but generates no CLI from it; deviation
+      interface-get-undocumented-ptp-field) and is likewise dropped at parse time
 
     ## Classes and Methods
 
@@ -1567,7 +1567,7 @@ def test_port_channel_trunk_host_interface_00840():
     with does_not_raise():
         instance = PortChannelTrunkHostInterfaceModel.from_response(response)
     assert not hasattr(instance.config_data.network_os.policy, "port_channel_id")
-    assert instance.config_data.network_os.policy.ptp is False
+    assert not hasattr(instance.config_data.network_os.policy, "ptp")
 
 
 # =============================================================================

--- a/tests/unit/module_utils/models/test_storm_control_mutex.py
+++ b/tests/unit/module_utils/models/test_storm_control_mutex.py
@@ -514,3 +514,30 @@ def test_storm_control_mutex_00260(interface_cls, policy_cls, interface_name) ->
     existing = interface_cls.from_response(nd_interface_response(policy_cls, interface_name, {PCT_ALIAS: PCT}))
     proposed = interface_cls.from_config(proposed_config(interface_name, {PCT_ATTR: PCT}))
     assert existing.get_diff(proposed, exclude_unset=True) is True
+
+
+@pytest.mark.parametrize("interface_cls,policy_cls,interface_name", INTERFACE_MODELS)
+def test_storm_control_mutex_00270(interface_cls, policy_cls, interface_name) -> None:
+    """
+    # Summary
+
+    `state: replaced`/`overridden` detect storm-control removal (issue #410): proposed config that omits an existing
+    storm-control level entirely must classify as a difference on the `exclude_unset=False` path, so the full-payload
+    PUT that clears the level (lab-verified on ND 4.2.1 in PR #360) is issued.
+
+    ## Test
+
+    - An existing model is built from an ND response carrying `adminState` plus a percentage-only broadcast level.
+    - A proposed model is built from config re-stating `admin_state` only (no storm-control intent), so the forward
+      subset comparison alone would classify `no_diff`.
+    - `get_diff(exclude_unset=False)` reports a difference.
+
+    ## Classes and Methods
+
+    - NDBaseModel.get_diff()
+    - NDBaseModel.to_reverse_diff_dict()
+    - utils.has_removals()
+    """
+    existing = interface_cls.from_response(nd_interface_response(policy_cls, interface_name, {"adminState": True, PCT_ALIAS: PCT}))
+    proposed = interface_cls.from_config(proposed_config(interface_name, {"admin_state": True}))
+    assert existing.get_diff(proposed, exclude_unset=False) is False

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -464,3 +464,128 @@ def test_nd_state_machine_00180() -> None:
     names = [name for name, _ in instance.model_orchestrator._calls]
     assert "create" not in names
     assert "create_bulk" not in names
+
+
+class _ExistingConfiguredLoopbackSpy(_SpyLoopbackOrchestrator):
+    """Spy whose inventory contains loopback10 with a configured policy carrying a description.
+
+    Used by the issue #410 tests: a proposed item that omits `description` is a removal-only change that
+    `replaced`/`overridden` must classify as an update, while `merged` must leave it untouched.
+    """
+
+    def query_all(self, model_instance=None, **kwargs) -> ResponseType:
+        return [
+            {
+                "switchIp": "192.168.12.151",
+                "interfaceName": "loopback10",
+                "interfaceType": "loopback",
+                "configData": {"networkOS": {"policy": {"policyType": "loopback", "adminState": True, "description": "stale description"}}},
+            }
+        ]
+
+
+_REMOVAL_CONFIG = [
+    {
+        "switch_ip": "192.168.12.151",
+        "interface_name": "loopback10",
+        "config_data": {"network_os": {"policy": {"admin_state": True}}},
+    }
+]
+
+
+def test_nd_state_machine_00190() -> None:
+    """
+    # Summary
+
+    Verify `replaced` state classifies a removal-only proposed item as an update (issue #410): the existing
+    interface carries a policy `description` the proposed config omits, so `manage_state` must issue the
+    `update` that resets it -- not silently classify the item `no_diff`.
+
+    ## Test
+
+    - Inventory contains `loopback10` with `admin_state` and a stale `description`; proposed re-sends the same
+      identifier with `admin_state` only under `replaced`
+    - An `update` call is recorded with the proposed (description-less) model
+    - No create is recorded (the item already exists)
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_create_update_state()
+    - NDBaseModel.get_diff()
+    """
+    spy = _ExistingConfiguredLoopbackSpy(rest_send=_build_rest_send())
+    module = _build_module(state="replaced", check_mode=False, config=_REMOVAL_CONFIG)
+    instance = NDStateMachine(module=module, model_orchestrator=spy)
+
+    with does_not_raise():
+        instance.manage_state()
+
+    calls = instance.model_orchestrator._calls
+    names = [name for name, _ in calls]
+    assert "update" in names
+    assert "create" not in names
+    assert "create_bulk" not in names
+    updated = [args for name, args in calls if name == "update"][0]
+    assert updated.get_identifier_value() == ("192.168.12.151", "loopback10")
+    assert updated.config_data.network_os.policy.description is None
+
+
+def test_nd_state_machine_00200() -> None:
+    """
+    # Summary
+
+    Verify `merged` state still classifies the same removal-only proposed item as `no_diff`: omitted fields mean
+    "leave untouched" under `merged`, so the issue #410 reverse pass must not fire on the `exclude_unset=True` path.
+
+    ## Test
+
+    - The identical inventory/config pair from `test_nd_state_machine_00190`, under `merged`
+    - No mutation is recorded (only the preflights run)
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_create_update_state()
+    - NDBaseModel.get_diff()
+    """
+    spy = _ExistingConfiguredLoopbackSpy(rest_send=_build_rest_send())
+    module = _build_module(state="merged", check_mode=False, config=_REMOVAL_CONFIG)
+    instance = NDStateMachine(module=module, model_orchestrator=spy)
+
+    with does_not_raise():
+        instance.manage_state()
+
+    names = [name for name, _ in instance.model_orchestrator._calls]
+    assert names == ["preflight_create", "preflight"]
+
+
+def test_nd_state_machine_00210() -> None:
+    """
+    # Summary
+
+    Verify `overridden` state classifies the removal-only proposed item as an update too (its update-classification
+    phase shares `_manage_create_update_state` with `replaced`), and does not delete the surviving item.
+
+    ## Test
+
+    - The identical inventory/config pair from `test_nd_state_machine_00190`, under `overridden`
+    - An `update` call is recorded; no delete is recorded (the identifier is still proposed)
+
+    ## Classes and Methods
+
+    - NDStateMachine.manage_state()
+    - NDStateMachine._manage_create_update_state()
+    - NDStateMachine._manage_override_deletions()
+    """
+    spy = _ExistingConfiguredLoopbackSpy(rest_send=_build_rest_send())
+    module = _build_module(state="overridden", check_mode=False, config=_REMOVAL_CONFIG)
+    instance = NDStateMachine(module=module, model_orchestrator=spy)
+
+    with does_not_raise():
+        instance.manage_state()
+
+    names = [name for name, _ in instance.model_orchestrator._calls]
+    assert "update" in names
+    assert "delete" not in names
+    assert "delete_bulk" not in names

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the pure diff helpers in `plugins/module_utils/utils.py`.
+
+Covers `issubset` (the one-way forward comparison used by `NDBaseModel.get_diff`) and `has_removals`
+(the reverse pass added for issue #410: detect fields present on the existing/device side that are
+absent from the proposed side, so `replaced`/`overridden` states can classify removal-only changes
+as a difference).
+"""
+
+# pylint: disable=line-too-long
+
+from __future__ import annotations
+
+from ansible_collections.cisco.nd.plugins.module_utils.utils import has_removals, issubset
+
+# --- issubset (001XX) ---
+
+
+def test_utils_00100() -> None:
+    """
+    # Summary
+
+    A dict whose keys/values all appear in the superset is a subset; extra superset keys are ignored.
+
+    ## Test
+
+    - `issubset` is called with a proposed dict that is a strict key-subset of the existing dict.
+    - The result is `True` (extra existing keys are not examined -- the documented one-way behavior).
+
+    ## Classes and Methods
+
+    - utils.issubset()
+    """
+    assert issubset({"a": 1}, {"a": 1, "b": 2}) is True
+
+
+def test_utils_00110() -> None:
+    """
+    # Summary
+
+    A differing scalar value, or a key missing from the superset, is not a subset.
+
+    ## Test
+
+    - `issubset` is called with a value mismatch, then with a key absent from the superset.
+    - Both results are `False`.
+
+    ## Classes and Methods
+
+    - utils.issubset()
+    """
+    assert issubset({"a": 1}, {"a": 2}) is False
+    assert issubset({"a": 1}, {"b": 1}) is False
+
+
+def test_utils_00120() -> None:
+    """
+    # Summary
+
+    Nested dicts recurse, and `None` values on the subset side are skipped.
+
+    ## Test
+
+    - A nested dict subset matches a deeper superset.
+    - A subset key with value `None` does not force a mismatch.
+
+    ## Classes and Methods
+
+    - utils.issubset()
+    """
+    assert issubset({"a": {"b": 1}}, {"a": {"b": 1, "c": 2}}) is True
+    assert issubset({"a": {"b": 2}}, {"a": {"b": 1, "c": 2}}) is False
+    assert issubset({"a": None}, {"b": 1}) is True
+
+
+def test_utils_00130() -> None:
+    """
+    # Summary
+
+    Lists require equal length and bidirectional element matches (order-independent full equality).
+
+    ## Test
+
+    - Equal lists in different order match.
+    - A shorter proposed list, or an element whose dict dropped a key, does not match.
+
+    ## Classes and Methods
+
+    - utils.issubset()
+    """
+    assert issubset({"a": [1, 2]}, {"a": [2, 1]}) is True
+    assert issubset({"a": [1]}, {"a": [1, 2]}) is False
+    assert issubset({"a": [{"b": 1}]}, {"a": [{"b": 1, "c": 2}]}) is False
+
+
+def test_utils_00140() -> None:
+    """
+    # Summary
+
+    A type mismatch between subset and superset is never a subset.
+
+    ## Test
+
+    - A dict compared against a list, and an int against a str, both return `False`.
+
+    ## Classes and Methods
+
+    - utils.issubset()
+    """
+    assert issubset({"a": 1}, [{"a": 1}]) is False
+    assert issubset(1, "1") is False
+
+
+# --- has_removals (002XX) ---
+
+
+def test_utils_00200() -> None:
+    """
+    # Summary
+
+    A key present on the existing side but absent from the proposed side is a removal.
+
+    ## Test
+
+    - `has_removals` is called with an existing dict carrying one extra non-empty key.
+    - The result is `True`.
+
+    ## Classes and Methods
+
+    - utils.has_removals()
+    """
+    assert has_removals({"a": 1, "b": 2}, {"a": 1}) is True
+
+
+def test_utils_00210() -> None:
+    """
+    # Summary
+
+    Identical key sets have no removals; value differences are NOT removals (they are the forward pass's job).
+
+    ## Test
+
+    - Same keys with equal values: `False`.
+    - Same keys with differing scalar values: still `False` -- `has_removals` only reports missing keys.
+
+    ## Classes and Methods
+
+    - utils.has_removals()
+    """
+    assert has_removals({"a": 1}, {"a": 1}) is False
+    assert has_removals({"a": 1}, {"a": 2}) is False
+
+
+def test_utils_00220() -> None:
+    """
+    # Summary
+
+    Empty values (`None`, `""`, `[]`, `{}`) on the existing side are normalized to absent and never count as removals.
+
+    ## Test
+
+    - Existing keys whose values are `None`, `""`, `[]`, and `{}` are all missing from proposed.
+    - The result is `False` for each (ND echoes empty markers for never-configured fields).
+
+    ## Classes and Methods
+
+    - utils.has_removals()
+    """
+    assert has_removals({"a": None}, {}) is False
+    assert has_removals({"a": ""}, {}) is False
+    assert has_removals({"a": []}, {}) is False
+    assert has_removals({"a": {}}, {}) is False
+
+
+def test_utils_00230() -> None:
+    """
+    # Summary
+
+    Removals are detected recursively inside nested dicts present on both sides.
+
+    ## Test
+
+    - A nested dict on both sides where the existing nested dict carries one extra non-empty key: `True`.
+    - The same shape with the extra nested key empty-valued: `False`.
+
+    ## Classes and Methods
+
+    - utils.has_removals()
+    """
+    assert has_removals({"a": {"b": 1, "c": 2}}, {"a": {"b": 1}}) is True
+    assert has_removals({"a": {"b": 1, "c": ""}}, {"a": {"b": 1}}) is False
+
+
+def test_utils_00240() -> None:
+    """
+    # Summary
+
+    A non-empty nested dict absent entirely from the proposed side is a removal.
+
+    ## Test
+
+    - Existing carries a nested dict with real content; proposed lacks the key.
+    - The result is `True`.
+
+    ## Classes and Methods
+
+    - utils.has_removals()
+    """
+    assert has_removals({"a": {"b": 1}}, {}) is True
+
+
+def test_utils_00250() -> None:
+    """
+    # Summary
+
+    A nested dict whose members are all empty-valued normalizes to absent as a whole.
+
+    ## Test
+
+    - Existing carries a nested dict containing only empty values; proposed lacks the key.
+    - The result is `False` (nothing user-visible would be removed).
+
+    ## Classes and Methods
+
+    - utils.has_removals()
+    """
+    assert has_removals({"a": {"b": "", "c": None}}, {}) is False
+
+
+def test_utils_00260() -> None:
+    """
+    # Summary
+
+    Keys present on both sides with list or scalar values are not recursed; list content is the forward pass's job.
+
+    ## Test
+
+    - A non-empty list present on existing and absent from proposed: `True` (removal).
+    - The same list present on both sides but with differing content: `False` (not a removal).
+
+    ## Classes and Methods
+
+    - utils.has_removals()
+    """
+    assert has_removals({"a": [1, 2]}, {}) is True
+    assert has_removals({"a": [1, 2]}, {"a": [1]}) is False
+
+
+def test_utils_00270() -> None:
+    """
+    # Summary
+
+    Non-dict top-level input never reports removals.
+
+    ## Test
+
+    - Scalars, lists, and `None` as the existing side all return `False`.
+
+    ## Classes and Methods
+
+    - utils.has_removals()
+    """
+    assert has_removals("a", "b") is False
+    assert has_removals([1], []) is False
+    assert has_removals(None, {"a": 1}) is False
+
+
+def test_utils_00280() -> None:
+    """
+    # Summary
+
+    A dict existing side compared against a non-dict proposed side reports no removals (type conflicts are the forward pass's job).
+
+    ## Test
+
+    - Existing is a dict, proposed is a scalar.
+    - The result is `False` -- the forward `issubset` type check already classifies this as changed.
+
+    ## Classes and Methods
+
+    - utils.has_removals()
+    """
+    assert has_removals({"a": 1}, "not-a-dict") is False


### PR DESCRIPTION
## Related Issue(s)

Fixes #410

## Merge order

- This PR
- #366
- #403
- #291
- Future PR to fix issue #447

## Proposed Changes

- `NDBaseModel.get_diff` gains a **reverse pass** on the `exclude_unset=False` (replaced/overridden) path: after the forward subset check, the new pure util `utils.has_removals()` walks the existing side's payload-scoped dump (`exclude_from_diff | payload_exclude_fields`) and classifies any non-empty field absent from proposed as a difference, so the full-payload PUT that resets omitted fields is actually issued. Merged-state semantics are unchanged.
- Empty existing-side values (`""`, `[]`, `{}`) normalize to absent, generalizing the `PrefixListModel` description precedent; its ad-hoc `get_diff` override is removed (its tests pass against the inherited behavior).
- **Default-echo normalization**: ND echoes the OpenAPI template default for every field the user never set (lab-verified: ~22 concrete fields on trunkHost; ND injects `routeMapTag: 12345` even on user-created loopbacks). New per-model `reverse_diff_defaults` ClassVars (alias → template default, sourced from the ND 4.2.1 OpenAPI template schemas, values in the model's dumped form) let `to_reverse_diff_dict()` strip default-valued echoes recursively, keeping replaced/overridden runs idempotent. Tables added for all nine interface policy models (loopback, ethernet access/trunkHost, port-channel access/trunkHost, vPC access/trunkHost, SVI, managed subinterface).
- Known residual: `TrunkVpcHostPolicyModel` — the schema defaults for `peer1AllowedVlans`/`peer2AllowedVlans` have no model fields (per-peer→collapsed `access_vlan` workaround); vPC families were not lab-verified in this PR.

**Post-review hardening** (three follow-up commits addressing all five findings from Claude's pre-merge code review):

- Commit *"Fix reverse-pass idempotency for server-populated existing-side data"* — three confirmed bugs, one mechanism: the reverse pass fired on existing-side data the proposed config can never express, permanently classifying items as changed.
  - New alias-keyed `reverse_diff_exclude` ClassVar, applied at each nested model's **own** level during the reverse scrub; both vPC policy models exclude the orchestrator-injected `peerSwitchId` (not in the argspec, injected only at payload-build time, echoed by ND on reads).
  - The reverse scrub drops `extra="allow"` server keys (`model_extra`) at every nesting level, so undeclared ND GET keys on the fabric models (top-level or nested management) never count as removals.
  - `LocalUserModel` gains a `reverse_diff_defaults` table for ND's falsy echoes (`xLaunch=false`, `reuseLimitation=0`, `timeIntervalLimitation=0` — the module's own integration tests assert these `before` values); `False`/`0` are real values, not empty markers, so empty-normalization alone could not cover them.
- Commit *"Add TODO(4.2.1) workaround markers to all reverse_diff_defaults tables"* — all ten table sites (nine interface policy models + `LocalUserModel`) carry `TODO(4.2.1) get-echoes-schema-defaults-for-unset-fields`, backed by a new bug-tracker vault note of the same id (resolvable via `get_bug_by_id`) documenting the defaults-echo behavior across both the interfaces and localUsers endpoint families, so `/nd-workaround-audit` can surface the tables for re-verification against future ND releases.
- Commit *"Derive reverse-pass dicts from the forward dumps (halve get_diff cost)"* — `to_reverse_diff_dict` now derives from `to_diff_dict` plus in-place scoping, and `get_diff` reuses its already-computed forward dumps: 2 dumps per no-diff comparison instead of 4, pinned by a dump-count regression test. Side benefit: subclass `to_diff_dict` overrides (e.g. the AI-eBGP `nxapiHttp` pop) now scope the reverse pass symmetrically. `NDOutput`'s two-directional changed loop is deliberately unchanged — payload-excluded-but-diff-compared fields (loopback `switch_ip`, SVI/subinterface `oper_data`, prefix-list `ip_version`) rely on the second direction, so removing it would be a semantics change, not an optimization (documented in the commit body).

## Test Notes

- New unit tests: `tests/unit/module_utils/test_utils.py` (first coverage for `issubset` + `has_removals`), `tests/unit/module_utils/models/test_base_model_reverse_diff.py` (removal detection, empty/default normalization, per-family default tables incl. the verbatim lab-captured trunkHost echo), state-machine replaced/overridden/merged classification tests, and the previously missing `exclude_unset=False` storm-control case.
- `test_loopback_interface_00620` updated: proposed-with-fewer-fields is now a difference by default (the old assertion documented the #410 bug).
- Post-review commits add a 005xx test section (per-bug phantom-removal reproductions built TDD-first, each paired with a genuine-removal guard proving the fix does not over-strip) and a 006xx efficiency section (dump-count contract: exactly one `model_dump` per side on the no-diff replaced path, plus standalone `to_reverse_diff_dict` behavior parity).
- Full unit suite passes: 3865 tests via `ndpytest tests/unit/` (nd-dev container machine).
- **Review re-verification:** the pre-merge code review's five findings (three confirmed idempotency bugs, the missing workaround markers, the redundant reverse dumps) were re-verified fixed at branch HEAD by re-running the original reproduction scripts — phantom changes now classify `no_diff`, genuine removals still classify `changed` — with no new findings.
- black/isort/pylint/mypy clean on changed files; `ndtest` sanity passes except the pre-existing `action-plugin-docs` findings on `plugins/action/tests/integration/*` (untouched by this PR).
- Lab verification (SITE1): the issue's repro passes — `state: replaced` omitting `storm_control_broadcast_level: 80.0` reports `changed: true`, issues the PUT, and clears the value on ND; replaced double-runs on `nd_interface_ethernet_trunk_host` and `nd_interface_loopback` report `changed: false` on the second run.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqAuV2pWYJTno2bfdcNZCm
