### PR TITLE
Added validation for Gather filter supported properties

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics.py
@@ -526,7 +526,6 @@ class EpManageFabricsSummaryGet(_EpManageFabricsBase):
     class_name: Literal["EpManageFabricsSummaryGet"] = Field(
         default="EpManageFabricsSummaryGet", frozen=True, description="Class name for backward compatibility"
     )
-
     _path_suffix: ClassVar[str | None] = "summary"
 
     endpoint_params: FabricsEndpointParams = Field(default_factory=FabricsEndpointParams, description="Endpoint-specific query parameters")

--- a/plugins/module_utils/manage_resource_manager/nd_manage_resource_manager_resources.py
+++ b/plugins/module_utils/manage_resource_manager/nd_manage_resource_manager_resources.py
@@ -744,10 +744,8 @@ class NDResourceManagerModule(ResourceManagerResourceHelpersMixin):
                 continue
 
             pool_name = filter_item.get("pool_name")
-            # Entity names are intentionally matched locally. ND may return canonical
-            # endpoint order for multi-switch resources, and some simple entity-only
-            # Lucene filters can exclude resources that should match after local
-            # normalization.
+            # TODO: resource-manager-gathered-server-filtering: Revisit Lucene filtering when exact server-side matching preserves
+            # normalized entity matching for device-pair and link resources.
             # Kept this filter_expr for future reference in case if we have any filter props with exact match
             filter_expr = None
             filter_switches = filter_item.get("switches") or [None]

--- a/plugins/module_utils/manage_resource_manager/nd_manage_resource_manager_resources.py
+++ b/plugins/module_utils/manage_resource_manager/nd_manage_resource_manager_resources.py
@@ -744,9 +744,12 @@ class NDResourceManagerModule(ResourceManagerResourceHelpersMixin):
                 continue
 
             pool_name = filter_item.get("pool_name")
-            # TODO: resource-manager-gathered-server-filtering: Revisit Lucene filtering when exact server-side matching preserves
-            # normalized entity matching for device-pair and link resources.
-            # Kept this filter_expr for future reference in case if we have any filter props with exact match
+            # TODO(4.2.1) resource-manager-gathered-entity-order-lucene: ND GET may canonicalize endpoint order in
+            # devicePair/link entityName values. Exact Lucene filter=entityName:... can then silently omit an existing
+            # resource stored under an equivalent endpoint ordering. Gather paginated candidates using poolName and
+            # switchId only, then match entity_name locally through _entity_names_match/_normalize_entity_key. Link
+            # normalization reverses complete serial/interface endpoint pairs rather than sorting individual segments.
+            # Keep filter_expr unset until server-side filtering is verified to preserve equivalent endpoint orderings.
             filter_expr = None
             filter_switches = filter_item.get("switches") or [None]
             for switch_id in filter_switches:

--- a/plugins/module_utils/manage_resource_manager/nd_manage_resource_manager_resources.py
+++ b/plugins/module_utils/manage_resource_manager/nd_manage_resource_manager_resources.py
@@ -7,7 +7,6 @@ import copy
 import logging
 import time
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ValidationError
 from ansible_collections.cisco.nd.plugins.module_utils.nd_v2 import NDModule
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
@@ -95,6 +94,9 @@ class NDResourceManagerModule(ResourceManagerResourceHelpersMixin):
         self.fabric = nd.params.get("fabric_name") or nd.params.get("fabric")
         self.state = nd.params["state"]
         self.config = nd.params.get("config") or []
+        if self.state == "gathered":
+            self.config = ResourceManagerConfigModel.validate_gathered_config(self.config)
+
         self.fabric_type = None
         if self.config:
             self.fabric_type = self._get_fabric_type()
@@ -316,29 +318,10 @@ class NDResourceManagerModule(ResourceManagerResourceHelpersMixin):
                 fabric_type=fabric_type,
             )
 
-        for idx, item in enumerate(self.config):
-            try:
-                ResourceManagerConfigModel.model_validate(
-                    item,
-                    context={"state": self.state, "fabric_type": fabric_type},
-                )
-            except ValidationError as exc:
-                error_detail = exc.errors() if hasattr(exc, "errors") else str(exc)
-                error_msg = f"Gathered filter validation failed for config index {idx}: {error_detail}"
-                self.log.error(error_msg)
-                raise ValueError(error_msg) from exc
-            except Exception as exc:
-                error_msg = f"Gathered filter validation failed for config index {idx}: {str(exc)}"
-                self.log.error(error_msg)
-                raise ValueError(error_msg) from exc
-            self.log.debug(
-                "Gathered filter [%s] validated: entity_name=%s, pool_name=%s, switches=%s",
-                idx,
-                item.get("entity_name"),
-                item.get("pool_name"),
-                item.get("switches"),
-            )
-
+        self.config = ResourceManagerConfigModel.validate_gathered_config(
+            self.config,
+            fabric_type=fabric_type,
+        )
         return []
 
     # ------------------------------------------------------------------

--- a/plugins/module_utils/manage_resource_manager/resource_manager_helpers.py
+++ b/plugins/module_utils/manage_resource_manager/resource_manager_helpers.py
@@ -493,17 +493,7 @@ class ResourceManagerResourceHelpersMixin:
     @staticmethod
     def _filter_has_active_criteria(filter_item):
         """Return True when a gathered filter item has at least one criterion."""
-        return any(
-            filter_item.get(key)
-            for key in (
-                "entity_name",
-                "pool_name",
-                "switches",
-                "resource",
-                "scope_type",
-                "pool_type",
-            )
-        )
+        return any(filter_item.get(key) for key in ResourceManagerConfigModel.GATHERED_FILTER_PROPERTIES)
 
     def _resource_matches_filter(self, resource, filter_item):
         """Return True when a resource matches one gathered filter item."""

--- a/plugins/module_utils/models/manage_resource_manager/resource_manager_config_model.py
+++ b/plugins/module_utils/models/manage_resource_manager/resource_manager_config_model.py
@@ -17,7 +17,7 @@ Fields map directly to the module's config suboptions:
   switch           → switch          (list of switch IPs/serials; required for non-fabric scopes)
 
 State-aware validation is supported when model_validate() is called with
-context={"state": "merged|deleted|query|gathered"}.
+context={"state": "merged|deleted|gathered"}.
 """
 
 from __future__ import annotations
@@ -50,14 +50,15 @@ class ResourceManagerConfigModel(NDBaseModel):
 
     Provides full per-field and cross-field validation for resource allocation
     configuration. Supports state-aware validation when model_validate() is
-    called with context={"state": "merged|deleted|query|gathered"}.
+    called with context={"state": "merged|deleted|gathered"}.
 
     Field requirements by state:
       merged:          entity_name, pool_type, pool_name, scope_type required;
                        switch required for non-fabric scopes.
       deleted:         entity_name, pool_type, pool_name, scope_type required;
                        switch required for non-fabric scopes.
-      query/gathered:  all fields optional (used as filters).
+      gathered:        config may be omitted or empty; each provided filter item
+                       requires at least one supported, non-null property.
 
     Note: The nd_manage_resource_manager module performs its own mandatory field
     checks before calling from_config(). This model adds per-field normalization
@@ -149,8 +150,8 @@ class ResourceManagerConfigModel(NDBaseModel):
         if state != "gathered" or not isinstance(data, dict):
             return data
 
-        supplied_properties = set(data)
-        unsupported = sorted(supplied_properties - set(cls.GATHERED_FILTER_PROPERTIES))
+        active_properties = {key for key, value in data.items() if value is not None}
+        unsupported = sorted(active_properties - set(cls.GATHERED_FILTER_PROPERTIES))
         if unsupported:
             raise ValueError(
                 "unsupported gathered filter properties: {0}. Supported gathered filter properties: {1}".format(
@@ -159,11 +160,6 @@ class ResourceManagerConfigModel(NDBaseModel):
                 )
             )
 
-        null_properties = sorted(key for key, value in data.items() if value is None)
-        if null_properties:
-            raise ValueError("gathered filter properties cannot be null: {0}".format(", ".join("'{0}'".format(key) for key in null_properties)))
-
-        active_properties = {key for key, value in data.items() if value is not None}
         if not active_properties:
             raise ValueError(
                 "gathered filter item must contain at least one supported property: {0}".format(
@@ -485,8 +481,9 @@ class ResourceManagerConfigModel(NDBaseModel):
         When model_validate(context={"state": "merged"}) or
         model_validate(context={"state": "deleted"}) is passed, the model
         enforces that entity_name, pool_type, pool_name, and scope_type are
-        all provided. For 'query' / 'gathered' state (or no context), all
-        fields remain optional and serve as filters.
+        all provided. For 'gathered' state, individual fields are optional, but
+        each provided filter item must contain at least one supported, non-null
+        property.
         """
         state = (info.context or {}).get("state") if info else None
         if state in ("merged", "deleted"):

--- a/plugins/module_utils/models/manage_resource_manager/resource_manager_config_model.py
+++ b/plugins/module_utils/models/manage_resource_manager/resource_manager_config_model.py
@@ -161,11 +161,7 @@ class ResourceManagerConfigModel(NDBaseModel):
 
         null_properties = sorted(key for key, value in data.items() if value is None)
         if null_properties:
-            raise ValueError(
-                "gathered filter properties cannot be null: {0}".format(
-                    ", ".join("'{0}'".format(key) for key in null_properties)
-                )
-            )
+            raise ValueError("gathered filter properties cannot be null: {0}".format(", ".join("'{0}'".format(key) for key in null_properties)))
 
         active_properties = {key for key, value in data.items() if value is not None}
         if not active_properties:

--- a/plugins/module_utils/models/manage_resource_manager/resource_manager_config_model.py
+++ b/plugins/module_utils/models/manage_resource_manager/resource_manager_config_model.py
@@ -36,6 +36,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_resource_ma
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.constants import is_pool_supported
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
+    ValidationError,
     field_validator,
     model_validator,
 )
@@ -64,6 +65,14 @@ class ResourceManagerConfigModel(NDBaseModel):
     """
 
     identifiers: ClassVar[list[str]] = []
+    GATHERED_FILTER_PROPERTIES: ClassVar[tuple[str, ...]] = (
+        "entity_name",
+        "pool_name",
+        "switches",
+        "resource",
+        "scope_type",
+        "pool_type",
+    )
 
     # Fields excluded from diff — operational input flags not present in gathered state.
     # entity_name, pool_type, pool_name, scope_type, resource and vrf_name
@@ -131,6 +140,81 @@ class ResourceManagerConfigModel(NDBaseModel):
     # -------------------------------------------------------------------------
     # Per-field validators
     # -------------------------------------------------------------------------
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_gathered_properties(cls, data: Any, info: Any) -> Any:
+        """Validate gathered filter keys before extra fields are discarded."""
+        state = (info.context or {}).get("state") if info else None
+        if state != "gathered" or not isinstance(data, dict):
+            return data
+
+        supplied_properties = set(data)
+        unsupported = sorted(supplied_properties - set(cls.GATHERED_FILTER_PROPERTIES))
+        if unsupported:
+            raise ValueError(
+                "unsupported gathered filter properties: {0}. Supported gathered filter properties: {1}".format(
+                    ", ".join("'{0}'".format(key) for key in unsupported),
+                    ", ".join("'{0}'".format(key) for key in cls.GATHERED_FILTER_PROPERTIES),
+                )
+            )
+
+        null_properties = sorted(key for key, value in data.items() if value is None)
+        if null_properties:
+            raise ValueError(
+                "gathered filter properties cannot be null: {0}".format(
+                    ", ".join("'{0}'".format(key) for key in null_properties)
+                )
+            )
+
+        active_properties = {key for key, value in data.items() if value is not None}
+        if not active_properties:
+            raise ValueError(
+                "gathered filter item must contain at least one supported property: {0}".format(
+                    ", ".join("'{0}'".format(key) for key in cls.GATHERED_FILTER_PROPERTIES)
+                )
+            )
+
+        return data
+
+    @classmethod
+    def validate_gathered_config(
+        cls,
+        config: list[dict[str, Any]] | None,
+        fabric_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Validate and normalize all gathered filter items."""
+        if not config:
+            return []
+
+        issues = []
+        validated_items = []
+        for idx, item in enumerate(config):
+            try:
+                validated = cls.model_validate(
+                    item,
+                    context={"state": "gathered", "fabric_type": fabric_type},
+                )
+            except ValidationError as exc:
+                error_detail = exc.errors() if hasattr(exc, "errors") else str(exc)
+                issues.append("config index {0}: {1}".format(idx, error_detail))
+                continue
+            except Exception as exc:
+                issues.append("config index {0}: {1}".format(idx, str(exc)))
+                continue
+
+            supplied_properties = set(item) if isinstance(item, dict) else set()
+            validated_items.append(
+                validated.model_dump(
+                    include=supplied_properties,
+                    exclude_none=True,
+                )
+            )
+
+        if issues:
+            raise ValueError("Gathered filter validation failed: {0}".format("; ".join(issues)))
+
+        return validated_items
 
     @field_validator("entity_name", mode="before")
     @classmethod

--- a/plugins/modules/nd_manage_resource_manager.py
+++ b/plugins/modules/nd_manage_resource_manager.py
@@ -44,7 +44,9 @@ options:
         Additional required field C(switches) when C(scope_type) is not C(fabric). Optional fields C(is_pre_allocated), C(vrf_name)."
       - "For C(state=gathered): C(config) may be omitted entirely to retrieve all resources, or provided with optional filter fields.
         Each config item can include any combination of C(entity_name), C(pool_name), C(switches), C(resource), C(scope_type), C(pool_type).
-        Filter fields act as match criteria; only those provided are used to select resources."
+        Filter fields act as match criteria; only those provided are used to select resources. Each provided item must contain at least one
+        supported filter property, and provided filter properties cannot be null. Unsupported or null properties cause the module to fail
+        before resources are queried. An explicit empty list has the same gather-all behavior as omitting C(config)."
     type: list
     elements: dict
     suboptions:
@@ -117,6 +119,7 @@ options:
           - When omitted, the module preserves legacy behavior and sends C(true).
           - When set to C(false), ND auto-allocates the resource value and C(resource) may be omitted.
           - Optional for C(state=merged) and C(state=deleted).
+          - Not supported as a filter for C(state=gathered).
         type: bool
         required: false
       vrf_name:
@@ -124,6 +127,7 @@ options:
           - Virtual Routing and Forwarding (VRF) name for the resource.
           - Applicable when the resource is scoped to a device or link using a specific VRF context.
           - Optional for C(state=merged) and C(state=deleted).
+          - Not supported as a filter for C(state=gathered).
         type: str
         required: false
 extends_documentation_fragment:
@@ -133,6 +137,11 @@ notes:
   - Idempotence checking compares the existing resource value to the desired value.
   - Entity name matching is order-insensitive for tilde-separated serial numbers.
   - For C(state=gathered), partial filter entries are supported (e.g., just C(entity_name) or just C(switches)) to retrieve specific subsets of resources.
+  - "Gathered filter support matrix (GET query / Lucene / local match): C(entity_name) (no / no / yes),
+    C(pool_name) (yes / no / yes), C(switches) (yes / no / yes), C(resource) (no / no / yes),
+    C(scope_type) (no / no / yes), and C(pool_type) (no / no / yes)."
+  - Gathered filters use the C(poolName) and C(switchId) GET query parameters. Lucene filtering is not used because exact server-side matching
+    cannot preserve normalized entity matching for device-pair and link resources.
 """
 
 EXAMPLES = """

--- a/plugins/modules/nd_manage_resource_manager.py
+++ b/plugins/modules/nd_manage_resource_manager.py
@@ -45,8 +45,9 @@ options:
       - "For C(state=gathered): C(config) may be omitted entirely to retrieve all resources, or provided with optional filter fields.
         Each config item can include any combination of C(entity_name), C(pool_name), C(switches), C(resource), C(scope_type), C(pool_type).
         Filter fields act as match criteria; only those provided are used to select resources. Each provided item must contain at least one
-        supported filter property, and provided filter properties cannot be null. Unsupported or null properties cause the module to fail
-        before resources are queried. An explicit empty list has the same gather-all behavior as omitting C(config)."
+        supported filter property with a non-null value. Null-valued properties are ignored because Ansible represents omitted suboptions as
+        null after argument validation. Active unsupported properties cause the module to fail before resources are queried. An explicit empty
+        list has the same gather-all behavior as omitting C(config)."
     type: list
     elements: dict
     suboptions:
@@ -137,11 +138,6 @@ notes:
   - Idempotence checking compares the existing resource value to the desired value.
   - Entity name matching is order-insensitive for tilde-separated serial numbers.
   - For C(state=gathered), partial filter entries are supported (e.g., just C(entity_name) or just C(switches)) to retrieve specific subsets of resources.
-  - "Gathered filter support matrix (GET query / Lucene / local match): C(entity_name) (no / no / yes),
-    C(pool_name) (yes / no / yes), C(switches) (yes / no / yes), C(resource) (no / no / yes),
-    C(scope_type) (no / no / yes), and C(pool_type) (no / no / yes)."
-  - Gathered filters use the C(poolName) and C(switchId) GET query parameters. Lucene filtering is not used because exact server-side matching
-    cannot preserve normalized entity matching for device-pair and link resources.
 """
 
 EXAMPLES = """

--- a/tests/integration/targets/nd_resource_manager/tests/nd/base/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/base/invalid_params.yaml
@@ -91,8 +91,7 @@
         that:
           - invalid_gathered_null_property is failed
           - invalid_gathered_null_property.msg is defined
-          - invalid_gathered_null_property.msg is search("cannot be null")
-          - invalid_gathered_null_property.msg is search("pool_name")
+          - invalid_gathered_null_property.msg is search("must contain at least one supported property")
 
     - name: BASE gathered filters - Valid property mixed with null
       cisco.nd.nd_manage_resource_manager:
@@ -101,13 +100,9 @@
         config:
           - entity_name: "base_invalid_gathered"
             pool_name: null
-      register: invalid_gathered_mixed_null_property
-      ignore_errors: true
+      register: valid_gathered_mixed_null_property
 
-    - name: BASE gathered filters - Assert mixed null property failed
+    - name: BASE gathered filters - Assert mixed null property was ignored
       ansible.builtin.assert:
         that:
-          - invalid_gathered_mixed_null_property is failed
-          - invalid_gathered_mixed_null_property.msg is defined
-          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
-          - invalid_gathered_mixed_null_property.msg is search("pool_name")
+          - valid_gathered_mixed_null_property is not failed

--- a/tests/integration/targets/nd_resource_manager/tests/nd/base/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/base/invalid_params.yaml
@@ -42,3 +42,72 @@
           - invalid_pool_name.msg is defined
           - invalid_pool_name.msg is search("Unsupported pool_name")
           - invalid_pool_name.msg is search("WRONG_POOL")
+
+    - name: BASE gathered filters - Unsupported property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "base_invalid_gathered"
+            vrf_name: "default"
+      register: invalid_gathered_unsupported_property
+      ignore_errors: true
+
+    - name: BASE gathered filters - Assert unsupported property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_unsupported_property is failed
+          - invalid_gathered_unsupported_property.msg is defined
+          - invalid_gathered_unsupported_property.msg is search("unsupported gathered filter properties")
+          - invalid_gathered_unsupported_property.msg is search("vrf_name")
+
+    - name: BASE gathered filters - Empty filter item
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - {}
+      register: invalid_gathered_empty_item
+      ignore_errors: true
+
+    - name: BASE gathered filters - Assert empty filter item failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_empty_item is failed
+          - invalid_gathered_empty_item.msg is defined
+          - invalid_gathered_empty_item.msg is search("must contain at least one supported property")
+
+    - name: BASE gathered filters - Null-only property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - pool_name: null
+      register: invalid_gathered_null_property
+      ignore_errors: true
+
+    - name: BASE gathered filters - Assert null-only property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_null_property is failed
+          - invalid_gathered_null_property.msg is defined
+          - invalid_gathered_null_property.msg is search("cannot be null")
+          - invalid_gathered_null_property.msg is search("pool_name")
+
+    - name: BASE gathered filters - Valid property mixed with null
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "base_invalid_gathered"
+            pool_name: null
+      register: invalid_gathered_mixed_null_property
+      ignore_errors: true
+
+    - name: BASE gathered filters - Assert mixed null property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_mixed_null_property is failed
+          - invalid_gathered_mixed_null_property.msg is defined
+          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
+          - invalid_gathered_mixed_null_property.msg is search("pool_name")

--- a/tests/integration/targets/nd_resource_manager/tests/nd/ebgp/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/ebgp/invalid_params.yaml
@@ -42,3 +42,72 @@
           - invalid_pool_name.msg is defined
           - invalid_pool_name.msg is search("Unsupported pool_name")
           - invalid_pool_name.msg is search("BGP_ASN_ID")
+
+    - name: eBGP gathered filters - Unsupported property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "ebgp_invalid_gathered"
+            vrf_name: "default"
+      register: invalid_gathered_unsupported_property
+      ignore_errors: true
+
+    - name: eBGP gathered filters - Assert unsupported property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_unsupported_property is failed
+          - invalid_gathered_unsupported_property.msg is defined
+          - invalid_gathered_unsupported_property.msg is search("unsupported gathered filter properties")
+          - invalid_gathered_unsupported_property.msg is search("vrf_name")
+
+    - name: eBGP gathered filters - Empty filter item
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - {}
+      register: invalid_gathered_empty_item
+      ignore_errors: true
+
+    - name: eBGP gathered filters - Assert empty filter item failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_empty_item is failed
+          - invalid_gathered_empty_item.msg is defined
+          - invalid_gathered_empty_item.msg is search("must contain at least one supported property")
+
+    - name: eBGP gathered filters - Null-only property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - pool_name: null
+      register: invalid_gathered_null_property
+      ignore_errors: true
+
+    - name: eBGP gathered filters - Assert null-only property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_null_property is failed
+          - invalid_gathered_null_property.msg is defined
+          - invalid_gathered_null_property.msg is search("cannot be null")
+          - invalid_gathered_null_property.msg is search("pool_name")
+
+    - name: eBGP gathered filters - Valid property mixed with null
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "ebgp_invalid_gathered"
+            pool_name: null
+      register: invalid_gathered_mixed_null_property
+      ignore_errors: true
+
+    - name: eBGP gathered filters - Assert mixed null property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_mixed_null_property is failed
+          - invalid_gathered_mixed_null_property.msg is defined
+          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
+          - invalid_gathered_mixed_null_property.msg is search("pool_name")

--- a/tests/integration/targets/nd_resource_manager/tests/nd/ebgp/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/ebgp/invalid_params.yaml
@@ -91,8 +91,7 @@
         that:
           - invalid_gathered_null_property is failed
           - invalid_gathered_null_property.msg is defined
-          - invalid_gathered_null_property.msg is search("cannot be null")
-          - invalid_gathered_null_property.msg is search("pool_name")
+          - invalid_gathered_null_property.msg is search("must contain at least one supported property")
 
     - name: eBGP gathered filters - Valid property mixed with null
       cisco.nd.nd_manage_resource_manager:
@@ -101,13 +100,9 @@
         config:
           - entity_name: "ebgp_invalid_gathered"
             pool_name: null
-      register: invalid_gathered_mixed_null_property
-      ignore_errors: true
+      register: valid_gathered_mixed_null_property
 
-    - name: eBGP gathered filters - Assert mixed null property failed
+    - name: eBGP gathered filters - Assert mixed null property was ignored
       ansible.builtin.assert:
         that:
-          - invalid_gathered_mixed_null_property is failed
-          - invalid_gathered_mixed_null_property.msg is defined
-          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
-          - invalid_gathered_mixed_null_property.msg is search("pool_name")
+          - valid_gathered_mixed_null_property is not failed

--- a/tests/integration/targets/nd_resource_manager/tests/nd/external/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/external/invalid_params.yaml
@@ -115,8 +115,7 @@
         that:
           - invalid_gathered_null_property is failed
           - invalid_gathered_null_property.msg is defined
-          - invalid_gathered_null_property.msg is search("cannot be null")
-          - invalid_gathered_null_property.msg is search("pool_name")
+          - invalid_gathered_null_property.msg is search("must contain at least one supported property")
 
     - name: External gathered filters - Valid property mixed with null
       cisco.nd.nd_manage_resource_manager:
@@ -125,13 +124,9 @@
         config:
           - entity_name: "external_invalid_gathered"
             pool_name: null
-      register: invalid_gathered_mixed_null_property
-      ignore_errors: true
+      register: valid_gathered_mixed_null_property
 
-    - name: External gathered filters - Assert mixed null property failed
+    - name: External gathered filters - Assert mixed null property was ignored
       ansible.builtin.assert:
         that:
-          - invalid_gathered_mixed_null_property is failed
-          - invalid_gathered_mixed_null_property.msg is defined
-          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
-          - invalid_gathered_mixed_null_property.msg is search("pool_name")
+          - valid_gathered_mixed_null_property is not failed

--- a/tests/integration/targets/nd_resource_manager/tests/nd/external/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/external/invalid_params.yaml
@@ -66,3 +66,72 @@
           - invalid_dynamic_pool_name.msg is defined
           - invalid_dynamic_pool_name.msg is search("Unsupported pool_name")
           - invalid_dynamic_pool_name.msg is search("10.4.99.0/30")
+
+    - name: External gathered filters - Unsupported property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "external_invalid_gathered"
+            vrf_name: "default"
+      register: invalid_gathered_unsupported_property
+      ignore_errors: true
+
+    - name: External gathered filters - Assert unsupported property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_unsupported_property is failed
+          - invalid_gathered_unsupported_property.msg is defined
+          - invalid_gathered_unsupported_property.msg is search("unsupported gathered filter properties")
+          - invalid_gathered_unsupported_property.msg is search("vrf_name")
+
+    - name: External gathered filters - Empty filter item
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - {}
+      register: invalid_gathered_empty_item
+      ignore_errors: true
+
+    - name: External gathered filters - Assert empty filter item failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_empty_item is failed
+          - invalid_gathered_empty_item.msg is defined
+          - invalid_gathered_empty_item.msg is search("must contain at least one supported property")
+
+    - name: External gathered filters - Null-only property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - pool_name: null
+      register: invalid_gathered_null_property
+      ignore_errors: true
+
+    - name: External gathered filters - Assert null-only property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_null_property is failed
+          - invalid_gathered_null_property.msg is defined
+          - invalid_gathered_null_property.msg is search("cannot be null")
+          - invalid_gathered_null_property.msg is search("pool_name")
+
+    - name: External gathered filters - Valid property mixed with null
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "external_invalid_gathered"
+            pool_name: null
+      register: invalid_gathered_mixed_null_property
+      ignore_errors: true
+
+    - name: External gathered filters - Assert mixed null property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_mixed_null_property is failed
+          - invalid_gathered_mixed_null_property.msg is defined
+          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
+          - invalid_gathered_mixed_null_property.msg is search("pool_name")

--- a/tests/integration/targets/nd_resource_manager/tests/nd/ibgp/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/ibgp/invalid_params.yaml
@@ -117,8 +117,7 @@
         that:
           - invalid_gathered_null_property is failed
           - invalid_gathered_null_property.msg is defined
-          - invalid_gathered_null_property.msg is search("cannot be null")
-          - invalid_gathered_null_property.msg is search("pool_name")
+          - invalid_gathered_null_property.msg is search("must contain at least one supported property")
 
     - name: iBGP gathered filters - Valid property mixed with null
       cisco.nd.nd_manage_resource_manager:
@@ -127,13 +126,9 @@
         config:
           - entity_name: "ibgp_invalid_gathered"
             pool_name: null
-      register: invalid_gathered_mixed_null_property
-      ignore_errors: true
+      register: valid_gathered_mixed_null_property
 
-    - name: iBGP gathered filters - Assert mixed null property failed
+    - name: iBGP gathered filters - Assert mixed null property was ignored
       ansible.builtin.assert:
         that:
-          - invalid_gathered_mixed_null_property is failed
-          - invalid_gathered_mixed_null_property.msg is defined
-          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
-          - invalid_gathered_mixed_null_property.msg is search("pool_name")
+          - valid_gathered_mixed_null_property is not failed

--- a/tests/integration/targets/nd_resource_manager/tests/nd/ibgp/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/ibgp/invalid_params.yaml
@@ -68,3 +68,72 @@
           - invalid_dynamic_pool_name.msg is defined
           - invalid_dynamic_pool_name.msg is search("Unsupported pool_name")
           - invalid_dynamic_pool_name.msg is search("10.4.99.0/30")
+
+    - name: iBGP gathered filters - Unsupported property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "ibgp_invalid_gathered"
+            vrf_name: "default"
+      register: invalid_gathered_unsupported_property
+      ignore_errors: true
+
+    - name: iBGP gathered filters - Assert unsupported property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_unsupported_property is failed
+          - invalid_gathered_unsupported_property.msg is defined
+          - invalid_gathered_unsupported_property.msg is search("unsupported gathered filter properties")
+          - invalid_gathered_unsupported_property.msg is search("vrf_name")
+
+    - name: iBGP gathered filters - Empty filter item
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - {}
+      register: invalid_gathered_empty_item
+      ignore_errors: true
+
+    - name: iBGP gathered filters - Assert empty filter item failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_empty_item is failed
+          - invalid_gathered_empty_item.msg is defined
+          - invalid_gathered_empty_item.msg is search("must contain at least one supported property")
+
+    - name: iBGP gathered filters - Null-only property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - pool_name: null
+      register: invalid_gathered_null_property
+      ignore_errors: true
+
+    - name: iBGP gathered filters - Assert null-only property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_null_property is failed
+          - invalid_gathered_null_property.msg is defined
+          - invalid_gathered_null_property.msg is search("cannot be null")
+          - invalid_gathered_null_property.msg is search("pool_name")
+
+    - name: iBGP gathered filters - Valid property mixed with null
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "ibgp_invalid_gathered"
+            pool_name: null
+      register: invalid_gathered_mixed_null_property
+      ignore_errors: true
+
+    - name: iBGP gathered filters - Assert mixed null property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_mixed_null_property is failed
+          - invalid_gathered_mixed_null_property.msg is defined
+          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
+          - invalid_gathered_mixed_null_property.msg is search("pool_name")

--- a/tests/integration/targets/nd_resource_manager/tests/nd/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/invalid_params.yaml
@@ -210,3 +210,72 @@
           - invalid_subnet_scope.msg is search("entity_name")
           - invalid_subnet_scope.msg is search("scope_type")
           - (invalid_subnet_scope.msg | lower) is search("device_interface")
+
+    - name: Gather Resources - Unsupported filter property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "invalid_gathered"
+            vrf_name: "default"
+      register: invalid_gathered_unsupported_property
+      ignore_errors: true
+
+    - name: Assert unsupported gathered filter property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_unsupported_property is failed
+          - invalid_gathered_unsupported_property.msg is defined
+          - invalid_gathered_unsupported_property.msg is search("unsupported gathered filter properties")
+          - invalid_gathered_unsupported_property.msg is search("vrf_name")
+
+    - name: Gather Resources - Empty filter item
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - {}
+      register: invalid_gathered_empty_item
+      ignore_errors: true
+
+    - name: Assert empty gathered filter item failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_empty_item is failed
+          - invalid_gathered_empty_item.msg is defined
+          - invalid_gathered_empty_item.msg is search("must contain at least one supported property")
+
+    - name: Gather Resources - Null-only filter property
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - pool_name: null
+      register: invalid_gathered_null_property
+      ignore_errors: true
+
+    - name: Assert null-only gathered filter property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_null_property is failed
+          - invalid_gathered_null_property.msg is defined
+          - invalid_gathered_null_property.msg is search("cannot be null")
+          - invalid_gathered_null_property.msg is search("pool_name")
+
+    - name: Gather Resources - Valid filter mixed with null
+      cisco.nd.nd_manage_resource_manager:
+        state: gathered
+        fabric_name: "{{ ansible_it_fabric }}"
+        config:
+          - entity_name: "invalid_gathered"
+            pool_name: null
+      register: invalid_gathered_mixed_null_property
+      ignore_errors: true
+
+    - name: Assert mixed null gathered filter property failed
+      ansible.builtin.assert:
+        that:
+          - invalid_gathered_mixed_null_property is failed
+          - invalid_gathered_mixed_null_property.msg is defined
+          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
+          - invalid_gathered_mixed_null_property.msg is search("pool_name")

--- a/tests/integration/targets/nd_resource_manager/tests/nd/invalid_params.yaml
+++ b/tests/integration/targets/nd_resource_manager/tests/nd/invalid_params.yaml
@@ -259,8 +259,7 @@
         that:
           - invalid_gathered_null_property is failed
           - invalid_gathered_null_property.msg is defined
-          - invalid_gathered_null_property.msg is search("cannot be null")
-          - invalid_gathered_null_property.msg is search("pool_name")
+          - invalid_gathered_null_property.msg is search("must contain at least one supported property")
 
     - name: Gather Resources - Valid filter mixed with null
       cisco.nd.nd_manage_resource_manager:
@@ -269,13 +268,9 @@
         config:
           - entity_name: "invalid_gathered"
             pool_name: null
-      register: invalid_gathered_mixed_null_property
-      ignore_errors: true
+      register: valid_gathered_mixed_null_property
 
-    - name: Assert mixed null gathered filter property failed
+    - name: Assert mixed null gathered filter property was ignored
       ansible.builtin.assert:
         that:
-          - invalid_gathered_mixed_null_property is failed
-          - invalid_gathered_mixed_null_property.msg is defined
-          - invalid_gathered_mixed_null_property.msg is search("cannot be null")
-          - invalid_gathered_mixed_null_property.msg is search("pool_name")
+          - valid_gathered_mixed_null_property is not failed

--- a/tests/unit/modules/test_manage_resource_manager.py
+++ b/tests/unit/modules/test_manage_resource_manager.py
@@ -17,6 +17,7 @@ import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
     NDModuleError,
 )
+from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import HAS_PYDANTIC
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_resources import (
     EpManageFabricResourcesGet,
@@ -525,27 +526,32 @@ def test_resource_manager_model_rejects_propertyless_gathered_items(item):
         ResourceManagerConfigModel.validate_gathered_config([item])
 
 
-@pytest.mark.parametrize("property_name", ResourceManagerConfigModel.GATHERED_FILTER_PROPERTIES)
-def test_resource_manager_model_rejects_null_gathered_properties(property_name):
-    """Every explicitly null gathered property is rejected."""
-    with pytest.raises(ValueError) as exc_info:
-        ResourceManagerConfigModel.validate_gathered_config([{property_name: None}])
-
-    message = str(exc_info.value)
-    assert "config index 0" in message
-    assert "cannot be null" in message
-    assert property_name in message
+def test_resource_manager_model_rejects_null_only_gathered_filter():
+    """A gathered item containing no active filter property is rejected."""
+    with pytest.raises(ValueError, match="must contain at least one supported property"):
+        ResourceManagerConfigModel.validate_gathered_config([{"pool_name": None}])
 
 
-def test_resource_manager_model_rejects_null_property_mixed_with_valid_filter():
-    """A valid gathered criterion does not hide another explicitly null field."""
-    with pytest.raises(ValueError) as exc_info:
-        ResourceManagerConfigModel.validate_gathered_config([{"entity_name": "loopback0", "pool_name": None}])
+def test_resource_manager_model_ignores_null_property_mixed_with_valid_filter():
+    """Null placeholders are ignored when an active gathered filter is present."""
+    validated = ResourceManagerConfigModel.validate_gathered_config([{"entity_name": "loopback0", "pool_name": None}])
 
-    message = str(exc_info.value)
-    assert "config index 0" in message
-    assert "cannot be null" in message
-    assert "pool_name" in message
+    assert validated == [{"entity_name": "loopback0"}]
+
+
+def test_resource_manager_model_accepts_ansible_normalized_gathered_filter():
+    """Omitted suboptions populated with None by Ansible are not treated as supplied."""
+    validator = ArgumentSpecValidator(ResourceManagerConfigModel.get_argument_spec())
+    result = validator.validate(
+        {
+            "fabric_name": "fabric-1",
+            "state": "gathered",
+            "config": [{"entity_name": "loopback0"}],
+        }
+    )
+
+    assert result.error_messages == []
+    assert ResourceManagerConfigModel.validate_gathered_config(result.validated_parameters["config"]) == [{"entity_name": "loopback0"}]
 
 
 def test_resource_manager_config_allows_auto_allocation_without_resource():
@@ -2812,18 +2818,11 @@ def test_gathered_rejects_unsupported_properties_before_api_calls(field, value):
     nd.request.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "config",
-    [
-        {"pool_name": None},
-        {"entity_name": "loopback0", "pool_name": None},
-    ],
-)
-def test_gathered_rejects_null_properties_before_api_calls(config):
-    """Gathered null validation runs before fabric or resource API calls."""
-    nd = _mock_nd_module(state="gathered", config=[config])
+def test_gathered_rejects_null_only_filter_before_api_calls():
+    """Gathered empty-filter validation runs before fabric or resource API calls."""
+    nd = _mock_nd_module(state="gathered", config=[{"pool_name": None}])
 
-    with pytest.raises(ValueError, match="pool_name"):
+    with pytest.raises(ValueError, match="must contain at least one supported property"):
         NDResourceManagerModule(nd, Results(), log=LOG)
 
     nd.request.assert_not_called()

--- a/tests/unit/modules/test_manage_resource_manager.py
+++ b/tests/unit/modules/test_manage_resource_manager.py
@@ -475,6 +475,79 @@ def test_resource_manager_config_allows_partial_gathered_filter():
     assert model.switches is None
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("entity_name", "loopback0"),
+        ("pool_name", "LOOPBACK_ID"),
+        ("switches", ["SER1"]),
+        ("resource", "10"),
+        ("scope_type", "device"),
+        ("pool_type", "id"),
+    ],
+)
+def test_resource_manager_model_validates_supported_gathered_properties(field, value):
+    """The model validates and normalizes every supported gathered property."""
+    validated = ResourceManagerConfigModel.validate_gathered_config([{field: value}])
+
+    expected = "ID" if field == "pool_type" else value
+    assert validated == [{field: expected}]
+
+
+def test_resource_manager_model_aggregates_unsupported_gathered_properties():
+    """The model reports every invalid gathered item with its config index."""
+    config = [
+        {"pool_name": "LOOPBACK_ID", "vrf_name": "blue"},
+        {"is_pre_allocated": False, "unknown_filter": "value"},
+    ]
+
+    with pytest.raises(ValueError) as exc_info:
+        ResourceManagerConfigModel.validate_gathered_config(config)
+
+    message = str(exc_info.value)
+    assert "config index 0" in message
+    assert "config index 1" in message
+    assert "vrf_name" in message
+    assert "is_pre_allocated" in message
+    assert "unknown_filter" in message
+
+
+@pytest.mark.parametrize("config", [None, []])
+def test_resource_manager_model_empty_gathered_config_gathers_all(config):
+    """Omitted and explicit empty gathered config both represent gather-all."""
+    assert ResourceManagerConfigModel.validate_gathered_config(config) == []
+
+
+@pytest.mark.parametrize("item", [{}, "not-a-dictionary"])
+def test_resource_manager_model_rejects_propertyless_gathered_items(item):
+    """A provided gathered item must contain a usable supported property."""
+    with pytest.raises(ValueError, match="config index 0"):
+        ResourceManagerConfigModel.validate_gathered_config([item])
+
+
+@pytest.mark.parametrize("property_name", ResourceManagerConfigModel.GATHERED_FILTER_PROPERTIES)
+def test_resource_manager_model_rejects_null_gathered_properties(property_name):
+    """Every explicitly null gathered property is rejected."""
+    with pytest.raises(ValueError) as exc_info:
+        ResourceManagerConfigModel.validate_gathered_config([{property_name: None}])
+
+    message = str(exc_info.value)
+    assert "config index 0" in message
+    assert "cannot be null" in message
+    assert property_name in message
+
+
+def test_resource_manager_model_rejects_null_property_mixed_with_valid_filter():
+    """A valid gathered criterion does not hide another explicitly null field."""
+    with pytest.raises(ValueError) as exc_info:
+        ResourceManagerConfigModel.validate_gathered_config([{"entity_name": "loopback0", "pool_name": None}])
+
+    message = str(exc_info.value)
+    assert "config index 0" in message
+    assert "cannot be null" in message
+    assert "pool_name" in message
+
+
 def test_resource_manager_config_allows_auto_allocation_without_resource():
     """Merged auto-allocation does not require an explicit resource value."""
     model = ResourceManagerConfigModel.model_validate(
@@ -2728,6 +2801,34 @@ def test_validate_input_gathered_with_partial_filter():
     assert result == []  # Gathered returns empty list
 
 
+@pytest.mark.parametrize("field,value", [("vrf_name", "blue"), ("is_pre_allocated", False)])
+def test_gathered_rejects_unsupported_properties_before_api_calls(field, value):
+    """Gathered property validation runs before fabric or resource API calls."""
+    nd = _mock_nd_module(state="gathered", config=[{field: value}])
+
+    with pytest.raises(ValueError, match=field):
+        NDResourceManagerModule(nd, Results(), log=LOG)
+
+    nd.request.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"pool_name": None},
+        {"entity_name": "loopback0", "pool_name": None},
+    ],
+)
+def test_gathered_rejects_null_properties_before_api_calls(config):
+    """Gathered null validation runs before fabric or resource API calls."""
+    nd = _mock_nd_module(state="gathered", config=[config])
+
+    with pytest.raises(ValueError, match="pool_name"):
+        NDResourceManagerModule(nd, Results(), log=LOG)
+
+    nd.request.assert_not_called()
+
+
 def test_validate_required_fields_compat_missing_entity_name():
     """_validate_required_fields_compat raises for missing entity_name."""
     module = _resource_manager()
@@ -3368,9 +3469,9 @@ def test_manage_deleted_with_no_matching_resource():
     assert module.results is not None
 
 
-def test_manage_gathered_with_empty_filter():
-    """manage_gathered with empty filter returns all resources."""
-    module, unused_nd = _resource_manager_with_nd(state="gathered", config=[{}], all_resources=[_response()])  # Empty filter = match all
+def test_manage_gathered_with_empty_config():
+    """manage_gathered with an empty config list returns all resources."""
+    module, unused_nd = _resource_manager_with_nd(state="gathered", config=[], all_resources=[_response()])
 
     # Run manage_gathered
     module.manage_gathered()  # pylint: disable=protected-access
@@ -3411,7 +3512,7 @@ def test_manage_gathered_with_entity_name_filter():
 
 def test_manage_gathered_empty_all_resources():
     """manage_gathered with empty resource list returns empty."""
-    module, unused_nd = _resource_manager_with_nd(state="gathered", config=[{}], all_resources=[])  # No resources
+    module, unused_nd = _resource_manager_with_nd(state="gathered", config=[], all_resources=[])
 
     # Run manage_gathered
     module.manage_gathered()  # pylint: disable=protected-access


### PR DESCRIPTION

## Proposed Changes

- Define and document the supported `state: gathered` filter properties:
  - `entity_name`
  - `pool_name`
  - `switches`
  - `resource`
  - `scope_type`
  - `pool_type`
- Use `pool_name` and `switches` as GET API query parameters.
- Apply all six supported properties during local resource matching.
- Do not use Lucene filtering because normalized entity matching for device-pair and link resources must be performed locally.
- Reject unsupported gathered filter properties before making API requests.
- Reject empty gathered filter items such as `config: [{}]`.
- Reject explicitly null supported properties, including when a null property is combined with another valid filter.
- Preserve gather-all behavior when `config` is omitted or specified as an empty list.
- Update module documentation with the supported filter matrix and validation behavior.
- Add unit tests for supported, unsupported, empty, null-only, and mixed-null gathered filters.
- Add invalid gathered-filter integration coverage to the root, BASE, iBGP, eBGP, and External resource-manager test suites.

## Test Notes

The following validation was completed:

- Focused gathered validation tests: `22 passed`
- Complete resource-manager unit suite: `291 passed`
- Parsed all five updated invalid_params.yaml files successfully.
- Verified register names are unique within each integration test file.
- Ran `ansible-test sanity --test validate-modules --venv plugins/modules/nd_manage_resource_manager.py` successfully.
- Verified no VS Code diagnostics in the changed Python and YAML files.

## Cisco Nexus Dashboard Version
Cisco Nexus Dashboard 4.3x

## Related ND API Resource Category
<!-- Please select ND API resource category, please specify -->
* [ ] analyze
* [ ] infa
* [x] manage
* [ ] onemanage
* [ ] other

Resource category: Manage resource manager API (`/manage/api/v1`).

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
