### PR TITLE
Integration: nd_interface_ethernet_access setup probe policy + deploy timeout

### DIFF
--- a/tests/integration/targets/nd_interface_ethernet_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_access/tasks/main.yaml
@@ -37,16 +37,12 @@
       output_level: '{{ api_key_output_level | default("debug") }}'
 
 - name: Run nd_interface_ethernet_access state tests with optional logging env
-  # The `timeout` module arg propagates via sender_nd.set_params() into the
-  # httpapi plugin, which calls connection.set_option("persistent_command_timeout", ...).
-  # The module arg's default (30s) overrides any inventory-level ansible_command_timeout
-  # on every task, and a multi-switch bulk interfaceActions/deploy (e.g. the overridden
-  # phase) can exceed 30s on slow testbeds (e.g. 9000v). 300s matches the port-channel
-  # targets, scoped to this test target via module_defaults so we don't modify shared
-  # argspec defaults.
-  module_defaults:
-    cisco.nd.nd_interface_ethernet_access:
-      timeout: 300
+  # 300s gives ND enough time to complete a multi-switch bulk interfaceActions/deploy
+  # (e.g. the overridden phase) on slow testbeds (e.g. 9000v) where the default 30s is
+  # too short. The native Ansible connection variable is scoped to this block, matching
+  # the port-channel targets.
+  vars:
+    ansible_command_timeout: 300
   block:
     - name: Pre-test cleanup
       ansible.builtin.include_tasks: setup.yaml

--- a/tests/integration/targets/nd_interface_ethernet_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_access/tasks/main.yaml
@@ -37,6 +37,16 @@
       output_level: '{{ api_key_output_level | default("debug") }}'
 
 - name: Run nd_interface_ethernet_access state tests with optional logging env
+  # The `timeout` module arg propagates via sender_nd.set_params() into the
+  # httpapi plugin, which calls connection.set_option("persistent_command_timeout", ...).
+  # The module arg's default (30s) overrides any inventory-level ansible_command_timeout
+  # on every task, and a multi-switch bulk interfaceActions/deploy (e.g. the overridden
+  # phase) can exceed 30s on slow testbeds (e.g. 9000v). 300s matches the port-channel
+  # targets, scoped to this test target via module_defaults so we don't modify shared
+  # argspec defaults.
+  module_defaults:
+    cisco.nd.nd_interface_ethernet_access:
+      timeout: 300
   block:
     - name: Pre-test cleanup
       ansible.builtin.include_tasks: setup.yaml

--- a/tests/integration/targets/nd_interface_ethernet_access/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_access/tasks/setup.yaml
@@ -26,6 +26,9 @@
     var: setup_cleanup
   tags: always
 
+# The probe supplies an empty (but present) policy: the policy-required-on-create preflight (issue #350) rejects a
+# create item whose policy is None -- and it runs in check mode by design -- so a bare `policy:` would fail here
+# whenever the cleanup above actually removed the interface (making this probe a "new" item).
 - name: "DEBUG: Re-query to see if interfaces are still present after cleanup"
   cisco.nd.nd_interface_ethernet_access:
     output_level: "{{ nd_info.output_level }}"
@@ -36,7 +39,7 @@
           - Ethernet1/41
         config_data:
           network_os:
-            policy:
+            policy: {}
     state: merged
   check_mode: true
   register: debug_requery


### PR DESCRIPTION
## Related Issue(s)

Fixes #408

## Proposed Changes

- `tasks/setup.yaml`: the check-mode re-query probe now sends an empty-but-present `policy: {}` instead of a bare `policy:` (null), which the policy-required-on-create preflight (#350, PR #362) rejects whenever the preceding cleanup actually removed the interface. Matches the fix already applied to `nd_interface_ethernet_trunk_host` in PR #360, including the explanatory comment.
- `tasks/main.yaml`: scope `vars: ansible_command_timeout: 300` to the test block, matching the port-channel targets. The multi-switch bulk `interfaceActions/deploy` in the overridden phase exceeds the 30s default on the 9000v testbed; since #486 removed the module-level `timeout` argument, the native connection variable is the intended control.

Scope audit re-run for #408: after this change, no integration target contains a truly null `policy:` key (a `policy:` line whose next non-comment line is not more-deeply indented).

## Test Notes

- Full `nd_interface_ethernet_access` network-integration target run green against the live SITE1 lab (ND 4.2.1, 9000v testbed) on the pre-#486 head (`module_defaults` timeout), including the overridden-phase deploy that previously timed out; the setup cleanup also reconciled the pending intent orphaned by the earlier mid-deploy timeout (setup task reported `changed`)
- Re-run from the current head (`ansible_command_timeout` block var) completed 2026-08-27 against the live SITE1 lab (ND 4.2.1.10, S1_BG1 N9K-C9300v / NX-OS 10.6(2)): `ok=89 changed=30 failed=0 skipped=1`, ~3 min wall clock, all deploy steps inside the timeout
- `ansible-test sanity --test yamllint` passes on both changed files (nd-dev container machine)

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)


