### PR TITLE
ND_Manage_Networks: Support Empty Network Attachment Interfaces and PVLAN Secondary Networks

### DIFF
--- a/plugins/module_utils/models/manage_networks/config_models.py
+++ b/plugins/module_utils/models/manage_networks/config_models.py
@@ -68,7 +68,7 @@ class NetworkAttachmentConfigModel(NDNestedModel):
 
     ip_address: str = Field(alias="ipAddress")
     vlan_id: int | None = Field(default=None, alias="vlanId")
-    interfaces: list[NetworkInterfaceConfigModel] = Field(default=...)
+    interfaces: list[NetworkInterfaceConfigModel] = Field(default_factory=list)
     deploy: bool | None = True
     attachment_options: dict[str, Any] | None = None
     extra_config: str | None = Field(default=None, alias="extraConfig")

--- a/plugins/module_utils/models/manage_networks/config_models.py
+++ b/plugins/module_utils/models/manage_networks/config_models.py
@@ -83,12 +83,6 @@ class NetworkAttachmentConfigModel(NDNestedModel):
     def _validate_vlan(cls, v: int | None) -> int | None:
         return NetworkValidators.validate_vlan_id(v)
 
-    @model_validator(mode="after")
-    def _check_interfaces(self):
-        if not self.interfaces:
-            raise ValueError("interfaces is required for network attachments")
-        return self
-
 
 class NetworkChildConfigModel(NDNestedModel):
     """Per-child-fabric override entry for MSD/MFD parent workflows."""

--- a/plugins/module_utils/models/manage_networks/config_models.py
+++ b/plugins/module_utils/models/manage_networks/config_models.py
@@ -153,9 +153,6 @@ class NetworkConfigModel(NDBaseModel):
     network_type: str | None = Field(default=None, alias="networkType")
     vlan_network_type: str = Field(default=VlanNetworkType.NORMAL.value, alias="vlanNetworkType")
     primary_network_id: int | None = Field(default=None, alias="primaryNetworkId")
-    primary_network_name: str | None = Field(default=None, alias="primaryNetworkName")
-    normal_network_id: int | None = Field(default=None, alias="normalNetworkId")
-    normal_network_name: str | None = Field(default=None, alias="normalNetworkName")
     display_name: str | None = Field(default=None, alias="displayName")
     vrf_name: str | None = Field(default=None, alias="vrfName", max_length=32)
     vlan_id: int | None = Field(default=None, alias="vlanId")
@@ -275,7 +272,7 @@ class NetworkConfigModel(NDBaseModel):
     def _validate_tenant_name(cls, v: str | None) -> str | None:
         return NetworkValidators.validate_tenant_name(v)
 
-    @field_validator("network_id", "primary_network_id", "normal_network_id", mode="before")
+    @field_validator("network_id", "primary_network_id", mode="before")
     @classmethod
     def _validate_network_id(cls, v: int | None) -> int | None:
         return NetworkValidators.validate_network_id(v)
@@ -358,38 +355,24 @@ class NetworkConfigModel(NDBaseModel):
 
     def _check_vlan_network_type_rules(self) -> None:
         role = self.vlan_network_type
-        primary_refs = [name for name in ("primary_network_id", "primary_network_name") if getattr(self, name) is not None]
-        normal_refs = [name for name in ("normal_network_id", "normal_network_name") if getattr(self, name) is not None]
+        primary_refs = [name for name in ("primary_network_id",) if getattr(self, name) is not None]
 
         if role in (VlanNetworkType.NORMAL.value, VlanNetworkType.PRIVATE_PRIMARY.value):
-            refs = primary_refs + normal_refs
-            if refs:
-                raise ValueError(f"{role} networks do not use parent network references: {', '.join(refs)}")
+            if primary_refs:
+                raise ValueError(f"{role} networks do not use parent network references: {', '.join(primary_refs)}")
             return
 
-        if role in (VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value, VlanNetworkType.PRIMARY_SECONDARY_ISOLATED.value):
+        if role == VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value:
             if not primary_refs:
-                raise ValueError(f"{role} requires primary_network_id or primary_network_name")
-            if normal_refs:
-                raise ValueError(f"{role} uses primary_network_id/name, not normal_network_id/name")
+                raise ValueError(f"{role} requires primary_network_id")
             self._reject_l3_fields_for_vlan_network_type(role)
             return
+
+        if role == VlanNetworkType.PRIMARY_SECONDARY_ISOLATED.value:
+            raise ValueError("primary_secondary_isolated networks are not supported by this module")
 
         if role == VlanNetworkType.CHILD.value:
-            if network_type := self.network_type:
-                if network_type in (NetworkType.ACI.value, NetworkType.VXLAN_ACI.value):
-                    if not normal_refs:
-                        raise ValueError("child networks with network_type aci/vxlanAci require normal_network_id or normal_network_name")
-                    if primary_refs:
-                        raise ValueError("child networks with network_type aci/vxlanAci use normal_network_id/name, not primary_network_id/name")
-                else:
-                    if not primary_refs:
-                        raise ValueError("child networks require primary_network_id or primary_network_name")
-                    if normal_refs:
-                        raise ValueError("child networks use primary_network_id/name unless network_type is aci/vxlanAci")
-            elif not primary_refs and not normal_refs:
-                raise ValueError("child networks require a parent reference")
-            self._reject_l3_fields_for_vlan_network_type(role)
+            raise ValueError("child networks require ACI normal-network association fields and are not supported by this module")
 
     def _reject_l3_fields_for_vlan_network_type(self, role: str) -> None:
         if self.layer == "layer3" or self.is_l2only is False:

--- a/plugins/module_utils/models/manage_networks/config_models.py
+++ b/plugins/module_utils/models/manage_networks/config_models.py
@@ -20,6 +20,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNe
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.enums import (
     MappingType,
     NetworkType,
+    VlanNetworkType,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.validators import (
     NetworkValidators,
@@ -30,6 +31,13 @@ _CUSTOM_NETWORK_TEMPLATE_FIELDS = (
     "network_extension_template_name",
     "network_template_config",
 )
+
+_NETWORK_TYPE_USER_DEFINED = NetworkType.USER_DEFINED.name.lower()
+
+
+def _snake_to_lower_camel(value: str) -> str:
+    parts = value.split("_")
+    return parts[0] + "".join(part.capitalize() for part in parts[1:])
 
 
 class NetworkInterfaceConfigModel(NDNestedModel):
@@ -143,6 +151,11 @@ class NetworkConfigModel(NDBaseModel):
     net_extension_template: str | None = None
     network_id: int | None = Field(default=None, alias="networkId")
     network_type: str | None = Field(default=None, alias="networkType")
+    vlan_network_type: str = Field(default=VlanNetworkType.NORMAL.value, alias="vlanNetworkType")
+    primary_network_id: int | None = Field(default=None, alias="primaryNetworkId")
+    primary_network_name: str | None = Field(default=None, alias="primaryNetworkName")
+    normal_network_id: int | None = Field(default=None, alias="normalNetworkId")
+    normal_network_name: str | None = Field(default=None, alias="normalNetworkName")
     display_name: str | None = Field(default=None, alias="displayName")
     vrf_name: str | None = Field(default=None, alias="vrfName", max_length=32)
     vlan_id: int | None = Field(default=None, alias="vlanId")
@@ -211,10 +224,12 @@ class NetworkConfigModel(NDBaseModel):
             if secondary:
                 normalized["secondary_gateway_ipv4_collection"] = secondary
 
-        normalized["dhcp_servers"] = cls._normalize_legacy_dhcp_servers(normalized)
+        dhcp_servers = cls._normalize_legacy_dhcp_servers(normalized)
+        if dhcp_servers is not None:
+            normalized["dhcp_servers"] = dhcp_servers
 
         network_type = normalized.get("network_type") or normalized.get("networkType")
-        if network_type == NetworkType.USER_DEFINED.value:
+        if network_type == _NETWORK_TYPE_USER_DEFINED:
             if normalized.get("net_template") and not normalized.get("network_template_name"):
                 normalized["network_template_name"] = normalized["net_template"]
             if normalized.get("net_extension_template") and not normalized.get("network_extension_template_name"):
@@ -225,6 +240,7 @@ class NetworkConfigModel(NDBaseModel):
     @staticmethod
     def _normalize_legacy_dhcp_servers(data: dict[str, Any]) -> list[dict[str, Any]] | None:
         """Normalize old DHCP server keys into API serverAddress/serverVrf shape."""
+        has_dhcp_input = "dhcp_servers" in data or "dhcpServers" in data or any(f"dhcp_srvr{index}_ip" in data for index in range(1, 4))
         normalized_servers: list[dict[str, Any]] = []
         for server in data.get("dhcp_servers") or data.get("dhcpServers") or []:
             if not isinstance(server, dict):
@@ -245,7 +261,9 @@ class NetworkConfigModel(NDBaseModel):
                 if vrf:
                     item["server_vrf"] = vrf
                 normalized_servers.append(item)
-        return normalized_servers or None
+        if normalized_servers:
+            return normalized_servers
+        return [] if has_dhcp_input else None
 
     @field_validator("network_name", mode="before")
     @classmethod
@@ -257,10 +275,32 @@ class NetworkConfigModel(NDBaseModel):
     def _validate_tenant_name(cls, v: str | None) -> str | None:
         return NetworkValidators.validate_tenant_name(v)
 
-    @field_validator("network_id", mode="before")
+    @field_validator("network_id", "primary_network_id", "normal_network_id", mode="before")
     @classmethod
     def _validate_network_id(cls, v: int | None) -> int | None:
         return NetworkValidators.validate_network_id(v)
+
+    @field_validator("network_type", mode="before")
+    @classmethod
+    def _validate_network_type(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if v == NetworkType.USER_DEFINED.value:
+            return v
+        if v != _NETWORK_TYPE_USER_DEFINED:
+            raise ValueError("network_type must be omitted unless using user_defined")
+        return NetworkType(_snake_to_lower_camel(v)).value
+
+    @field_validator("vlan_network_type", mode="before")
+    @classmethod
+    def _validate_vlan_network_type(cls, v: str | None) -> str:
+        if v is None:
+            return VlanNetworkType.NORMAL.value
+        try:
+            return VlanNetworkType(_snake_to_lower_camel(v)).value
+        except ValueError as exc:
+            choices = sorted(item.name.lower() for item in VlanNetworkType)
+            raise ValueError(f"vlan_network_type must be one of {choices}, got: {v}") from exc
 
     @field_validator("vlan_id", mode="before")
     @classmethod
@@ -308,12 +348,72 @@ class NetworkConfigModel(NDBaseModel):
         custom_fields = {field: getattr(self, field) for field in _CUSTOM_NETWORK_TEMPLATE_FIELDS}
         set_custom_fields = [field for field, value in custom_fields.items() if value is not None]
         if set_custom_fields and network_type != NetworkType.USER_DEFINED.value:
-            raise ValueError("network template fields require network_type=userDefined: " + ", ".join(set_custom_fields))
+            raise ValueError("network template fields require network_type=user_defined: " + ", ".join(set_custom_fields))
+        self._check_vlan_network_type_rules()
         if self.deploy_type not in ("switch", "network"):
             raise ValueError("deploy_type must be either 'switch' or 'network'")
         if self.is_l2only is False and not self.vrf_name:
             raise ValueError("vrf_name is required for layer3 networks")
         return self
+
+    def _check_vlan_network_type_rules(self) -> None:
+        role = self.vlan_network_type
+        primary_refs = [name for name in ("primary_network_id", "primary_network_name") if getattr(self, name) is not None]
+        normal_refs = [name for name in ("normal_network_id", "normal_network_name") if getattr(self, name) is not None]
+
+        if role in (VlanNetworkType.NORMAL.value, VlanNetworkType.PRIVATE_PRIMARY.value):
+            refs = primary_refs + normal_refs
+            if refs:
+                raise ValueError(f"{role} networks do not use parent network references: {', '.join(refs)}")
+            return
+
+        if role in (VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value, VlanNetworkType.PRIMARY_SECONDARY_ISOLATED.value):
+            if not primary_refs:
+                raise ValueError(f"{role} requires primary_network_id or primary_network_name")
+            if normal_refs:
+                raise ValueError(f"{role} uses primary_network_id/name, not normal_network_id/name")
+            self._reject_l3_fields_for_vlan_network_type(role)
+            return
+
+        if role == VlanNetworkType.CHILD.value:
+            if network_type := self.network_type:
+                if network_type in (NetworkType.ACI.value, NetworkType.VXLAN_ACI.value):
+                    if not normal_refs:
+                        raise ValueError("child networks with network_type aci/vxlanAci require normal_network_id or normal_network_name")
+                    if primary_refs:
+                        raise ValueError("child networks with network_type aci/vxlanAci use normal_network_id/name, not primary_network_id/name")
+                else:
+                    if not primary_refs:
+                        raise ValueError("child networks require primary_network_id or primary_network_name")
+                    if normal_refs:
+                        raise ValueError("child networks use primary_network_id/name unless network_type is aci/vxlanAci")
+            elif not primary_refs and not normal_refs:
+                raise ValueError("child networks require a parent reference")
+            self._reject_l3_fields_for_vlan_network_type(role)
+
+    def _reject_l3_fields_for_vlan_network_type(self, role: str) -> None:
+        if self.layer == "layer3" or self.is_l2only is False:
+            raise ValueError(f"{role} networks do not support layer3 intent")
+        l3_fields = {
+            "gateway_ipv4_address",
+            "gateway_ipv6_address",
+            "secondary_gateway_ipv4_collection",
+            "secondary_gateway_ipv6_collection",
+            "vlan_intf_desc",
+            "mtu",
+            "arp_suppression",
+            "routing_tag",
+            "dhcp_servers",
+            "loopback_id",
+            "igmp_version",
+            "trm_enable",
+            "ipv6_trm",
+            "netflow_enable",
+            "gateway_on_border",
+        }
+        set_l3_fields = sorted(field for field in l3_fields if field in self.model_fields_set)
+        if set_l3_fields:
+            raise ValueError(f"{role} networks do not support L3 fields: {', '.join(set_l3_fields)}")
 
 
 class NetworkParentConfigModel(NetworkConfigModel):

--- a/plugins/module_utils/models/manage_networks/config_models.py
+++ b/plugins/module_utils/models/manage_networks/config_models.py
@@ -21,6 +21,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.en
     MappingType,
     NetworkType,
     VlanNetworkType,
+    normalize_vlan_network_type,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.validators import (
     NetworkValidators,
@@ -33,6 +34,10 @@ _CUSTOM_NETWORK_TEMPLATE_FIELDS = (
 )
 
 _NETWORK_TYPE_USER_DEFINED = NetworkType.USER_DEFINED.name.lower()
+_PRIVATE_SECONDARY_VLAN_NETWORK_TYPES = (
+    VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value,
+    VlanNetworkType.PRIVATE_SECONDARY_ISOLATED.value,
+)
 
 
 def _snake_to_lower_camel(value: str) -> str:
@@ -153,6 +158,7 @@ class NetworkConfigModel(NDBaseModel):
     network_type: str | None = Field(default=None, alias="networkType")
     vlan_network_type: str = Field(default=VlanNetworkType.NORMAL.value, alias="vlanNetworkType")
     primary_network_id: int | None = Field(default=None, alias="primaryNetworkId")
+    primary_network_name: str | None = Field(default=None, alias="primaryNetworkName")
     display_name: str | None = Field(default=None, alias="displayName")
     vrf_name: str | None = Field(default=None, alias="vrfName", max_length=32)
     vlan_id: int | None = Field(default=None, alias="vlanId")
@@ -262,7 +268,7 @@ class NetworkConfigModel(NDBaseModel):
             return normalized_servers
         return [] if has_dhcp_input else None
 
-    @field_validator("network_name", mode="before")
+    @field_validator("network_name", "primary_network_name", mode="before")
     @classmethod
     def _validate_network_name(cls, v: str | None) -> str | None:
         return NetworkValidators.validate_network_name(v)
@@ -291,13 +297,7 @@ class NetworkConfigModel(NDBaseModel):
     @field_validator("vlan_network_type", mode="before")
     @classmethod
     def _validate_vlan_network_type(cls, v: str | None) -> str:
-        if v is None:
-            return VlanNetworkType.NORMAL.value
-        try:
-            return VlanNetworkType(_snake_to_lower_camel(v)).value
-        except ValueError as exc:
-            choices = sorted(item.name.lower() for item in VlanNetworkType)
-            raise ValueError(f"vlan_network_type must be one of {choices}, got: {v}") from exc
+        return normalize_vlan_network_type(v)
 
     @field_validator("vlan_id", mode="before")
     @classmethod
@@ -344,7 +344,8 @@ class NetworkConfigModel(NDBaseModel):
         network_type = self.network_type
         custom_fields = {field: getattr(self, field) for field in _CUSTOM_NETWORK_TEMPLATE_FIELDS}
         set_custom_fields = [field for field, value in custom_fields.items() if value is not None]
-        if set_custom_fields and network_type != NetworkType.USER_DEFINED.value:
+        secondary_template_network = self.vlan_network_type in _PRIVATE_SECONDARY_VLAN_NETWORK_TYPES
+        if set_custom_fields and network_type != NetworkType.USER_DEFINED.value and not secondary_template_network:
             raise ValueError("network template fields require network_type=user_defined: " + ", ".join(set_custom_fields))
         self._check_vlan_network_type_rules()
         if self.deploy_type not in ("switch", "network"):
@@ -355,48 +356,68 @@ class NetworkConfigModel(NDBaseModel):
 
     def _check_vlan_network_type_rules(self) -> None:
         role = self.vlan_network_type
-        primary_refs = [name for name in ("primary_network_id",) if getattr(self, name) is not None]
+        primary_refs = [name for name in ("primary_network_id", "primary_network_name") if getattr(self, name) is not None]
 
         if role in (VlanNetworkType.NORMAL.value, VlanNetworkType.PRIVATE_PRIMARY.value):
             if primary_refs:
                 raise ValueError(f"{role} networks do not use parent network references: {', '.join(primary_refs)}")
             return
 
-        if role == VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value:
+        if role in _PRIVATE_SECONDARY_VLAN_NETWORK_TYPES:
             if not primary_refs:
-                raise ValueError(f"{role} requires primary_network_id")
-            self._reject_l3_fields_for_vlan_network_type(role)
+                raise ValueError(f"{role} requires primary_network_id or primary_network_name")
+            self._check_private_secondary_template_fields(role)
             return
-
-        if role == VlanNetworkType.PRIMARY_SECONDARY_ISOLATED.value:
-            raise ValueError("primary_secondary_isolated networks are not supported by this module")
 
         if role == VlanNetworkType.CHILD.value:
             raise ValueError("child networks require ACI normal-network association fields and are not supported by this module")
 
-    def _reject_l3_fields_for_vlan_network_type(self, role: str) -> None:
+    def _check_private_secondary_template_fields(self, role: str) -> None:
         if self.layer == "layer3" or self.is_l2only is False:
             raise ValueError(f"{role} networks do not support layer3 intent")
-        l3_fields = {
+        disallowed_fields = {
             "gateway_ipv4_address",
             "gateway_ipv6_address",
+            "gw_ip_subnet",
+            "gw_ipv6_subnet",
             "secondary_gateway_ipv4_collection",
             "secondary_gateway_ipv6_collection",
+            "secondary_ip_gw1",
+            "secondary_ip_gw2",
+            "secondary_ip_gw3",
+            "secondary_ip_gw4",
             "vlan_intf_desc",
+            "int_desc",
             "mtu",
+            "mtu_l3intf",
             "arp_suppression",
+            "arp_suppress",
             "routing_tag",
             "dhcp_servers",
+            "dhcp_srvr1_ip",
+            "dhcp_srvr1_vrf",
+            "dhcp_srvr2_ip",
+            "dhcp_srvr2_vrf",
+            "dhcp_srvr3_ip",
+            "dhcp_srvr3_vrf",
             "loopback_id",
+            "dhcp_loopback_id",
             "igmp_version",
             "trm_enable",
             "ipv6_trm",
             "netflow_enable",
             "gateway_on_border",
+            "l3gw_on_border",
+            "tenant_name",
+            "x_connect",
+            "l2_fabric_data",
+            "stretch",
+            "ds_vni",
+            "network_template_config",
         }
-        set_l3_fields = sorted(field for field in l3_fields if field in self.model_fields_set)
-        if set_l3_fields:
-            raise ValueError(f"{role} networks do not support L3 fields: {', '.join(set_l3_fields)}")
+        rejected_fields = sorted(field for field in disallowed_fields if field in self.model_fields_set)
+        if rejected_fields:
+            raise ValueError(f"{role} networks support only PVLAN secondary template fields: {', '.join(rejected_fields)}")
 
 
 class NetworkParentConfigModel(NetworkConfigModel):

--- a/plugins/module_utils/models/manage_networks/enums.py
+++ b/plugins/module_utils/models/manage_networks/enums.py
@@ -91,12 +91,38 @@ class VlanNetworkType(str, Enum):
     NORMAL = "normal"
     PRIVATE_PRIMARY = "privatePrimary"
     PRIVATE_SECONDARY_COMMUNITY = "privateSecondaryCommunity"
-    PRIMARY_SECONDARY_ISOLATED = "primarySecondaryIsolated"
+    PRIVATE_SECONDARY_ISOLATED = "privateSecondaryIsolated"
     CHILD = "child"
 
     @classmethod
     def choices(cls) -> list[str]:
         return [e.value for e in cls]
+
+
+PUBLIC_VLAN_NETWORK_TYPE_TO_API = {
+    "normal": VlanNetworkType.NORMAL.value,
+    "primary": VlanNetworkType.PRIVATE_PRIMARY.value,
+    "community": VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value,
+    "isolated": VlanNetworkType.PRIVATE_SECONDARY_ISOLATED.value,
+}
+API_VLAN_NETWORK_TYPE_TO_PUBLIC = {value: key for key, value in PUBLIC_VLAN_NETWORK_TYPE_TO_API.items()}
+
+
+def normalize_vlan_network_type(value: str | None) -> str:
+    if value is None:
+        return VlanNetworkType.NORMAL.value
+    if value in PUBLIC_VLAN_NETWORK_TYPE_TO_API:
+        return PUBLIC_VLAN_NETWORK_TYPE_TO_API[value]
+    if value in VlanNetworkType.choices():
+        return value
+    choices = sorted(PUBLIC_VLAN_NETWORK_TYPE_TO_API)
+    raise ValueError(f"vlan_network_type must be one of {choices}, got: {value}")
+
+
+def public_vlan_network_type(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return API_VLAN_NETWORK_TYPE_TO_PUBLIC.get(value, value)
 
 
 class AciVlanNetworkType(str, Enum):

--- a/plugins/module_utils/models/manage_networks/network_data_models.py
+++ b/plugins/module_utils/models/manage_networks/network_data_models.py
@@ -29,6 +29,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.en
     OperationStatus,
     VlanNetworkType,
     VlanPoolDomainType,
+    public_vlan_network_type,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.validators import (
     NetworkValidators,
@@ -367,6 +368,12 @@ class NetworkBaseModel(NetworkCommonModel):
     @classmethod
     def validate_network_id(cls, v: int | None) -> int | None:
         return NetworkValidators.validate_network_id(v)
+
+    def to_config(self, **kwargs) -> dict[str, Any]:
+        data = super().to_config(**kwargs)
+        if "vlan_network_type" in data:
+            data["vlan_network_type"] = public_vlan_network_type(data["vlan_network_type"])
+        return data
 
     @classmethod
     def from_response(cls, response: dict[str, Any], **kwargs) -> "NetworkBaseModel":

--- a/plugins/module_utils/models/manage_networks/network_data_models.py
+++ b/plugins/module_utils/models/manage_networks/network_data_models.py
@@ -347,7 +347,7 @@ class NetworkBaseModel(NetworkCommonModel):
     """Generic model for components/schemas/networkBase discriminator payloads."""
 
     network_type: NetworkType | str | None = Field(default=None, alias="networkType")
-    vlan_network_type: VlanNetworkType | str | None = Field(default=None, alias="vlanNetworkType")
+    vlan_network_type: VlanNetworkType | str | None = Field(default=VlanNetworkType.NORMAL, alias="vlanNetworkType")
     primary_network_id: int | None = Field(default=None, alias="primaryNetworkId")
     primary_network_name: str | None = Field(default=None, alias="primaryNetworkName")
     normal_network_id: int | None = Field(default=None, alias="normalNetworkId")
@@ -446,7 +446,7 @@ class VxlanAciNetworkModel(NetworkBaseModel):
     """VXLAN ACI network model."""
 
     network_type: Literal[NetworkType.VXLAN_ACI] = Field(default=NetworkType.VXLAN_ACI, alias="networkType")
-    vlan_network_type: AciVlanNetworkType | str | None = Field(default=None, alias="vlanNetworkType")
+    vlan_network_type: AciVlanNetworkType | str | None = Field(default=AciVlanNetworkType.NORMAL, alias="vlanNetworkType")
 
 
 class AciNetworkModel(VxlanAciNetworkModel):

--- a/plugins/module_utils/orchestrators/network_argument_specs.py
+++ b/plugins/module_utils/orchestrators/network_argument_specs.py
@@ -33,7 +33,7 @@ def _attachment_spec():
     return dict(
         ip_address=dict(type="str", required=True),
         vlan_id=dict(type="int"),
-        interfaces=dict(type="list", elements="dict", required=True, options=_network_interface_spec()),
+        interfaces=dict(type="list", elements="dict", default=[], options=_network_interface_spec()),
         deploy=dict(type="bool", default=True),
         attachment_options=dict(type="dict"),
         extra_config=dict(type="str"),

--- a/plugins/module_utils/orchestrators/network_argument_specs.py
+++ b/plugins/module_utils/orchestrators/network_argument_specs.py
@@ -7,8 +7,16 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.en
     MappingType,
     NetworkAttachmentMode,
     NetworkLayer,
-    NetworkType,
 )
+
+NETWORK_TYPE_CHOICES = ["user_defined"]
+VLAN_NETWORK_TYPE_CHOICES = [
+    "normal",
+    "private_primary",
+    "private_secondary_community",
+    "primary_secondary_isolated",
+    "child",
+]
 
 
 def _dhcp_server_spec():
@@ -120,7 +128,12 @@ def network_base_argument_spec():
     spec = dict(
         network_name=dict(type="str"),
         net_name=dict(type="str"),
-        network_type=dict(type="str", choices=NetworkType.choices()),
+        network_type=dict(type="str", choices=NETWORK_TYPE_CHOICES),
+        vlan_network_type=dict(type="str", choices=VLAN_NETWORK_TYPE_CHOICES),
+        primary_network_id=dict(type="int"),
+        primary_network_name=dict(type="str"),
+        normal_network_id=dict(type="int"),
+        normal_network_name=dict(type="str"),
         display_name=dict(type="str"),
         vrf_name=dict(type="str"),
         tenant_name=dict(type="str"),

--- a/plugins/module_utils/orchestrators/network_argument_specs.py
+++ b/plugins/module_utils/orchestrators/network_argument_specs.py
@@ -12,8 +12,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.en
 NETWORK_TYPE_CHOICES = ["user_defined"]
 VLAN_NETWORK_TYPE_CHOICES = [
     "normal",
-    "private_primary",
-    "private_secondary_community",
+    "primary",
+    "community",
+    "isolated",
 ]
 
 
@@ -128,6 +129,7 @@ def network_base_argument_spec():
         network_type=dict(type="str", choices=NETWORK_TYPE_CHOICES),
         vlan_network_type=dict(type="str", choices=VLAN_NETWORK_TYPE_CHOICES),
         primary_network_id=dict(type="int"),
+        primary_network_name=dict(type="str"),
         display_name=dict(type="str"),
         vrf_name=dict(type="str"),
         tenant_name=dict(type="str"),

--- a/plugins/module_utils/orchestrators/network_argument_specs.py
+++ b/plugins/module_utils/orchestrators/network_argument_specs.py
@@ -14,8 +14,6 @@ VLAN_NETWORK_TYPE_CHOICES = [
     "normal",
     "private_primary",
     "private_secondary_community",
-    "primary_secondary_isolated",
-    "child",
 ]
 
 
@@ -48,8 +46,7 @@ def _attachment_spec():
     )
 
 
-def _shared_network_fields(defaults=True):
-    bool_default = False if defaults else None
+def _shared_network_fields():
     return dict(
         network_id=dict(type="int"),
         net_id=dict(type="int"),
@@ -67,10 +64,10 @@ def _shared_network_fields(defaults=True):
         secondary_gateway_ipv6_collection=dict(type="list", elements="str"),
         vlan_intf_desc=dict(type="str"),
         int_desc=dict(type="str"),
-        mtu=dict(type="int", default=9216) if defaults else dict(type="int"),
-        mtu_l3intf=dict(type="int", default=9216) if defaults else dict(type="int"),
-        arp_suppression=dict(type="bool", default=bool_default) if defaults else dict(type="bool"),
-        arp_suppress=dict(type="bool", default=bool_default) if defaults else dict(type="bool"),
+        mtu=dict(type="int"),
+        mtu_l3intf=dict(type="int"),
+        arp_suppression=dict(type="bool"),
+        arp_suppress=dict(type="bool"),
         routing_tag=dict(type="int"),
         dhcp_servers=dict(type="list", elements="dict", options=_dhcp_server_spec()),
         dhcp_srvr1_ip=dict(type="str"),
@@ -84,13 +81,13 @@ def _shared_network_fields(defaults=True):
         igmp_version=dict(type="int", choices=[1, 2, 3]),
         trm_enable=dict(type="bool"),
         ipv6_trm=dict(type="bool"),
-        route_target_both=dict(type="bool", default=bool_default) if defaults else dict(type="bool"),
+        route_target_both=dict(type="bool"),
         l2_fabric_data=dict(type="dict"),
         stretch=dict(type="str"),
-        enable_ir=dict(type="bool", default=False) if defaults else dict(type="bool"),
+        enable_ir=dict(type="bool"),
         multicast_group_address=dict(type="str"),
         ds_vni=dict(type="int"),
-        netflow_enable=dict(type="bool", default=bool_default) if defaults else dict(type="bool"),
+        netflow_enable=dict(type="bool"),
         intfvlan_nf_monitor=dict(type="str"),
         vlan_nf_monitor=dict(type="str"),
         gateway_on_border=dict(type="bool"),
@@ -131,9 +128,6 @@ def network_base_argument_spec():
         network_type=dict(type="str", choices=NETWORK_TYPE_CHOICES),
         vlan_network_type=dict(type="str", choices=VLAN_NETWORK_TYPE_CHOICES),
         primary_network_id=dict(type="int"),
-        primary_network_name=dict(type="str"),
-        normal_network_id=dict(type="int"),
-        normal_network_name=dict(type="str"),
         display_name=dict(type="str"),
         vrf_name=dict(type="str"),
         tenant_name=dict(type="str"),
@@ -150,7 +144,7 @@ def network_base_argument_spec():
         deploy_type=dict(type="str", default="switch", choices=["switch", "network"]),
         attach=dict(type="list", elements="dict", options=_attachment_spec()),
     )
-    spec.update(_shared_network_fields(defaults=True))
+    spec.update(_shared_network_fields())
     return spec
 
 

--- a/plugins/module_utils/orchestrators/network_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/network_attachment_manager.py
@@ -235,9 +235,11 @@ class NetworkAttachmentManager:
 
     @staticmethod
     def _attachment_interfaces(attachment: dict[str, Any]) -> list[dict[str, Any]] | None:
+        if "interfaces" not in attachment:
+            return None
         interfaces = attachment.get("interfaces")
         if not interfaces:
-            return None
+            return []
         payloads = []
         for interface in interfaces:
             mapping_type = interface.get("mapping_type") or interface.get("mappingType")

--- a/plugins/module_utils/orchestrators/network_workflow_coordinator.py
+++ b/plugins/module_utils/orchestrators/network_workflow_coordinator.py
@@ -266,7 +266,7 @@ class NetworkWorkflowCoordinator:
             try:
                 operational_only = isinstance(entry, dict) and not NDNetworkOrchestrator.has_network_definition_intent(entry)
                 model = model_cls.from_config(entry)
-                parsed_config = model.to_config()
+                parsed_config = model.to_config(exclude_unset=True)
                 if operational_only:
                     sparse_config = {"network_name": parsed_config["network_name"]}
                     for key in ("attach", "deploy", "deploy_type"):

--- a/plugins/module_utils/orchestrators/networks.py
+++ b/plugins/module_utils/orchestrators/networks.py
@@ -83,12 +83,6 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
         "vlanNetworkType",
         "primary_network_id",
         "primaryNetworkId",
-        "primary_network_name",
-        "primaryNetworkName",
-        "normal_network_id",
-        "normalNetworkId",
-        "normal_network_name",
-        "normalNetworkName",
         "display_name",
         "displayName",
         "vrf_name",
@@ -171,39 +165,13 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
         if is_l2only is True:
             return NetworkLayer.LAYER2.value
         vlan_network_type = self._value(config, "vlan_network_type", "vlanNetworkType")
-        if vlan_network_type in (
-            VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value,
-            VlanNetworkType.PRIMARY_SECONDARY_ISOLATED.value,
-            VlanNetworkType.CHILD.value,
-        ):
+        if vlan_network_type in (VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value,):
             return NetworkLayer.LAYER2.value
         return NetworkLayer.LAYER3.value
 
     @staticmethod
     def _allows_l3_data(vlan_network_type: str | None) -> bool:
         return vlan_network_type in (None, VlanNetworkType.NORMAL.value, VlanNetworkType.PRIVATE_PRIMARY.value)
-
-    def _validate_effective_vlan_network_association(self, config: dict[str, Any], network_type: str) -> None:
-        vlan_network_type = self._value(config, "vlan_network_type", "vlanNetworkType", default=VlanNetworkType.NORMAL.value)
-        primary_refs = [
-            name for name in ("primary_network_id", "primaryNetworkId", "primary_network_name", "primaryNetworkName") if self._value(config, name) is not None
-        ]
-        normal_refs = [
-            name for name in ("normal_network_id", "normalNetworkId", "normal_network_name", "normalNetworkName") if self._value(config, name) is not None
-        ]
-
-        if vlan_network_type != VlanNetworkType.CHILD.value:
-            return
-        if network_type in (NetworkType.ACI.value, NetworkType.VXLAN_ACI.value):
-            if not normal_refs:
-                raise ValueError("child networks on aci/vxlanAci fabrics require normal_network_id or normal_network_name")
-            if primary_refs:
-                raise ValueError("child networks on aci/vxlanAci fabrics use normal_network_id/name, not primary_network_id/name")
-            return
-        if not primary_refs:
-            raise ValueError("child networks require primary_network_id or primary_network_name")
-        if normal_refs:
-            raise ValueError("child networks use primary_network_id/name unless the fabric network type is aci/vxlanAci")
 
     def _l2_data(self, config: dict[str, Any], network_type: str) -> dict[str, Any] | None:
         fabric_data_payload = None
@@ -317,7 +285,6 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
             }
 
         network_type = self._value(config, "network_type", "networkType", default=self._default_network_type())
-        self._validate_effective_vlan_network_association(config, network_type)
         transformed: dict[str, Any] = {
             "fabric_name": self._value(config, "fabric_name", "fabricName", default=fabric_name),
             "network_name": self._value(config, "network_name", "networkName"),
@@ -331,9 +298,6 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
             "network_id": ("network_id", "networkId"),
             "vlan_network_type": ("vlan_network_type", "vlanNetworkType"),
             "primary_network_id": ("primary_network_id", "primaryNetworkId"),
-            "primary_network_name": ("primary_network_name", "primaryNetworkName"),
-            "normal_network_id": ("normal_network_id", "normalNetworkId"),
-            "normal_network_name": ("normal_network_name", "normalNetworkName"),
         }.items():
             value = self._value(config, *names)
             if value is not None:
@@ -392,7 +356,7 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
         for entry in raw_config:
             if isinstance(entry, dict):
                 if not (self.strategy and self.strategy.is_child) and self.has_network_definition_intent(entry):
-                    entry = self.strategy.config_model_cls.from_config(entry).to_config()
+                    entry = self.strategy.config_model_cls.from_config(entry).to_config(exclude_unset=True)
                 transformed = self._transform_config_to_payload_model_data(entry, fabric_name)
                 if self.strategy and self.strategy.is_child and transformed.get("network_name"):
                     self._child_payload_source_by_name[transformed["network_name"]] = transformed
@@ -657,7 +621,7 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
             normalized["networkType"] = self._default_network_type()
         if normalized.get("networkStatus") == "NA":
             normalized["networkStatus"] = "notApplicable"
-        for optional_id in ("primaryNetworkId", "normalNetworkId"):
+        for optional_id in ("primaryNetworkId",):
             if normalized.get(optional_id) in (0, "0", ""):
                 normalized.pop(optional_id, None)
 

--- a/plugins/module_utils/orchestrators/networks.py
+++ b/plugins/module_utils/orchestrators/networks.py
@@ -15,6 +15,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBase
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.enums import (
     NetworkLayer,
     NetworkType,
+    VlanNetworkType,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.network_actions_models import (
     NetworkRemoveRequestModel,
@@ -78,6 +79,16 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
         "networkId",
         "network_type",
         "networkType",
+        "vlan_network_type",
+        "vlanNetworkType",
+        "primary_network_id",
+        "primaryNetworkId",
+        "primary_network_name",
+        "primaryNetworkName",
+        "normal_network_id",
+        "normalNetworkId",
+        "normal_network_name",
+        "normalNetworkName",
         "display_name",
         "displayName",
         "vrf_name",
@@ -159,7 +170,40 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
         is_l2only = self._value(config, "is_l2only", "isL2Only")
         if is_l2only is True:
             return NetworkLayer.LAYER2.value
+        vlan_network_type = self._value(config, "vlan_network_type", "vlanNetworkType")
+        if vlan_network_type in (
+            VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value,
+            VlanNetworkType.PRIMARY_SECONDARY_ISOLATED.value,
+            VlanNetworkType.CHILD.value,
+        ):
+            return NetworkLayer.LAYER2.value
         return NetworkLayer.LAYER3.value
+
+    @staticmethod
+    def _allows_l3_data(vlan_network_type: str | None) -> bool:
+        return vlan_network_type in (None, VlanNetworkType.NORMAL.value, VlanNetworkType.PRIVATE_PRIMARY.value)
+
+    def _validate_effective_vlan_network_association(self, config: dict[str, Any], network_type: str) -> None:
+        vlan_network_type = self._value(config, "vlan_network_type", "vlanNetworkType", default=VlanNetworkType.NORMAL.value)
+        primary_refs = [
+            name for name in ("primary_network_id", "primaryNetworkId", "primary_network_name", "primaryNetworkName") if self._value(config, name) is not None
+        ]
+        normal_refs = [
+            name for name in ("normal_network_id", "normalNetworkId", "normal_network_name", "normalNetworkName") if self._value(config, name) is not None
+        ]
+
+        if vlan_network_type != VlanNetworkType.CHILD.value:
+            return
+        if network_type in (NetworkType.ACI.value, NetworkType.VXLAN_ACI.value):
+            if not normal_refs:
+                raise ValueError("child networks on aci/vxlanAci fabrics require normal_network_id or normal_network_name")
+            if primary_refs:
+                raise ValueError("child networks on aci/vxlanAci fabrics use normal_network_id/name, not primary_network_id/name")
+            return
+        if not primary_refs:
+            raise ValueError("child networks require primary_network_id or primary_network_name")
+        if normal_refs:
+            raise ValueError("child networks use primary_network_id/name unless the fabric network type is aci/vxlanAci")
 
     def _l2_data(self, config: dict[str, Any], network_type: str) -> dict[str, Any] | None:
         fabric_data_payload = None
@@ -273,6 +317,7 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
             }
 
         network_type = self._value(config, "network_type", "networkType", default=self._default_network_type())
+        self._validate_effective_vlan_network_association(config, network_type)
         transformed: dict[str, Any] = {
             "fabric_name": self._value(config, "fabric_name", "fabricName", default=fabric_name),
             "network_name": self._value(config, "network_name", "networkName"),
@@ -315,7 +360,8 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
         l2_data = self._l2_data(config, network_type)
         if l2_data:
             transformed["l2_data"] = l2_data
-        if layer == NetworkLayer.LAYER3.value:
+        vlan_network_type = self._value(config, "vlan_network_type", "vlanNetworkType", default=VlanNetworkType.NORMAL.value)
+        if layer == NetworkLayer.LAYER3.value and self._allows_l3_data(vlan_network_type):
             l3_data = self._l3_data(config, network_type)
             if l3_data:
                 transformed["l3_data"] = l3_data
@@ -345,6 +391,8 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
             self._child_payload_source_by_name = {}
         for entry in raw_config:
             if isinstance(entry, dict):
+                if not (self.strategy and self.strategy.is_child) and self.has_network_definition_intent(entry):
+                    entry = self.strategy.config_model_cls.from_config(entry).to_config()
                 transformed = self._transform_config_to_payload_model_data(entry, fabric_name)
                 if self.strategy and self.strategy.is_child and transformed.get("network_name"):
                     self._child_payload_source_by_name[transformed["network_name"]] = transformed
@@ -841,6 +889,10 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
             l2_data["vlanName"] = ""
             l2_data["fabricData"] = {}
             payload["l2Data"] = l2_data
+
+        if not self._allows_l3_data(payload.get("vlanNetworkType")):
+            payload.pop("l3Data", None)
+            return payload
 
         if payload.get("networkMode") == NetworkLayer.LAYER2.value:
             payload["l3Data"] = self._mcfg_parent_default_l3_data()

--- a/plugins/module_utils/orchestrators/networks.py
+++ b/plugins/module_utils/orchestrators/networks.py
@@ -83,6 +83,8 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
         "vlanNetworkType",
         "primary_network_id",
         "primaryNetworkId",
+        "primary_network_name",
+        "primaryNetworkName",
         "display_name",
         "displayName",
         "vrf_name",
@@ -165,13 +167,34 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
         if is_l2only is True:
             return NetworkLayer.LAYER2.value
         vlan_network_type = self._value(config, "vlan_network_type", "vlanNetworkType")
-        if vlan_network_type in (VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value,):
+        if self._is_private_secondary_vlan_network_type(vlan_network_type):
             return NetworkLayer.LAYER2.value
         return NetworkLayer.LAYER3.value
 
     @staticmethod
     def _allows_l3_data(vlan_network_type: str | None) -> bool:
         return vlan_network_type in (None, VlanNetworkType.NORMAL.value, VlanNetworkType.PRIVATE_PRIMARY.value)
+
+    @staticmethod
+    def _is_private_secondary_vlan_network_type(vlan_network_type: str | None) -> bool:
+        return vlan_network_type in (
+            VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value,
+            VlanNetworkType.PRIVATE_SECONDARY_ISOLATED.value,
+        )
+
+    @staticmethod
+    def _private_secondary_template_type(vlan_network_type: str) -> str:
+        if vlan_network_type == VlanNetworkType.PRIVATE_SECONDARY_ISOLATED.value:
+            return "Isolated"
+        return "Community"
+
+    @staticmethod
+    def _template_config_string(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, bool):
+            return str(value).lower()
+        return str(value)
 
     def _l2_data(self, config: dict[str, Any], network_type: str) -> dict[str, Any] | None:
         fabric_data_payload = None
@@ -284,6 +307,10 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
                 "network_name": self._value(config, "network_name", "networkName"),
             }
 
+        vlan_network_type = self._value(config, "vlan_network_type", "vlanNetworkType", default=VlanNetworkType.NORMAL.value)
+        if self._is_private_secondary_vlan_network_type(vlan_network_type):
+            return self._private_secondary_payload_model_data(config, fabric_name, vlan_network_type)
+
         network_type = self._value(config, "network_type", "networkType", default=self._default_network_type())
         transformed: dict[str, Any] = {
             "fabric_name": self._value(config, "fabric_name", "fabricName", default=fabric_name),
@@ -298,6 +325,7 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
             "network_id": ("network_id", "networkId"),
             "vlan_network_type": ("vlan_network_type", "vlanNetworkType"),
             "primary_network_id": ("primary_network_id", "primaryNetworkId"),
+            "primary_network_name": ("primary_network_name", "primaryNetworkName"),
         }.items():
             value = self._value(config, *names)
             if value is not None:
@@ -324,11 +352,64 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
         l2_data = self._l2_data(config, network_type)
         if l2_data:
             transformed["l2_data"] = l2_data
-        vlan_network_type = self._value(config, "vlan_network_type", "vlanNetworkType", default=VlanNetworkType.NORMAL.value)
         if layer == NetworkLayer.LAYER3.value and self._allows_l3_data(vlan_network_type):
             l3_data = self._l3_data(config, network_type)
             if l3_data:
                 transformed["l3_data"] = l3_data
+        return transformed
+
+    def _private_secondary_payload_model_data(self, config: dict[str, Any], fabric_name: str, vlan_network_type: str) -> dict[str, Any]:
+        template_name = self._value(config, "network_template_name", "networkTemplateName", "net_template", default="Pvlan_Secondary_Network")
+        primary_network_name = self._value(config, "primary_network_name", "primaryNetworkName")
+        primary_network_id = self._value(config, "primary_network_id", "primaryNetworkId")
+        if primary_network_id is None and primary_network_name:
+            primary_network_id = getattr(self, "_network_id_by_name_for_transform", {}).get(primary_network_name)
+        template_config = {
+            "enableIR": self._template_config_string(self._value(config, "enable_ir", "enableIr", default=True)),
+            "isLayer2Only": "true",
+            "networkMode": NetworkLayer.LAYER2.value,
+            "networkName": self._value(config, "network_name", "networkName"),
+            "networkType": NetworkType.USER_DEFINED.value,
+            "nveId": "1",
+            "rtBothAuto": self._template_config_string(self._value(config, "rt_auto", "rtAuto", default=False)),
+            "segmentId": self._template_config_string(self._value(config, "network_id", "networkId")),
+            "type": self._private_secondary_template_type(vlan_network_type),
+            "vlanId": self._template_config_string(self._value(config, "vlan_id", "vlanId")),
+            "vrfName": self._value(config, "vrf_name", "vrfName", default="NA") or "NA",
+        }
+        vlan_name = self._value(config, "vlan_name", "vlanName")
+        if vlan_name is not None:
+            template_config["vlanName"] = self._template_config_string(vlan_name)
+        multicast_group = self._value(config, "multicast_group_address", "multicastGroup")
+        if multicast_group is not None:
+            template_config["mcastGroup"] = self._template_config_string(multicast_group)
+
+        transformed: dict[str, Any] = {
+            "fabric_name": self._value(config, "fabric_name", "fabricName", default=fabric_name),
+            "network_name": self._value(config, "network_name", "networkName"),
+            "network_type": NetworkType.USER_DEFINED.value,
+            "vlan_network_type": vlan_network_type,
+            "display_name": self._value(config, "display_name", "displayName", default=self._value(config, "network_name", "networkName")),
+            "vrf_name": self._value(config, "vrf_name", "vrfName", default="NA") or "NA",
+            "network_id": self._value(config, "network_id", "networkId"),
+            "layer": NetworkLayer.LAYER2.value,
+            "network_template_name": template_name,
+            "network_extension_template_name": self._value(
+                config,
+                "network_extension_template_name",
+                "networkExtensionTemplateName",
+                "net_extension_template",
+                default=template_name,
+            ),
+            "network_template_config": template_config,
+        }
+        vlan_id = self._value(config, "vlan_id", "vlanId")
+        if vlan_id is not None:
+            transformed["vlan_id"] = vlan_id
+        if primary_network_id is not None:
+            transformed["primary_network_id"] = primary_network_id
+        if primary_network_name is not None:
+            transformed["primary_network_name"] = primary_network_name
         return transformed
 
     @classmethod
@@ -351,6 +432,14 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
             return raw_config
         fabric_name = self.strategy.fabric_name
         result = []
+        self._network_id_by_name_for_transform = {
+            network_name: network_id
+            for item in raw_config
+            if isinstance(item, dict)
+            for network_name in [self._value(item, "network_name", "networkName")]
+            for network_id in [self._value(item, "network_id", "networkId")]
+            if network_name and network_id is not None
+        }
         if self.strategy and self.strategy.is_child:
             self._child_payload_source_by_name = {}
         for entry in raw_config:
@@ -609,18 +698,17 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
     def _normalize_query_network_item(self, item: Any) -> Any:
         if not isinstance(item, dict):
             return item
-        if not self._is_mcfg_parent():
-            return item
 
         normalized = dict(item)
-        if not normalized.get("fabricName"):
-            normalized["fabricName"] = normalized.get("fabric") or self.strategy.fabric_name
-        if not normalized.get("vrfName") and normalized.get("vrf"):
-            normalized["vrfName"] = normalized.get("vrf")
-        if not normalized.get("networkType"):
-            normalized["networkType"] = self._default_network_type()
-        if normalized.get("networkStatus") == "NA":
-            normalized["networkStatus"] = "notApplicable"
+        if self._is_mcfg_parent():
+            if not normalized.get("fabricName"):
+                normalized["fabricName"] = normalized.get("fabric") or self.strategy.fabric_name
+            if not normalized.get("vrfName") and normalized.get("vrf"):
+                normalized["vrfName"] = normalized.get("vrf")
+            if not normalized.get("networkType"):
+                normalized["networkType"] = self._default_network_type()
+            if normalized.get("networkStatus") == "NA":
+                normalized["networkStatus"] = "notApplicable"
         for optional_id in ("primaryNetworkId",):
             if normalized.get(optional_id) in (0, "0", ""):
                 normalized.pop(optional_id, None)
@@ -631,9 +719,15 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
                 template_config = json.loads(template_config)
             except ValueError:
                 template_config = {}
-            normalized["networkTemplateConfig"] = {str(key): "" if value is None else str(value) for key, value in template_config.items()}
         if isinstance(template_config, dict):
+            template_config = {str(key): "" if value is None else str(value) for key, value in template_config.items()}
+            normalized["networkTemplateConfig"] = template_config
             normalized.update(self._schema_fields_from_top_down_template(template_config))
+            template_type = str(template_config.get("type") or "").strip().lower()
+            if template_type == "community":
+                normalized["vlanNetworkType"] = VlanNetworkType.PRIVATE_SECONDARY_COMMUNITY.value
+            elif template_type == "isolated":
+                normalized["vlanNetworkType"] = VlanNetworkType.PRIVATE_SECONDARY_ISOLATED.value
         return normalized
 
     def _normalize_query_network_items(self, items: Any) -> list[Any]:
@@ -940,7 +1034,10 @@ class NDNetworkOrchestrator(NDBaseOrchestrator["NDNetworkModel"]):
             return self._child_network_update_payload(model_instance)
         if self._is_mcfg_parent():
             return self._mcfg_parent_network_payload(model_instance)
-        return model_instance.to_payload()
+        payload = model_instance.to_payload()
+        if self._is_private_secondary_vlan_network_type(payload.get("vlanNetworkType")):
+            payload.pop("vlanId", None)
+        return payload
 
     def create(self, model_instance: NDNetworkModel, **kwargs) -> ResponseType:
         return self.create_bulk([model_instance])

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -216,19 +216,15 @@ options:
       mtu:
         description: Network interface MTU.
         type: int
-        default: 9216
       mtu_l3intf:
         description: Compatibility alias for C(mtu).
         type: int
-        default: 9216
       arp_suppression:
         description: Enable ARP suppression.
         type: bool
-        default: false
       arp_suppress:
         description: Compatibility alias for C(arp_suppression).
         type: bool
-        default: false
       routing_tag:
         description: Routing tag.
         type: int
@@ -281,7 +277,6 @@ options:
       route_target_both:
         description: Compatibility route-target auto flag.
         type: bool
-        default: false
       l2_fabric_data:
         description: L2 fabric data overrides.
         type: dict
@@ -291,7 +286,6 @@ options:
       enable_ir:
         description: Enable ingress replication.
         type: bool
-        default: false
       multicast_group_address:
         description: Multicast group address.
         type: str
@@ -301,7 +295,6 @@ options:
       netflow_enable:
         description: Enable netflow.
         type: bool
-        default: false
       intfvlan_nf_monitor:
         description: Interface VLAN netflow monitor name.
         type: str

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -117,7 +117,10 @@ options:
             description: Attachment VLAN ID.
             type: int
           interfaces:
-            description: Interface attachment entries.
+            description:
+              - Interface attachment entries.
+              - Provide an empty list when attaching the Network to a switch without
+                per-interface bindings.
             type: list
             required: true
             elements: dict

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -52,15 +52,21 @@ options:
         description:
           - VLAN network role for normal and PVLAN networks.
           - Defaults to C(normal) when omitted.
-          - Value C(private_secondary_community) requires C(primary_network_id).
+          - Values C(community) and C(isolated) require C(primary_network_id) or C(primary_network_name).
+          - PVLAN secondary Networks accept only primary Network reference, Network ID, VLAN ID, ingress replication, multicast group,
+            VLAN name, and L2VNI route-target options for template generation.
         type: str
         choices:
           - normal
-          - private_primary
-          - private_secondary_community
+          - primary
+          - community
+          - isolated
       primary_network_id:
         description: Primary Network ID associated with a PVLAN secondary Network.
         type: int
+      primary_network_name:
+        description: Primary Network name associated with a PVLAN secondary Network.
+        type: str
       display_name:
         description: Display name.
         type: str
@@ -449,7 +455,7 @@ EXAMPLES = r"""
     state: merged
     config:
       - network_name: PVLAN_PRIMARY
-        vlan_network_type: private_primary
+        vlan_network_type: primary
         is_l2only: true
         network_id: 50100
         vlan_id: 2100
@@ -461,11 +467,27 @@ EXAMPLES = r"""
     state: merged
     config:
       - network_name: PVLAN_SECONDARY_COMMUNITY
-        vlan_network_type: private_secondary_community
+        vlan_network_type: community
         primary_network_id: 50100
         is_l2only: true
         network_id: 50101
         vlan_id: 2101
+        deploy: false
+
+- name: Create a private secondary isolated Network
+  cisco.nd.nd_manage_networks:
+    fabric_name: fab1
+    state: merged
+    config:
+      - network_name: PVLAN_SECONDARY_ISOLATED
+        vlan_network_type: isolated
+        primary_network_name: PVLAN_PRIMARY
+        network_id: 50102
+        vlan_id: 2102
+        enable_ir: false
+        multicast_group_address: 239.1.1.102
+        vlan_name: PVLAN_SECONDARY_ISOLATED_VLAN
+        rt_auto: true
         deploy: false
 
 - name: Create Network on a parent fabric with child fabric overrides

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -50,32 +50,17 @@ options:
           - user_defined
       vlan_network_type:
         description:
-          - VLAN network role for normal, PVLAN, and child networks.
+          - VLAN network role for normal and PVLAN networks.
           - Defaults to C(normal) when omitted.
-          - Values C(private_secondary_community) and C(primary_secondary_isolated) require
-            C(primary_network_id) or C(primary_network_name).
-          - Value C(child) requires a parent reference. The module derives whether
-            the effective fabric Network type needs C(normal_network_id/name) or
-            C(primary_network_id/name).
+          - Value C(private_secondary_community) requires C(primary_network_id).
         type: str
         choices:
           - normal
           - private_primary
           - private_secondary_community
-          - primary_secondary_isolated
-          - child
       primary_network_id:
-        description: Primary Network ID associated with a PVLAN secondary or non-ACI child Network.
+        description: Primary Network ID associated with a PVLAN secondary Network.
         type: int
-      primary_network_name:
-        description: Primary Network name associated with a PVLAN secondary or non-ACI child Network.
-        type: str
-      normal_network_id:
-        description: Normal Network ID associated with an ACI child Network.
-        type: int
-      normal_network_name:
-        description: Normal Network name associated with an ACI child Network.
-        type: str
       display_name:
         description: Display name.
         type: str
@@ -484,7 +469,7 @@ EXAMPLES = r"""
     config:
       - network_name: PVLAN_SECONDARY_COMMUNITY
         vlan_network_type: private_secondary_community
-        primary_network_name: PVLAN_PRIMARY
+        primary_network_id: 50100
         is_l2only: true
         network_id: 50101
         vlan_id: 2101

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -41,23 +41,41 @@ options:
         description: Compatibility alias for C(network_name).
         type: str
       network_type:
-        description: Network type.
+        description:
+          - User-defined Network type selector.
+          - Omit this option for standard fabrics; the module derives the API Network type from the target fabric.
+          - Set to C(user_defined) only when using custom Network template fields.
         type: str
         choices:
-          - vxlan
-          - vxlanIbgp
-          - vxlanEbgp
-          - vxlanCampus
-          - aimlVxlanIbgp
-          - aimlVxlanEbgp
-          - aimlRouted
-          - routed
-          - classicLanEnhanced
-          - userDefined
-          - vxlanAci
-          - aci
-          - externalConnectivity
-          - vxlanExternal
+          - user_defined
+      vlan_network_type:
+        description:
+          - VLAN network role for normal, PVLAN, and child networks.
+          - Defaults to C(normal) when omitted.
+          - Values C(private_secondary_community) and C(primary_secondary_isolated) require
+            C(primary_network_id) or C(primary_network_name).
+          - Value C(child) requires a parent reference. The module derives whether
+            the effective fabric Network type needs C(normal_network_id/name) or
+            C(primary_network_id/name).
+        type: str
+        choices:
+          - normal
+          - private_primary
+          - private_secondary_community
+          - primary_secondary_isolated
+          - child
+      primary_network_id:
+        description: Primary Network ID associated with a PVLAN secondary or non-ACI child Network.
+        type: int
+      primary_network_name:
+        description: Primary Network name associated with a PVLAN secondary or non-ACI child Network.
+        type: str
+      normal_network_id:
+        description: Normal Network ID associated with an ACI child Network.
+        type: int
+      normal_network_name:
+        description: Normal Network name associated with an ACI child Network.
+        type: str
       display_name:
         description: Display name.
         type: str
@@ -445,6 +463,31 @@ EXAMPLES = r"""
         gateway_ipv4_address: 10.10.20.1/24
         arp_suppression: true
         routing_tag: 12345
+        deploy: false
+
+- name: Create a private primary Network
+  cisco.nd.nd_manage_networks:
+    fabric_name: fab1
+    state: merged
+    config:
+      - network_name: PVLAN_PRIMARY
+        vlan_network_type: private_primary
+        is_l2only: true
+        network_id: 50100
+        vlan_id: 2100
+        deploy: false
+
+- name: Create a private secondary community Network
+  cisco.nd.nd_manage_networks:
+    fabric_name: fab1
+    state: merged
+    config:
+      - network_name: PVLAN_SECONDARY_COMMUNITY
+        vlan_network_type: private_secondary_community
+        primary_network_name: PVLAN_PRIMARY
+        is_l2only: true
+        network_id: 50101
+        vlan_id: 2101
         deploy: false
 
 - name: Create Network on a parent fabric with child fabric overrides

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -119,10 +119,11 @@ options:
           interfaces:
             description:
               - Interface attachment entries.
-              - Provide an empty list when attaching the Network to a switch without
-                per-interface bindings.
+              - Defaults to an empty list when omitted.
+              - Use an empty list to attach the Network to a switch without per-interface
+                bindings.
             type: list
-            required: true
+            default: []
             elements: dict
             suboptions:
               mode:

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -204,18 +204,17 @@ def test_network_parent_argument_spec_includes_child_config():
         "normal",
         "private_primary",
         "private_secondary_community",
-        "primary_secondary_isolated",
-        "child",
     ]
     assert "primary_network_id" in spec
-    assert "primary_network_name" in spec
-    assert "normal_network_id" in spec
-    assert "normal_network_name" in spec
+    assert "primary_network_name" not in spec
+    assert "normal_network_id" not in spec
+    assert "normal_network_name" not in spec
     assert "network_id" not in child_spec
     assert "vlan_id" not in child_spec
     assert "vlan_name" not in child_spec
     assert "vlan_network_type" not in child_spec
     assert "primary_network_name" not in child_spec
+    assert "normal_network_id" not in child_spec
     assert "normal_network_name" not in child_spec
     assert "vrf_name" not in child_spec
     assert "gateway_ipv4_address" not in child_spec
@@ -253,7 +252,7 @@ def test_network_config_model_defaults_vlan_network_type_to_normal():
 
 
 def test_private_secondary_network_requires_primary_reference_and_rejects_l3_fields():
-    with pytest.raises(ValueError, match="requires primary_network_id or primary_network_name"):
+    with pytest.raises(ValueError, match="requires primary_network_id"):
         NetworkConfigModel.from_config(
             {
                 "network_name": "PVLAN_SECONDARY",
@@ -266,55 +265,29 @@ def test_private_secondary_network_requires_primary_reference_and_rejects_l3_fie
             {
                 "network_name": "PVLAN_SECONDARY",
                 "vlan_network_type": "private_secondary_community",
-                "primary_network_name": "PVLAN_PRIMARY",
+                "primary_network_id": 50100,
                 "gateway_ipv4_address": "192.0.2.1/24",
             }
         )
 
 
-def test_child_network_reference_validation_defers_fabric_type_to_orchestrator():
-    config_model = NetworkConfigModel.from_config(
-        {
-            "network_name": "CHILD_NET",
-            "vlan_network_type": "child",
-            "normal_network_name": "NORMAL_NET",
-        }
-    )
-    assert config_model.to_config()["normal_network_name"] == "NORMAL_NET"
-
-    config_model = NetworkConfigModel.from_config(
-        {
-            "network_name": "CHILD_NET",
-            "vlan_network_type": "child",
-            "primary_network_name": "PVLAN_PRIMARY",
-        }
-    )
-    assert config_model.to_config()["primary_network_name"] == "PVLAN_PRIMARY"
-
-    with pytest.raises(ValueError, match="primary_network_id or primary_network_name"):
-        _orchestrator().prepare_config_data(
-            [
-                {
-                    "network_name": "BAD_CHILD",
-                    "vlan_network_type": "child",
-                    "normal_network_name": "NORMAL_NET",
-                }
-            ]
+def test_unsupported_vlan_network_types_are_not_playbook_supported():
+    with pytest.raises(ValueError, match="primary_secondary_isolated networks are not supported"):
+        NetworkConfigModel.from_config(
+            {
+                "network_name": "BAD_ISOLATED",
+                "vlan_network_type": "primary_secondary_isolated",
+                "primary_network_id": 50100,
+            }
         )
 
-    aci_orchestrator = NDNetworkOrchestrator(
-        rest_send=RestSend({"state": "merged", "config": [], "check_mode": False}),
-        strategy=StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanAci"}),
-    )
-    with pytest.raises(ValueError, match="normal_network_id or normal_network_name"):
-        aci_orchestrator.prepare_config_data(
-            [
-                {
-                    "network_name": "BAD_ACI_CHILD",
-                    "vlan_network_type": "child",
-                    "primary_network_name": "PVLAN_PRIMARY",
-                }
-            ]
+    with pytest.raises(ValueError, match="child networks require ACI normal-network association fields"):
+        NetworkConfigModel.from_config(
+            {
+                "network_name": "BAD_CHILD",
+                "vlan_network_type": "child",
+                "primary_network_id": 50100,
+            }
         )
 
     with pytest.raises(ValueError, match="network_type must be omitted"):
@@ -351,7 +324,7 @@ def test_private_secondary_payload_maps_pvlan_fields_and_omits_l3_data():
                 "network_id": 50101,
                 "vlan_id": 2101,
                 "vlan_network_type": "private_secondary_community",
-                "primary_network_name": "PVLAN_PRIMARY",
+                "primary_network_id": 50100,
             }
         ]
     )[0]
@@ -362,34 +335,8 @@ def test_private_secondary_payload_maps_pvlan_fields_and_omits_l3_data():
     assert payload["networkName"] == "PVLAN_SECONDARY"
     assert payload["networkType"] == "vxlanIbgp"
     assert payload["vlanNetworkType"] == "privateSecondaryCommunity"
-    assert payload["primaryNetworkName"] == "PVLAN_PRIMARY"
-    assert payload["layer"] == "layer2"
-    assert "l3Data" not in payload
-
-
-def test_aci_child_payload_maps_normal_network_reference():
-    orchestrator = NDNetworkOrchestrator(
-        rest_send=RestSend({"state": "merged", "config": [], "check_mode": False}),
-        strategy=StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanAci"}),
-    )
-    transformed = orchestrator.prepare_config_data(
-        [
-            {
-                "network_name": "ACI_CHILD",
-                "network_id": 50102,
-                "vlan_id": 2102,
-                "vlan_network_type": "child",
-                "normal_network_name": "NORMAL_NET",
-            }
-        ]
-    )[0]
-    model = NDNetworkOrchestrator.model_class.from_config(transformed)
-
-    payload = orchestrator._create_or_update_payload(model)
-
-    assert payload["networkType"] == "vxlanAci"
-    assert payload["vlanNetworkType"] == "child"
-    assert payload["normalNetworkName"] == "NORMAL_NET"
+    assert payload["primaryNetworkId"] == 50100
+    assert "primaryNetworkName" not in payload
     assert payload["layer"] == "layer2"
     assert "l3Data" not in payload
 
@@ -816,10 +763,8 @@ def test_parse_config_preserves_attachment_only_shape_before_transform():
                         {
                             "mode": "trunk",
                             "interface_range": "Ethernet1/1",
-                            "native_vlan": False,
                         }
                     ],
-                    "deploy": True,
                 }
             ],
             "deploy": True,
@@ -921,14 +866,14 @@ def test_child_task_exception_returns_structured_network_failure():
     assert child["workflow_trace"][-1]["exception"] == "RuntimeError"
 
 
-def test_argument_spec_uses_manage_json_defaults():
+def test_argument_spec_leaves_contextual_defaults_to_models():
     spec = network_parent_argument_spec()
 
-    assert spec["mtu"]["default"] == 9216
-    assert spec["mtu_l3intf"]["default"] == 9216
+    assert "default" not in spec["mtu"]
+    assert "default" not in spec["mtu_l3intf"]
     assert "default" not in spec["trm_enable"]
     assert "default" not in spec["ipv6_trm"]
-    assert spec["enable_ir"]["default"] is False
+    assert "default" not in spec["enable_ir"]
     assert spec["dhcp_servers"]["options"]["server_address"]["required"] is True
 
 
@@ -1681,6 +1626,47 @@ def test_mcfg_parent_network_create_uses_onemanage_manage_schema_payload():
         "secondaryGatewayIpv4Collection": None,
         "routingTag": 12345,
     }
+
+
+def test_mcfg_parent_private_secondary_network_create_preserves_primary_id_for_onemanage():
+    orchestrator = _mcfg_parent_orchestrator()
+    requests = []
+
+    def request(**kwargs):
+        requests.append(kwargs)
+        return {"results": [{"networkName": "PVLAN_SECONDARY", "status": "success"}]}
+
+    object.__setattr__(orchestrator, "_request", request)
+    model = NDNetworkOrchestrator.model_class.from_config(
+        orchestrator.prepare_config_data(
+            [
+                {
+                    "network_name": "PVLAN_SECONDARY",
+                    "network_id": 901031,
+                    "vlan_id": 3131,
+                    "vlan_network_type": "private_secondary_community",
+                    "primary_network_id": 901030,
+                    "is_l2only": True,
+                    "vrf_name": "NA",
+                }
+            ]
+        )[0]
+    )
+
+    result = orchestrator.create_bulk([model])
+
+    assert result == {"results": [{"networkName": "PVLAN_SECONDARY", "status": "success"}]}
+    assert requests[0]["path"] == "/api/v1/oneManage/manage/fabrics/MCFG_FAB/networks"
+    payload = requests[0]["data"]["networks"][0]
+    assert payload["networkName"] == "PVLAN_SECONDARY"
+    assert payload["fabricName"] == "MCFG_FAB"
+    assert payload["networkType"] == "vxlan"
+    assert payload["networkMode"] == "layer2"
+    assert payload["vlanNetworkType"] == "privateSecondaryCommunity"
+    assert payload["primaryNetworkId"] == 901030
+    assert "primaryNetworkName" not in payload
+    assert "vlanId" not in payload
+    assert "l3Data" not in payload
 
 
 def test_mcfg_parent_network_update_uses_l2_onemanage_manage_schema_payload():

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -202,11 +202,12 @@ def test_network_parent_argument_spec_includes_child_config():
     assert spec["deploy_type"]["choices"] == ["switch", "network"]
     assert spec["vlan_network_type"]["choices"] == [
         "normal",
-        "private_primary",
-        "private_secondary_community",
+        "primary",
+        "community",
+        "isolated",
     ]
     assert "primary_network_id" in spec
-    assert "primary_network_name" not in spec
+    assert "primary_network_name" in spec
     assert "normal_network_id" not in spec
     assert "normal_network_name" not in spec
     assert "network_id" not in child_spec
@@ -252,31 +253,40 @@ def test_network_config_model_defaults_vlan_network_type_to_normal():
 
 
 def test_private_secondary_network_requires_primary_reference_and_rejects_l3_fields():
-    with pytest.raises(ValueError, match="requires primary_network_id"):
+    with pytest.raises(ValueError, match="requires primary_network_id or primary_network_name"):
         NetworkConfigModel.from_config(
             {
                 "network_name": "PVLAN_SECONDARY",
-                "vlan_network_type": "private_secondary_community",
+                "vlan_network_type": "community",
             }
         )
 
-    with pytest.raises(ValueError, match="do not support L3 fields"):
+    with pytest.raises(ValueError, match="support only PVLAN secondary template fields"):
         NetworkConfigModel.from_config(
             {
                 "network_name": "PVLAN_SECONDARY",
-                "vlan_network_type": "private_secondary_community",
+                "vlan_network_type": "community",
                 "primary_network_id": 50100,
                 "gateway_ipv4_address": "192.0.2.1/24",
             }
         )
 
+    model = NetworkConfigModel.from_config(
+        {
+            "network_name": "PVLAN_SECONDARY",
+            "vlan_network_type": "isolated",
+            "primary_network_name": "PVLAN_PRIMARY",
+        }
+    )
+    assert model.to_config()["primary_network_name"] == "PVLAN_PRIMARY"
+
 
 def test_unsupported_vlan_network_types_are_not_playbook_supported():
-    with pytest.raises(ValueError, match="primary_secondary_isolated networks are not supported"):
+    with pytest.raises(ValueError, match="vlan_network_type must be one of"):
         NetworkConfigModel.from_config(
             {
-                "network_name": "BAD_ISOLATED",
-                "vlan_network_type": "primary_secondary_isolated",
+                "network_name": "BAD_SNAKE_CASE",
+                "vlan_network_type": "private_secondary_community",
                 "primary_network_id": 50100,
             }
         )
@@ -323,8 +333,12 @@ def test_private_secondary_payload_maps_pvlan_fields_and_omits_l3_data():
                 "network_name": "PVLAN_SECONDARY",
                 "network_id": 50101,
                 "vlan_id": 2101,
-                "vlan_network_type": "private_secondary_community",
+                "vlan_network_type": "community",
                 "primary_network_id": 50100,
+                "enable_ir": False,
+                "multicast_group_address": "239.1.1.101",
+                "vlan_name": "PVLAN_SECONDARY_VLAN",
+                "rt_auto": True,
             }
         ]
     )[0]
@@ -333,12 +347,113 @@ def test_private_secondary_payload_maps_pvlan_fields_and_omits_l3_data():
     payload = orchestrator._create_or_update_payload(model)
 
     assert payload["networkName"] == "PVLAN_SECONDARY"
-    assert payload["networkType"] == "vxlanIbgp"
+    assert payload["networkType"] == "userDefined"
     assert payload["vlanNetworkType"] == "privateSecondaryCommunity"
     assert payload["primaryNetworkId"] == 50100
     assert "primaryNetworkName" not in payload
     assert payload["layer"] == "layer2"
+    assert payload["networkTemplateName"] == "Pvlan_Secondary_Network"
+    assert payload["networkExtensionTemplateName"] == "Pvlan_Secondary_Network"
+    assert payload["networkTemplateConfig"] == {
+        "enableIR": "false",
+        "isLayer2Only": "true",
+        "networkMode": "layer2",
+        "networkName": "PVLAN_SECONDARY",
+        "networkType": "userDefined",
+        "nveId": "1",
+        "rtBothAuto": "true",
+        "segmentId": "50101",
+        "type": "Community",
+        "vlanId": "2101",
+        "vlanName": "PVLAN_SECONDARY_VLAN",
+        "vrfName": "NA",
+        "mcastGroup": "239.1.1.101",
+    }
+    assert "vlanId" not in payload
     assert "l3Data" not in payload
+    assert model.to_config()["vlan_network_type"] == "community"
+
+
+def test_private_secondary_isolated_payload_maps_template_type_and_primary_name():
+    orchestrator = _orchestrator()
+    transformed = orchestrator.prepare_config_data(
+        [
+            {
+                "network_name": "PVLAN_ISOLATED",
+                "network_id": 50102,
+                "vlan_id": 2102,
+                "vlan_network_type": "isolated",
+                "primary_network_name": "PVLAN_PRIMARY",
+            }
+        ]
+    )[0]
+    model = NDNetworkOrchestrator.model_class.from_config(transformed)
+
+    payload = orchestrator._create_or_update_payload(model)
+
+    assert payload["networkType"] == "userDefined"
+    assert payload["vlanNetworkType"] == "privateSecondaryIsolated"
+    assert payload["primaryNetworkName"] == "PVLAN_PRIMARY"
+    assert "primaryNetworkId" not in payload
+    assert payload["networkTemplateConfig"]["type"] == "Isolated"
+    assert payload["networkTemplateConfig"]["vlanId"] == "2102"
+    assert payload["networkTemplateConfig"]["networkType"] == "userDefined"
+    assert "vlanId" not in payload
+    assert model.to_config()["vlan_network_type"] == "isolated"
+
+
+def test_private_secondary_primary_name_resolves_id_from_same_config_batch():
+    orchestrator = _orchestrator()
+    transformed = orchestrator.prepare_config_data(
+        [
+            {
+                "network_name": "PVLAN_PRIMARY",
+                "network_id": 50100,
+                "vlan_id": 2100,
+                "vlan_network_type": "primary",
+                "is_l2only": True,
+            },
+            {
+                "network_name": "PVLAN_ISOLATED",
+                "network_id": 50102,
+                "vlan_id": 2102,
+                "vlan_network_type": "isolated",
+                "primary_network_name": "PVLAN_PRIMARY",
+            },
+        ]
+    )
+    model = NDNetworkOrchestrator.model_class.from_config(transformed[1])
+
+    payload = orchestrator._create_or_update_payload(model)
+
+    assert payload["primaryNetworkName"] == "PVLAN_PRIMARY"
+    assert payload["primaryNetworkId"] == 50100
+
+
+def test_private_secondary_rejects_freeform_template_and_l3_only_options():
+    with pytest.raises(ValueError, match="support only PVLAN secondary template fields"):
+        NetworkConfigModel.from_config(
+            {
+                "network_name": "PVLAN_BAD",
+                "network_id": 50103,
+                "vlan_id": 2103,
+                "vlan_network_type": "community",
+                "primary_network_name": "PVLAN_PRIMARY",
+                "network_template_config": {"type": "Community"},
+            }
+        )
+
+    with pytest.raises(ValueError, match="support only PVLAN secondary template fields"):
+        NetworkConfigModel.from_config(
+            {
+                "network_name": "PVLAN_BAD",
+                "network_id": 50103,
+                "vlan_id": 2103,
+                "vlan_network_type": "isolated",
+                "primary_network_name": "PVLAN_PRIMARY",
+                "mtu": 9216,
+            }
+        )
 
 
 def test_parent_config_accepts_child_fabric_overrides():
@@ -1644,7 +1759,7 @@ def test_mcfg_parent_private_secondary_network_create_preserves_primary_id_for_o
                     "network_name": "PVLAN_SECONDARY",
                     "network_id": 901031,
                     "vlan_id": 3131,
-                    "vlan_network_type": "private_secondary_community",
+                    "vlan_network_type": "community",
                     "primary_network_id": 901030,
                     "is_l2only": True,
                     "vrf_name": "NA",
@@ -1660,13 +1775,18 @@ def test_mcfg_parent_private_secondary_network_create_preserves_primary_id_for_o
     payload = requests[0]["data"]["networks"][0]
     assert payload["networkName"] == "PVLAN_SECONDARY"
     assert payload["fabricName"] == "MCFG_FAB"
-    assert payload["networkType"] == "vxlan"
+    assert payload["networkType"] == "userDefined"
     assert payload["networkMode"] == "layer2"
     assert payload["vlanNetworkType"] == "privateSecondaryCommunity"
     assert payload["primaryNetworkId"] == 901030
     assert "primaryNetworkName" not in payload
     assert "vlanId" not in payload
     assert "l3Data" not in payload
+    assert payload["networkTemplateName"] == "Pvlan_Secondary_Network"
+    assert payload["networkExtensionTemplateName"] == "Pvlan_Secondary_Network"
+    assert payload["networkTemplateConfig"]["type"] == "Community"
+    assert payload["networkTemplateConfig"]["segmentId"] == "901031"
+    assert payload["networkTemplateConfig"]["vlanId"] == "3131"
 
 
 def test_mcfg_parent_network_update_uses_l2_onemanage_manage_schema_payload():

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -200,9 +200,23 @@ def test_network_parent_argument_spec_includes_child_config():
     assert "net_id" in spec
     assert "gw_ip_subnet" in spec
     assert spec["deploy_type"]["choices"] == ["switch", "network"]
+    assert spec["vlan_network_type"]["choices"] == [
+        "normal",
+        "private_primary",
+        "private_secondary_community",
+        "primary_secondary_isolated",
+        "child",
+    ]
+    assert "primary_network_id" in spec
+    assert "primary_network_name" in spec
+    assert "normal_network_id" in spec
+    assert "normal_network_name" in spec
     assert "network_id" not in child_spec
     assert "vlan_id" not in child_spec
     assert "vlan_name" not in child_spec
+    assert "vlan_network_type" not in child_spec
+    assert "primary_network_name" not in child_spec
+    assert "normal_network_name" not in child_spec
     assert "vrf_name" not in child_spec
     assert "gateway_ipv4_address" not in child_spec
     assert "routing_tag" not in child_spec
@@ -218,10 +232,166 @@ def test_user_defined_template_fields_require_user_defined_type():
         NetworkConfigModel.from_config(
             {
                 "network_name": "BAD_TEMPLATE",
-                "network_type": "vxlanIbgp",
                 "network_template_name": "Custom_Network",
             }
         )
+    model = NetworkConfigModel.from_config(
+        {
+            "network_name": "GOOD_TEMPLATE",
+            "network_type": "user_defined",
+            "network_template_name": "Custom_Network",
+        }
+    )
+    assert model.to_config()["network_type"] == "userDefined"
+
+
+def test_network_config_model_defaults_vlan_network_type_to_normal():
+    model = NetworkConfigModel.from_config({"network_name": "BLUE_NET"})
+
+    assert model.to_config()["vlan_network_type"] == "normal"
+    assert "dhcp_servers" not in model.model_fields_set
+
+
+def test_private_secondary_network_requires_primary_reference_and_rejects_l3_fields():
+    with pytest.raises(ValueError, match="requires primary_network_id or primary_network_name"):
+        NetworkConfigModel.from_config(
+            {
+                "network_name": "PVLAN_SECONDARY",
+                "vlan_network_type": "private_secondary_community",
+            }
+        )
+
+    with pytest.raises(ValueError, match="do not support L3 fields"):
+        NetworkConfigModel.from_config(
+            {
+                "network_name": "PVLAN_SECONDARY",
+                "vlan_network_type": "private_secondary_community",
+                "primary_network_name": "PVLAN_PRIMARY",
+                "gateway_ipv4_address": "192.0.2.1/24",
+            }
+        )
+
+
+def test_child_network_reference_validation_defers_fabric_type_to_orchestrator():
+    config_model = NetworkConfigModel.from_config(
+        {
+            "network_name": "CHILD_NET",
+            "vlan_network_type": "child",
+            "normal_network_name": "NORMAL_NET",
+        }
+    )
+    assert config_model.to_config()["normal_network_name"] == "NORMAL_NET"
+
+    config_model = NetworkConfigModel.from_config(
+        {
+            "network_name": "CHILD_NET",
+            "vlan_network_type": "child",
+            "primary_network_name": "PVLAN_PRIMARY",
+        }
+    )
+    assert config_model.to_config()["primary_network_name"] == "PVLAN_PRIMARY"
+
+    with pytest.raises(ValueError, match="primary_network_id or primary_network_name"):
+        _orchestrator().prepare_config_data(
+            [
+                {
+                    "network_name": "BAD_CHILD",
+                    "vlan_network_type": "child",
+                    "normal_network_name": "NORMAL_NET",
+                }
+            ]
+        )
+
+    aci_orchestrator = NDNetworkOrchestrator(
+        rest_send=RestSend({"state": "merged", "config": [], "check_mode": False}),
+        strategy=StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanAci"}),
+    )
+    with pytest.raises(ValueError, match="normal_network_id or normal_network_name"):
+        aci_orchestrator.prepare_config_data(
+            [
+                {
+                    "network_name": "BAD_ACI_CHILD",
+                    "vlan_network_type": "child",
+                    "primary_network_name": "PVLAN_PRIMARY",
+                }
+            ]
+        )
+
+    with pytest.raises(ValueError, match="network_type must be omitted"):
+        NetworkConfigModel.from_config(
+            {
+                "network_type": "vxlanAci",
+                "network_name": "BAD_NETWORK_TYPE",
+            }
+        )
+
+
+def test_user_defined_network_type_maps_to_api_payload_type():
+    orchestrator = _orchestrator()
+    transformed = orchestrator.prepare_config_data(
+        [
+            {
+                "network_name": "CUSTOM_NET",
+                "network_type": "user_defined",
+                "network_template_name": "Custom_Network",
+                "network_template_config": {"segmentId": "50100"},
+            }
+        ]
+    )[0]
+
+    assert transformed["network_type"] == "userDefined"
+
+
+def test_private_secondary_payload_maps_pvlan_fields_and_omits_l3_data():
+    orchestrator = _orchestrator()
+    transformed = orchestrator.prepare_config_data(
+        [
+            {
+                "network_name": "PVLAN_SECONDARY",
+                "network_id": 50101,
+                "vlan_id": 2101,
+                "vlan_network_type": "private_secondary_community",
+                "primary_network_name": "PVLAN_PRIMARY",
+            }
+        ]
+    )[0]
+    model = NDNetworkOrchestrator.model_class.from_config(transformed)
+
+    payload = orchestrator._create_or_update_payload(model)
+
+    assert payload["networkName"] == "PVLAN_SECONDARY"
+    assert payload["networkType"] == "vxlanIbgp"
+    assert payload["vlanNetworkType"] == "privateSecondaryCommunity"
+    assert payload["primaryNetworkName"] == "PVLAN_PRIMARY"
+    assert payload["layer"] == "layer2"
+    assert "l3Data" not in payload
+
+
+def test_aci_child_payload_maps_normal_network_reference():
+    orchestrator = NDNetworkOrchestrator(
+        rest_send=RestSend({"state": "merged", "config": [], "check_mode": False}),
+        strategy=StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanAci"}),
+    )
+    transformed = orchestrator.prepare_config_data(
+        [
+            {
+                "network_name": "ACI_CHILD",
+                "network_id": 50102,
+                "vlan_id": 2102,
+                "vlan_network_type": "child",
+                "normal_network_name": "NORMAL_NET",
+            }
+        ]
+    )[0]
+    model = NDNetworkOrchestrator.model_class.from_config(transformed)
+
+    payload = orchestrator._create_or_update_payload(model)
+
+    assert payload["networkType"] == "vxlanAci"
+    assert payload["vlanNetworkType"] == "child"
+    assert payload["normalNetworkName"] == "NORMAL_NET"
+    assert payload["layer"] == "layer2"
+    assert "l3Data" not in payload
 
 
 def test_parent_config_accepts_child_fabric_overrides():

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -147,7 +147,7 @@ def _mcfg_parent_orchestrator():
     )
 
 
-def test_network_config_model_requires_attachment_interfaces():
+def test_network_config_model_requires_attachment_interfaces_key():
     with pytest.raises(ValueError, match="interfaces"):
         NetworkConfigModel.from_config(
             {
@@ -161,6 +161,24 @@ def test_network_config_model_requires_attachment_interfaces():
                 ],
             }
         )
+
+
+def test_network_config_model_accepts_empty_attachment_interfaces():
+    model = NetworkConfigModel.from_config(
+        {
+            "network_name": "BLUE_NET",
+            "is_l2only": True,
+            "vlan_id": 2301,
+            "attach": [
+                {
+                    "ip_address": "10.1.1.11",
+                    "interfaces": [],
+                }
+            ],
+        }
+    )
+
+    assert model.to_config()["attach"][0]["interfaces"] == []
 
 
 def test_network_parent_argument_spec_includes_child_config():
@@ -1306,6 +1324,28 @@ def test_tor_is_modeled_as_normal_attachment_payload():
             "nativeVlan": False,
         }
     ]
+
+
+def test_empty_attachment_interfaces_are_preserved_in_payload():
+    model = NetworkConfigModel.from_config(
+        {
+            "net_name": "EMPTY_ATTACH",
+            "is_l2only": True,
+            "attach": [
+                {
+                    "ip_address": "10.1.1.11",
+                    "interfaces": [],
+                }
+            ],
+        }
+    )
+    config = model.to_config()
+
+    manager = NetworkAttachmentManager(coordinator=None)
+    manager.resolve_switch_ids = lambda *_args: {"10.1.1.11": "LEAF123"}
+    desired = manager.desired_attachment_map({"config": [config]}, _orchestrator().strategy)
+
+    assert desired[("EMPTY_ATTACH", "LEAF123")]["interfaces"] == []
 
 
 def test_module_level_query_is_normalized_to_gathered():

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -147,20 +147,21 @@ def _mcfg_parent_orchestrator():
     )
 
 
-def test_network_config_model_requires_attachment_interfaces_key():
-    with pytest.raises(ValueError, match="interfaces"):
-        NetworkConfigModel.from_config(
-            {
-                "network_name": "BLUE_NET",
-                "is_l2only": True,
-                "vlan_id": 2301,
-                "attach": [
-                    {
-                        "ip_address": "10.1.1.11",
-                    }
-                ],
-            }
-        )
+def test_network_config_model_defaults_missing_attachment_interfaces_to_empty_list():
+    model = NetworkConfigModel.from_config(
+        {
+            "network_name": "BLUE_NET",
+            "is_l2only": True,
+            "vlan_id": 2301,
+            "attach": [
+                {
+                    "ip_address": "10.1.1.11",
+                }
+            ],
+        }
+    )
+
+    assert model.to_config()["attach"][0]["interfaces"] == []
 
 
 def test_network_config_model_accepts_empty_attachment_interfaces():
@@ -189,7 +190,7 @@ def test_network_parent_argument_spec_includes_child_config():
     assert spec["attach"]["options"]["interfaces"]["options"]["mode"]["choices"]
     assert spec["attach"]["options"]["interfaces"]["options"]["mode"]["required"] is True
     assert spec["attach"]["options"]["interfaces"]["options"]["interface_range"]["required"] is True
-    assert spec["attach"]["options"]["interfaces"]["required"] is True
+    assert spec["attach"]["options"]["interfaces"]["default"] == []
     assert spec["attach"]["options"]["deploy"]["default"] is True
     assert "ports" not in spec["attach"]["options"]
     assert "tor_ports" not in spec["attach"]["options"]
@@ -1052,7 +1053,7 @@ def test_legacy_network_names_are_normalized():
     assert config["rt_auto"] is True
 
 
-def test_attachment_shape_rejects_ports_without_interfaces():
+def test_attachment_shape_accepts_interfaces_and_defaults_missing_interfaces():
     model = NetworkConfigModel.from_config(
         {
             "net_name": "LEGACY_ATTACH",
@@ -1076,19 +1077,19 @@ def test_attachment_shape_rejects_ports_without_interfaces():
     assert attach["deploy"] is False
     assert attach["interfaces"][0]["interface_range"] == "Ethernet1/1"
 
-    with pytest.raises(ValueError, match="interfaces"):
-        NetworkConfigModel.from_config(
-            {
-                "net_name": "LEGACY_ATTACH",
-                "is_l2only": True,
-                "attach": [
-                    {
-                        "ip_address": "10.1.1.11",
-                        "ports": ["Ethernet1/1"],
-                    }
-                ],
-            }
-        )
+    omitted = NetworkConfigModel.from_config(
+        {
+            "net_name": "OMITTED_INTERFACES_ATTACH",
+            "is_l2only": True,
+            "attach": [
+                {
+                    "ip_address": "10.1.1.11",
+                }
+            ],
+        }
+    )
+
+    assert omitted.to_config()["attach"][0]["interfaces"] == []
 
     with pytest.raises(ValueError, match="mode"):
         NetworkConfigModel.from_config(


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->
https://github.com/CiscoDevNet/ansible-nd/issues/489

## Proposed Changes
<!--- Please provide a description of proposed changes -->

- Allow `nd_manage_networks` attachments to omit `attach[].interfaces`; missing interfaces now default to an empty list.
- Preserve empty interface payloads so Network attachments can be applied without explicit interface selection.
- Add playbook-facing PVLAN Network support for:
  - `vlan_network_type: private_primary`
  - `vlan_network_type: private_secondary_community`
  - `primary_network_id` for secondary community Networks
- Limit the public PVLAN contract to tested/supported values: `normal`, `private_primary`, and `private_secondary_community`.
- Ensure PVLAN secondary Network payloads are L2-only and do not emit `l3Data`.
- Preserve `primaryNetworkId` in standalone and MCFG oneManage Network payload flows.
- Avoid injecting contextual L3 defaults from argspec into sparse/PVLAN Network configs.

## Test Notes
<!--- Please provide notes or description of testing -->

- Ran focused unit tests:
  - `PYENV_VERSION=ndfclab PYTHONPATH=$PWD/collections python -m pytest -q tests/unit/module_utils/orchestrators/test_networks.py`
  - Result: `84 passed`
- Ran formatting:
  - `black -l 159`
- Live tested on `Fabric`:
  - `private_primary` Network create succeeded.
  - `private_secondary_community` Network create succeeded with `primary_network_id`.
  - Secondary community Network merged update, replaced, explicit delete, and cleanup succeeded.

## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->

Cisco Nexus Dashboard 4.2.1

## Related ND API Resource Category
<!-- Please select ND API resource category, please specify -->
- [ ] analyze
- [ ] infa
- [x] manage
- [x] onemanage
- [ ] other


## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] New or updates to documentation has been made accordingly
- [ ] Assigned the proper reviewers