### PR TITLE
Address fabric module issues and fix save without switches issue (NDA-35)

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 __metaclass__ = type
 
 from typing import ClassVar, Literal
+from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
@@ -150,7 +151,7 @@ class _EpManageFabricsBase(FabricNameMixin, NDEndpointBaseModel):
             raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
         segments = ["fabrics"]
         if self.fabric_name is not None:
-            segments.append(self.fabric_name)
+            segments.append(quote(self.fabric_name, safe=""))
         if self._path_suffix:
             segments.append(self._path_suffix)
         base_path = BasePath.path(*segments)
@@ -205,7 +206,7 @@ class EpManageFabricsGet(_EpManageFabricsBase):
     ```
     """
 
-    class_name: Literal["EpManageFabricsGet"] = Field(default="EpManageFabricsGet", description="Class name for backward compatibility")
+    class_name: Literal["EpManageFabricsGet"] = Field(default="EpManageFabricsGet", frozen=True, description="Class name for backward compatibility")
 
     endpoint_params: FabricsEndpointParams = Field(default_factory=FabricsEndpointParams, description="Endpoint-specific query parameters")
 
@@ -317,7 +318,7 @@ class EpManageFabricsListGet(_EpManageFabricsBase):
 
     _require_fabric_name: ClassVar[bool] = False
 
-    class_name: Literal["EpManageFabricsListGet"] = Field(default="EpManageFabricsListGet", description="Class name for backward compatibility")
+    class_name: Literal["EpManageFabricsListGet"] = Field(default="EpManageFabricsListGet", frozen=True, description="Class name for backward compatibility")
 
     endpoint_params: FabricsListEndpointParams = Field(default_factory=FabricsListEndpointParams, description="Endpoint-specific query parameters")
 
@@ -379,7 +380,7 @@ class EpManageFabricsPost(_EpManageFabricsBase):
 
     _require_fabric_name: ClassVar[bool] = False
 
-    class_name: Literal["EpManageFabricsPost"] = Field(default="EpManageFabricsPost", description="Class name for backward compatibility")
+    class_name: Literal["EpManageFabricsPost"] = Field(default="EpManageFabricsPost", frozen=True, description="Class name for backward compatibility")
 
     endpoint_params: FabricsEndpointParams = Field(default_factory=FabricsEndpointParams, description="Endpoint-specific query parameters")
 
@@ -433,7 +434,7 @@ class EpManageFabricsPut(_EpManageFabricsBase):
     ```
     """
 
-    class_name: Literal["EpManageFabricsPut"] = Field(default="EpManageFabricsPut", description="Class name for backward compatibility")
+    class_name: Literal["EpManageFabricsPut"] = Field(default="EpManageFabricsPut", frozen=True, description="Class name for backward compatibility")
 
     endpoint_params: FabricsEndpointParams = Field(default_factory=FabricsEndpointParams, description="Endpoint-specific query parameters")
 
@@ -477,7 +478,7 @@ class EpManageFabricsDelete(_EpManageFabricsBase):
     ```
     """
 
-    class_name: Literal["EpManageFabricsDelete"] = Field(default="EpManageFabricsDelete", description="Class name for backward compatibility")
+    class_name: Literal["EpManageFabricsDelete"] = Field(default="EpManageFabricsDelete", frozen=True, description="Class name for backward compatibility")
 
     endpoint_params: FabricsEndpointParams = Field(default_factory=FabricsEndpointParams, description="Endpoint-specific query parameters")
 
@@ -522,7 +523,7 @@ class EpManageFabricsSummaryGet(_EpManageFabricsBase):
     ```
     """
 
-    class_name: Literal["EpManageFabricsSummaryGet"] = Field(default="EpManageFabricsSummaryGet", description="Class name for backward compatibility")
+    class_name: Literal["EpManageFabricsSummaryGet"] = Field(default="EpManageFabricsSummaryGet", frozen=True, description="Class name for backward compatibility")
 
     _path_suffix: ClassVar[str | None] = "summary"
 
@@ -588,7 +589,7 @@ class EpManageFabricConfigDeployPost(_EpManageFabricsBase):
         """Build the endpoint path with optional query string."""
         if self.fabric_name is None:
             raise ValueError("fabric_name must be set before accessing path")
-        base = BasePath.path("fabrics", self.fabric_name, "actions", "configDeploy")
+        base = BasePath.path("fabrics", quote(self.fabric_name, safe=""), "actions", "configDeploy")
         query_string = self.endpoint_params.to_query_string()
         if query_string:
             return f"{base}?{query_string}"

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics_actions_config_save.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics_actions_config_save.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from typing import Literal
+from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     ConfigDict,
@@ -44,7 +45,7 @@ class EpFabricConfigSavePost(
     def path(self) -> str:
         if self.fabric_name is None:
             raise ValueError("fabric_name is required")
-        return BasePath.path("fabrics", self.fabric_name, "actions", "configSave")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "actions", "configSave")
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics_actions_deploy.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics_actions_deploy.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from typing import Literal
+from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     ConfigDict,
@@ -44,7 +45,7 @@ class EpFabricDeployPost(
     def path(self) -> str:
         if self.fabric_name is None:
             raise ValueError("fabric_name is required")
-        return BasePath.path("fabrics", self.fabric_name, "actions", "deploy")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "actions", "deploy")
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics_switchactions.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics_switchactions.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 __author__ = "Akshayanat C S"
 
 from typing import Literal
+from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import (
@@ -112,7 +113,7 @@ class _EpManageFabricsSwitchActionsBase(FabricNameMixin, NDEndpointBaseModel):
         """Build the base endpoint path."""
         if self.fabric_name is None:
             raise ValueError("fabric_name must be set before accessing path")
-        return BasePath.path("fabrics", self.fabric_name, "switchActions")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "switchActions")
 
 
 class EpManageFabricsSwitchActionsRemovePost(_EpManageFabricsSwitchActionsBase):

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics_switches.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics_switches.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 __author__ = "Akshayanat C S"
 
 from typing import Literal
+from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import (
@@ -120,7 +121,7 @@ class _EpManageFabricsSwitchesBase(FabricNameMixin, NDEndpointBaseModel):
         """Build the base endpoint path."""
         if self.fabric_name is None:
             raise ValueError("fabric_name must be set before accessing path")
-        return BasePath.path("fabrics", self.fabric_name, "switches")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "switches")
 
 
 class EpManageFabricsSwitchesGet(_EpManageFabricsSwitchesBase):

--- a/plugins/module_utils/manage_vpc_pair/runtime_endpoints.py
+++ b/plugins/module_utils/manage_vpc_pair/runtime_endpoints.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-from urllib.parse import quote
-
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import (
     CompositeQueryParams,
     EndpointQueryParams,
@@ -103,7 +101,7 @@ class VpcPairEndpoints:
         Returns:
             Path: /api/v1/manage/fabrics/{fabricName}
         """
-        endpoint = EpManageFabricsGet(fabric_name=quote(fabric_name, safe=""))
+        endpoint = EpManageFabricsGet(fabric_name=fabric_name)
         return endpoint.path
 
     @staticmethod

--- a/plugins/module_utils/orchestrators/config_actions_mixin.py
+++ b/plugins/module_utils/orchestrators/config_actions_mixin.py
@@ -32,6 +32,8 @@ Or use the convenience method to process a batch::
 
 from __future__ import annotations
 
+import logging
+
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_config_save import (
     EpFabricConfigSavePost,
 )
@@ -46,6 +48,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
 )
 from ansible_collections.cisco.nd.plugins.module_utils.enums import OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+logger = logging.getLogger("nd.ConfigActionsMixin")
 
 
 class ConfigActionsMixin:
@@ -85,6 +89,21 @@ class ConfigActionsMixin:
             verb=ep.verb,
             operation_type=OperationType.UPDATE,
         )
+
+    def _fabric_has_switches(self, fabric_name: str) -> bool:
+        """Return True if the fabric currently has any switches on the controller.
+
+        ND rejects configSave/deploy on a switchless fabric ("Fabric ... cannot be
+        deployed without any switches"), so callers must skip save when this is False.
+        """
+        ep = EpManageFabricsSwitchesGet(fabric_name=fabric_name)
+        result = self._request(
+            path=ep.path,
+            verb=ep.verb,
+            not_found_ok=True,
+            operation_type=OperationType.QUERY,
+        )
+        return bool(result.get("switches")) if result else False
 
     def config_deploy(self, fabric_name: str, deploy_type: str = "global") -> ResponseType:
         """Deploy fabric configuration.
@@ -216,6 +235,13 @@ class ConfigActionsMixin:
             return
 
         for fabric_name in fabric_names:
+            # ND rejects save/deploy on a switchless fabric. Skip (not an error) so
+            # a day-0 fabric create — or the fabric step on a first run, before the
+            # switches step adds switches — does not fail. Once switches exist,
+            # saves (including idempotent fabric-setting updates) and deploys proceed.
+            if not self._fabric_has_switches(fabric_name):
+                logger.info("Skipping config save/deploy for '%s': fabric has no switches.", fabric_name)
+                continue
             if save:
                 self.config_save(fabric_name)
             if deploy:

--- a/plugins/module_utils/orchestrators/config_actions_mixin.py
+++ b/plugins/module_utils/orchestrators/config_actions_mixin.py
@@ -32,8 +32,6 @@ Or use the convenience method to process a batch::
 
 from __future__ import annotations
 
-import logging
-
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_config_save import (
     EpFabricConfigSavePost,
 )
@@ -48,8 +46,6 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
 )
 from ansible_collections.cisco.nd.plugins.module_utils.enums import OperationType
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
-
-logger = logging.getLogger("nd.ConfigActionsMixin")
 
 
 class ConfigActionsMixin:
@@ -90,11 +86,13 @@ class ConfigActionsMixin:
             operation_type=OperationType.UPDATE,
         )
 
-    def _fabric_has_switches(self, fabric_name: str) -> bool:
-        """Return True if the fabric currently has any switches on the controller.
+    def _get_fabric_switches(self, fabric_name: str) -> list[dict]:
+        """Return the fabric's switches from the controller (empty list if none).
 
         ND rejects configSave/deploy on a switchless fabric ("Fabric ... cannot be
-        deployed without any switches"), so callers must skip save when this is False.
+        deployed without any switches"), so callers skip save/deploy when this is
+        empty. Fetched once per fabric per run and passed to the deploy path so the
+        switches endpoint is queried at most once per fabric.
         """
         ep = EpManageFabricsSwitchesGet(fabric_name=fabric_name)
         result = self._request(
@@ -103,15 +101,18 @@ class ConfigActionsMixin:
             not_found_ok=True,
             operation_type=OperationType.QUERY,
         )
-        return bool(result.get("switches")) if result else False
+        return result.get("switches", []) if result else []
 
-    def config_deploy(self, fabric_name: str, deploy_type: str = "global") -> ResponseType:
+    def config_deploy(self, fabric_name: str, deploy_type: str = "global", switches: list[dict] | None = None) -> ResponseType:
         """Deploy fabric configuration.
 
         Args:
             fabric_name: Name of the fabric to deploy.
             deploy_type: ``"global"`` for fabric-wide deploy, ``"switch"`` for
                 switch-level deploy targeting only out-of-sync switches.
+            switches: Optional pre-fetched switch list (from
+                ``_get_fabric_switches``) reused for switch-level deploy to avoid a
+                redundant switches query. Fetched on demand when None.
 
         Returns:
             API response data, or None if no switches need deployment
@@ -124,7 +125,7 @@ class ConfigActionsMixin:
         if deploy_type == "global":
             return self._deploy_global(fabric_name)
         elif deploy_type == "switch":
-            return self._deploy_switches(fabric_name)
+            return self._deploy_switches(fabric_name, switches)
         else:
             raise ValueError(f"Invalid deploy_type '{deploy_type}'. Must be 'global' or 'switch'.")
 
@@ -137,16 +138,18 @@ class ConfigActionsMixin:
             operation_type=OperationType.UPDATE,
         )
 
-    def _deploy_switches(self, fabric_name: str) -> ResponseType:
+    def _deploy_switches(self, fabric_name: str, switches: list[dict] | None = None) -> ResponseType:
         """Deploy to switches that need configuration deployment.
 
-        Queries the fabric's switches, identifies those with a
-        ``configSyncStatus`` that is not ``inSync``, and deploys
-        to them via the switchActions/deploy endpoint.
+        Identifies switches with a ``configSyncStatus`` that is not ``inSync`` and
+        deploys to them via the switchActions/deploy endpoint. When ``switches`` is
+        provided it is reused; otherwise the switch list is fetched.
 
         Returns None if all switches are already in sync.
         """
-        switch_ids = self._get_switches_needing_deploy(fabric_name)
+        if switches is None:
+            switches = self._get_fabric_switches(fabric_name)
+        switch_ids = self._filter_switches_needing_deploy(switches)
         if not switch_ids:
             return None
 
@@ -163,15 +166,11 @@ class ConfigActionsMixin:
 
         A switch needs deployment if its ``configSyncStatus`` is not ``inSync``.
         """
-        ep = EpManageFabricsSwitchesGet(fabric_name=fabric_name)
-        result = self._request(
-            path=ep.path,
-            verb=ep.verb,
-            not_found_ok=True,
-            operation_type=OperationType.QUERY,
-        )
+        return self._filter_switches_needing_deploy(self._get_fabric_switches(fabric_name))
 
-        switches = result.get("switches", []) if result else []
+    @staticmethod
+    def _filter_switches_needing_deploy(switches: list[dict]) -> list[str]:
+        """Return serial numbers of switches whose ``configSyncStatus`` is not ``inSync``."""
         switch_ids = []
         for switch in switches:
             additional_data = switch.get("additionalData", {})
@@ -219,6 +218,13 @@ class ConfigActionsMixin:
     ) -> None:
         """Execute config save and/or deploy for a list of fabrics.
 
+        Fabrics with no switches on the controller are skipped (not an error):
+        ND rejects save/deploy on a switchless fabric, so a day-0 fabric create —
+        or the fabric step on a first run, before switches are added — must not
+        fail. The skip is surfaced as a warning via ``rest_send.warn``. The
+        fabric's switch list is fetched once per fabric and reused for the
+        switch-level deploy filter.
+
         Args:
             fabric_names: List of fabric names to process.
             save: Whether to save configuration.
@@ -235,14 +241,13 @@ class ConfigActionsMixin:
             return
 
         for fabric_name in fabric_names:
-            # ND rejects save/deploy on a switchless fabric. Skip (not an error) so
-            # a day-0 fabric create — or the fabric step on a first run, before the
-            # switches step adds switches — does not fail. Once switches exist,
-            # saves (including idempotent fabric-setting updates) and deploys proceed.
-            if not self._fabric_has_switches(fabric_name):
-                logger.info("Skipping config save/deploy for '%s': fabric has no switches.", fabric_name)
+            # Fetch the switch list once per fabric and reuse it for both the
+            # switchless-skip check and the switch-level deploy filter.
+            switches = self._get_fabric_switches(fabric_name)
+            if not switches:
+                self.rest_send.warn(f"Skipping config save/deploy for '{fabric_name}': fabric has no switches.")
                 continue
             if save:
                 self.config_save(fabric_name)
             if deploy:
-                self.config_deploy(fabric_name, deploy_type)
+                self.config_deploy(fabric_name, deploy_type, switches=switches)

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics.py
@@ -1056,3 +1056,57 @@ def test_endpoints_api_v1_manage_fabrics_00810():
     assert add_members.verb == HttpVerbEnum.POST
     assert remove_members.path == "/api/v1/manage/fabrics/my-fabric/actions/removeMembers?clusterName=cluster1&ticketId=CHG456"
     assert remove_members.verb == HttpVerbEnum.POST
+
+
+# =============================================================================
+# Test: fabric_name is URL-encoded in the path (issue #292)
+# =============================================================================
+
+
+def test_endpoints_api_v1_manage_fabrics_00940():
+    """
+    # Summary
+
+    Verify fabric_name is percent-encoded in the base path builder.
+
+    ## Test
+
+    - Reserved characters (``/``, space, ``#``) in fabric_name are encoded so a
+      malformed request path is not produced.
+
+    ## Classes and Methods
+
+    - EpManageFabricsGet.path
+    - EpManageFabricsSummaryGet.path
+    """
+    with does_not_raise():
+        get_instance = EpManageFabricsGet()
+        get_instance.fabric_name = "my/fabric name#1"
+        get_result = get_instance.path
+        summary_instance = EpManageFabricsSummaryGet()
+        summary_instance.fabric_name = "my/fabric name#1"
+        summary_result = summary_instance.path
+    assert get_result == "/api/v1/manage/fabrics/my%2Ffabric%20name%231"
+    assert summary_result == "/api/v1/manage/fabrics/my%2Ffabric%20name%231/summary"
+
+
+def test_endpoints_api_v1_manage_fabrics_00950():
+    """
+    # Summary
+
+    Verify fabric_name is percent-encoded in the config deploy path builder.
+
+    ## Test
+
+    - Reserved characters in fabric_name are encoded in the overridden
+      EpManageFabricConfigDeployPost.path.
+
+    ## Classes and Methods
+
+    - EpManageFabricConfigDeployPost.path
+    """
+    with does_not_raise():
+        instance = EpManageFabricConfigDeployPost()
+        instance.fabric_name = "my/fabric name#1"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/my%2Ffabric%20name%231/actions/configDeploy"

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_actions_config_save_deploy.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_actions_config_save_deploy.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Matt Tarkington (@mtarking)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for manage_fabrics_actions_config_save.py and manage_fabrics_actions_deploy.py
+
+Tests the ND Manage fabric configSave and deploy action endpoint classes used by
+ConfigActionsMixin, including fabric_name URL-encoding (issue #292).
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_config_save import (
+    EpFabricConfigSavePost,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_deploy import (
+    EpFabricDeployPost,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
+    does_not_raise,
+)
+
+# =============================================================================
+# Test: EpFabricConfigSavePost
+# =============================================================================
+
+
+def test_endpoints_api_v1_manage_fabrics_actions_config_save_00100():
+    """
+    # Summary
+
+    Verify EpFabricConfigSavePost path and verb.
+
+    ## Classes and Methods
+
+    - EpFabricConfigSavePost.path
+    - EpFabricConfigSavePost.verb
+    """
+    with does_not_raise():
+        instance = EpFabricConfigSavePost()
+        instance.fabric_name = "MyFabric"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/MyFabric/actions/configSave"
+    assert instance.verb == HttpVerbEnum.POST
+
+
+def test_endpoints_api_v1_manage_fabrics_actions_config_save_00110():
+    """
+    # Summary
+
+    Verify EpFabricConfigSavePost raises ValueError when fabric_name is not set.
+
+    ## Classes and Methods
+
+    - EpFabricConfigSavePost.path
+    """
+    instance = EpFabricConfigSavePost()
+    with pytest.raises(ValueError, match="fabric_name is required"):
+        _ = instance.path
+
+
+def test_endpoints_api_v1_manage_fabrics_actions_config_save_00120():
+    """
+    # Summary
+
+    Verify fabric_name is percent-encoded in EpFabricConfigSavePost.path (issue #292).
+
+    ## Test
+
+    - Reserved characters (``/``, space, ``#``) in fabric_name are encoded so a
+      malformed request path is not produced.
+
+    ## Classes and Methods
+
+    - EpFabricConfigSavePost.path
+    """
+    with does_not_raise():
+        instance = EpFabricConfigSavePost()
+        instance.fabric_name = "my/fabric name#1"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/my%2Ffabric%20name%231/actions/configSave"
+
+
+# =============================================================================
+# Test: EpFabricDeployPost
+# =============================================================================
+
+
+def test_endpoints_api_v1_manage_fabrics_actions_deploy_00100():
+    """
+    # Summary
+
+    Verify EpFabricDeployPost path and verb.
+
+    ## Classes and Methods
+
+    - EpFabricDeployPost.path
+    - EpFabricDeployPost.verb
+    """
+    with does_not_raise():
+        instance = EpFabricDeployPost()
+        instance.fabric_name = "MyFabric"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/MyFabric/actions/deploy"
+    assert instance.verb == HttpVerbEnum.POST
+
+
+def test_endpoints_api_v1_manage_fabrics_actions_deploy_00110():
+    """
+    # Summary
+
+    Verify EpFabricDeployPost raises ValueError when fabric_name is not set.
+
+    ## Classes and Methods
+
+    - EpFabricDeployPost.path
+    """
+    instance = EpFabricDeployPost()
+    with pytest.raises(ValueError, match="fabric_name is required"):
+        _ = instance.path
+
+
+def test_endpoints_api_v1_manage_fabrics_actions_deploy_00120():
+    """
+    # Summary
+
+    Verify fabric_name is percent-encoded in EpFabricDeployPost.path (issue #292).
+
+    ## Test
+
+    - Reserved characters (``/``, space, ``#``) in fabric_name are encoded so a
+      malformed request path is not produced.
+
+    ## Classes and Methods
+
+    - EpFabricDeployPost.path
+    """
+    with does_not_raise():
+        instance = EpFabricDeployPost()
+        instance.fabric_name = "my/fabric name#1"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/my%2Ffabric%20name%231/actions/deploy"

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_switchactions.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_switchactions.py
@@ -17,6 +17,7 @@ __metaclass__ = type
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switchactions import (
     EpManageFabricsSwitchActionsChangeRolesPost,
+    EpManageFabricsSwitchActionsDeployPost,
     EpManageFabricsSwitchActionsImportBootstrapPost,
     EpManageFabricsSwitchActionsPreProvisionPost,
     EpManageFabricsSwitchActionsRediscoverPost,
@@ -489,3 +490,25 @@ def test_endpoints_api_v1_manage_fabrics_switchactions_00730():
         instance.endpoint_params.ticket_id = "CHG12345"
         result = instance.path
     assert result == "/api/v1/manage/fabrics/MyFabric/switchActions/rediscover?ticketId=CHG12345"
+
+
+def test_endpoints_api_v1_manage_fabrics_switchactions_00800():
+    """
+    # Summary
+
+    Verify fabric_name is percent-encoded in the switchActions base path (issue #292).
+
+    ## Test
+
+    - Reserved characters (``/``, space, ``#``) in fabric_name are encoded so a
+      malformed request path is not produced.
+
+    ## Classes and Methods
+
+    - EpManageFabricsSwitchActionsDeployPost.path
+    """
+    with does_not_raise():
+        instance = EpManageFabricsSwitchActionsDeployPost()
+        instance.fabric_name = "my/fabric name#1"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/my%2Ffabric%20name%231/switchActions/deploy"

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_switches.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_switches.py
@@ -665,3 +665,25 @@ def test_endpoints_api_v1_manage_fabrics_switches_00640():
         instance.endpoint_params.cluster_name = "cluster1"
         result = instance.path
     assert result == "/api/v1/manage/fabrics/MyFabric/switches/SAL1948TRTT/actions/changeSwitchSerialNumber?clusterName=cluster1"
+
+
+def test_endpoints_api_v1_manage_fabrics_switches_00700():
+    """
+    # Summary
+
+    Verify fabric_name is percent-encoded in EpManageFabricsSwitchesGet.path (issue #292).
+
+    ## Test
+
+    - Reserved characters (``/``, space, ``#``) in fabric_name are encoded so a
+      malformed request path is not produced.
+
+    ## Classes and Methods
+
+    - EpManageFabricsSwitchesGet.path
+    """
+    with does_not_raise():
+        instance = EpManageFabricsSwitchesGet()
+        instance.fabric_name = "my/fabric name#1"
+        result = instance.path
+    assert result == "/api/v1/manage/fabrics/my%2Ffabric%20name%231/switches"

--- a/tests/unit/module_utils/orchestrators/test_config_actions_mixin.py
+++ b/tests/unit/module_utils/orchestrators/test_config_actions_mixin.py
@@ -598,10 +598,14 @@ class TestExecuteConfigActions:
         """
         rest_send = _make_rest_send(
             [
+                # Fabric 1: query switches (non-empty so the fabric is not skipped)
+                _success_response(data={"switches": [{"serialNumber": "FOC111AAA"}]}, method="GET"),
                 # Fabric 1: save
                 _success_response(data={"status": "Config save is completed"}),
                 # Fabric 1: deploy
                 _success_response(data={"status": "Configuration deployment completed"}),
+                # Fabric 2: query switches
+                _success_response(data={"switches": [{"serialNumber": "FOC222BBB"}]}, method="GET"),
                 # Fabric 2: save
                 _success_response(data={"status": "Config save is completed"}),
                 # Fabric 2: deploy
@@ -618,8 +622,8 @@ class TestExecuteConfigActions:
             deploy_type="global",
         )
 
-        # 4 API calls: save + deploy for each of 2 fabrics
-        assert len(results._tasks) == 4
+        # 6 API calls: switches query + save + deploy for each of 2 fabrics
+        assert len(results._tasks) == 6
 
     def test_execute_save_only(self):
         """
@@ -639,7 +643,13 @@ class TestExecuteConfigActions:
         """
         rest_send = _make_rest_send(
             [
+                # Fabric 1: query switches (non-empty so the fabric is not skipped)
+                _success_response(data={"switches": [{"serialNumber": "FOC111AAA"}]}, method="GET"),
+                # Fabric 1: save
                 _success_response(data={"status": "Config save is completed"}),
+                # Fabric 2: query switches
+                _success_response(data={"switches": [{"serialNumber": "FOC222BBB"}]}, method="GET"),
+                # Fabric 2: save
                 _success_response(data={"status": "Config save is completed"}),
             ]
         )
@@ -652,8 +662,8 @@ class TestExecuteConfigActions:
             deploy=False,
         )
 
-        # 2 API calls: save for each fabric
-        assert len(results._tasks) == 2
+        # 4 API calls: switches query + save for each fabric
+        assert len(results._tasks) == 4
 
     def test_execute_deploy_without_save_raises_value_error(self):
         """
@@ -741,10 +751,10 @@ class TestExecuteConfigActions:
 
         rest_send = _make_rest_send(
             [
+                # query switches once per fabric (reused for the deploy filter)
+                _success_response(data=switches_response, method="GET"),
                 # save
                 _success_response(data={"status": "Config save is completed"}),
-                # query switches
-                _success_response(data=switches_response, method="GET"),
                 # switch deploy
                 _success_response(data={"switchIds": [{"switchId": "FOC111AAA", "status": "success"}]}),
             ]
@@ -759,8 +769,47 @@ class TestExecuteConfigActions:
             deploy_type="switch",
         )
 
-        # 3 API calls: save + GET switches + POST switchActions/deploy
+        # 3 API calls: GET switches + save + POST switchActions/deploy
         assert len(results._tasks) == 3
+
+
+    def test_execute_skips_switchless_fabric(self):
+        """
+        # Summary
+
+        Verify execute_config_actions skips save/deploy for a fabric with no
+        switches and surfaces a warning instead of failing.
+
+        ## Test
+
+        - Only the switches query is made (no save, no deploy)
+        - A warning is emitted via rest_send.warn
+
+        ## Classes and Methods
+
+        - ConfigActionsMixin.execute_config_actions()
+        - ConfigActionsMixin._get_fabric_switches()
+        """
+        rest_send = _make_rest_send(
+            [
+                # query switches: empty -> fabric is switchless
+                _success_response(data={"switches": []}, method="GET"),
+            ]
+        )
+        results = _make_results()
+        orch = _make_orchestrator(rest_send, results)
+
+        orch.execute_config_actions(
+            fabric_names=["switchless-fabric"],
+            save=True,
+            deploy=True,
+            deploy_type="global",
+        )
+
+        # Only the switches query was made; save/deploy were skipped
+        assert len(results._tasks) == 1
+        warnings = rest_send.sender.ansible_module.warnings
+        assert any("switchless-fabric" in w and "no switches" in w for w in warnings)
 
 
 # =============================================================================


### PR DESCRIPTION
## Related Issue(s)

Resolves #292  
Resolves #272  
Resolves #490 

## Proposed Changes

`_EpManageFabricsBase.path` appended `fabric_name` to the path segments without URL-encoding, unlike the sibling endpoint files (`manage_interfaces.py`, `manage_switches.py`) which wrap it in `quote(..., safe="")`. A `fabric_name` containing characters that require percent-encoding (space, `/`, `#`, `%`, `?`, etc.) produced a malformed request path — a `/` in particular would be interpreted as an extra path segment and hit the wrong endpoint.

- Added `from urllib.parse import quote` to `plugins/module_utils/endpoints/v1/manage/manage_fabrics.py`.
- `_EpManageFabricsBase.path` now appends `quote(self.fabric_name, safe="")`. Because the base class is inherited by every fabrics endpoint that embeds a fabric name in the path, this fixes them all: `EpManageFabricsGet`, `EpManageFabricsPut`, `EpManageFabricsDelete`, `EpManageFabricsSummaryGet`, `EpManageFabricsDeploymentFreezeGet`, and the four `EpManageFabricsMembers*` / `EpManageFabricsMemberCandidatesGet` endpoints. (`EpManageFabricsListGet` and `EpManageFabricsPost` set `_require_fabric_name = False` and are unaffected.)
- Also encoded `fabric_name` in `EpManageFabricConfigDeployPost.path`, which overrides `path` and had the same unencoded bug (not called out in the issue).

This is backward compatible: normal fabric names (alphanumeric, `-`, `_`) are unchanged by `quote`.

## Test Notes

- Added two unit tests to `tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics.py` asserting that reserved characters (`/`, space, `#`) in `fabric_name` are percent-encoded in both the base path builder and the `EpManageFabricConfigDeployPost` path override.
- Full module passes (41 existing + 2 new = 43 passed):

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infa
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers