### PR TITLE
Staged configuration addition and removal audit for Vrf_lite

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics_actions_config_save.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics_actions_config_save.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from typing import Literal
+from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     ConfigDict,
@@ -44,7 +45,7 @@ class EpFabricConfigSavePost(
     def path(self) -> str:
         if self.fabric_name is None:
             raise ValueError("fabric_name is required")
-        return BasePath.path("fabrics", self.fabric_name, "actions", "configSave")
+        return BasePath.path("fabrics", quote(self.fabric_name, safe=""), "actions", "configSave")
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics_actions_deploy.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics_actions_deploy.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from typing import Literal
+from urllib.parse import quote
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     ConfigDict,
@@ -39,12 +40,16 @@ class EpFabricDeployPost(
     api_version: Literal["v1"] = Field(default="v1")
     min_controller_version: str = Field(default="3.0.0")
     class_name: Literal["EpFabricDeployPost"] = Field(default="EpFabricDeployPost")
+    force_show_run: bool = Field(default=False, description="Include forceShowRun=true in the deploy query string.")
 
     @property
     def path(self) -> str:
         if self.fabric_name is None:
             raise ValueError("fabric_name is required")
-        return BasePath.path("fabrics", self.fabric_name, "actions", "deploy")
+        path = BasePath.path("fabrics", quote(self.fabric_name, safe=""), "actions", "deploy")
+        if self.force_show_run:
+            return "{0}?forceShowRun=true".format(path)
+        return path
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/fabric_context.py
+++ b/plugins/module_utils/fabric_context.py
@@ -57,6 +57,7 @@ class FabricContext:
         self._fabric_summary = _NOT_FETCHED
         self._switch_map: dict[str, str] | None = None
         self._switch_map_by_id: dict[str, str] | None = None
+        self._switch_inventory_by_id: dict[str, dict] | None = None
 
     def _query_get(self, path: str) -> dict:
         """
@@ -182,6 +183,7 @@ class FabricContext:
         self._fabric_summary = _NOT_FETCHED
         self._switch_map = None
         self._switch_map_by_id = None
+        self._switch_inventory_by_id = None
 
     def _load_switch_maps(self) -> None:
         """
@@ -203,6 +205,7 @@ class FabricContext:
         switches = (result.get("switches") or []) if result else []
         self._switch_map = {sw["fabricManagementIp"]: sw["switchId"] for sw in switches if sw.get("fabricManagementIp") and sw.get("switchId")}
         self._switch_map_by_id = {sw["switchId"]: sw["fabricManagementIp"] for sw in switches if sw.get("switchId") and sw.get("fabricManagementIp")}
+        self._switch_inventory_by_id = {sw["switchId"]: sw for sw in switches if sw.get("switchId")}
 
     @property
     def switch_map(self) -> dict[str, str]:
@@ -243,6 +246,22 @@ class FabricContext:
         if self._switch_map_by_id is None:
             raise AssertionError("switch_map_by_id is None after _load_switch_maps()")
         return self._switch_map_by_id
+
+    @property
+    def switch_inventory_by_id(self) -> dict[str, dict]:
+        """
+        # Summary
+
+        Return cached raw switch inventory keyed by ``switchId``.
+
+        This uses the same switch-list response as ``switch_map`` and
+        ``switch_map_by_id`` so callers that need role or fabric-type metadata
+        do not need to issue a second switches query.
+        """
+        self._load_switch_maps()
+        if self._switch_inventory_by_id is None:
+            raise AssertionError("switch_inventory_by_id is None after _load_switch_maps()")
+        return self._switch_inventory_by_id
 
     def get_switch_id(self, switch_ip: str) -> str:
         """

--- a/plugins/module_utils/manage_vrf_lite/actions.py
+++ b/plugins/module_utils/manage_vrf_lite/actions.py
@@ -1,0 +1,410 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDModuleError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.common import (
+    _raise_vrf_lite_error,
+    _resolve_serial,
+    request_with_rest_send,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query import (
+    query_vrf_lite_state,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.runtime_endpoints import (
+    VrfLiteEndpoints,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.exceptions import (
+    VrfLiteResourceError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.runtime_payloads import (
+    build_instance_values,
+    build_vrf_lite_extension_values,
+    parse_instance_values,
+    vrf_lite_items_to_config,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation import (
+    get_cached_vrf_lite_prototypes,
+)
+
+
+def _request_vrf_lite_payload(module: Any, rest_send: Any, path: str, verb: HttpVerbEnum, payload: Any) -> Any:
+    """Send VRF Lite payloads without widening the shared REST sender contract."""
+    try:
+        return request_with_rest_send(
+            module=module,
+            rest_send=rest_send,
+            path=path,
+            verb=verb,
+            data=payload,
+        )
+    except NDModuleError as error:
+        controller_response = error.response_payload if error.response_payload is not None else error.raw
+        response_context = ""
+        if controller_response is not None:
+            response_context = "; controller_response={0}".format(json.dumps(controller_response, sort_keys=True, default=str))
+        _raise_vrf_lite_error(
+            msg="{0}; status={1}{2}".format(error.msg, error.status, response_context),
+            request_path=path,
+            request_payload=payload,
+            **{key: value for key, value in error.to_dict().items() if key not in {"msg", "request_payload"}},
+        )
+    except Exception as error:
+        _raise_vrf_lite_error(
+            msg="{0}; request_payload={1}".format(error, json.dumps(payload, sort_keys=True)),
+            request_payload=payload,
+        )
+
+
+def _ensure_vrf_exists(module: Any, rest_send: Any, vrf_name: str) -> None:
+    known_vrfs = module.params.get("_known_vrfs") or []
+    if vrf_name in known_vrfs:
+        return
+
+    fabric_name = module.params.get("fabric_name")
+    # The state machine's initial query records the complete VRF inventory,
+    # including VRFs without managed attachment rows.  Once that snapshot is
+    # loaded, an absent name is authoritative and must not trigger another
+    # switch/VRF/attachment query from inside a bulk validation loop.
+    if module.params.get("_known_vrfs_loaded") is not True:
+        query_vrf_lite_state(
+            module=module,
+            rest_send=rest_send,
+            fabric_name=fabric_name,
+            filter_vrfs={vrf_name},
+        )
+        known_vrfs = module.params.get("_known_vrfs") or []
+
+    if vrf_name not in known_vrfs:
+        _raise_vrf_lite_error(
+            msg="VRF '{0}' does not exist in fabric '{1}'.".format(vrf_name, fabric_name),
+            fabric=fabric_name,
+            vrf_name=vrf_name,
+        )
+
+
+def _reserve_dot1q_if_needed(
+    module: Any,
+    rest_send: Any,
+    fabric_name: str,
+    vrf_name: str,
+    serial_number: str,
+    lite_item: dict[str, Any],
+) -> dict[str, Any]:
+    if lite_item.get("dot1q") not in (None, ""):
+        return lite_item
+
+    interface = lite_item.get("interface")
+    if not interface:
+        return lite_item
+
+    payload = {
+        "scopeType": "DeviceInterface",
+        "usageType": "TOP_DOWN_L3_DOT1Q",
+        "serialNumber": serial_number,
+        "switchId": serial_number,
+        "ifName": interface,
+        "allocatedTo": vrf_name,
+    }
+
+    response = request_with_rest_send(
+        module,
+        rest_send,
+        VrfLiteEndpoints.reserve_id(fabric_name),
+        HttpVerbEnum.POST,
+        payload,
+    )
+
+    dot1q_value = None
+    if isinstance(response, dict):
+        # TODO(4.2.1) vrf-lite-reserve-id-shape-drift: different controller
+        # versions return either a scalar DATA-equivalent or a dict-like body
+        # for reserve-id, so several keys are probed with a scalar fallback.
+        # Remove once the reserve-id response shape is stable (see vault note).
+        for key in ("dot1q", "id", "value", "allocatedId"):
+            if response.get(key) not in (None, ""):
+                dot1q_value = response.get(key)
+                break
+    else:
+        dot1q_value = response
+
+    if dot1q_value in (None, ""):
+        _raise_vrf_lite_error(
+            msg="Failed to reserve dot1q for VRF Lite interface '{0}' on switch '{1}'.".format(interface, serial_number),
+            vrf_name=vrf_name,
+            serial_number=serial_number,
+            reserve_response=response,
+        )
+
+    updated = dict(lite_item)
+    updated["dot1q"] = dot1q_value
+    return updated
+
+
+def _raw_attachment_entry(module: Any, vrf_name: str, serial_number: str) -> dict[str, Any]:
+    raw_vrf_attachment_map = module.params.get("_raw_vrf_attachment_map") or {}
+    raw_attachment_map = raw_vrf_attachment_map.get(vrf_name, {}) if isinstance(raw_vrf_attachment_map, dict) else {}
+    raw_attach = raw_attachment_map.get(serial_number) if isinstance(raw_attachment_map, dict) else None
+    return raw_attach if isinstance(raw_attach, dict) else {}
+
+
+def _empty_vrf_lite_extension_values(existing_extension_values: Any) -> str:
+    """Clear only the managed VRF Lite extension in a legacy attachment row."""
+    rendered = build_vrf_lite_extension_values(
+        [],
+        existing_extension_values=existing_extension_values,
+    )
+    if rendered:
+        return rendered
+
+    return build_vrf_lite_extension_values(
+        [],
+        existing_extension_values={
+            "VRF_LITE_CONN": json.dumps({"VRF_LITE_CONN": []}, separators=(",", ":")),
+            "MULTISITE_CONN": json.dumps({"MULTISITE_CONN": []}, separators=(",", ":")),
+        },
+    )
+
+
+def _build_instance_values_for_payload(import_evpn_rt: Any, export_evpn_rt: Any, existing_instance_values: Any = None) -> str:
+    """Preserve controller-owned values while updating the VRF Lite RT fields."""
+    existing = dict(parse_instance_values(existing_instance_values))
+    if not existing:
+        return build_instance_values(import_evpn_rt, export_evpn_rt)
+
+    existing["switchRouteTargetImportEvpn"] = import_evpn_rt or ""
+    existing["switchRouteTargetExportEvpn"] = export_evpn_rt or ""
+    if "evpnRouteTargetImport" in existing:
+        existing["evpnRouteTargetImport"] = import_evpn_rt or ""
+    if "evpnRouteTargetExport" in existing:
+        existing["evpnRouteTargetExport"] = export_evpn_rt or ""
+    for key in ("loopbackId", "loopbackIpAddress", "loopbackIpV6Address"):
+        existing.setdefault(key, "")
+
+    return json.dumps(existing, separators=(",", ":"))
+
+
+def _build_instance_values_for_detach(existing_instance_values: Any = None) -> str:
+    """Clear managed route targets while preserving other attachment values."""
+    existing = dict(parse_instance_values(existing_instance_values))
+    if not existing:
+        return build_instance_values("", "")
+
+    for key in (
+        "switchRouteTargetImportEvpn",
+        "switchRouteTargetExportEvpn",
+        "evpnRouteTargetImport",
+        "evpnRouteTargetExport",
+    ):
+        if key in existing:
+            existing[key] = ""
+    return json.dumps(existing, separators=(",", ":"))
+
+
+def _freeform_config_for_payload(raw_attach: dict[str, Any]) -> str:
+    value = raw_attach.get("freeform_config") if isinstance(raw_attach, dict) else None
+    if value in (None, "None"):
+        return ""
+    return str(value)
+
+
+def _entry_extensions(entry: Any) -> list[dict[str, Any]]:
+    return entry.to_config().get("extensions", []) if hasattr(entry, "to_config") else list(getattr(entry, "extensions", None) or [])
+
+
+def _entry_vlan_id(module: Any, entry: Any, raw_attach: dict[str, Any] | None = None) -> int:
+    if getattr(entry, "vlan_id", None) is not None:
+        return int(entry.vlan_id)
+
+    vlan_map = module.params.get("_vrf_lite_vrf_vlan_map") or {}
+    mapped_vlan = vlan_map.get(entry.vrf_name)
+    if mapped_vlan not in (None, ""):
+        try:
+            return int(mapped_vlan)
+        except (TypeError, ValueError):
+            pass
+
+    if isinstance(raw_attach, dict) and raw_attach.get("vlan") not in (None, ""):
+        try:
+            return int(raw_attach.get("vlan"))
+        except (TypeError, ValueError):
+            pass
+
+    _raise_vrf_lite_error(
+        msg=("vlan_id is required for VRF '{0}' because the current VRF VLAN " "could not be determined from the controller.").format(entry.vrf_name),
+        vrf_name=entry.vrf_name,
+        switch_ip=entry.switch_ip,
+    )
+
+
+def build_attach_payload_for_entry(module: Any, rest_send: Any, entry: Any) -> dict[str, Any]:
+    """Build one legacy attachment row for one flat VRF Lite entry."""
+    serial_number = _resolve_serial(module, entry.switch_ip)
+    raw_attach = _raw_attachment_entry(module, entry.vrf_name, serial_number)
+    vlan_id = _entry_vlan_id(module, entry, raw_attach)
+
+    resolved_extensions = []
+    for lite_item in vrf_lite_items_to_config(_entry_extensions(entry)):
+        resolved_extensions.append(
+            _reserve_dot1q_if_needed(
+                module,
+                rest_send,
+                module.params.get("fabric_name"),
+                entry.vrf_name,
+                serial_number,
+                lite_item,
+            )
+        )
+
+    extension_values = build_vrf_lite_extension_values(
+        resolved_extensions,
+        existing_extension_values=(raw_attach.get("extension_values") if isinstance(raw_attach, dict) else None),
+        prototype_values_by_interface=get_cached_vrf_lite_prototypes(
+            module,
+            module.params.get("fabric_name"),
+            entry.vrf_name,
+            serial_number,
+        ),
+    )
+    instance_values = _build_instance_values_for_payload(
+        getattr(entry, "import_evpn_rt", None),
+        getattr(entry, "export_evpn_rt", None),
+        raw_attach.get("instance_values") if isinstance(raw_attach, dict) else None,
+    )
+
+    return {
+        "fabric": module.params.get("fabric_name"),
+        "vrfName": entry.vrf_name,
+        "serialNumber": serial_number,
+        "vlan": vlan_id,
+        "deployment": True,
+        "isAttached": True,
+        "extensionValues": extension_values,
+        "instanceValues": instance_values,
+        "freeformConfig": _freeform_config_for_payload(raw_attach),
+    }
+
+
+def _build_detach_payload(
+    module: Any,
+    vrf_name: str,
+    serial_number: str,
+    vlan_id: Any,
+    extension_values: Any = None,
+    instance_values: Any = None,
+    freeform_config: Any = None,
+) -> dict[str, Any]:
+    # Removing VRF Lite configuration must retain the parent VRF attachment.
+    # The legacy endpoint does that by posting an attached row whose managed
+    # VRF_LITE_CONN value is explicitly empty.
+    return {
+        "fabric": module.params.get("fabric_name"),
+        "vrfName": vrf_name,
+        "serialNumber": serial_number,
+        "vlan": vlan_id if vlan_id is not None else 0,
+        "deployment": True,
+        "isAttached": True,
+        "extensionValues": _empty_vrf_lite_extension_values(extension_values),
+        "instanceValues": _build_instance_values_for_detach(instance_values),
+        "freeformConfig": _freeform_config_for_payload({"freeform_config": freeform_config}),
+    }
+
+
+def build_detach_payload_for_entry(module: Any, entry: Any) -> dict[str, Any]:
+    """Build one ND row that removes VRF Lite data for one flat entry."""
+    serial_number = _resolve_serial(module, entry.switch_ip)
+    raw_attach = _raw_attachment_entry(module, entry.vrf_name, serial_number)
+    vlan_id = getattr(entry, "vlan_id", None)
+    if vlan_id in (None, ""):
+        vlan_id = raw_attach.get("vlan")
+    if vlan_id in (None, ""):
+        vlan_id = (module.params.get("_vrf_lite_vrf_vlan_map") or {}).get(entry.vrf_name)
+
+    return _build_detach_payload(
+        module=module,
+        vrf_name=entry.vrf_name,
+        serial_number=serial_number,
+        vlan_id=vlan_id,
+        extension_values=raw_attach.get("extension_values"),
+        instance_values=raw_attach.get("instance_values"),
+        freeform_config=raw_attach.get("freeform_config"),
+    )
+
+
+_FAILURE_STATUSES = frozenset({"failed", "failure", "error"})
+
+
+def _collect_attachment_failures(response: Any) -> list[str]:
+    failures: list[str] = []
+
+    if isinstance(response, str):
+        lowered = response.lower()
+        if any(signature in lowered for signature in _FAILURE_STATUSES):
+            failures.append(response)
+        return failures
+
+    if isinstance(response, dict):
+        status = str(response.get("status") or "").strip().lower()
+        if status in _FAILURE_STATUSES:
+            vrf_name = response.get("vrfName") or "unknown-vrf"
+            switch_id = response.get("switchId") or response.get("switchName") or "unknown-switch"
+            message = response.get("message") or "attachment operation failed"
+            return ["{0}/{1}: {2}".format(vrf_name, switch_id, message)]
+
+        for value in response.values():
+            failures.extend(_collect_attachment_failures(value))
+        return failures
+
+    if isinstance(response, list):
+        for item in response:
+            failures.extend(_collect_attachment_failures(item))
+
+    return failures
+
+
+def _post_attachment_payload(
+    module: Any,
+    rest_send: Any,
+    fabric_name: str,
+    vrf_name: str,
+    lan_attach_list: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if not lan_attach_list:
+        return {}
+
+    path = VrfLiteEndpoints.vrf_attachments_post(fabric_name)
+    # VRF Lite's public model intentionally does not require neighborAsn or an
+    # already-created extension object.  Those are mandatory for the newer
+    # /vrfAttachments API, so first-time VRF Lite writes use the compatible
+    # /vrfs/attachments contract that accepts VRF_LITE_CONN template data.
+    payload = [{"vrfName": vrf_name, "lanAttachList": lan_attach_list}]
+    try:
+        response = _request_vrf_lite_payload(module, rest_send, path, HttpVerbEnum.POST, payload)
+    except VrfLiteResourceError:
+        raise
+    except Exception as error:
+        _raise_vrf_lite_error(
+            msg="{0}; request_path={1}; request_payload={2}".format(error, path, json.dumps(payload, sort_keys=True)),
+            request_path=path,
+            request_payload=payload,
+        )
+    failures = _collect_attachment_failures(response)
+    if failures:
+        _raise_vrf_lite_error(
+            msg="VRF Lite attachment API reported failure: {0}".format("; ".join(failures)),
+            fabric=fabric_name,
+            vrf_name=vrf_name,
+            controller_failures=failures,
+            response=response,
+        )
+    return response

--- a/plugins/module_utils/manage_vrf_lite/common.py
+++ b/plugins/module_utils/manage_vrf_lite/common.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any, NoReturn
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDModuleError
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.exceptions import (
+    VrfLiteResourceError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
+
+DEFAULT_VERIFY_TIMEOUT = 10
+DEFAULT_VERIFY_RETRIES = 5
+DEFAULT_CONFIG_ACTION_TYPE = "switch"
+CONFIG_ACTION_TYPE_CHOICES = ("switch", "global")
+
+
+class _VrfLiteListPayloadRestSend(RestSend):
+    """RestSend variant for the ND VRF attachment API's top-level list body."""
+
+    @property
+    def payload(self) -> Any:
+        return self._payload
+
+    @payload.setter
+    def payload(self, value: Any) -> None:
+        if not isinstance(value, (dict, list)):
+            msg = "{0}.payload: payload must be a dict or list. ".format(self.class_name)
+            msg += "Got {0}.".format(value)
+            raise TypeError(msg)
+        self._payload = value
+
+
+class _VrfLiteListPayloadSender(Sender):
+    """Sender variant for the ND VRF attachment API's top-level list body."""
+
+    @property
+    def payload(self) -> Any:
+        return self._payload
+
+    @payload.setter
+    def payload(self, value: Any) -> None:
+        if value is not None and not isinstance(value, (dict, list)):
+            msg = "{0}.payload: payload must be a dict, list, or None. ".format(self.class_name)
+            msg += "Got type {0}, value {1}.".format(type(value).__name__, value)
+            raise TypeError(msg)
+        self._payload = value
+
+
+def _params(source: Any) -> dict[str, Any]:
+    if isinstance(source, dict):
+        return source
+    params = getattr(source, "params", None)
+    return params if isinstance(params, dict) else {}
+
+
+def _raise_vrf_lite_error(msg: str, **details: Any) -> NoReturn:
+    raise VrfLiteResourceError(msg=msg, **details)
+
+
+def _is_ip_literal(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+
+    text = value.strip()
+    if not text:
+        return False
+
+    try:
+        ipaddress.ip_address(text)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_serial(module: Any, switch_identifier: Any) -> str:
+    """Resolve a switch management IP to serial when the query cache has it."""
+    if switch_identifier is None:
+        return ""
+
+    text = str(switch_identifier).strip()
+    if not text:
+        return ""
+
+    mapping = module.params.get("_ip_to_sn_mapping") or {}
+    if text in mapping:
+        return mapping[text]
+
+    if _is_ip_literal(text):
+        _raise_vrf_lite_error(
+            msg=("Switch identifier '{0}' appears to be an IP, but it could not " "be resolved to a fabric switch serial number.").format(text),
+            switch_id=text,
+        )
+
+    return text
+
+
+def vrf_name_from_config_item(item: Any) -> str:
+    """Return a normalized VRF name from public or controller-style keys."""
+    if not isinstance(item, dict):
+        return ""
+
+    vrf_name = item.get("vrf_name") or item.get("vrfName")
+    return str(vrf_name).strip() if vrf_name else ""
+
+
+def append_runtime_warning(source: Any, message: str) -> None:
+    """Collect runtime warnings without requiring direct Ansible dependencies."""
+    params = _params(source)
+    warnings = params.get("_warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+    warnings.append(str(message))
+    params["_warnings"] = warnings
+
+
+def get_runtime_warnings(source: Any) -> list[str]:
+    params = _params(source)
+    warnings = params.get("_warnings")
+    if not isinstance(warnings, list):
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for warning in warnings:
+        text = str(warning)
+        if text in seen:
+            continue
+        seen.add(text)
+        normalized.append(text)
+    return normalized
+
+
+def get_verify_settings(source: Any) -> dict[str, Any]:
+    params = _params(source)
+    raw_verify = params.get("verify")
+    if isinstance(raw_verify, dict):
+        return {
+            "enabled": raw_verify.get("enabled", True),
+            "retries": raw_verify.get("retries", DEFAULT_VERIFY_RETRIES),
+            "timeout": raw_verify.get("timeout", DEFAULT_VERIFY_TIMEOUT),
+        }
+
+    return {
+        "enabled": True,
+        "retries": DEFAULT_VERIFY_RETRIES,
+        "timeout": DEFAULT_VERIFY_TIMEOUT,
+    }
+
+
+def _list_payload_rest_send(module: Any, base_rest_send: RestSend) -> RestSend:
+    rest_send = _VrfLiteListPayloadRestSend(
+        {
+            "check_mode": module.check_mode,
+            "state": module.params.get("state"),
+        }
+    )
+    rest_send.timeout = base_rest_send.timeout
+    rest_send.send_interval = base_rest_send.send_interval
+    rest_send.unit_test = base_rest_send.unit_test
+
+    sender = _VrfLiteListPayloadSender()
+    sender.ansible_module = module
+    rest_send.sender = sender
+    rest_send.response_handler = ResponseHandler()
+    return rest_send
+
+
+def request_with_rest_send(
+    module: Any,
+    rest_send: RestSend,
+    path: str,
+    verb: HttpVerbEnum,
+    data: Any = None,
+    timeout: int | None = None,
+    force_check_mode: bool = False,
+) -> Any:
+    """Run a controller request through the orchestrator's RestSend path."""
+    active_rest_send = _list_payload_rest_send(module, rest_send) if isinstance(data, list) else rest_send
+
+    active_rest_send.save_settings()
+    if timeout is not None:
+        active_rest_send.timeout = timeout
+    if force_check_mode:
+        active_rest_send.check_mode = False
+
+    try:
+        active_rest_send.path = path
+        active_rest_send.verb = verb
+        if data is not None:
+            active_rest_send.payload = data
+        active_rest_send.commit()
+    except (TypeError, ValueError) as error:
+        raise ValueError("Error in request: {0}".format(error)) from error
+    finally:
+        active_rest_send.restore_settings()
+
+    response = active_rest_send.response_current
+    result = active_rest_send.result_current
+
+    if not result.get("success", False):
+        response_data = response.get("DATA")
+        raw = None
+        payload = None
+
+        if isinstance(response_data, dict):
+            if "raw_response" in response_data:
+                raw = response_data["raw_response"]
+            else:
+                payload = response_data
+
+        error_msg = active_rest_send.response_handler.error_message if active_rest_send.response_handler else "Unknown error"
+        raise NDModuleError(
+            msg=error_msg or "Unknown error",
+            status=response.get("RETURN_CODE", -1),
+            request_payload=data if isinstance(data, dict) else None,
+            response_payload=payload,
+            raw=raw,
+        )
+
+    return response.get("DATA", {})
+
+
+def _is_transient_error(error: Exception) -> bool:
+    """Return True for errors worth retrying.
+
+    Client errors (HTTP 4xx) will not succeed on retry, so they are raised
+    immediately. Server errors (5xx) and errors with an unknown status
+    (e.g. transport/timeout failures reported with status < 0) are treated
+    as transient and retried.
+    """
+    if isinstance(error, NDModuleError):
+        return error.status >= 500 or error.status < 0
+    return True
+
+
+def request_with_verify_settings(module: Any, rest_send: RestSend, path: str, verb: HttpVerbEnum, data: Any = None) -> Any:
+    """Run a controller read using the configured verify timeout/retry policy."""
+    settings = get_verify_settings(module.params)
+    timeout = settings.get("timeout", DEFAULT_VERIFY_TIMEOUT)
+    retries = settings.get("retries", DEFAULT_VERIFY_RETRIES)
+    try:
+        retries = max(1, int(retries))
+    except (TypeError, ValueError):
+        retries = DEFAULT_VERIFY_RETRIES
+
+    for attempt in range(retries):
+        try:
+            return request_with_rest_send(
+                module=module,
+                rest_send=rest_send,
+                path=path,
+                verb=verb,
+                data=data,
+                timeout=timeout,
+                force_check_mode=True,
+            )
+        except Exception as error:
+            if attempt + 1 >= retries or not _is_transient_error(error):
+                raise
+
+
+def get_config_actions(source: Any) -> dict[str, Any]:
+    params = _params(source)
+    raw_actions = params.get("config_actions")
+    if isinstance(raw_actions, dict):
+        action_type_raw = raw_actions.get("type", DEFAULT_CONFIG_ACTION_TYPE)
+        action_type = str(action_type_raw).strip().lower() if action_type_raw is not None else DEFAULT_CONFIG_ACTION_TYPE
+        if action_type not in CONFIG_ACTION_TYPE_CHOICES:
+            action_type = DEFAULT_CONFIG_ACTION_TYPE
+
+        return {
+            "save": raw_actions.get("save", True),
+            "deploy": raw_actions.get("deploy", True),
+            "type": action_type,
+        }
+
+    return {
+        "save": True,
+        "deploy": True,
+        "type": DEFAULT_CONFIG_ACTION_TYPE,
+    }

--- a/plugins/module_utils/manage_vrf_lite/config_transform.py
+++ b/plugins/module_utils/manage_vrf_lite/config_transform.py
@@ -72,6 +72,11 @@ def explode_playbook_to_entries(
     current_entries = current_entries or []
     current_by_key = {(item.get("vrf_name"), item.get("switch_ip")): item for item in current_entries}
     current_keys = set(current_by_key)
+    pending_delete_keys = {
+        (str(target.get("vrf_name") or "").strip(), str(target.get("switch_ip") or "").strip())
+        for target in module.params.get("_pending_deploy_targets") or []
+        if isinstance(target, dict) and target.get("operation") == "delete"
+    }
     for vrf_item in config or []:
         if not isinstance(vrf_item, dict):
             continue
@@ -99,7 +104,8 @@ def explode_playbook_to_entries(
                 entry = _merge_current_entry(current_by_key[(entry.get("vrf_name"), entry.get("switch_ip"))], entry)
             entries.append(entry)
 
-            if state == "deleted" and (entry.get("vrf_name"), entry.get("switch_ip")) not in current_keys:
+            entry_key = (entry.get("vrf_name"), entry.get("switch_ip"))
+            if state == "deleted" and entry_key not in current_keys and entry_key not in pending_delete_keys:
                 append_runtime_warning(
                     module.params,
                     "No matching VRF Lite attachment found to delete for VRF '{0}' switch '{1}'. "

--- a/plugins/module_utils/manage_vrf_lite/config_transform.py
+++ b/plugins/module_utils/manage_vrf_lite/config_transform.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.common import (
+    _resolve_serial,
+    append_runtime_warning,
+    vrf_name_from_config_item,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_vrf_lite.vrf_lite_attachment_entry import (
+    VrfLiteAttachmentEntry,
+)
+
+
+def _canonical_switch_id(module: Any, switch_identifier: Any) -> str:
+    if switch_identifier is None:
+        return ""
+    if module is None:
+        return str(switch_identifier).strip()
+    return _resolve_serial(module, switch_identifier)
+
+
+def _entry_from_attach(module: Any, vrf_item: dict[str, Any], attach: dict[str, Any]) -> dict[str, Any]:
+    vrf_name = vrf_name_from_config_item(vrf_item)
+    switch_identifier = attach.get("ip_address") or attach.get("switch_ip") or attach.get("serial_number")
+    switch_ip = _canonical_switch_id(module, switch_identifier)
+
+    entry: dict[str, Any] = {
+        "vrf_name": vrf_name,
+        "switch_ip": switch_ip,
+    }
+
+    vlan_id = attach.get("vlan_id", vrf_item.get("vlan_id"))
+    if vlan_id is not None:
+        entry["vlan_id"] = vlan_id
+
+    if "deploy" in attach:
+        entry["deploy"] = attach.get("deploy")
+    elif "deploy" in vrf_item:
+        entry["deploy"] = vrf_item.get("deploy")
+
+    for key in ("import_evpn_rt", "export_evpn_rt"):
+        if attach.get(key) is not None:
+            entry[key] = attach.get(key)
+
+    extensions = attach.get("extensions", attach.get("vrf_lite"))
+    if extensions is not None:
+        entry["extensions"] = extensions
+
+    return {key: value for key, value in entry.items() if value is not None}
+
+
+def _merge_current_entry(current: dict[str, Any], proposed: dict[str, Any]) -> dict[str, Any]:
+    """Build the effective merged attachment row before generic diffing."""
+    return VrfLiteAttachmentEntry.from_config(current).merge(VrfLiteAttachmentEntry.from_config(proposed)).to_config()
+
+
+def explode_playbook_to_entries(
+    config: list[dict[str, Any]],
+    module: Any,
+    state: str,
+    current_entries: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Flatten nested playbook config into attachment-level payload DTO data."""
+    entries: list[dict[str, Any]] = []
+    current_entries = current_entries or []
+    current_by_key = {(item.get("vrf_name"), item.get("switch_ip")): item for item in current_entries}
+    current_keys = set(current_by_key)
+    for vrf_item in config or []:
+        if not isinstance(vrf_item, dict):
+            continue
+
+        vrf_name = vrf_name_from_config_item(vrf_item)
+        if not vrf_name:
+            continue
+
+        attachments = vrf_item.get("attach")
+
+        if state == "deleted" and not attachments:
+            entries.extend([dict(item) for item in current_entries if item.get("vrf_name") == vrf_name])
+            continue
+
+        if not isinstance(attachments, list):
+            continue
+
+        for attach in attachments:
+            if not isinstance(attach, dict):
+                continue
+            entry = _entry_from_attach(module, vrf_item, attach)
+            if not entry.get("switch_ip") or not entry.get("vrf_name"):
+                continue
+            if state == "merged" and (entry.get("vrf_name"), entry.get("switch_ip")) in current_by_key:
+                entry = _merge_current_entry(current_by_key[(entry.get("vrf_name"), entry.get("switch_ip"))], entry)
+            entries.append(entry)
+
+            if state == "deleted" and (entry.get("vrf_name"), entry.get("switch_ip")) not in current_keys:
+                append_runtime_warning(
+                    module.params,
+                    "No matching VRF Lite attachment found to delete for VRF '{0}' switch '{1}'. "
+                    "No detach payload was sent.".format(entry.get("vrf_name"), entry.get("switch_ip")),
+                )
+
+    return sorted(entries, key=lambda item: (item.get("vrf_name", ""), item.get("switch_ip", "")))
+
+
+def config_vrf_names(config: list[dict[str, Any]]) -> list[str]:
+    """Return unique VRF names from playbook-style config."""
+    vrfs = []
+    for item in config or []:
+        if not isinstance(item, dict):
+            continue
+        vrf_name = vrf_name_from_config_item(item)
+        if vrf_name:
+            vrfs.append(vrf_name)
+    return sorted(set(vrfs))
+
+
+def replacement_scope_vrfs(config: list[dict[str, Any]]) -> list[str]:
+    """Return VRF names whose attachment set is managed by replaced state."""
+    return config_vrf_names(config)
+
+
+def group_attachment_entries_to_vrfs(
+    entries: list[Any],
+    module: Any = None,
+    include_vrfs: list[str] | set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Convert flat attachment DTOs back to the public nested VRF shape."""
+    sn_to_ip = {}
+    vlan_map = {}
+    known_vrfs = set()
+    if module is not None and isinstance(getattr(module, "params", None), dict):
+        sn_to_ip = module.params.get("_sn_to_ip_mapping") or {}
+        vlan_map = module.params.get("_vrf_lite_vrf_vlan_map") or {}
+        known_vrfs = set(module.params.get("_known_vrfs") or [])
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for raw_vrf_name in include_vrfs or []:
+        if not raw_vrf_name:
+            continue
+        vrf_name = str(raw_vrf_name).strip()
+        if known_vrfs and vrf_name not in known_vrfs:
+            continue
+        grouped.setdefault(vrf_name, {"vrf_name": vrf_name, "attach": []})
+        if vlan_map.get(vrf_name) is not None:
+            grouped[vrf_name]["vlan_id"] = vlan_map.get(vrf_name)
+
+    for entry in entries or []:
+        data = entry.to_config() if hasattr(entry, "to_config") else dict(entry)
+        vrf_name = data.get("vrf_name")
+        if not vrf_name:
+            continue
+
+        vrf = grouped.setdefault(str(vrf_name), {"vrf_name": str(vrf_name), "attach": []})
+        if data.get("vlan_id") is not None and vrf.get("vlan_id") is None:
+            vrf["vlan_id"] = data.get("vlan_id")
+
+        if data.get("deploy") is True:
+            vrf["deploy"] = True
+        elif data.get("deploy") is not None and "deploy" not in vrf:
+            vrf["deploy"] = data.get("deploy")
+
+        switch_id = data.get("switch_ip")
+        attach: dict[str, Any] = {
+            "ip_address": sn_to_ip.get(switch_id, switch_id),
+        }
+        for key in ("deploy", "import_evpn_rt", "export_evpn_rt"):
+            if data.get(key) is not None:
+                attach[key] = data.get(key)
+        if data.get("extensions") is not None:
+            attach["vrf_lite"] = data.get("extensions")
+
+        vrf["attach"].append(attach)
+
+    result = []
+    for vrf_name in sorted(grouped):
+        vrf = grouped[vrf_name]
+        vrf["attach"] = sorted(vrf.get("attach", []), key=lambda item: item.get("ip_address", ""))
+        result.append(vrf)
+    return result

--- a/plugins/module_utils/manage_vrf_lite/deploy.py
+++ b/plugins/module_utils/manage_vrf_lite/deploy.py
@@ -11,6 +11,7 @@ from typing import Any
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDModuleError
 from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.common import (
     _resolve_serial,
+    get_config_actions,
     vrf_name_from_config_item,
 )
 
@@ -69,6 +70,78 @@ def _deployment_intent(module: Any) -> tuple[set[tuple[str, str]], set[tuple[str
     return enabled_pairs, disabled_pairs, disabled_vrfs
 
 
+def _scoped_pending_deploy_targets(module: Any) -> list[dict[str, str]]:
+    """Return deploy-enabled pending targets covered by this invocation.
+
+    Controller-derived pending rows are intentionally scoped by the requested
+    resource state and config. This lets a later identical run deploy its own
+    staged intent without sweeping unrelated pending work from the fabric.
+    """
+    pending_targets = module.params.get("_pending_deploy_targets") or []
+    if not isinstance(pending_targets, list):
+        return []
+
+    state = module.params.get("_vrf_lite_requested_state") or module.params.get("state", "merged")
+    config = _deploy_intent_config(module)
+    configured_vrfs: set[str] = set()
+    configured_pairs: set[tuple[str, str]] = set()
+    delete_all_vrfs: set[str] = set()
+
+    for item in config:
+        if not isinstance(item, dict):
+            continue
+        vrf_name = vrf_name_from_config_item(item)
+        if not vrf_name:
+            continue
+        configured_vrfs.add(vrf_name)
+        attachments = item.get("attach")
+        if state == "deleted" and not attachments:
+            delete_all_vrfs.add(vrf_name)
+        if not isinstance(attachments, list):
+            continue
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            switch_id = attachment.get("ip_address") or attachment.get("switch_ip") or attachment.get("serial_number")
+            if switch_id:
+                configured_pairs.add((vrf_name, _resolve_serial(module, switch_id)))
+
+    enabled_pairs, disabled_pairs, disabled_vrfs = _deployment_intent(module)
+    scoped: dict[tuple[str, str], dict[str, str]] = {}
+    for target in pending_targets:
+        if not isinstance(target, dict):
+            continue
+        vrf_name = str(target.get("vrf_name") or "").strip()
+        switch_id = _resolve_serial(module, target.get("switch_ip"))
+        operation = str(target.get("operation") or "").strip().lower()
+        if not vrf_name or not switch_id or operation not in ("write", "delete"):
+            continue
+
+        pair = (vrf_name, switch_id)
+        in_scope = False
+        if state == "merged":
+            in_scope = pair in configured_pairs
+        elif state == "replaced":
+            in_scope = vrf_name in configured_vrfs
+        elif state == "overridden":
+            in_scope = True
+        elif state == "deleted":
+            in_scope = operation == "delete" and (vrf_name in delete_all_vrfs or pair in configured_pairs)
+
+        if not in_scope or vrf_name in disabled_vrfs or pair in disabled_pairs:
+            continue
+        if operation == "write" and pair not in enabled_pairs:
+            continue
+
+        scoped[pair] = {
+            "vrf_name": vrf_name,
+            "switch_ip": switch_id,
+            "operation": operation,
+        }
+
+    return [scoped[key] for key in sorted(scoped)]
+
+
 def _is_non_fatal_config_save_error(error: NDModuleError) -> bool:
     # TODO(4.2.1) vrf-lite-configsave-500-nonfatal: ND returns HTTP 500 for a
     # non-fatal vPC sanity condition on configSave instead of a success/no-op
@@ -90,18 +163,16 @@ def _is_non_fatal_config_save_error(error: NDModuleError) -> bool:
 
 
 def _needs_deployment(result: dict[str, Any], module: Any) -> bool:
-    """Return True only when actual config changes were applied.
-
-    Deploying against the controller when no configuration changed would
-    violate Ansible's idempotency contract.  A VRF that is still PENDING
-    from a previous run is a controller-side timing concern; the module
-    re-deploys only when the user's intent has actually been modified.
-    """
+    """Return whether this run must save changes or deploy staged intent."""
     if result.get("changed"):
         return True
 
     changed_vrfs = module.params.get("_changed_vrfs") or []
-    return bool(changed_vrfs)
+    if changed_vrfs:
+        return True
+
+    config_actions = get_config_actions(module.params)
+    return bool(config_actions.get("deploy") and _scoped_pending_deploy_targets(module))
 
 
 def _changed_entries_from_preview(before: Any, after: Any) -> list[Any]:

--- a/plugins/module_utils/manage_vrf_lite/deploy.py
+++ b/plugins/module_utils/manage_vrf_lite/deploy.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDModuleError
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.common import (
+    _resolve_serial,
+    vrf_name_from_config_item,
+)
+
+
+def _deploy_intent_config(module: Any) -> list[dict[str, Any]]:
+    """Return the preserved nested playbook config used for deploy intent."""
+    nested_config = module.params.get("_vrf_lite_nested_config")
+    if isinstance(nested_config, list):
+        return nested_config
+
+    config = module.params.get("config")
+    return config if isinstance(config, list) else []
+
+
+def _deployment_intent(module: Any) -> tuple[set[tuple[str, str]], set[tuple[str, str]], set[str]]:
+    """Return enabled pairs, disabled pairs, and disabled VRFs for deploy."""
+    enabled_pairs: set[tuple[str, str]] = set()
+    disabled_pairs: set[tuple[str, str]] = set()
+    disabled_vrfs: set[str] = set()
+
+    for item in _deploy_intent_config(module):
+        if not isinstance(item, dict):
+            continue
+        vrf_name = vrf_name_from_config_item(item)
+        if not vrf_name:
+            continue
+
+        vrf_deploy = item.get("deploy")
+        attachments = item.get("attach")
+        if isinstance(attachments, list):
+            if vrf_deploy is False:
+                disabled_vrfs.add(vrf_name)
+                continue
+
+            for attachment in attachments:
+                if not isinstance(attachment, dict):
+                    continue
+                switch_id = attachment.get("ip_address") or attachment.get("switch_ip") or attachment.get("serial_number")
+                if not switch_id:
+                    continue
+                pair = (vrf_name, _resolve_serial(module, switch_id))
+                if vrf_deploy is True or attachment.get("deploy") is not False:
+                    enabled_pairs.add(pair)
+                else:
+                    disabled_pairs.add(pair)
+            continue
+
+        # Direct callers may provide the already-flattened attachment shape.
+        switch_id = item.get("switch_ip") or item.get("ip_address") or item.get("serial_number")
+        if switch_id:
+            pair = (vrf_name, _resolve_serial(module, switch_id))
+            (disabled_pairs if vrf_deploy is False else enabled_pairs).add(pair)
+        elif vrf_deploy is False:
+            disabled_vrfs.add(vrf_name)
+
+    return enabled_pairs, disabled_pairs, disabled_vrfs
+
+
+def _is_non_fatal_config_save_error(error: NDModuleError) -> bool:
+    # TODO(4.2.1) vrf-lite-configsave-500-nonfatal: ND returns HTTP 500 for a
+    # non-fatal vPC sanity condition on configSave instead of a success/no-op
+    # status, so the message is sniffed to swallow it. Remove once the
+    # controller returns a correct status for this condition (see bug-tracker
+    # vault note).
+    if not isinstance(error, NDModuleError):
+        return False
+    if error.status != 500:
+        return False
+
+    message = (error.msg or "").lower()
+    signatures = (
+        "vpc fabric peering is not supported",
+        "unexpected error generating vpc configuration",
+        "vpcsanitycheck",
+    )
+    return any(signature in message for signature in signatures)
+
+
+def _needs_deployment(result: dict[str, Any], module: Any) -> bool:
+    """Return True only when actual config changes were applied.
+
+    Deploying against the controller when no configuration changed would
+    violate Ansible's idempotency contract.  A VRF that is still PENDING
+    from a previous run is a controller-side timing concern; the module
+    re-deploys only when the user's intent has actually been modified.
+    """
+    if result.get("changed"):
+        return True
+
+    changed_vrfs = module.params.get("_changed_vrfs") or []
+    return bool(changed_vrfs)
+
+
+def _changed_entries_from_preview(before: Any, after: Any) -> list[Any]:
+    """Recover the change set from the before/after preview.
+
+    In check mode the state machine's ``sent`` collection is empty by design,
+    so the deploy scope is derived from the previewed states instead: created
+    or updated rows are taken from ``after``; removed rows are taken from
+    ``before``. This mirrors the create/update/delete set a real run records in
+    ``sent`` (VRF Lite tracks deletes there too), so a check-mode plan reports
+    the same VRFs a real run would deploy instead of an empty (false-green) scope.
+    """
+    changed: list[Any] = []
+    for entry in after:
+        if before.get_diff_config(entry) != "no_diff":
+            changed.append(entry)
+    after_keys = set(after.keys())
+    for entry in before:
+        if entry.get_identifier_value() not in after_keys:
+            changed.append(entry)
+    return changed

--- a/plugins/module_utils/manage_vrf_lite/exceptions.py
+++ b/plugins/module_utils/manage_vrf_lite/exceptions.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class VrfLiteResourceError(Exception):
+    """Structured error for nd_manage_vrf_lite workflows."""
+
+    def __init__(self, msg: str, **details: Any) -> None:
+        super().__init__(msg)
+        self.msg = msg
+        self.details = details or {}

--- a/plugins/module_utils/manage_vrf_lite/query.py
+++ b/plugins/module_utils/manage_vrf_lite/query.py
@@ -249,6 +249,27 @@ def _value_from_attachment_or_detail(attach: dict[str, Any], detail: dict[str, A
     return None
 
 
+def _has_vrf_lite_extension_marker(extension_values: Any) -> bool:
+    """Return whether extensionValues explicitly carries ``VRF_LITE_CONN``.
+
+    A staged VRF-Lite removal is represented by an empty ``VRF_LITE_CONN``
+    value.  Parsing only the connection rows loses the difference between that
+    explicit empty marker and an ordinary VRF attachment that has never used
+    VRF-Lite, so retain the outer-key signal for later deployment discovery.
+    """
+    if isinstance(extension_values, dict):
+        outer = extension_values
+    elif extension_values in (None, ""):
+        return False
+    else:
+        try:
+            outer = json.loads(str(extension_values))
+        except Exception:
+            return False
+
+    return isinstance(outer, dict) and "VRF_LITE_CONN" in outer
+
+
 def _flatten_to_entries(nested: list[dict[str, Any]], module: Any = None) -> list[dict[str, Any]]:
     """Convert nested VRF list into a flat list of per-(vrf, switch) entries.
 
@@ -343,6 +364,7 @@ def query_vrf_lite_state(
 
     not_in_sync_vrfs: set[str] = set()
     raw_vrf_attachment_map: dict[str, dict[str, dict[str, Any]]] = {}
+    pending_deploy_targets: dict[tuple[str, str], dict[str, str]] = {}
 
     # First pass: collect, across every VRF, the switches whose attachment rows
     # arrived without ``extensionValues`` so they can be enriched together. The
@@ -442,10 +464,12 @@ def query_vrf_lite_state(
             )
             is_attached = attached_value is True or str(attached_value).strip().lower() in ("true", "1", "yes")
             extension_values = _value_from_attachment_or_detail(attach, switch_detail, "extensionValues")
+            has_vrf_lite_marker = _has_vrf_lite_extension_marker(extension_values)
             # For VRF Lite, include entries that have extension values even if
             # not yet lan-attached (pending save/deploy state).
             has_extension_values = bool(extension_values and str(extension_values).strip() and str(extension_values).strip() != "[]")
-            if not is_attached and not has_extension_values:
+            pending_state = attach_state in ("OUT-OF-SYNC", "PENDING", "FAILED")
+            if not is_attached and not has_extension_values and not (pending_state and has_vrf_lite_marker):
                 continue
 
             instance_values_raw = _value_from_attachment_or_detail(attach, switch_detail, "instanceValues")
@@ -467,10 +491,18 @@ def query_vrf_lite_state(
 
             vrf_lite_list = parse_vrf_lite_extension_values(extension_values)
             managed_fields_present = bool(vrf_lite_list) or import_evpn_rt not in (None, "") or export_evpn_rt not in (None, "")
+            if pending_state and serial_number and (managed_fields_present or has_vrf_lite_marker):
+                operation = "write" if managed_fields_present else "delete"
+                pending_deploy_targets[(vrf_name, serial_number)] = {
+                    "vrf_name": vrf_name,
+                    "switch_ip": serial_number,
+                    "operation": operation,
+                }
+                not_in_sync_vrfs.add(vrf_name)
             if not managed_fields_present:
                 continue
 
-            deployed = attach_state not in ("OUT-OF-SYNC", "PENDING", "FAILED")
+            deployed = not pending_state
             if not deployed:
                 not_in_sync_vrfs.add(vrf_name)
             else:
@@ -502,6 +534,7 @@ def query_vrf_lite_state(
     module.params["_ip_to_sn_mapping"] = ip_to_sn
     module.params["_sn_to_ip_mapping"] = sn_to_ip
     module.params["_not_in_sync_vrfs"] = sorted(not_in_sync_vrfs)
+    module.params["_pending_deploy_targets"] = [pending_deploy_targets[key] for key in sorted(pending_deploy_targets)]
     module.params["_known_vrfs"] = sorted(known_vrfs)
     module.params["_known_vrfs_loaded"] = True
     module.params["_raw_vrf_attachment_map"] = raw_vrf_attachment_map

--- a/plugins/module_utils/manage_vrf_lite/query.py
+++ b/plugins/module_utils/manage_vrf_lite/query.py
@@ -1,0 +1,514 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.common import (
+    request_with_verify_settings,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.runtime_endpoints import (
+    VrfLiteEndpoints,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.runtime_payloads import (
+    parse_instance_values,
+    parse_vrf_lite_extension_values,
+)
+
+
+def _coerce_vlan(value: Any) -> int | None:
+    if value in (None, "", 0):
+        return None
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def _parse_vrf_template_vlan(vrf_object: dict[str, Any]) -> int | None:
+    template_cfg = vrf_object.get("vrfTemplateConfig")
+    if not template_cfg:
+        return None
+
+    if isinstance(template_cfg, dict):
+        parsed = template_cfg
+    else:
+        try:
+            parsed = json.loads(str(template_cfg))
+        except Exception:
+            return None
+
+    return _coerce_vlan(parsed.get("vrfVlanId"))
+
+
+def _resolve_vrf_vlan(vrf_object: dict[str, Any]) -> int | None:
+    """Resolve the VRF VLAN id from a controller VRF object.
+
+    Prefer the current top-level ``vlanId`` field returned by the OpenAPI VRF
+    object and fall back to the legacy serialized ``vrfTemplateConfig.vrfVlanId``
+    for older controller response shapes. Without this, a VRF returned in the
+    current shape (``vlanId`` set, ``vrfTemplateConfig`` empty) would resolve to
+    a ``None`` VLAN and break otherwise-valid attach/detach payloads.
+    """
+    top_level = _coerce_vlan(vrf_object.get("vlanId"))
+    if top_level is not None:
+        return top_level
+    # TODO(4.2.1) vrf-lite-vlan-shape-drift: fall back to the legacy serialized
+    # ``vrfTemplateConfig.vrfVlanId`` for older controller response shapes.
+    # Remove once all supported controllers return the top-level ``vlanId``
+    # (see bug-tracker vault note).
+    return _parse_vrf_template_vlan(vrf_object)
+
+
+def _result_list(data: Any, keys: tuple[str, ...]) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, list):
+                return value
+    return []
+
+
+def _query_fabric_switches(module: Any, rest_send: Any, fabric_name: str) -> dict[str, str]:
+    """Return serial->mgmt-ip mapping from fabric switch inventory."""
+    fabric_context = FabricContext(rest_send=rest_send, fabric_name=fabric_name)
+    inventory = fabric_context.switch_inventory_by_id
+    module.params["_fabric_switch_inventory"] = inventory
+    # Keep an explicit loaded marker because an empty fabric inventory is a
+    # valid, authoritative result.  Truthiness alone cannot distinguish that
+    # result from an inventory that has not been queried yet.
+    module.params["_fabric_switch_inventory_loaded"] = True
+    module.params["_fabric_switch_inventory_normalized"] = False
+    return {str(serial).strip(): str(switch.get("fabricManagementIp")).strip() for serial, switch in inventory.items() if switch.get("fabricManagementIp")}
+
+
+def _query_vrfs(module: Any, rest_send: Any, fabric_name: str) -> list[dict[str, Any]]:
+    path = VrfLiteEndpoints.vrfs(fabric_name)
+    response = request_with_verify_settings(module, rest_send, path, HttpVerbEnum.GET)
+
+    return [item for item in _result_list(response, ("DATA", "data", "vrfs", "items")) if isinstance(item, dict)]
+
+
+def _query_vrf_attachments(module: Any, rest_send: Any, fabric_name: str, vrf_names: list[str]) -> list[dict[str, Any]]:
+    if not vrf_names:
+        return []
+
+    path = VrfLiteEndpoints.vrf_attachments_query(fabric_name, ",".join(vrf_names))
+    response = request_with_verify_settings(module, rest_send, path, HttpVerbEnum.GET)
+    attachments = _result_list(response, ("attachments", "DATA", "data", "items"))
+    # TODO(4.2.1) vrf-lite-attachments-flat-shape-drift: some controller versions
+    # return a flat per-switch attachment list without the ``lanAttachList``
+    # grouping, so rows are regrouped by ``vrfName`` here. Remove once the
+    # response shape is stable (see bug-tracker vault note).
+    if attachments and all(isinstance(item, dict) and "vrfName" in item and "lanAttachList" not in item for item in attachments):
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for item in attachments:
+            vrf_name = str(item.get("vrfName") or "").strip()
+            if vrf_name:
+                grouped.setdefault(vrf_name, []).append(item)
+        return [{"vrfName": vrf_name, "lanAttachList": items} for vrf_name, items in sorted(grouped.items())]
+
+    return [item for item in _result_list(response, ("DATA", "data", "vrfs", "items", "attachments")) if isinstance(item, dict)]
+
+
+def _vrf_lite_switch_detail_cache_key(fabric_name: str, vrf_name: str, serial_number: str) -> str:
+    return "{0}\0{1}\0{2}".format(fabric_name, vrf_name, serial_number)
+
+
+def _query_vrf_switch_details_bulk(
+    module: Any,
+    rest_send: Any,
+    fabric_name: str,
+    serials_by_vrf: dict[str, list[str]],
+) -> dict[tuple[str, str], dict[str, Any]]:
+    """Return per-(vrf, switch) attachment details from a single batched request.
+
+    The ``vrf-names`` and ``serial-numbers`` query params are both plural, so
+    every VRF that has attachments lacking ``extensionValues`` in the bulk list
+    response (e.g. PENDING state rows) is enriched with ONE cross-VRF GET rather
+    than one request per VRF -- mirroring how the write-path validation prefetch
+    batches serial numbers. Each returned object is attributed to its VRF by the
+    ``vrfName`` it carries and keyed by ``(vrf_name, serial_number)``. Results
+    are memoized in the shared ``_vrf_lite_switch_detail_cache`` so repeated
+    queries never re-fetch the same pair. The request is skipped entirely when
+    every requested pair is already cached.
+    """
+    normalized: dict[str, list[str]] = {}
+    for vrf_name, serial_numbers in serials_by_vrf.items():
+        serials = sorted({str(serial_number).strip() for serial_number in serial_numbers if str(serial_number).strip()})
+        if serials:
+            normalized[str(vrf_name).strip()] = serials
+    if not normalized:
+        return {}
+
+    cache = module.params.get("_vrf_lite_switch_detail_cache")
+    if not isinstance(cache, dict):
+        cache = {}
+        module.params["_vrf_lite_switch_detail_cache"] = cache
+
+    missing_by_vrf: dict[str, list[str]] = {}
+    for vrf_name, serials in normalized.items():
+        missing = [serial_number for serial_number in serials if _vrf_lite_switch_detail_cache_key(fabric_name, vrf_name, serial_number) not in cache]
+        if missing:
+            missing_by_vrf[vrf_name] = missing
+
+    if missing_by_vrf:
+        vrf_names = sorted(missing_by_vrf)
+        union_serials = sorted({serial_number for serials in missing_by_vrf.values() for serial_number in serials})
+        path = VrfLiteEndpoints.vrf_switch(fabric_name, ",".join(vrf_names), ",".join(union_serials))
+        response = request_with_verify_settings(module, rest_send, path, HttpVerbEnum.GET)
+
+        returned: dict[tuple[str, str], dict[str, Any]] = {}
+        for vrf_switch in _result_list(response, ("DATA", "data", "vrfs", "items")):
+            if not isinstance(vrf_switch, dict):
+                continue
+            # Attribute each switch detail to its VRF via the returned ``vrfName``;
+            # fall back to the sole requested VRF only when the response omits it.
+            returned_vrf = str(vrf_switch.get("vrfName") or "").strip()
+            if not returned_vrf and len(vrf_names) == 1:
+                returned_vrf = vrf_names[0]
+            if not returned_vrf:
+                continue
+            for switch_detail in vrf_switch.get("switchDetailsList") or []:
+                if not isinstance(switch_detail, dict):
+                    continue
+
+                serial_number = switch_detail.get("serialNumber")
+                if not serial_number:
+                    continue
+
+                returned[(returned_vrf, str(serial_number).strip())] = switch_detail
+
+        for vrf_name, serials in missing_by_vrf.items():
+            for serial_number in serials:
+                cache[_vrf_lite_switch_detail_cache_key(fabric_name, vrf_name, serial_number)] = returned.get((vrf_name, serial_number), {})
+
+    detail_map: dict[tuple[str, str], dict[str, Any]] = {}
+    for vrf_name, serials in normalized.items():
+        for serial_number in serials:
+            cached_detail = cache.get(_vrf_lite_switch_detail_cache_key(fabric_name, vrf_name, serial_number))
+            if isinstance(cached_detail, dict) and cached_detail:
+                detail_map[(vrf_name, serial_number)] = cached_detail
+    return detail_map
+
+
+def _query_vrf_switch_details(
+    module: Any,
+    rest_send: Any,
+    fabric_name: str,
+    vrf_name: str,
+    serial_numbers: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Return per-switch VRF attachment details keyed by serial number.
+
+    Thin single-VRF wrapper over :func:`_query_vrf_switch_details_bulk` used by
+    the write-path validation prefetch, which resolves one VRF group at a time.
+    Returns an entry for every requested serial (``{}`` when the controller has
+    no detail for it), preserving the original per-VRF contract.
+    """
+    vrf_key = str(vrf_name).strip()
+    normalized_serials = sorted({str(serial_number).strip() for serial_number in serial_numbers if str(serial_number).strip()})
+    if not normalized_serials:
+        return {}
+
+    bulk = _query_vrf_switch_details_bulk(
+        module=module,
+        rest_send=rest_send,
+        fabric_name=fabric_name,
+        serials_by_vrf={vrf_key: normalized_serials},
+    )
+
+    detail_map: dict[str, dict[str, Any]] = {}
+    for serial_number in normalized_serials:
+        detail = bulk.get((vrf_key, serial_number))
+        detail_map[serial_number] = detail if isinstance(detail, dict) else {}
+    return detail_map
+
+
+def _value_from_attachment_or_detail(attach: dict[str, Any], detail: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in attach:
+            value = attach.get(key)
+            if value is not None:
+                return value
+
+    for key in keys:
+        value = detail.get(key)
+        if value is not None:
+            return value
+
+    return None
+
+
+def _flatten_to_entries(nested: list[dict[str, Any]], module: Any = None) -> list[dict[str, Any]]:
+    """Convert nested VRF list into a flat list of per-(vrf, switch) entries.
+
+    Each entry has the shape expected by ``VrfLiteAttachmentEntry``:
+    ``vrf_name``, ``switch_ip``, ``vlan_id``, ``deploy``, ``import_evpn_rt``,
+    ``export_evpn_rt``, and ``extensions``. VRFs without attachments produce
+    no entries; the state machine handles their absence via diff identifiers.
+    """
+    entries: list[dict[str, Any]] = []
+    for vrf in nested or []:
+        if not isinstance(vrf, dict):
+            continue
+        vrf_name = vrf.get("vrf_name")
+        if not vrf_name:
+            continue
+        vrf_level_vlan = vrf.get("vlan_id")
+        for attach in vrf.get("attach") or []:
+            if not isinstance(attach, dict):
+                continue
+            switch_identifier = attach.get("ip_address")
+            if not switch_identifier:
+                continue
+            switch_ip = switch_identifier
+            mapping = {}
+            if module is not None and isinstance(getattr(module, "params", None), dict):
+                mapping = module.params.get("_ip_to_sn_mapping") or {}
+            if switch_identifier in mapping:
+                switch_ip = mapping[switch_identifier]
+            entry: dict[str, Any] = {
+                "vrf_name": vrf_name,
+                "switch_ip": switch_ip,
+                "vlan_id": vrf_level_vlan,
+                "deploy": attach.get("deploy"),
+                "import_evpn_rt": attach.get("import_evpn_rt"),
+                "export_evpn_rt": attach.get("export_evpn_rt"),
+            }
+            extensions = attach.get("vrf_lite")
+            if extensions:
+                entry["extensions"] = extensions
+            entries.append({k: v for k, v in entry.items() if v is not None})
+
+    entries.sort(key=lambda item: (item.get("vrf_name", ""), item.get("switch_ip", "")))
+    return entries
+
+
+def query_vrf_lite_state(
+    module: Any,
+    rest_send: Any,
+    fabric_name: str,
+    filter_vrfs: set[str] | None = None,
+    flat: bool = False,
+) -> list[dict[str, Any]]:
+    """
+    Query controller state and return normalized vrf-lite config shape.
+
+    When ``flat=True`` returns a flat list of per-(vrf_name, switch_ip)
+    attachment entries shaped for ``VrfLiteAttachmentEntry``. When
+    ``flat=False`` (default) returns the legacy nested list of VRFs with an
+    ``attach`` sub-list per VRF.
+    """
+    sn_to_ip = _query_fabric_switches(module, rest_send, fabric_name)
+    ip_to_sn = {ip: sn for sn, ip in sn_to_ip.items()}
+
+    vrf_objects = _query_vrfs(module, rest_send, fabric_name)
+
+    result_map: dict[str, dict[str, Any]] = {}
+    known_vrfs: set[str] = set()
+    for vrf in vrf_objects:
+        vrf_name = vrf.get("vrfName") or vrf.get("vrf_name")
+        if not vrf_name:
+            continue
+
+        vrf_name = str(vrf_name).strip()
+        known_vrfs.add(vrf_name)
+
+        if filter_vrfs and vrf_name not in filter_vrfs:
+            continue
+
+        result_map[vrf_name] = {
+            "vrf_name": vrf_name,
+            "vlan_id": _resolve_vrf_vlan(vrf),
+            "deploy": False,
+            "attach": [],
+        }
+
+    attachment_objects = _query_vrf_attachments(
+        module=module,
+        rest_send=rest_send,
+        fabric_name=fabric_name,
+        vrf_names=sorted(result_map.keys()),
+    )
+
+    not_in_sync_vrfs: set[str] = set()
+    raw_vrf_attachment_map: dict[str, dict[str, dict[str, Any]]] = {}
+
+    # First pass: collect, across every VRF, the switches whose attachment rows
+    # arrived without ``extensionValues`` so they can be enriched together. The
+    # ``vrf-names`` query param is plural, so these are fetched with one batched
+    # cross-VRF request below instead of one GET per VRF (PR #281 review).
+    serials_by_vrf: dict[str, list[str]] = {}
+    for vrf_attach in attachment_objects:
+        vrf_name = vrf_attach.get("vrfName")
+        if not vrf_name:
+            continue
+
+        vrf_name = str(vrf_name).strip()
+        if filter_vrfs and vrf_name not in filter_vrfs:
+            continue
+
+        # TODO(4.2.1) vrf-lite-pending-extensionvalues-dropped: the bulk
+        # attachment list omits ``extensionValues`` for PENDING rows, so each
+        # affected switch is enriched with the batched switch-detail GET below.
+        # Remove the enrichment once the bulk list returns extensionValues for
+        # all states (see bug-tracker vault note).
+        for attach in vrf_attach.get("lanAttachList") or []:
+            if not isinstance(attach, dict):
+                continue
+
+            if "extensionValues" in attach:
+                continue
+
+            # TODO(4.2.1) vrf-lite-attach-key-spelling-drift: controller versions
+            # disagree on attachment key spellings, so several are probed here and
+            # in the main loop below. Remove once the keys are stable (see vault note).
+            attach_state = str(attach.get("lanAttachState") or attach.get("lanAttachedState") or "").upper()
+            attached_value = attach.get("isLanAttached", attach.get("isAttached", attach.get("attach", False)))
+            is_attached = attached_value is True or str(attached_value).strip().lower() in ("true", "1", "yes")
+            if not is_attached and attach_state not in ("PENDING", "OUT-OF-SYNC", "FAILED"):
+                continue
+
+            serial_number = attach.get("switchSerialNo") or attach.get("serialNumber") or attach.get("switchId")
+            if serial_number:
+                serials_by_vrf.setdefault(vrf_name, []).append(str(serial_number).strip())
+
+    switch_detail_map = _query_vrf_switch_details_bulk(
+        module=module,
+        rest_send=rest_send,
+        fabric_name=fabric_name,
+        serials_by_vrf=serials_by_vrf,
+    )
+
+    for vrf_attach in attachment_objects:
+        vrf_name = vrf_attach.get("vrfName")
+        if not vrf_name:
+            continue
+
+        vrf_name = str(vrf_name).strip()
+        if filter_vrfs and vrf_name not in filter_vrfs:
+            continue
+
+        entry = result_map.get(vrf_name)
+        if entry is None:
+            entry = {
+                "vrf_name": vrf_name,
+                "vlan_id": None,
+                "deploy": False,
+                "attach": [],
+            }
+            result_map[vrf_name] = entry
+
+        attach_list = vrf_attach.get("lanAttachList") or []
+        if not isinstance(attach_list, list):
+            continue
+
+        for attach in attach_list:
+            if not isinstance(attach, dict):
+                continue
+
+            serial_number = attach.get("switchSerialNo") or attach.get("serialNumber") or attach.get("switchId")
+            serial_number = str(serial_number).strip() if serial_number else ""
+            switch_detail = switch_detail_map.get((vrf_name, serial_number), {})
+
+            ip_address = attach.get("ipAddress")
+            if ip_address:
+                ip_address = str(ip_address).strip()
+            elif serial_number:
+                ip_address = sn_to_ip.get(serial_number, serial_number)
+            else:
+                continue
+
+            # TODO(4.2.1) vrf-lite-attach-key-spelling-drift: see note in the
+            # enrichment loop; also probes the lowercase-l ``islanAttached``
+            # variant from the switch-detail response.
+            attach_state = str(_value_from_attachment_or_detail(attach, switch_detail, "lanAttachState", "lanAttachedState") or "").upper()
+            attached_value = attach.get(
+                "isLanAttached",
+                attach.get(
+                    "isAttached",
+                    attach.get("attach", switch_detail.get("islanAttached", switch_detail.get("isLanAttached", False))),
+                ),
+            )
+            is_attached = attached_value is True or str(attached_value).strip().lower() in ("true", "1", "yes")
+            extension_values = _value_from_attachment_or_detail(attach, switch_detail, "extensionValues")
+            # For VRF Lite, include entries that have extension values even if
+            # not yet lan-attached (pending save/deploy state).
+            has_extension_values = bool(extension_values and str(extension_values).strip() and str(extension_values).strip() != "[]")
+            if not is_attached and not has_extension_values:
+                continue
+
+            instance_values_raw = _value_from_attachment_or_detail(attach, switch_detail, "instanceValues")
+            freeform_config = _value_from_attachment_or_detail(attach, switch_detail, "freeformConfig")
+            vrf_vlan_raw = _value_from_attachment_or_detail(attach, switch_detail, "vlanId", "vlan")
+            attachment_vlan_raw = _value_from_attachment_or_detail(switch_detail, attach, "vlan", "vlanId")
+
+            if serial_number:
+                raw_vrf_attachment_map.setdefault(vrf_name, {})[serial_number] = {
+                    "extension_values": extension_values,
+                    "instance_values": instance_values_raw,
+                    "freeform_config": freeform_config,
+                    "vlan": attachment_vlan_raw,
+                }
+
+            instance_values = parse_instance_values(instance_values_raw)
+            import_evpn_rt = instance_values.get("switchRouteTargetImportEvpn") or instance_values.get("evpnRouteTargetImport")
+            export_evpn_rt = instance_values.get("switchRouteTargetExportEvpn") or instance_values.get("evpnRouteTargetExport")
+
+            vrf_lite_list = parse_vrf_lite_extension_values(extension_values)
+            managed_fields_present = bool(vrf_lite_list) or import_evpn_rt not in (None, "") or export_evpn_rt not in (None, "")
+            if not managed_fields_present:
+                continue
+
+            deployed = attach_state not in ("OUT-OF-SYNC", "PENDING", "FAILED")
+            if not deployed:
+                not_in_sync_vrfs.add(vrf_name)
+            else:
+                entry["deploy"] = True
+
+            if entry.get("vlan_id") is None:
+                try:
+                    if vrf_vlan_raw not in (None, ""):
+                        entry["vlan_id"] = int(vrf_vlan_raw)
+                except Exception:
+                    pass
+
+            attach_item = {
+                "ip_address": ip_address,
+                "deploy": deployed,
+                "import_evpn_rt": import_evpn_rt if import_evpn_rt is not None else "",
+                "export_evpn_rt": export_evpn_rt if export_evpn_rt is not None else "",
+            }
+
+            if vrf_lite_list:
+                attach_item["vrf_lite"] = vrf_lite_list
+
+            entry["attach"].append(attach_item)
+
+    result = sorted(result_map.values(), key=lambda item: item.get("vrf_name", ""))
+    for entry in result:
+        entry["attach"] = sorted(entry.get("attach", []), key=lambda item: item.get("ip_address", ""))
+
+    module.params["_ip_to_sn_mapping"] = ip_to_sn
+    module.params["_sn_to_ip_mapping"] = sn_to_ip
+    module.params["_not_in_sync_vrfs"] = sorted(not_in_sync_vrfs)
+    module.params["_known_vrfs"] = sorted(known_vrfs)
+    module.params["_known_vrfs_loaded"] = True
+    module.params["_raw_vrf_attachment_map"] = raw_vrf_attachment_map
+    module.params["_vrf_lite_vrf_vlan_map"] = {
+        item.get("vrf_name"): item.get("vlan_id") for item in result if item.get("vrf_name") and item.get("vlan_id") is not None
+    }
+
+    if flat:
+        return _flatten_to_entries(result, module=module)
+    return result

--- a/plugins/module_utils/manage_vrf_lite/runtime_endpoints.py
+++ b/plugins/module_utils/manage_vrf_lite/runtime_endpoints.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_config_save import (
+    EpFabricConfigSavePost,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_vrf_actions import (
+    EpManageFabricsVrfActionsDeployPost,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_vrfs import (
+    EpManageFabricsVrfsGet,
+)
+
+
+class VrfLiteEndpoints:
+    """Resolve the mixed Manage and legacy top-down paths used by VRF Lite workflows.
+
+    VRF inventory, deployment, and config actions delegate to the canonical
+    Manage-API endpoint models. VRF Lite attachment details and writes still
+    require the controller's legacy top-down contract because equivalent Manage plural
+    paths are not exposed, so those paths are built here.
+    """
+
+    _LAN_FABRIC_API = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest"
+    _TOP_DOWN_API = "{0}/top-down".format(_LAN_FABRIC_API)
+
+    @staticmethod
+    def _top_down_fabric_path(fabric_name: str, *segments: str) -> str:
+        suffix = "/".join(("fabrics", quote(fabric_name, safe=""), *segments))
+        return "{0}/{1}".format(VrfLiteEndpoints._TOP_DOWN_API, suffix)
+
+    @staticmethod
+    def vrfs(fabric_name: str) -> str:
+        return EpManageFabricsVrfsGet(fabric_name=fabric_name).path
+
+    @staticmethod
+    def vrf_attachments_query(fabric_name: str, vrf_names_csv: str) -> str:
+        return "{0}?vrf-names={1}".format(
+            VrfLiteEndpoints._top_down_fabric_path(fabric_name, "vrfs", "attachments"),
+            quote(vrf_names_csv, safe=","),
+        )
+
+    @staticmethod
+    def vrf_attachments_post(fabric_name: str) -> str:
+        return VrfLiteEndpoints._top_down_fabric_path(fabric_name, "vrfs", "attachments")
+
+    @staticmethod
+    def vrf_deployments(fabric_name: str) -> str:
+        return EpManageFabricsVrfActionsDeployPost(fabric_name=fabric_name).path
+
+    @staticmethod
+    def vrf_switch(fabric_name: str, vrf_names_csv: str, serial_numbers_csv: str) -> str:
+        # Both query params are plural: ``vrf-names`` and ``serial-numbers`` each
+        # accept a comma-separated list, so a single request can enrich several
+        # switches across several VRFs at once. Commas are kept ``safe`` for both
+        # so the list separators survive URL-encoding.
+        return "{0}?vrf-names={1}&serial-numbers={2}".format(
+            VrfLiteEndpoints._top_down_fabric_path(fabric_name, "vrfs", "switches"),
+            quote(vrf_names_csv, safe=","),
+            quote(serial_numbers_csv, safe=","),
+        )
+
+    @staticmethod
+    def reserve_id(fabric_name: str) -> str:
+        # The legacy resource-manager endpoint is global rather than fabric-scoped.
+        del fabric_name
+        return "{0}/resource-manager/reserve-id".format(VrfLiteEndpoints._LAN_FABRIC_API)
+
+    @staticmethod
+    def config_save(fabric_name: str) -> str:
+        return EpFabricConfigSavePost(fabric_name=fabric_name).path

--- a/plugins/module_utils/manage_vrf_lite/runtime_payloads.py
+++ b/plugins/module_utils/manage_vrf_lite/runtime_payloads.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import ValidationError
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_vrf_lite.vrf_lite_model import (
+    VrfLiteConnectionModel,
+)
+
+
+def vrf_lite_items_to_config(vrf_lite_items: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for item in vrf_lite_items or []:
+        try:
+            model = VrfLiteConnectionModel.model_validate(item, by_alias=True, by_name=True)
+        except ValidationError:
+            continue
+        data = model.model_dump(by_alias=False, exclude_none=True)
+        items.append({key: value for key, value in data.items() if value != ""})
+    return sorted(items, key=lambda i: (str(i.get("interface", "")).lower(), int(i.get("dot1q") or 0)))
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, (dict, list)):
+        return value
+    if value in (None, ""):
+        return None
+    try:
+        return json.loads(str(value))
+    except Exception:
+        return None
+
+
+def build_vrf_lite_extension_values(
+    vrf_lite_items: list[dict[str, Any]] | None,
+    existing_extension_values: Any = None,
+    prototype_values_by_interface: dict[str, dict[str, Any]] | None = None,
+) -> str:
+    """
+    Build extensionValues string expected by top-down VRF attachment APIs.
+    """
+    existing_outer = _json_value(existing_extension_values)
+    if isinstance(existing_outer, dict):
+        existing_outer = dict(existing_outer)
+    else:
+        existing_outer = {}
+
+    configured_items = vrf_lite_items_to_config(vrf_lite_items)
+    if not configured_items:
+        if "VRF_LITE_CONN" in existing_outer:
+            existing_outer["VRF_LITE_CONN"] = json.dumps(
+                {"VRF_LITE_CONN": []},
+                separators=(",", ":"),
+            )
+
+        if not existing_outer:
+            return ""
+        return json.dumps(existing_outer, separators=(",", ":"))
+
+    existing_rows_by_interface: dict[str, list[dict[str, Any]]] = {}
+    existing_inner = _json_value(existing_outer.get("VRF_LITE_CONN"))
+    if isinstance(existing_inner, dict):
+        existing_rows = existing_inner.get("VRF_LITE_CONN")
+        if isinstance(existing_rows, list):
+            for existing_row in existing_rows:
+                if not isinstance(existing_row, dict) or not existing_row.get("IF_NAME"):
+                    continue
+                interface_key = str(existing_row["IF_NAME"]).strip().casefold()
+                existing_rows_by_interface.setdefault(interface_key, []).append(dict(existing_row))
+
+    prototypes_by_interface = {
+        str(interface).strip().casefold(): dict(values) for interface, values in (prototype_values_by_interface or {}).items() if isinstance(values, dict)
+    }
+
+    connection_rows: list[dict[str, Any]] = []
+    for item in configured_items:
+        interface = str(item.get("interface", "")).strip()
+        interface_key = interface.casefold()
+        prototype = prototypes_by_interface.get(interface_key, {})
+        prototype_fields = (
+            "IF_NAME",
+            "DOT1Q_ID",
+            "IP_MASK",
+            "NEIGHBOR_IP",
+            "NEIGHBOR_ASN",
+            "IPV6_MASK",
+            "IPV6_NEIGHBOR",
+            "AUTO_VRF_LITE_FLAG",
+            "PEER_VRF_NAME",
+            "VRF_LITE_JYTHON_TEMPLATE",
+        )
+        row = {key: prototype[key] for key in prototype_fields if key in prototype}
+
+        existing_candidates = existing_rows_by_interface.get(interface_key, [])
+        existing_row = {}
+        requested_dot1q = item.get("dot1q")
+        if requested_dot1q not in (None, ""):
+            existing_row = next(
+                (candidate for candidate in existing_candidates if str(candidate.get("DOT1Q_ID") or "") == str(requested_dot1q)),
+                {},
+            )
+        if not existing_row and existing_candidates:
+            existing_row = existing_candidates[0]
+        row.update(existing_row)
+
+        canonical_interface = prototype.get("IF_NAME") or existing_row.get("IF_NAME") or interface
+        row["IF_NAME"] = str(canonical_interface).strip()
+
+        field_map = {
+            "ipv4_addr": "IP_MASK",
+            "ipv6_addr": "IPV6_MASK",
+            "neighbor_ipv6": "IPV6_NEIGHBOR",
+            "neighbor_ipv4": "NEIGHBOR_IP",
+            "peer_vrf": "PEER_VRF_NAME",
+        }
+        for config_key, payload_key in field_map.items():
+            configured_value = item.get(config_key)
+            if configured_value not in (None, ""):
+                row[payload_key] = configured_value
+            else:
+                row.setdefault(payload_key, "")
+
+        if item.get("dot1q") is not None and item.get("dot1q") != "":
+            row["DOT1Q_ID"] = str(item.get("dot1q"))
+        else:
+            row["DOT1Q_ID"] = str(row.get("DOT1Q_ID") or "")
+        row["VRF_LITE_JYTHON_TEMPLATE"] = "Ext_VRF_Lite_Jython"
+        connection_rows.append(row)
+
+    vrf_lite_conn = {"VRF_LITE_CONN": connection_rows}
+    extension_values = dict(existing_outer)
+    extension_values["VRF_LITE_CONN"] = json.dumps(vrf_lite_conn, separators=(",", ":"))
+    if "MULTISITE_CONN" not in extension_values:
+        extension_values["MULTISITE_CONN"] = json.dumps({"MULTISITE_CONN": []}, separators=(",", ":"))
+
+    return json.dumps(extension_values, separators=(",", ":"))
+
+
+def parse_vrf_lite_extension_values(extension_values: Any) -> list[dict[str, Any]]:
+    """
+    Parse controller extensionValues into playbook-style vrf_lite list.
+    """
+    if isinstance(extension_values, list):
+        parsed_api_rows: list[dict[str, Any]] = []
+        for row in extension_values:
+            if not isinstance(row, dict):
+                continue
+            item = {
+                "interface": row.get("interfaceName"),
+                "dot1q": row.get("dot1qId"),
+                "ipv4_addr": row.get("ipv4Address"),
+                "neighbor_ipv4": row.get("neighborIpv4Address"),
+                "ipv6_addr": row.get("ipv6Address"),
+                "neighbor_ipv6": row.get("neighborIpv6Address"),
+                "peer_vrf": row.get("peerVrfName"),
+            }
+            if item.get("interface"):
+                parsed_api_rows.append({k: v for k, v in item.items() if v is not None and v != ""})
+        return vrf_lite_items_to_config(parsed_api_rows)
+
+    outer = _json_value(extension_values)
+    if not isinstance(outer, dict):
+        return []
+
+    inner = outer.get("VRF_LITE_CONN")
+    inner = _json_value(inner)
+    if not isinstance(inner, dict):
+        return []
+
+    rows = inner.get("VRF_LITE_CONN")
+    if not isinstance(rows, list):
+        return []
+
+    parsed: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+
+        item = {
+            "interface": row.get("IF_NAME"),
+            "dot1q": None,
+            "ipv4_addr": row.get("IP_MASK") or None,
+            "neighbor_ipv4": row.get("NEIGHBOR_IP") or None,
+            "ipv6_addr": row.get("IPV6_MASK") or None,
+            "neighbor_ipv6": row.get("IPV6_NEIGHBOR") or None,
+            "peer_vrf": row.get("PEER_VRF_NAME") or None,
+        }
+
+        dot1q = row.get("DOT1Q_ID")
+        if dot1q not in (None, ""):
+            try:
+                item["dot1q"] = int(dot1q)
+            except Exception:
+                item["dot1q"] = dot1q
+
+        if item.get("interface"):
+            parsed.append({k: v for k, v in item.items() if v is not None and v != ""})
+
+    return vrf_lite_items_to_config(parsed)
+
+
+def build_instance_values(import_evpn_rt: str | None, export_evpn_rt: str | None) -> str:
+    values = {
+        "loopbackId": "",
+        "loopbackIpAddress": "",
+        "loopbackIpV6Address": "",
+        "switchRouteTargetImportEvpn": import_evpn_rt or "",
+        "switchRouteTargetExportEvpn": export_evpn_rt or "",
+    }
+    return json.dumps(values, separators=(",", ":"))
+
+
+def parse_instance_values(instance_values: Any) -> dict[str, Any]:
+    parsed = _json_value(instance_values)
+    if isinstance(parsed, dict):
+        return parsed
+    return {}

--- a/plugins/module_utils/manage_vrf_lite/validation.py
+++ b/plugins/module_utils/manage_vrf_lite/validation.py
@@ -1,0 +1,362 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import ast
+import json
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.common import (
+    _raise_vrf_lite_error,
+    _resolve_serial,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query import (
+    _query_vrf_switch_details,
+)
+
+
+def _coerce_switch_list(response: Any) -> list[dict[str, Any]]:
+    if isinstance(response, list):
+        return [item for item in response if isinstance(item, dict)]
+
+    if isinstance(response, dict):
+        switches = response.get("switches")
+        if isinstance(switches, list):
+            return [item for item in switches if isinstance(item, dict)]
+
+    return []
+
+
+def _normalize_role(switch_data: dict[str, Any]) -> str:
+    role_value = switch_data.get("switchRole") or switch_data.get("role") or switch_data.get("switch_role") or ""
+    return str(role_value).strip().lower()
+
+
+def _is_border_role(role: str) -> bool:
+    if not role:
+        return False
+    keywords = (
+        "border",
+        "bgw",
+    )
+    return any(keyword in role for keyword in keywords)
+
+
+def _is_external_connectivity_switch(switch_data: dict[str, Any]) -> bool:
+    # TODO(#405): source the fabric type from the shared fabric_details_cache utility
+    # once #405 merges, instead of re-deriving it from the raw switch payload here.
+    raw = switch_data.get("raw")
+    fabric_type = switch_data.get("fabric_type")
+    if not fabric_type and isinstance(raw, dict):
+        fabric_type = raw.get("fabricType") or raw.get("fabric_type")
+
+    return str(fabric_type or "").strip().lower() == "externalconnectivity"
+
+
+def _normalize_switch_inventory(response: Any) -> dict[str, dict[str, Any]]:
+    inventory: dict[str, dict[str, Any]] = {}
+
+    if isinstance(response, dict) and "switches" not in response:
+        switch_items = response.items()
+    else:
+        switch_items = [(None, switch) for switch in _coerce_switch_list(response)]
+
+    for key, switch in switch_items:
+        if not isinstance(switch, dict):
+            continue
+
+        raw = switch.get("raw") if isinstance(switch.get("raw"), dict) and switch.get("raw") else switch
+        serial = switch.get("serialNumber") or switch.get("switchId") or raw.get("serialNumber") or raw.get("switchId") or key
+        if not serial:
+            continue
+
+        serial_text = str(serial).strip()
+        if not serial_text:
+            continue
+
+        inventory[serial_text] = {
+            "role": _normalize_role(switch),
+            # TODO(#405): source fabric_type from the shared fabric_details_cache utility
+            # (added in #405) instead of re-deriving it from the raw switch payload here,
+            # so every module resolves the fabric type consistently.
+            "fabric_type": switch.get("fabricType") or switch.get("fabric_type") or raw.get("fabricType") or raw.get("fabric_type"),
+            "ip_address": switch.get("fabricManagementIp") or switch.get("ip_address") or raw.get("fabricManagementIp"),
+            "raw": raw,
+        }
+    return inventory
+
+
+def _load_switch_inventory(module: Any, fabric_name: str, rest_send: Any) -> dict[str, dict[str, Any]]:
+    cached = module.params.get("_fabric_switch_inventory")
+    cache_loaded = module.params.get("_fabric_switch_inventory_loaded") is True
+    if isinstance(cached, dict) and (cache_loaded or cached):
+        if module.params.get("_fabric_switch_inventory_normalized") is True:
+            return cached
+
+        inventory = _normalize_switch_inventory(cached)
+        module.params["_fabric_switch_inventory"] = inventory
+        module.params["_fabric_switch_inventory_loaded"] = True
+        module.params["_fabric_switch_inventory_normalized"] = True
+        return inventory
+
+    fabric_context = FabricContext(rest_send=rest_send, fabric_name=fabric_name)
+    inventory = _normalize_switch_inventory(fabric_context.switch_inventory_by_id)
+
+    module.params["_fabric_switch_inventory"] = inventory
+    module.params["_fabric_switch_inventory_loaded"] = True
+    module.params["_fabric_switch_inventory_normalized"] = True
+    return inventory
+
+
+def _extract_support_flag(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, dict):
+        for key in (
+            "isVrfLiteSupported",
+            "vrfLiteSupported",
+            "isVrfLiteCapable",
+            "vrfLiteCapable",
+            "supported",
+        ):
+            if key in value and isinstance(value.get(key), bool):
+                return value.get(key)
+        for child in value.values():
+            if not isinstance(child, (dict, list)):
+                continue
+            support = _extract_support_flag(child)
+            if support is not None:
+                return support
+
+    if isinstance(value, list):
+        for item in value:
+            if not isinstance(item, (dict, list)):
+                continue
+            support = _extract_support_flag(item)
+            if support is not None:
+                return support
+
+    return None
+
+
+def _vrf_lite_cache_key(fabric_name: str, vrf_name: str, serial_number: str) -> str:
+    return "{0}\0{1}\0{2}".format(fabric_name, vrf_name, serial_number)
+
+
+def _parse_prototype_extension_values(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return dict(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        try:
+            parsed = ast.literal_eval(value)
+        except (SyntaxError, ValueError):
+            return None
+    return dict(parsed) if isinstance(parsed, dict) else None
+
+
+def _extract_vrf_lite_prototypes(response: Any, serial_number: str) -> dict[str, dict[str, Any]] | None:
+    """Return controller-owned prototypes, or ``None`` if the field is absent."""
+    prototypes: dict[str, dict[str, Any]] = {}
+    prototype_field_seen = False
+
+    def _visit(value: Any) -> None:
+        nonlocal prototype_field_seen
+        if isinstance(value, list):
+            for item in value:
+                _visit(item)
+            return
+        if not isinstance(value, dict):
+            return
+
+        has_prototype_field = "extensionPrototypeValues" in value
+        prototype_rows = value.get("extensionPrototypeValues")
+        detail_serial = value.get("serialNumber") or value.get("switchId")
+        serial_matches = not detail_serial or str(detail_serial).strip() == str(serial_number).strip()
+        if has_prototype_field and serial_matches:
+            prototype_field_seen = True
+        if isinstance(prototype_rows, list) and serial_matches:
+            for prototype in prototype_rows:
+                if not isinstance(prototype, dict):
+                    continue
+                extension_type = str(prototype.get("extensionType") or "").strip().upper()
+                if extension_type != "VRF_LITE":
+                    continue
+                parsed_extension_values = _parse_prototype_extension_values(prototype.get("extensionValues"))
+                extension_values = dict(parsed_extension_values or {})
+                interface = extension_values.get("IF_NAME") or prototype.get("interfaceName")
+                if not interface:
+                    continue
+                interface_text = str(interface).strip()
+                if not interface_text:
+                    continue
+                extension_values["IF_NAME"] = interface_text
+                prototypes[interface_text] = extension_values
+
+        for child in value.values():
+            if child is not prototype_rows:
+                _visit(child)
+
+    _visit(response)
+    return prototypes if prototype_field_seen else None
+
+
+def get_cached_vrf_lite_prototypes(
+    module: Any,
+    fabric_name: str,
+    vrf_name: str,
+    serial_number: str,
+) -> dict[str, dict[str, Any]] | None:
+    """Return cached prototypes, or ``None`` when no prototype query ran."""
+    cache = module.params.get("_vrf_lite_prototype_cache")
+    if not isinstance(cache, dict):
+        return None
+    return cache.get(_vrf_lite_cache_key(fabric_name, vrf_name, serial_number))
+
+
+def _query_vrf_lite_support(module: Any, rest_send: Any, fabric_name: str, vrf_name: str, serial_number: str) -> bool | None:
+    cache = module.params.get("_vrf_lite_support_cache")
+    if not isinstance(cache, dict):
+        cache = {}
+        module.params["_vrf_lite_support_cache"] = cache
+
+    prototype_cache = module.params.get("_vrf_lite_prototype_cache")
+    if not isinstance(prototype_cache, dict):
+        prototype_cache = {}
+        module.params["_vrf_lite_prototype_cache"] = prototype_cache
+
+    cache_key = _vrf_lite_cache_key(fabric_name, vrf_name, serial_number)
+    if cache_key in cache and cache_key in prototype_cache:
+        return cache[cache_key]
+
+    response = _query_vrf_switch_details(
+        module=module,
+        rest_send=rest_send,
+        fabric_name=fabric_name,
+        vrf_name=vrf_name,
+        serial_numbers=[serial_number],
+    ).get(serial_number, {})
+
+    prototypes = _extract_vrf_lite_prototypes(response, serial_number)
+    prototype_cache[cache_key] = prototypes
+    support = _extract_support_flag(response)
+    if support is None and prototypes:
+        support = True
+    cache[cache_key] = support
+    return support
+
+
+def _configured_interface(item: Any) -> str:
+    value = getattr(item, "interface", None)
+    if value is None and isinstance(item, dict):
+        value = item.get("interface")
+    return str(value or "").strip()
+
+
+def validate_vrf_lite_write_guardrails(module: Any, model_instance: Any, rest_send: Any) -> None:
+    """
+    Validate switch existence, role suitability, and platform support hints.
+    """
+    if hasattr(model_instance, "switch_ip"):
+        attachments = [model_instance]
+    else:
+        attachments = model_instance.attach or []
+    if not attachments:
+        return
+
+    fabric_name = module.params.get("fabric_name")
+    vrf_name = model_instance.vrf_name
+    inventory = _load_switch_inventory(module, fabric_name, rest_send)
+
+    for attach in attachments:
+        switch_identifier = getattr(attach, "switch_ip", None) or getattr(attach, "ip_address", None)
+        serial_number = _resolve_serial(module, switch_identifier)
+        if not serial_number:
+            continue
+
+        if serial_number not in inventory:
+            _raise_vrf_lite_error(
+                msg=("Switch '{0}' is not present in fabric '{1}'.").format(serial_number, fabric_name),
+                fabric=fabric_name,
+                serial_number=serial_number,
+                vrf_name=vrf_name,
+            )
+
+        vrf_lite_entries = getattr(attach, "extensions", None) or getattr(attach, "vrf_lite", None)
+        if not vrf_lite_entries:
+            continue
+
+        support = _query_vrf_lite_support(module, rest_send, fabric_name, vrf_name, serial_number)
+
+        if support is False:
+            _raise_vrf_lite_error(
+                msg=("Switch '{0}' does not report VRF Lite support in fabric '{1}'.").format(serial_number, fabric_name),
+                fabric=fabric_name,
+                serial_number=serial_number,
+                vrf_name=vrf_name,
+            )
+
+        prototypes = get_cached_vrf_lite_prototypes(module, fabric_name, vrf_name, serial_number)
+        if prototypes is None:
+            _raise_vrf_lite_error(
+                msg=("The controller did not return VRF Lite interface prototype metadata " "for switch '{0}' in fabric '{1}'.").format(
+                    serial_number, fabric_name
+                ),
+                fabric=fabric_name,
+                serial_number=serial_number,
+                vrf_name=vrf_name,
+            )
+        if not prototypes:
+            _raise_vrf_lite_error(
+                msg=("No VRF Lite-capable interfaces were reported for switch '{0}' in fabric '{1}'.").format(serial_number, fabric_name),
+                fabric=fabric_name,
+                serial_number=serial_number,
+                vrf_name=vrf_name,
+            )
+
+        requested_interfaces = sorted({_configured_interface(item) for item in vrf_lite_entries if _configured_interface(item)})
+        available_by_normalized_name = {name.casefold(): name for name in prototypes}
+        missing_interfaces = [name for name in requested_interfaces if name.casefold() not in available_by_normalized_name]
+        if missing_interfaces:
+            _raise_vrf_lite_error(
+                msg=(
+                    "No matching VRF Lite interface prototype was found on switch '{0}'. " "Requested interface(s): {1}. Available interface(s): {2}."
+                ).format(
+                    serial_number,
+                    ", ".join(missing_interfaces),
+                    ", ".join(sorted(prototypes)),
+                ),
+                fabric=fabric_name,
+                serial_number=serial_number,
+                vrf_name=vrf_name,
+                requested_interfaces=missing_interfaces,
+                available_interfaces=sorted(prototypes),
+            )
+
+        unusable_interfaces = []
+        for interface in requested_interfaces:
+            prototype = prototypes[available_by_normalized_name[interface.casefold()]]
+            missing_fields = [field for field in ("NEIGHBOR_ASN", "AUTO_VRF_LITE_FLAG") if field not in prototype or prototype.get(field) in (None, "")]
+            if missing_fields:
+                unusable_interfaces.append("{0} (missing {1})".format(interface, ", ".join(missing_fields)))
+
+        if unusable_interfaces:
+            _raise_vrf_lite_error(
+                msg=("The controller returned unusable VRF Lite prototype metadata " "for switch '{0}': {1}.").format(
+                    serial_number, "; ".join(unusable_interfaces)
+                ),
+                fabric=fabric_name,
+                serial_number=serial_number,
+                vrf_name=vrf_name,
+                unusable_interfaces=unusable_interfaces,
+            )

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -2,10 +2,10 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from abc import ABC
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Set, Tuple, Union
+from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict
 from ansible_collections.cisco.nd.plugins.module_utils.utils import issubset
@@ -54,23 +54,23 @@ class NDBaseModel(BaseModel, ABC):
 
     # --- Identifier Configuration ---
 
-    identifiers: ClassVar[Optional[List[str]]] = None
-    identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "singleton"
+    identifiers: ClassVar[list[str] | None] = None
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "singleton"
 
     # --- Serialization Configuration ---
 
-    exclude_from_diff: ClassVar[Set[str]] = set()
-    unwanted_keys: ClassVar[List] = []
+    exclude_from_diff: ClassVar[set[str]] = set()
+    unwanted_keys: ClassVar[list] = []
 
     # Declarative nested-field grouping for payload mode
     # e.g., {"passwordPolicy": ["reuse_limitation", "time_interval_limitation"]}
     # means: in payload mode, remove these fields from top level and nest them
     # under "passwordPolicy" with their alias names.
-    payload_nested_fields: ClassVar[Dict[str, List[str]]] = {}
+    payload_nested_fields: ClassVar[dict[str, list[str]]] = {}
 
     # Fields to explicitly exclude per mode
-    payload_exclude_fields: ClassVar[Set[str]] = set()
-    config_exclude_fields: ClassVar[Set[str]] = set()
+    payload_exclude_fields: ClassVar[set[str]] = set()
+    config_exclude_fields: ClassVar[set[str]] = set()
 
     # --- Subclass Validation ---
 
@@ -82,13 +82,13 @@ class NDBaseModel(BaseModel, ABC):
             return
 
         if not hasattr(cls, "identifiers") or cls.identifiers is None:
-            raise ValueError(f"Class {cls.__name__} must define 'identifiers'. " f"Example: identifiers: ClassVar[Optional[List[str]]] = ['login_id']")
+            raise ValueError(f"Class {cls.__name__} must define 'identifiers'. " f"Example: identifiers: ClassVar[list[str] | None] = ['login_id']")
         if not hasattr(cls, "identifier_strategy") or cls.identifier_strategy is None:
             raise ValueError(f"Class {cls.__name__} must define 'identifier_strategy'. " f"Example: identifier_strategy: ClassVar[...] = 'single'")
 
     # --- Core Serialization ---
 
-    def _build_payload_nested(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _build_payload_nested(self, data: dict[str, Any]) -> dict[str, Any]:
         """
         Apply payload_nested_fields: pull specified fields out of the top-level
         dict and group them under their declared parent key.
@@ -117,7 +117,7 @@ class NDBaseModel(BaseModel, ABC):
 
         return result
 
-    def to_payload(self, **kwargs) -> Dict[str, Any]:
+    def to_payload(self, **kwargs) -> dict[str, Any]:
         """Convert model to API payload format (aliased keys, nested structures)."""
         data = self.model_dump(
             by_alias=True,
@@ -129,7 +129,7 @@ class NDBaseModel(BaseModel, ABC):
         )
         return self._build_payload_nested(data)
 
-    def to_config(self, **kwargs) -> Dict[str, Any]:
+    def to_config(self, **kwargs) -> dict[str, Any]:
         """Convert model to Ansible config format (Python field names, flat structure)."""
         return self.model_dump(
             by_alias=False,
@@ -142,13 +142,13 @@ class NDBaseModel(BaseModel, ABC):
     # --- Core Deserialization ---
 
     @classmethod
-    def from_response(cls, response: Dict[str, Any], **kwargs) -> "NDBaseModel":
+    def from_response(cls, response: dict[str, Any], **kwargs) -> "NDBaseModel":
         """Create model instance from API response dict (validation context ``mode=response``)."""
         context = {"mode": "response", **(kwargs.pop("context", None) or {})}
         return cls.model_validate(response, by_alias=True, context=context, **kwargs)
 
     @classmethod
-    def from_config(cls, ansible_config: Dict[str, Any], **kwargs) -> "NDBaseModel":
+    def from_config(cls, ansible_config: dict[str, Any], **kwargs) -> "NDBaseModel":
         """Create model instance from Ansible config dict.
 
         Strips None values recursively before validation so that Ansible's
@@ -163,7 +163,7 @@ class NDBaseModel(BaseModel, ABC):
 
     # --- Identifier Access ---
 
-    def get_identifier_value(self) -> Optional[Union[str, int, Tuple[Any, ...]]]:
+    def get_identifier_value(self) -> str | int | tuple[Any, ...] | None:
         """
         Extract identifier value(s) based on the configured strategy.
 
@@ -211,7 +211,7 @@ class NDBaseModel(BaseModel, ABC):
 
     # --- Diff & Merge ---
 
-    def to_diff_dict(self, **kwargs) -> Dict[str, Any]:
+    def to_diff_dict(self, **kwargs) -> dict[str, Any]:
         """Export for diff comparison, excluding sensitive fields."""
         return self.model_dump(
             by_alias=True,
@@ -221,7 +221,7 @@ class NDBaseModel(BaseModel, ABC):
             **kwargs,
         )
 
-    def get_diff(self, other: "NDBaseModel", exclude_unset: bool = False) -> bool:
+    def get_diff(self, other: "NDBaseModel", exclude_unset: bool = False, allow_superset: bool = False) -> bool:
         """Diff comparison.
 
         Args:
@@ -229,15 +229,18 @@ class NDBaseModel(BaseModel, ABC):
             exclude_unset: When True, only compare fields explicitly set in
                 ``other`` (via Pydantic's ``exclude_unset``). This prevents
                 default values from triggering false diffs during merge
-                operations. This is the merge-path comparison, so a subset
-                match is additionally cross-checked with ``merge_would_change``
-                to catch merge side effects the one-way subset test cannot see
-                (e.g. mutually exclusive counterpart fields that the merge
-                would clear).
+                operations.
+            allow_superset: When True, list elements are matched
+                one-directionally so that an existing item with extra fields
+                (e.g. ``deploy``) does not trigger a spurious diff when the
+                proposed item omits those fields. This is independent of
+                ``exclude_unset``: the former controls which of ``other``'s
+                fields are compared, while this controls how list elements are
+                matched.
         """
         self_data = self.to_diff_dict()
         other_data = other.to_diff_dict(exclude_unset=exclude_unset)
-        is_subset = issubset(other_data, self_data)
+        is_subset = issubset(other_data, self_data, allow_superset=allow_superset)
         if is_subset and exclude_unset and self.merge_would_change(other):
             return False
         return is_subset

--- a/plugins/module_utils/models/manage_vrf_lite/vrf_lite_attachment_entry.py
+++ b/plugins/module_utils/models/manage_vrf_lite/vrf_lite_attachment_entry.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    ConfigDict,
+    Field,
+    field_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_vrf_lite.vrf_lite_model import (
+    VrfLiteConnectionModel,
+    merge_vrf_lite_connections,
+)
+
+
+class VrfLiteAttachmentEntry(NDBaseModel):
+    """Flat per-switch VRF Lite attachment row used by the state machine.
+
+    Represents one (vrf_name, switch_ip) attachment row. The state machine
+    diffs proposed entries against existing entries at this granularity, so
+    classification into create / update / delete happens generically and the
+    orchestrator only needs to build a single attachment row per call.
+    """
+
+    identifiers: ClassVar[list[str]] = ["vrf_name", "switch_ip"]
+    identifier_strategy: ClassVar[Literal["composite"]] = "composite"
+    exclude_from_diff: ClassVar[set[str]] = {"deploy"}
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        use_enum_values=True,
+        validate_assignment=True,
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+        extra="ignore",
+    )
+
+    vrf_name: str = Field(min_length=1, max_length=32)
+    switch_ip: str = Field(min_length=1, max_length=128)
+    vlan_id: int | None = Field(default=None, ge=2, le=4094)
+    deploy: bool | None = Field(default=None)
+    import_evpn_rt: str | None = Field(default=None)
+    export_evpn_rt: str | None = Field(default=None)
+    extensions: list[VrfLiteConnectionModel] | None = Field(default=None)
+
+    @field_validator("import_evpn_rt", "export_evpn_rt")
+    @classmethod
+    def _coerce_empty_string_to_none(cls, value: str | None) -> str | None:
+        """Normalize empty-string EVPN RT values to None.
+
+        The query layer may return '' for absent EVPN RT fields on a switch.
+        Coercing to None ensures they are excluded from diff comparisons via
+        exclude_none=True in to_diff_dict, preventing false 'changed'
+        classifications on replace/override states.
+        """
+        if value is not None and not str(value).strip():
+            return None
+        return value
+
+    def merge(self, other: "VrfLiteAttachmentEntry") -> "VrfLiteAttachmentEntry":
+        """Merge another entry into this one.
+
+        Custom behavior:
+        - scalar fields follow NDBaseModel merge semantics (only explicitly set
+          fields on ``other`` are applied)
+        - ``extensions`` list is merged by ``interface`` + ``dot1q`` so
+          merged-state runs preserve existing subinterfaces that the user did
+          not mention
+        """
+        if not isinstance(other, type(self)):
+            raise TypeError("VrfLiteAttachmentEntry.merge requires both models to be the same type")
+
+        merged_data = self.model_dump(by_alias=False, exclude_none=False)
+        incoming_data = other.model_dump(by_alias=False, exclude_none=False, exclude_unset=True)
+
+        for field, value in incoming_data.items():
+            if field == "extensions":
+                continue
+            if value is None:
+                continue
+            merged_data[field] = value
+
+        if "extensions" in incoming_data and incoming_data.get("extensions") is not None:
+            current_extensions = self.extensions or []
+            incoming_extensions = other.extensions or []
+            merged_extensions = merge_vrf_lite_connections(current_extensions, incoming_extensions)
+            merged_data["extensions"] = [item.model_dump(by_alias=False, exclude_none=False) for item in merged_extensions]
+
+        return type(self).model_validate(merged_data, by_name=True, by_alias=True)

--- a/plugins/module_utils/models/manage_vrf_lite/vrf_lite_model.py
+++ b/plugins/module_utils/models/manage_vrf_lite/vrf_lite_model.py
@@ -1,0 +1,384 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+
+# Single-sourced so VrfLiteModel and VrfLitePlaybookItemModel cannot drift (PR #281 review).
+VRF_NAME_MAX_LENGTH = 32
+VLAN_ID_MIN = 2
+VLAN_ID_MAX = 4094
+
+
+def _validate_vrf_name_value(value: str) -> str:
+    if value is None or not str(value).strip():
+        raise ValueError("vrf_name must be a non-empty string")
+    return str(value).strip()
+
+
+class VrfLiteConnectionModel(NDNestedModel):
+    """VRF Lite extension connection details for a single interface."""
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        use_enum_values=True,
+        validate_assignment=True,
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+        extra="ignore",
+    )
+
+    interface: str = Field(min_length=1, max_length=128)
+    dot1q: int | None = Field(default=None, ge=2, le=4094)
+    ipv4_addr: str | None = Field(default=None)
+    neighbor_ipv4: str | None = Field(default=None)
+    ipv6_addr: str | None = Field(default=None)
+    neighbor_ipv6: str | None = Field(default=None)
+    peer_vrf: str | None = Field(default=None)
+
+
+def _vrf_lite_connection_key(item: VrfLiteConnectionModel) -> tuple[str, str]:
+    interface = str(item.interface).strip().lower()
+    dot1q = "" if item.dot1q in (None, "") else str(item.dot1q)
+    return (interface, dot1q)
+
+
+def merge_vrf_lite_connections(
+    current_items: list[VrfLiteConnectionModel],
+    incoming_items: list[VrfLiteConnectionModel],
+) -> list[VrfLiteConnectionModel]:
+    merged: dict[tuple[str, str], VrfLiteConnectionModel] = {}
+
+    for item in current_items:
+        merged[_vrf_lite_connection_key(item)] = deepcopy(item)
+
+    for item in incoming_items:
+        key = _vrf_lite_connection_key(item)
+        existing_key = key
+
+        if existing_key not in merged:
+            interface_matches = [candidate_key for candidate_key in merged if candidate_key[0] == key[0]]
+            single_interface_match = interface_matches[0] if len(interface_matches) == 1 else None
+            if single_interface_match and (not key[1] or not single_interface_match[1]):
+                existing_key = single_interface_match
+
+        existing_item = merged.get(existing_key)
+        if existing_item is None:
+            merged[key] = deepcopy(item)
+        else:
+            merged[existing_key] = existing_item.merge(item)
+
+    return [item for _key, item in sorted(merged.items(), key=lambda kv: kv[0])]
+
+
+class VrfLiteAttachmentModel(NDNestedModel):
+    """Attachment data for one switch under a VRF."""
+
+    exclude_from_diff: ClassVar[set[str]] = {"deploy"}
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        use_enum_values=True,
+        validate_assignment=True,
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+        extra="ignore",
+    )
+
+    ip_address: str = Field(min_length=1, max_length=128)
+    deploy: bool | None = Field(default=None)
+    import_evpn_rt: str | None = Field(default=None)
+    export_evpn_rt: str | None = Field(default=None)
+    vrf_lite: list[VrfLiteConnectionModel] | None = Field(default=None)
+
+    @field_validator("ip_address")
+    @classmethod
+    def validate_ip_address_not_empty(cls, value: str) -> str:
+        if value is None or not str(value).strip():
+            raise ValueError("ip_address must be a non-empty string")
+        return str(value).strip()
+
+    def merge(self, other: "VrfLiteAttachmentModel") -> "VrfLiteAttachmentModel":
+        """
+        Merge another attachment model into this one.
+
+        Custom behavior:
+        - scalar fields follow NDBaseModel merge semantics (explicit fields only)
+        - `vrf_lite` list is merged by interface + dot1q so merged mode
+          preserves existing subinterfaces not mentioned in the playbook input
+        """
+        if not isinstance(other, type(self)):
+            raise TypeError("VrfLiteAttachmentModel.merge requires both models to be the same type")
+
+        merged_data = self.model_dump(by_alias=False, exclude_none=False)
+        incoming_data = other.model_dump(
+            by_alias=False,
+            exclude_none=False,
+            exclude_unset=True,
+        )
+
+        for field, value in incoming_data.items():
+            if field == "vrf_lite":
+                continue
+            if value is None:
+                continue
+            merged_data[field] = value
+
+        if "vrf_lite" in incoming_data and incoming_data.get("vrf_lite") is not None:
+            current_vrf_lite = self.vrf_lite or []
+            incoming_vrf_lite = other.vrf_lite or []
+            merged_vrf_lite = merge_vrf_lite_connections(current_vrf_lite, incoming_vrf_lite)
+            merged_data["vrf_lite"] = [item.model_dump(by_alias=False, exclude_none=False) for item in merged_vrf_lite]
+
+        return type(self).model_validate(merged_data, by_name=True, by_alias=True)
+
+
+class VrfLiteModel(NDBaseModel):
+    """Runtime model for nd_manage_vrf_lite state reconciliation."""
+
+    identifiers: ClassVar[list[str]] = ["vrf_name"]
+    identifier_strategy: ClassVar[Literal["single"]] = "single"
+    exclude_from_diff: ClassVar[set[str]] = {"deploy"}
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        use_enum_values=True,
+        validate_assignment=True,
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+        extra="ignore",
+    )
+
+    vrf_name: str = Field(min_length=1, max_length=VRF_NAME_MAX_LENGTH)
+    vlan_id: int | None = Field(default=None, ge=VLAN_ID_MIN, le=VLAN_ID_MAX)
+    deploy: bool | None = Field(default=None)
+    attach: list[VrfLiteAttachmentModel] | None = Field(default=None)
+
+    @field_validator("vrf_name")
+    @classmethod
+    def validate_vrf_name(cls, value: str) -> str:
+        return _validate_vrf_name_value(value)
+
+    def to_diff_dict(self, **kwargs) -> dict[str, Any]:
+        """Exclude nested attachment deploy field from diff comparison."""
+        return self.model_dump(
+            by_alias=True,
+            exclude_none=True,
+            exclude={
+                "deploy": True,
+                "attach": {"__all__": {"deploy": True}},
+            },
+            mode="json",
+            **kwargs,
+        )
+
+    @classmethod
+    def get_argument_spec(cls) -> dict[str, Any]:
+        """Return the Ansible argument spec for nd_manage_vrf_lite."""
+        return VrfLitePlaybookConfigModel.get_argument_spec()
+
+    def merge(self, other: "VrfLiteModel") -> "VrfLiteModel":
+        """
+        Merge another VrfLiteModel into this one.
+
+        Custom behavior:
+        - scalar fields follow NDBaseModel merge semantics (explicit fields only)
+        - `attach` list is merged by `ip_address` instead of replacing the full list
+        """
+        if not isinstance(other, type(self)):
+            raise TypeError("VrfLiteModel.merge requires both models to be the same type")
+
+        merged_data = self.model_dump(by_alias=False, exclude_none=False)
+        incoming_data = other.model_dump(by_alias=False, exclude_none=False, exclude_unset=True)
+
+        for field, value in incoming_data.items():
+            if field == "attach":
+                continue
+            if value is None:
+                continue
+            merged_data[field] = value
+
+        if "attach" in incoming_data and incoming_data.get("attach") is not None:
+            current_attach = self.attach or []
+            incoming_attach = other.attach or []
+
+            merged_attach = {}
+            for item in current_attach:
+                key = str(item.ip_address).strip().lower()
+                merged_attach[key] = deepcopy(item)
+
+            for item in incoming_attach:
+                key = str(item.ip_address).strip().lower()
+                existing_item = merged_attach.get(key)
+                if existing_item is None:
+                    merged_attach[key] = deepcopy(item)
+                else:
+                    merged_attach[key] = existing_item.merge(item)
+
+            merged_data["attach"] = [item.model_dump(by_alias=False, exclude_none=False) for _key, item in sorted(merged_attach.items(), key=lambda kv: kv[0])]
+
+        return type(self).model_validate(merged_data, by_name=True, by_alias=True)
+
+
+class VrfLitePlaybookItemModel(BaseModel):
+    """One config item under playbook `config`."""
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        use_enum_values=True,
+        validate_assignment=True,
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+        extra="ignore",
+    )
+
+    vrf_name: str = Field(min_length=1, max_length=VRF_NAME_MAX_LENGTH)
+    vlan_id: int | None = Field(default=None, ge=VLAN_ID_MIN, le=VLAN_ID_MAX)
+    deploy: bool | None = Field(default=None)
+    attach: list[VrfLiteAttachmentModel] | None = Field(default=None)
+
+    @field_validator("vrf_name")
+    @classmethod
+    def validate_vrf_name(cls, value: str) -> str:
+        return _validate_vrf_name_value(value)
+
+    def to_runtime_config(self) -> dict[str, Any]:
+        return self.model_dump(by_alias=False, exclude_none=True)
+
+
+class VerifyConfigModel(BaseModel):
+    """Verification controls for post-write refresh behavior."""
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        extra="ignore",
+    )
+
+    enabled: bool = Field(default=True)
+    retries: int = Field(default=5, ge=1)
+    timeout: int = Field(default=10, ge=1)
+
+
+class ConfigActionsModel(BaseModel):
+    """Config save/deploy controls for write workflows."""
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        extra="ignore",
+    )
+
+    save: bool = Field(default=True)
+    deploy: bool = Field(default=True)
+    type: Literal["switch", "global"] = Field(default="switch")
+
+    @model_validator(mode="after")
+    def validate_save_deploy_dependency(self) -> "ConfigActionsModel":
+        if not self.save and self.deploy:
+            raise ValueError("config_actions.deploy=true requires config_actions.save=true")
+        return self
+
+
+class VrfLitePlaybookConfigModel(BaseModel):
+    """Top-level playbook model for nd_manage_vrf_lite."""
+
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        use_enum_values=True,
+        validate_assignment=True,
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+        extra="ignore",
+    )
+
+    state: Literal["merged", "replaced", "deleted", "overridden", "gathered"] = Field(default="merged")
+    # TODO: Replace with the shared fabric_name Field once the collection adds it.
+    fabric_name: str = Field(min_length=1)
+    verify: VerifyConfigModel | None = Field(default=None)
+    config_actions: ConfigActionsModel | None = Field(default=None)
+    config: list[VrfLitePlaybookItemModel] | None = Field(default=None)
+
+    def to_runtime_config(self) -> list[dict[str, Any]]:
+        """Normalize playbook config into NDStateMachine runtime items."""
+        return [item.to_runtime_config() for item in (self.config or [])]
+
+    @classmethod
+    def get_argument_spec(cls) -> dict[str, Any]:
+        return dict(
+            state=dict(type="str", default="merged", choices=["merged", "replaced", "deleted", "overridden", "gathered"]),
+            fabric_name=dict(type="str", required=True),
+            verify=dict(
+                type="dict",
+                required=False,
+                options=dict(
+                    enabled=dict(type="bool", default=True),
+                    retries=dict(type="int", default=5),
+                    timeout=dict(type="int", default=10),
+                ),
+            ),
+            config_actions=dict(
+                type="dict",
+                required=False,
+                options=dict(
+                    save=dict(type="bool", default=True),
+                    deploy=dict(type="bool", default=True),
+                    type=dict(type="str", default="switch", choices=["switch", "global"]),
+                ),
+            ),
+            config=dict(
+                type="list",
+                elements="dict",
+                required=False,
+                options=dict(
+                    vrf_name=dict(type="str", required=True),
+                    vlan_id=dict(type="int", required=False),
+                    deploy=dict(type="bool", required=False),
+                    attach=dict(
+                        type="list",
+                        elements="dict",
+                        required=False,
+                        options=dict(
+                            ip_address=dict(type="str", required=True),
+                            deploy=dict(type="bool", required=False),
+                            import_evpn_rt=dict(type="str", required=False),
+                            export_evpn_rt=dict(type="str", required=False),
+                            vrf_lite=dict(
+                                type="list",
+                                elements="dict",
+                                required=False,
+                                options=dict(
+                                    interface=dict(type="str", required=True),
+                                    dot1q=dict(type="int", required=False),
+                                    ipv4_addr=dict(type="str", required=False),
+                                    neighbor_ipv4=dict(type="str", required=False),
+                                    ipv6_addr=dict(type="str", required=False),
+                                    neighbor_ipv6=dict(type="str", required=False),
+                                    peer_vrf=dict(type="str", required=False),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )

--- a/plugins/module_utils/nd_config_collection.py
+++ b/plugins/module_utils/nd_config_collection.py
@@ -150,7 +150,7 @@ class NDConfigCollection:
 
     # Diff Operations
 
-    def get_diff_config(self, new_item: NDBaseModel, exclude_unset: bool = False) -> Literal["new", "no_diff", "changed"]:
+    def get_diff_config(self, new_item: NDBaseModel, exclude_unset: bool = False, allow_superset: bool = False) -> Literal["new", "no_diff", "changed"]:
         """
         Compare single item against collection.
 
@@ -159,6 +159,9 @@ class NDConfigCollection:
             exclude_unset: When True, only compare fields explicitly set in
                 ``new_item``. Useful for merge operations where unspecified
                 fields should not trigger a diff.
+            allow_superset: When True, list elements are matched
+                one-directionally so an existing item carrying extra list
+                elements (or extra dict keys) is not flagged as changed.
         """
         try:
             key = self._extract_key(new_item)
@@ -170,7 +173,7 @@ class NDConfigCollection:
         if existing is None:
             return "new"
 
-        is_subset = existing.get_diff(new_item, exclude_unset=exclude_unset)
+        is_subset = existing.get_diff(new_item, exclude_unset=exclude_unset, allow_superset=allow_superset)
 
         return "no_diff" if is_subset else "changed"
 
@@ -240,11 +243,15 @@ class NDConfigCollection:
         return [item.to_payload(**kwargs) for item in self._items]
 
     @staticmethod
-    def from_ansible_config(data: List[Dict], model_class: type[NDBaseModel], **kwargs) -> "NDConfigCollection":
+    def from_ansible_config(data: Optional[List[Dict]], model_class: type[NDBaseModel], **kwargs) -> "NDConfigCollection":
         """
         Create collection from Ansible config.
+
+        ``data`` may be ``None`` when the module's ``config`` parameter is
+        omitted or explicitly set to null. It is normalized to an empty
+        collection so callers never have to special-case the absent config.
         """
-        items = [model_class.from_config(item_data, **kwargs) for item_data in data]
+        items = [model_class.from_config(item_data, **kwargs) for item_data in (data or [])]
         return NDConfigCollection(model_class=model_class, items=items)
 
     @staticmethod

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -3,7 +3,7 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, annotations, division, print_function
+from __future__ import annotations
 
 from typing import Any, Callable
 
@@ -64,6 +64,8 @@ class NDStateMachine:
         self.ignore_errors = self.module.params.get("ignore_errors", False)
         self.supports_bulk_create = self.model_orchestrator.supports_bulk_create
         self.supports_bulk_delete = self.model_orchestrator.supports_bulk_delete
+        self.track_deletes_in_sent = self.model_orchestrator.track_deletes_in_sent
+        self.merge_allow_list_superset = self.model_orchestrator.merge_allow_list_superset
 
         # Initialize collections
         try:
@@ -79,7 +81,9 @@ class NDStateMachine:
             # state-aware validation (e.g. require certain fields for write states while accepting
             # identifier-only items for ``deleted``). Models that do not read the context ignore it.
             self.proposed = NDConfigCollection.from_ansible_config(
-                data=self.module.params.get("config", []), model_class=self.model_class, context={"state": self.state}
+                data=self.module.params.get("config", []),
+                model_class=self.model_class,
+                context={"state": self.state},
             )
 
             self.output.assign(after=self.existing, before=self.before, proposed=self.proposed)
@@ -134,23 +138,54 @@ class NDStateMachine:
         else:
             raise NDStateMachineError(f"Invalid state: {self.state}")
 
+    def pending_create_update_items(self) -> list[NDBaseModel]:
+        """Return the proposed items a real run would create or update.
+
+        Mirrors the create/update classification in ``_manage_create_update_state``
+        -- same ``exclude_unset``/``allow_superset`` diff test -- but performs no
+        mutation. A check-mode preflight can use this to validate exactly the
+        items the execution path would touch, instead of every proposed item,
+        so a dry-run neither approves nor rejects a set that differs from the
+        real run (PR #281 review). Returns an empty list for non-write states.
+        """
+        if self.state not in ("merged", "replaced", "overridden"):
+            return []
+        exclude_unset = self.state == "merged"
+        allow_superset = exclude_unset and self.merge_allow_list_superset
+        pending: list[NDBaseModel] = []
+        for proposed_item in self.proposed:
+            diff_status = self.existing.get_diff_config(proposed_item, exclude_unset=exclude_unset, allow_superset=allow_superset)
+            if diff_status != "no_diff":
+                pending.append(proposed_item)
+        return pending
+
     def _execute_operation(
         self,
         operation: Callable[..., ResponseType],
         *args: Any,
         error_msg_prefix: str = "Operation failed",
         **kwargs: Any,
-    ) -> ResponseType | None:
-        """Execute an API operation with standardized error handling."""
+    ) -> bool:
+        """Execute an API operation with standardized error handling.
+
+        Returns True if the operation completed without raising. In check mode
+        the API call is skipped but still reported as completed (True) so that
+        the previewed 'after' state can be built. Returns False only when the
+        operation raised and the error was suppressed via ``ignore_errors``.
+
+        The orchestrator's return value is deliberately not used as the success
+        signal: some orchestrators defer the actual API call (queue-and-deploy)
+        and legitimately return None on success.
+        """
         try:
             if not self.check_mode:
-                return operation(*args, **kwargs)
-            return None
+                operation(*args, **kwargs)
+            return True
         except Exception as e:
             error_msg = f"{error_msg_prefix}: {e}"
             if not self.ignore_errors:
                 raise NDStateMachineError(error_msg) from e
-        return None
+        return False
 
     def _manage_create_update_state(self) -> None:
         """
@@ -167,9 +202,17 @@ class NDStateMachine:
                 # Determine diff status
                 # For merged state, only compare fields explicitly provided by
                 # the user so that Pydantic default values do not trigger false
-                # diffs or overwrite existing configuration.
+                # diffs or overwrite existing configuration. Merged also matches
+                # list elements one-directionally (allow_superset) so an
+                # existing item with extra list entries is not seen as changed --
+                # but only for orchestrators that opt in via
+                # ``merge_allow_list_superset`` and whose models merge lists
+                # element-wise, so diff and merge agree (PR #281 review). Modules
+                # that do not opt in keep wholesale list-replace semantics in
+                # both diff and merge.
                 exclude_unset = self.state == "merged"
-                diff_status = self.existing.get_diff_config(proposed_item, exclude_unset=exclude_unset)
+                allow_superset = exclude_unset and self.merge_allow_list_superset
+                diff_status = self.existing.get_diff_config(proposed_item, exclude_unset=exclude_unset, allow_superset=allow_superset)
 
                 # No changes needed
                 if diff_status == "no_diff":
@@ -204,21 +247,28 @@ class NDStateMachine:
         # The policy-required-on-create guard (issue #350) runs in manage_state, before the capability
         # preflight and before this method mutates self.existing (PR #362 review).
 
-        # Execute updates (always individual)
+        # Execute updates (always individual). An operation that does not fail
+        # is counted as sent; check mode skips the API call but returns True.
+        successfully_sent: list[NDBaseModel] = []
         for item in items_to_update:
-            self._execute_operation(self.model_orchestrator.update, item, error_msg_prefix=f"Failed to update {item.get_identifier_value()}")
+            if self._execute_operation(self.model_orchestrator.update, item, error_msg_prefix=f"Failed to update {item.get_identifier_value()}"):
+                successfully_sent.append(item)
 
         # Execute creates (bulk or individual)
         if items_to_create:
             if self.supports_bulk_create:
-                self._execute_operation(self.model_orchestrator.create_bulk, items_to_create, error_msg_prefix="Failed to create in bulk")
+                if self._execute_operation(self.model_orchestrator.create_bulk, items_to_create, error_msg_prefix="Failed to create in bulk"):
+                    successfully_sent.extend(items_to_create)
             else:
                 for item in items_to_create:
-                    self._execute_operation(self.model_orchestrator.create, item, error_msg_prefix=f"Failed to create {item.get_identifier_value()}")
+                    if self._execute_operation(self.model_orchestrator.create, item, error_msg_prefix=f"Failed to create {item.get_identifier_value()}"):
+                        successfully_sent.append(item)
 
-        # Mark as sent only after successful API operations
-        successfully_sent = items_to_update + items_to_create
-        if successfully_sent:
+        # Mark as sent only for items actually pushed to the controller. In
+        # check mode no API call is made, so nothing is marked as sent (avoids
+        # false deploy triggers); the previewed 'after' state is still reflected
+        # in self.existing (mutated above), which is what drives 'changed'.
+        if not self.check_mode and successfully_sent:
             self.sent.add_many(successfully_sent)
 
         # Log operation
@@ -244,16 +294,28 @@ class NDStateMachine:
         if not items:
             return
 
-        # Execute deletes (bulk or individual)
+        # Execute deletes (bulk or individual). An item is counted as deleted
+        # when the operation does not fail; check mode skips the API call but
+        # returns True so the deletion is still previewed. Items whose delete
+        # failed under ignore_errors are left in 'existing' so the reported
+        # 'after' state stays accurate.
+        deleted: list[NDBaseModel] = []
         if self.supports_bulk_delete:
-            self._execute_operation(self.model_orchestrator.delete_bulk, items, error_msg_prefix="Failed to delete in bulk")
+            if self._execute_operation(self.model_orchestrator.delete_bulk, items, error_msg_prefix="Failed to delete in bulk"):
+                deleted.extend(items)
         else:
             for item in items:
-                self._execute_operation(self.model_orchestrator.delete, item, error_msg_prefix=f"Failed to delete {item.get_identifier_value()}")
+                if self._execute_operation(self.model_orchestrator.delete, item, error_msg_prefix=f"Failed to delete {item.get_identifier_value()}"):
+                    deleted.append(item)
 
-        # Batch remove from collection (single index rebuild)
-        keys_to_delete = [item.get_identifier_value() for item in items]
-        self.existing.delete_many(keys_to_delete)
+        # Batch remove from collection (single index rebuild).
+        self.existing.delete_many([item.get_identifier_value() for item in deleted])
+
+        # Mark as sent only for items actually pushed to the controller. In
+        # check mode no API call is made, so nothing is marked as sent (avoids
+        # false deploy triggers).
+        if not self.check_mode and self.track_deletes_in_sent and deleted:
+            self.sent.add_many(deleted)
 
         # Log deletion
         self.output.assign(after=self.existing)

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -50,6 +50,19 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     model_class: ClassVar[type[NDBaseModel]] = NDBaseModel
     supports_bulk_create: ClassVar[bool] = False
     supports_bulk_delete: ClassVar[bool] = False
+    # When True, items removed during deleted/overridden states are also added
+    # to the state machine's ``sent`` collection. Off by default so the
+    # generic ``sent`` keeps its "created/updated only" meaning for modules
+    # that do not opt in.
+    track_deletes_in_sent: ClassVar[bool] = False
+    # When True, merged-state diffing matches list elements one-directionally
+    # (``allow_superset``) so an existing item with extra list entries is not
+    # seen as changed. Off by default: enabling it globally would silently
+    # change idempotency results for shipped modules whose ``merge`` replaces
+    # list fields wholesale, making diff and merge disagree (PR #281 review).
+    # Only orchestrators whose models override ``merge`` with element-wise list
+    # merging (e.g. vrf_lite) should opt in, so diff and merge stay consistent.
+    merge_allow_list_superset: ClassVar[bool] = False
 
     # NOTE: if not defined by subclasses, return an error as they are required
     create_endpoint: type[NDEndpointBaseModel]

--- a/plugins/module_utils/orchestrators/manage_vrf_lite.py
+++ b/plugins/module_utils/orchestrators/manage_vrf_lite.py
@@ -1,0 +1,660 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from itertools import groupby
+from typing import Any, ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDModuleError
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import (
+    EpManageFabricsGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions import (
+    _ensure_vrf_exists,
+    _post_attachment_payload,
+    build_attach_payload_for_entry,
+    build_detach_payload_for_entry,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.common import (
+    _raise_vrf_lite_error,
+    _resolve_serial,
+    append_runtime_warning,
+    get_config_actions,
+    get_runtime_warnings,
+    get_verify_settings,
+    request_with_rest_send,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.deploy import (
+    _deployment_intent,
+    _is_non_fatal_config_save_error,
+    _needs_deployment,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.exceptions import (
+    VrfLiteResourceError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.config_transform import (
+    config_vrf_names,
+    explode_playbook_to_entries,
+    group_attachment_entries_to_vrfs,
+    replacement_scope_vrfs,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query import (
+    _query_vrf_switch_details,
+    query_vrf_lite_state,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.runtime_endpoints import (
+    VrfLiteEndpoints,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation import (
+    _load_switch_inventory,
+    validate_vrf_lite_write_guardrails,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_vrf_lite.vrf_lite_attachment_entry import (
+    VrfLiteAttachmentEntry,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import (
+    NDBaseOrchestrator,
+)
+
+logger = logging.getLogger("nd.ManageVrfLiteOrchestrator")
+
+
+class ManageVrfLiteOrchestrator(NDBaseOrchestrator):
+    """Attachment-level VRF Lite adapter for the generic ND state machine."""
+
+    model_class: ClassVar[type[NDBaseModel]] = VrfLiteAttachmentEntry
+    supports_bulk_create: ClassVar[bool] = True
+    supports_bulk_delete: ClassVar[bool] = True
+    track_deletes_in_sent: ClassVar[bool] = True
+    # vrf_lite models (VrfLiteAttachmentEntry/VrfLiteModel/VrfLiteAttachmentModel)
+    # override ``merge`` to merge list fields element-wise, so one-directional
+    # list matching in merged-state diffing is consistent with merge here.
+    merge_allow_list_superset: ClassVar[bool] = True
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
+    update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
+    create_bulk_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
+    delete_bulk_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
+
+    @staticmethod
+    def prepare_module_params(module: Any, module_config: Any, normalized_config: list[dict[str, Any]] | None = None) -> None:
+        """Normalize module params while preserving nested playbook config."""
+        state = module_config.state
+        if normalized_config is None:
+            normalized_config = module_config.to_runtime_config()
+        config_actions = get_config_actions(module.params)
+        verify_settings = get_verify_settings(module.params)
+
+        if state == "gathered":
+            raw_module_args = ManageVrfLiteOrchestrator._get_raw_module_args()
+            raw_config_actions = raw_module_args.get("config_actions")
+            if isinstance(raw_config_actions, dict):
+                normalized_actions = module.params.get("config_actions") or {}
+                save_requested = "save" in raw_config_actions and normalized_actions.get("save") is True
+                deploy_requested = "deploy" in raw_config_actions and normalized_actions.get("deploy") is True
+                if save_requested or deploy_requested:
+                    module.fail_json(
+                        msg="config_actions.save/config_actions.deploy are not allowed with 'gathered' state. " "Gathered workflows are strictly read-only."
+                    )
+
+            config_actions = {
+                "save": False,
+                "deploy": False,
+                "type": config_actions.get("type", "switch"),
+            }
+
+        if config_actions.get("deploy") and not config_actions.get("save"):
+            module.fail_json(msg="Invalid config_actions: config_actions.deploy=true requires config_actions.save=true")
+
+        module.params["config"] = normalized_config
+        module.params["_vrf_lite_nested_config"] = list(normalized_config)
+        module.params["config_actions"] = config_actions
+        module.params["verify"] = verify_settings
+
+        if state == "gathered":
+            module.params["_gather_filter_config"] = list(normalized_config)
+            module.params["config"] = []
+        else:
+            module.params["_gather_filter_config"] = []
+
+        if state == "deleted" and not normalized_config:
+            module.fail_json(msg="Config parameter is required for state 'deleted'. Specify one or more vrf_name entries in config.")
+
+        module.params["_changed_vrfs"] = []
+        module.params["_vrf_lite_requested_state"] = state
+        module.params["_not_in_sync_vrfs"] = []
+        module.params["_ip_to_sn_mapping"] = {}
+        module.params["_sn_to_ip_mapping"] = {}
+        module.params["_vrf_lite_vrf_vlan_map"] = {}
+        module.params["_have"] = []
+        module.params["_have_loaded"] = False
+        module.params["_known_vrfs"] = []
+        module.params["_known_vrfs_loaded"] = False
+        module.params["_raw_vrf_attachment_map"] = {}
+        module.params["_fabric_switch_inventory"] = {}
+        module.params["_fabric_switch_inventory_loaded"] = False
+        module.params["_fabric_switch_inventory_normalized"] = False
+        module.params["_vrf_lite_support_cache"] = {}
+        module.params["_vrf_lite_prototype_cache"] = {}
+        module.params["_vrf_lite_switch_detail_cache"] = {}
+        module.params["_warnings"] = list(module.params.get("_warnings")) if isinstance(module.params.get("_warnings"), list) else []
+
+    @staticmethod
+    def _get_raw_module_args() -> dict[str, Any]:
+        """Best-effort extraction of raw user-provided args before defaults."""
+        try:
+            from ansible.module_utils import basic as ansible_basic
+
+            raw_payload = getattr(ansible_basic, "_ANSIBLE_ARGS", None)
+            if raw_payload is None:
+                return {}
+
+            if isinstance(raw_payload, (bytes, bytearray)):
+                decoded = raw_payload.decode("utf-8")
+            elif isinstance(raw_payload, str):
+                decoded = raw_payload
+            else:
+                return {}
+
+            parsed = json.loads(decoded)
+            module_args = parsed.get("ANSIBLE_MODULE_ARGS")
+            return module_args if isinstance(module_args, dict) else {}
+        except Exception:
+            return {}
+
+    def _module(self) -> Any:
+        return self.rest_send.sender.ansible_module
+
+    def _public_scope_vrfs(self) -> list[str]:
+        module = self._module()
+        state = module.params.get("_vrf_lite_requested_state") or module.params.get("state", "merged")
+        if state == "gathered":
+            config = module.params.get("_gather_filter_config") or []
+        else:
+            config = module.params.get("_vrf_lite_nested_config") or module.params.get("config") or []
+        return replacement_scope_vrfs(config)
+
+    def _prepare_state_machine_config(self, current_entries: list[dict[str, Any]]) -> None:
+        """Prepare flat attachment rows before the generic state machine builds proposed."""
+        module = self._module()
+        state = module.params.get("_vrf_lite_requested_state") or module.params.get("state", "merged")
+        if state == "gathered":
+            return
+        config = module.params.get("_vrf_lite_nested_config") or module.params.get("config") or []
+        module.params["config"] = explode_playbook_to_entries(config=config, module=module, state=state, current_entries=current_entries)
+
+    def query_all(self, **kwargs: Any) -> list[dict[str, Any]]:
+        current = self._query_current_state(flat=True)
+        logger.debug("query_all: loaded %d current VRF Lite attachment row(s)", len(current))
+        self._prepare_state_machine_config(current)
+        return current
+
+    def create(self, model_instance: Any, **kwargs: Any) -> dict[str, Any]:
+        return self.create_bulk([model_instance], **kwargs)
+
+    def update(self, model_instance: Any, **kwargs: Any) -> dict[str, Any]:
+        # TODO(#487): add a post-diff bulk-update hook so multiple changed entries
+        # can share one support prefetch and attachment POST per VRF.
+        return self._post_attach_entries([model_instance])
+
+    def delete(self, model_instance: Any, **kwargs: Any) -> dict[str, Any]:
+        return self.delete_bulk([model_instance], **kwargs)
+
+    def create_bulk(self, model_instances: list[Any], **kwargs: Any) -> dict[str, Any]:
+        return self._post_attach_entries(model_instances)
+
+    def delete_bulk(self, model_instances: list[Any], **kwargs: Any) -> dict[str, Any]:
+        return self._post_detach_entries(model_instances)
+
+    def _prefetch_vrf_lite_support_details(self, entries: list[Any]) -> None:
+        """Prime per-switch detail cache with one request per VRF."""
+        if not entries:
+            return
+
+        module = self._module()
+        fabric_name = module.params.get("fabric_name")
+        serials_by_vrf: dict[str, set[str]] = defaultdict(set)
+
+        for entry in entries:
+            serial_number = _resolve_serial(module, getattr(entry, "switch_ip", None))
+            if serial_number and getattr(entry, "extensions", None):
+                serials_by_vrf[entry.vrf_name].add(serial_number)
+
+        for vrf_name in sorted(serials_by_vrf):
+            serial_numbers = sorted(serials_by_vrf[vrf_name])
+            logger.debug(
+                "_validate_attach_entries: prefetching VRF Lite details for VRF %s on %d switch(es)",
+                vrf_name,
+                len(serial_numbers),
+            )
+            _query_vrf_switch_details(
+                module=module,
+                rest_send=self.rest_send,
+                fabric_name=fabric_name,
+                vrf_name=vrf_name,
+                serial_numbers=serial_numbers,
+            )
+
+    def _locally_valid_switch_prefix(self, entries: list[Any]) -> tuple[list[Any], Any | None, VrfLiteResourceError | None]:
+        """Return entries up to the first locally invalid switch, preserving order."""
+        module = self._module()
+        fabric_name = module.params.get("fabric_name")
+        inventory = _load_switch_inventory(module, fabric_name, self.rest_send)
+        valid_prefix = []
+
+        for entry in entries:
+            try:
+                serial_number = _resolve_serial(module, getattr(entry, "switch_ip", None))
+            except VrfLiteResourceError as error:
+                return valid_prefix, entry, error
+            if serial_number and serial_number not in inventory:
+                return valid_prefix, entry, None
+            valid_prefix.append(entry)
+
+        return valid_prefix, None, None
+
+    def _validate_attach_entries(self, entries: list[Any]) -> None:
+        module = self._module()
+        # Production entries are sorted by VRF, so each valid bulk workload
+        # gets one group per VRF.  Group only consecutive entries here rather
+        # than collecting equal names globally, preserving exact input/error
+        # order for direct callers that supply interleaved VRFs.
+        for vrf_name, grouped_entries in groupby(entries, key=lambda entry: entry.vrf_name):
+            vrf_entries = list(grouped_entries)
+            _ensure_vrf_exists(module, self.rest_send, vrf_name)
+            valid_prefix, invalid_entry, resolution_error = self._locally_valid_switch_prefix(vrf_entries)
+            self._prefetch_vrf_lite_support_details(valid_prefix)
+            for entry in valid_prefix:
+                validate_vrf_lite_write_guardrails(module=module, model_instance=entry, rest_send=self.rest_send)
+            if resolution_error is not None:
+                raise resolution_error
+            if invalid_entry is not None:
+                # Reuse the normal guardrail for the canonical structured
+                # unknown-switch error after every earlier entry has passed.
+                validate_vrf_lite_write_guardrails(module=module, model_instance=invalid_entry, rest_send=self.rest_send)
+
+    def preflight_validate_check_mode(self, proposed_entries: list[Any]) -> None:
+        """Run the non-mutating attach preflight during a check-mode run.
+
+        The generic state machine skips all write methods in check mode
+        (``_execute_operation`` only calls the operation ``if not check_mode``),
+        so the VRF-existence and switch role/support guardrails inside
+        ``_post_attach_entries`` are never reached. Without this, check mode
+        would approve a plan that references a nonexistent VRF or an
+        unsupported switch and then fail on the real run. This reuses the same
+        read-only ``_validate_attach_entries`` guardrails so check mode rejects
+        the same inputs the execution path would.
+
+        ``proposed_entries`` must be the create/update subset the execution
+        path would actually attach (see
+        ``NDStateMachine.pending_create_update_items``), not every proposed
+        row, so check mode validates exactly the entries the real run touches
+        and does not reject idempotent no-op rows the real run skips.
+        """
+        module = self._module()
+        if not module.check_mode:
+            return
+        state = module.params.get("_vrf_lite_requested_state") or module.params.get("state", "merged")
+        if state not in ("merged", "replaced", "overridden"):
+            return
+        attach_entries = [entry for entry in proposed_entries if getattr(entry, "switch_ip", None)]
+        if attach_entries:
+            self._validate_attach_entries(attach_entries)
+
+    def _post_grouped_rows(self, rows_by_vrf: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
+        module = self._module()
+        responses = []
+        for vrf_name in sorted(rows_by_vrf):
+            rows = rows_by_vrf[vrf_name]
+            if not rows:
+                continue
+            logger.debug("_post_grouped_rows: posting %d attachment row(s) for VRF %s", len(rows), vrf_name)
+            responses.append(
+                {
+                    "vrf_name": vrf_name,
+                    "response": _post_attachment_payload(module, self.rest_send, module.params.get("fabric_name"), vrf_name, rows),
+                }
+            )
+        return {"response": responses}
+
+    def _post_attach_entries(self, entries: list[Any]) -> dict[str, Any]:
+        if not entries:
+            return {}
+        module = self._module()
+        if module.check_mode:
+            logger.debug("_post_attach_entries: check_mode, planning %d attach entry(ies)", len(entries))
+            return {"planned": [entry.to_config() for entry in entries]}
+
+        logger.info("_post_attach_entries: attaching %d entry(ies) across VRF(s) %s", len(entries), sorted({entry.vrf_name for entry in entries}))
+        self._validate_attach_entries(entries)
+        rows_by_vrf: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for entry in entries:
+            rows_by_vrf[entry.vrf_name].append(build_attach_payload_for_entry(module, self.rest_send, entry))
+        return self._post_grouped_rows(rows_by_vrf)
+
+    def _post_detach_entries(self, entries: list[Any]) -> dict[str, Any]:
+        # _validate_attach_entries is intentionally skipped here: detach entries only
+        # reference attachments already confirmed present in current state by the state
+        # machine before calling delete_bulk.  VRF-existence and role-guardrail checks
+        # are not needed for a clear/detach operation.
+        if not entries:
+            return {}
+        module = self._module()
+        if module.check_mode:
+            logger.debug("_post_detach_entries: check_mode, planning %d detach entry(ies)", len(entries))
+            return {"planned": [entry.to_config() for entry in entries]}
+
+        logger.info("_post_detach_entries: detaching %d entry(ies) across VRF(s) %s", len(entries), sorted({entry.vrf_name for entry in entries}))
+        rows_by_vrf: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for entry in entries:
+            rows_by_vrf[entry.vrf_name].append(build_detach_payload_for_entry(module, entry))
+        return self._post_grouped_rows(rows_by_vrf)
+
+    def gather(self) -> dict[str, Any]:
+        flat_gathered = self._query_current_state(flat=True)
+        gathered = group_attachment_entries_to_vrfs(flat_gathered, module=self._module(), include_vrfs=self._public_scope_vrfs())
+        logger.info("gather: returning %d VRF(s) with VRF Lite attachments", len(gathered))
+        output = {
+            "output_level": self._module().params.get("output_level", "normal"),
+            "changed": False,
+            "before": gathered,
+            "after": gathered,
+            "current": gathered,
+            "diff": [],
+            "response": [],
+            "result": [],
+            "gathered": gathered,
+        }
+        return self.inject_runtime_metadata(output)
+
+    def deploy_pending(self, result: dict[str, Any]) -> dict[str, Any] | None:
+        module = self._module()
+        config_actions = get_config_actions(module.params)
+
+        if not config_actions.get("save", False) and not config_actions.get("deploy", False):
+            logger.debug("deploy_pending: save/deploy both disabled, skipping config actions")
+            return None
+
+        logger.info(
+            "deploy_pending: executing config actions (save=%s, deploy=%s, type=%s)",
+            config_actions.get("save"),
+            config_actions.get("deploy"),
+            config_actions.get("type"),
+        )
+        return self._execute_config_actions(result)
+
+    def refresh_verified_state(self, result: dict[str, Any]) -> dict[str, Any]:
+        module = self._module()
+        verify_settings = get_verify_settings(module.params)
+        if not verify_settings.get("enabled", True):
+            return result
+        if module.check_mode or not result.get("changed"):
+            return result
+
+        logger.debug("refresh_verified_state: re-querying fabric to verify post-deploy state")
+        # Per-switch details may have been cached during preflight.  They are
+        # authoritative only until a write occurs; retain immutable prototype
+        # metadata but force attachment details to be read again for verify.
+        module.params["_vrf_lite_switch_detail_cache"] = {}
+        refreshed = self._query_current_state(flat=True)
+        result["after"] = group_attachment_entries_to_vrfs(refreshed, module=module, include_vrfs=self._public_scope_vrfs())
+        result["current"] = result["after"]
+        return result
+
+    def format_public_output(self, result: dict[str, Any]) -> dict[str, Any]:
+        module = self._module()
+        state = module.params.get("state", "merged")
+        scoped_empty_keys = {"before", "after", "current", "gathered"}
+        include_vrfs = self._public_scope_vrfs() if state in ("deleted", "replaced", "overridden", "gathered") else []
+        for key in ("before", "after", "current", "proposed", "diff", "gathered"):
+            value = result.get(key)
+            if not isinstance(value, list):
+                continue
+            has_flat_entries = any(isinstance(item, VrfLiteAttachmentEntry) or (isinstance(item, dict) and "switch_ip" in item) for item in value)
+            should_preserve_empty_scope = not value and include_vrfs and key in scoped_empty_keys
+            if has_flat_entries or should_preserve_empty_scope:
+                result[key] = group_attachment_entries_to_vrfs(value, module=module, include_vrfs=include_vrfs)
+        result.setdefault("current", result.get("after", []))
+        return result
+
+    def _query_current_state(self, flat: bool = True) -> list[dict[str, Any]]:
+        module = self._module()
+        fabric_name = module.params.get("fabric_name")
+        state = module.params.get("state", "merged")
+
+        if not fabric_name:
+            raise ValueError("fabric_name must be set")
+
+        if state == "gathered":
+            if module.params.get("_have_loaded") and isinstance(module.params.get("_have"), list):
+                have = module.params["_have"]
+                return have if flat else group_attachment_entries_to_vrfs(have, module=module, include_vrfs=self._public_scope_vrfs())
+            config = module.params.get("_gather_filter_config") or []
+        else:
+            config = module.params.get("_vrf_lite_nested_config") or module.params.get("config") or []
+
+        # For overridden, query the full fabric so VRFs absent from config can be removed.
+        requested_state = module.params.get("_vrf_lite_requested_state") or state
+        filter_vrfs = None if requested_state == "overridden" else set(config_vrf_names(config))
+        try:
+            have = query_vrf_lite_state(
+                module=module,
+                rest_send=self.rest_send,
+                fabric_name=fabric_name,
+                filter_vrfs=(filter_vrfs if filter_vrfs else None),
+                flat=True,
+            )
+        except NDModuleError as error:
+            logger.error("Failed to query VRF Lite state for fabric %s: %s", fabric_name, error.msg)
+            error_dict = error.to_dict()
+            if "msg" in error_dict:
+                error_dict["api_error_msg"] = error_dict.pop("msg")
+            _raise_vrf_lite_error(msg="Failed to query VRF Lite state: {0}".format(error.msg), fabric=fabric_name, **error_dict)
+        except VrfLiteResourceError:
+            raise
+        except Exception as error:
+            _raise_vrf_lite_error(
+                msg="Failed to query VRF Lite state: {0}".format(str(error)),
+                fabric=fabric_name,
+                exception_type=type(error).__name__,
+            )
+
+        module.params["_have"] = have
+        module.params["_have_loaded"] = True
+        logger.debug("_query_current_state: queried %d attachment row(s) for fabric %s", len(have), fabric_name)
+        return have if flat else group_attachment_entries_to_vrfs(have, module=module, include_vrfs=self._public_scope_vrfs())
+
+    def _execute_config_actions(self, result: dict[str, Any]) -> dict[str, Any]:
+        module = self._module()
+        fabric_name = module.params.get("fabric_name")
+        config_actions = get_config_actions(module.params)
+        save_enabled = config_actions.get("save", True)
+        deploy_enabled = config_actions.get("deploy", True)
+
+        if deploy_enabled and not save_enabled:
+            _raise_vrf_lite_error(msg="Invalid config_actions: deploy=true requires save=true")
+
+        if not save_enabled and not deploy_enabled:
+            return {
+                "msg": "Config actions disabled (save=false, deploy=false), skipping config save/deploy",
+                "deployment_needed": False,
+                "changed": False,
+                "config_actions": config_actions,
+                "response": [],
+            }
+
+        deployment_needed = _needs_deployment(result, module)
+        if not deployment_needed:
+            logger.info("_execute_config_actions: no changes or out-of-sync attachments, skipping save/deploy")
+            return {
+                "msg": "No changes or out-of-sync VRF Lite attachments detected, skipping config actions",
+                "deployment_needed": False,
+                "changed": False,
+                "config_actions": config_actions,
+                "response": [],
+            }
+
+        deploy_enabled_config_pairs, explicitly_disabled_pairs, explicitly_disabled_vrfs = _deployment_intent(module)
+        changed_vrfs = set(module.params.get("_changed_vrfs") or [])
+
+        # Build deployment scope from the state-machine operation journal rather than
+        # the retained desired config. The journal preserves before-state identities
+        # for detaches, including remove-all, and marks each pair as a write or delete.
+        # Explicit VRF/attachment deploy:false intent still suppresses matching work.
+        deploy_targets = module.params.get("_deploy_targets") or []
+        journal = {
+            (
+                str(target.get("vrf_name")),
+                _resolve_serial(module, target.get("switch_ip")),
+                target.get("operation"),
+            )
+            for target in deploy_targets
+            if isinstance(target, dict) and target.get("vrf_name") and target.get("switch_ip")
+        }
+        removed_pairs = {(vrf_name, switch_id) for vrf_name, switch_id, operation in journal if operation == "delete"}
+        write_pairs = {(vrf_name, switch_id) for vrf_name, switch_id, operation in journal if operation == "write"}
+        eligible_operation_pairs = {
+            pair
+            for pair in removed_pairs | (write_pairs & deploy_enabled_config_pairs)
+            if pair[0] not in explicitly_disabled_vrfs and pair not in explicitly_disabled_pairs
+        }
+        eligible_operation_vrfs = {vrf_name for vrf_name, _switch_id in eligible_operation_pairs}
+
+        target_vrfs = sorted(changed_vrfs & eligible_operation_vrfs)
+        logger.info("_execute_config_actions: save=%s deploy=%s target_vrfs=%s", save_enabled, deploy_enabled, target_vrfs)
+
+        planned_actions = []
+        if save_enabled:
+            planned_actions.append("POST {0}".format(VrfLiteEndpoints.config_save(fabric_name)))
+
+        deploy_payloads: list[dict[str, list[str]]] = []
+        if deploy_enabled and target_vrfs:
+            if config_actions.get("type") == "global":
+                deploy_payloads.append({"vrfNames": target_vrfs})
+            else:
+                # Keep each VRF bound to exactly the switches recorded for it. VRFs
+                # with identical switch sets can safely share one controller request;
+                # flattening all VRFs and switches would create a Cartesian product.
+                vrfs_by_switch_ids: dict[tuple[str, ...], list[str]] = defaultdict(list)
+                for vrf_name in target_vrfs:
+                    switch_ids = tuple(sorted(switch_id for pair_vrf, switch_id in eligible_operation_pairs if pair_vrf == vrf_name))
+                    if switch_ids:
+                        vrfs_by_switch_ids[switch_ids].append(vrf_name)
+                deploy_payloads.extend(
+                    {"vrfNames": sorted(vrf_names), "switchIds": list(switch_ids)} for switch_ids, vrf_names in sorted(vrfs_by_switch_ids.items())
+                )
+
+            for deploy_payload in deploy_payloads:
+                deploy_action = "POST {0} vrfNames={1}".format(
+                    VrfLiteEndpoints.vrf_deployments(fabric_name),
+                    ",".join(deploy_payload["vrfNames"]),
+                )
+                if deploy_payload.get("switchIds"):
+                    deploy_action += " switchIds={0}".format(",".join(deploy_payload["switchIds"]))
+                planned_actions.append(deploy_action)
+
+        if module.check_mode:
+            return {
+                "msg": "CHECK MODE: Would run VRF Lite save/deploy actions",
+                "deployment_needed": True,
+                "changed": True,
+                "config_actions": config_actions,
+                "target_vrfs": target_vrfs,
+                "planned_actions": planned_actions,
+                "response": [],
+            }
+
+        responses = []
+        changed = bool(module.params.get("_changed_vrfs"))
+
+        if save_enabled:
+            # config save is a fabric-wide trigger with no request body; the deploy scope
+            # (switch vs global) is applied to the VRF deploy call below, not to config save.
+            save_payload = {}
+            try:
+                save_resp = request_with_rest_send(module, self.rest_send, VrfLiteEndpoints.config_save(fabric_name), HttpVerbEnum.POST, save_payload)
+                logger.debug("config_save POST succeeded for fabric %s", fabric_name)
+                responses.append(
+                    {
+                        "operation": "config_save",
+                        "path": VrfLiteEndpoints.config_save(fabric_name),
+                        "payload": save_payload,
+                        "response": save_resp,
+                        "success": True,
+                    }
+                )
+            except NDModuleError as error:
+                if deploy_enabled and _is_non_fatal_config_save_error(error):
+                    logger.warning("config_save returned known non-fatal error: %s; continuing with deploy", error.msg)
+                    append_runtime_warning(
+                        module.params,
+                        "Config save returned a known non-fatal platform error: {0}. Continuing with deploy.".format(error.msg),
+                    )
+                    responses.append(
+                        {
+                            "operation": "config_save",
+                            "path": VrfLiteEndpoints.config_save(fabric_name),
+                            "payload": save_payload,
+                            "response": error.to_dict(),
+                            "success": False,
+                            "non_fatal": True,
+                        }
+                    )
+                else:
+                    error_dict = error.to_dict()
+                    if "msg" in error_dict:
+                        error_dict["api_error_msg"] = error_dict.pop("msg")
+                    _raise_vrf_lite_error(msg="Config save failed: {0}".format(error.msg), **error_dict)
+
+        for deploy_payload in deploy_payloads:
+            try:
+                deploy_resp = request_with_rest_send(module, self.rest_send, VrfLiteEndpoints.vrf_deployments(fabric_name), HttpVerbEnum.POST, deploy_payload)
+                logger.info("vrf_deploy POST succeeded for VRF(s) %s", deploy_payload["vrfNames"])
+                responses.append(
+                    {
+                        "operation": "vrf_deploy",
+                        "path": VrfLiteEndpoints.vrf_deployments(fabric_name),
+                        "payload": deploy_payload,
+                        "response": deploy_resp,
+                        "success": True,
+                    }
+                )
+            except NDModuleError as error:
+                error_dict = error.to_dict()
+                if "msg" in error_dict:
+                    error_dict["api_error_msg"] = error_dict.pop("msg")
+                _raise_vrf_lite_error(msg="VRF deploy failed: {0}".format(error.msg), **error_dict)
+
+        return {
+            "msg": "VRF Lite config actions completed",
+            "deployment_needed": True,
+            "changed": changed,
+            "config_actions": config_actions,
+            "target_vrfs": target_vrfs,
+            "planned_actions": planned_actions,
+            "response": responses,
+        }
+
+    def inject_runtime_metadata(self, payload: dict[str, Any]) -> dict[str, Any]:
+        module = self._module()
+        warnings = get_runtime_warnings(module.params)
+        if warnings:
+            payload["warnings"] = warnings
+
+        if module.params.get("_ip_to_sn_mapping"):
+            payload["ip_to_sn_mapping"] = module.params.get("_ip_to_sn_mapping")
+
+        return payload

--- a/plugins/module_utils/orchestrators/manage_vrf_lite.py
+++ b/plugins/module_utils/orchestrators/manage_vrf_lite.py
@@ -521,9 +521,7 @@ class ManageVrfLiteOrchestrator(NDBaseOrchestrator):
         # Start with targets rediscovered from the controller, then let this
         # run's journal replace them. For example, an overridden run can turn a
         # previously pending write into a delete before the final deployment.
-        journal_by_pair: dict[tuple[str, str], str] = {
-            (target["vrf_name"], target["switch_ip"]): target["operation"] for target in pending_targets
-        }
+        journal_by_pair: dict[tuple[str, str], str] = {(target["vrf_name"], target["switch_ip"]): target["operation"] for target in pending_targets}
         for target in deploy_targets:
             if not isinstance(target, dict) or not target.get("vrf_name") or not target.get("switch_ip"):
                 continue

--- a/plugins/module_utils/orchestrators/manage_vrf_lite.py
+++ b/plugins/module_utils/orchestrators/manage_vrf_lite.py
@@ -37,6 +37,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.deploy im
     _deployment_intent,
     _is_non_fatal_config_save_error,
     _needs_deployment,
+    _scoped_pending_deploy_targets,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.exceptions import (
     VrfLiteResourceError,
@@ -136,6 +137,7 @@ class ManageVrfLiteOrchestrator(NDBaseOrchestrator):
         module.params["_changed_vrfs"] = []
         module.params["_vrf_lite_requested_state"] = state
         module.params["_not_in_sync_vrfs"] = []
+        module.params["_pending_deploy_targets"] = []
         module.params["_ip_to_sn_mapping"] = {}
         module.params["_sn_to_ip_mapping"] = {}
         module.params["_vrf_lite_vrf_vlan_map"] = {}
@@ -508,22 +510,26 @@ class ManageVrfLiteOrchestrator(NDBaseOrchestrator):
             }
 
         deploy_enabled_config_pairs, explicitly_disabled_pairs, explicitly_disabled_vrfs = _deployment_intent(module)
-        changed_vrfs = set(module.params.get("_changed_vrfs") or [])
+        pending_targets = _scoped_pending_deploy_targets(module) if deploy_enabled else []
+        changed_vrfs = set(module.params.get("_changed_vrfs") or []) | {target["vrf_name"] for target in pending_targets}
 
         # Build deployment scope from the state-machine operation journal rather than
         # the retained desired config. The journal preserves before-state identities
         # for detaches, including remove-all, and marks each pair as a write or delete.
         # Explicit VRF/attachment deploy:false intent still suppresses matching work.
         deploy_targets = module.params.get("_deploy_targets") or []
-        journal = {
-            (
-                str(target.get("vrf_name")),
-                _resolve_serial(module, target.get("switch_ip")),
-                target.get("operation"),
-            )
-            for target in deploy_targets
-            if isinstance(target, dict) and target.get("vrf_name") and target.get("switch_ip")
+        # Start with targets rediscovered from the controller, then let this
+        # run's journal replace them. For example, an overridden run can turn a
+        # previously pending write into a delete before the final deployment.
+        journal_by_pair: dict[tuple[str, str], str] = {
+            (target["vrf_name"], target["switch_ip"]): target["operation"] for target in pending_targets
         }
+        for target in deploy_targets:
+            if not isinstance(target, dict) or not target.get("vrf_name") or not target.get("switch_ip"):
+                continue
+            pair = (str(target.get("vrf_name")), _resolve_serial(module, target.get("switch_ip")))
+            journal_by_pair[pair] = str(target.get("operation"))
+        journal = {(vrf_name, switch_id, operation) for (vrf_name, switch_id), operation in journal_by_pair.items()}
         removed_pairs = {(vrf_name, switch_id) for vrf_name, switch_id, operation in journal if operation == "delete"}
         write_pairs = {(vrf_name, switch_id) for vrf_name, switch_id, operation in journal if operation == "write"}
         eligible_operation_pairs = {
@@ -578,7 +584,7 @@ class ManageVrfLiteOrchestrator(NDBaseOrchestrator):
             }
 
         responses = []
-        changed = bool(module.params.get("_changed_vrfs"))
+        changed = bool(module.params.get("_changed_vrfs")) or bool(deploy_payloads)
 
         if save_enabled:
             # config save is a fabric-wide trigger with no request body; the deploy scope

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -2,7 +2,7 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, annotations, division, print_function
+from __future__ import annotations
 
 import logging
 from copy import deepcopy
@@ -41,25 +41,93 @@ def sanitize_dict(dict_to_sanitize, keys=None, values=None, recursive=True, remo
     return result
 
 
-def issubset(subset: Any, superset: Any) -> bool:
-    """Check if subset is contained in superset."""
+def _has_perfect_matching(adjacency: list[list[int]]) -> bool:
+    """Return True if every subset item can be matched to a distinct candidate.
+
+    ``adjacency[i]`` holds the indices of the candidates that subset item ``i``
+    can match. This solves the maximum bipartite matching problem with Kuhn's
+    augmenting-path algorithm so that a less-specific item never greedily
+    consumes a candidate that a more-specific item needs.
+    """
+    # candidate index -> subset item index it is currently assigned to
+    match_to_item: dict[int, int] = {}
+
+    def _try_assign(item_index: int, visited: set[int]) -> bool:
+        for candidate_index in adjacency[item_index]:
+            if candidate_index in visited:
+                continue
+            visited.add(candidate_index)
+            assigned_item = match_to_item.get(candidate_index)
+            # Candidate is free, or its current owner can be reassigned elsewhere.
+            if assigned_item is None or _try_assign(assigned_item, visited):
+                match_to_item[candidate_index] = item_index
+                return True
+        return False
+
+    for item_index in range(len(adjacency)):
+        if not _try_assign(item_index, set()):
+            return False
+    return True
+
+
+def issubset(subset: Any, superset: Any, allow_superset: bool = False) -> bool:
+    """Check if subset is contained in superset.
+
+    For dicts, only the non-``None`` keys of ``subset`` are compared; keys whose
+    value is ``None`` are ignored, and keys present only in ``superset`` are
+    allowed. For lists, every ``subset`` element must pair with a distinct
+    ``superset`` element (matching is order-independent). By default the two
+    lists must be the same length; when ``allow_superset`` is True the
+    ``subset`` list may be shorter so that extra existing elements are
+    tolerated (``len(subset) <= len(superset)``).
+
+    Args:
+        subset: The value to check.
+        superset: The value to check against.
+        allow_superset: When True, list matching is one-directional: an element
+            in ``subset`` is considered matched when it is a subset of a
+            candidate in ``superset``, even if the candidate has additional
+            keys, and ``superset`` may contain extra elements that ``subset``
+            does not (``len(subset) <= len(superset)``). When False (default)
+            matching is bidirectional and the lengths must be equal. For lists
+            of dicts the default is equivalent to equality *after* ``None``
+            -valued keys are dropped from both sides (it is not strict ``==``
+            equality, because such keys are ignored).
+    """
     if type(subset) is not type(superset):
         return False
 
     if not isinstance(subset, dict):
         if isinstance(subset, list):
-            if len(subset) != len(superset):
+            # Under allow_superset the proposed list only needs to map into the
+            # existing one, so extra existing elements are tolerated
+            # (len(subset) <= len(superset)). Otherwise matching is
+            # bidirectional and the lengths must be identical.
+            if allow_superset:
+                if len(subset) > len(superset):
+                    return False
+            elif len(subset) != len(superset):
                 return False
 
-            remaining = list(superset)
+            # Build the bipartite adjacency: for each subset item, which
+            # candidates it can match. A full matching is then required so a
+            # less-specific item cannot greedily consume a candidate that a
+            # more-specific item needs (relevant under allow_superset=True).
+            adjacency: list[list[int]] = []
             for item in subset:
-                for index, candidate in enumerate(remaining):
-                    if issubset(item, candidate) and issubset(candidate, item):
-                        del remaining[index]
-                        break
-                else:
+                matches = []
+                for index, candidate in enumerate(superset):
+                    if allow_superset:
+                        match = issubset(item, candidate, allow_superset=True)
+                    else:
+                        match = issubset(item, candidate) and issubset(candidate, item)
+                    if match:
+                        matches.append(index)
+                if not matches:
                     return False
-            return True
+                adjacency.append(matches)
+
+            return _has_perfect_matching(adjacency)
         return subset == superset
 
     for key, value in subset.items():
@@ -69,7 +137,7 @@ def issubset(subset: Any, superset: Any) -> bool:
         if key not in superset:
             return False
 
-        if not issubset(value, superset[key]):
+        if not issubset(value, superset[key], allow_superset=allow_superset):
             return False
 
     return True

--- a/plugins/modules/nd_manage_vrf_lite.py
+++ b/plugins/modules/nd_manage_vrf_lite.py
@@ -1,0 +1,557 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_manage_vrf_lite
+version_added: "2.0.0"
+short_description: Manage VRF Lite attachments on Cisco Nexus Dashboard
+
+description:
+- Manage VRF Lite attachment configuration in ND fabrics.
+- Supports C(gathered), C(merged), C(replaced), C(overridden), and C(deleted) states.
+- Supports optional save/deploy controls through C(config_actions).
+
+author:
+- Sivakami Sivaraman (@sivakasi)
+
+options:
+  state:
+    description:
+    - Desired state of the VRF Lite configuration.
+    type: str
+    default: merged
+    choices: [ merged, replaced, deleted, overridden, gathered ]
+
+  fabric_name:
+    description:
+    - Target fabric name.
+    type: str
+    required: true
+
+  config_actions:
+    description:
+    - Optional save/deploy actions applied after state reconciliation.
+    type: dict
+    suboptions:
+      save:
+        description:
+        - Trigger a fabric config save after state reconciliation.
+        - Controls only whether the config-save API is called.
+        type: bool
+        default: true
+      deploy:
+        description:
+        - Trigger a VRF deploy after the config save. Requires C(save=true).
+        type: bool
+        default: true
+      type:
+        description:
+        - Scope of the VRF deploy operation.
+        - C(switch) deploys only the switches affected by the changed VRFs.
+        - C(global) performs a fabric-wide deploy of the changed VRFs.
+        - A global deploy cannot exclude an individual switch. If any changed
+          attachment for a VRF is deploy-enabled, the whole VRF is deployed;
+          use C(switch) to honor per-attachment C(deploy=false) exclusions.
+        type: str
+        default: switch
+        choices: [ switch, global ]
+
+  verify:
+    description:
+    - Verification controls used by runtime query/deploy helpers.
+    - When O(verify.enabled=true) the module performs a single post-deploy state
+      refresh of the affected VRF Lite attachments. Retry-based polling until the
+      controller reports a converged state is not yet implemented; O(verify.retries)
+      is accepted for forward compatibility but does not currently re-poll for
+      convergence.
+    type: dict
+    suboptions:
+      enabled:
+        description:
+        - Perform a single post-deploy state refresh of the affected VRF Lite attachments.
+        type: bool
+        default: true
+      retries:
+        description:
+        - Reserved for future post-deploy convergence polling.
+        - Currently accepted but does not yet retry until controller state converges.
+        type: int
+        default: 5
+      timeout:
+        description:
+        - Total per-request timeout budget used by verification queries.
+        type: int
+        default: 10
+
+  config:
+    description:
+    - List of VRF Lite entries.
+    - Required and must not be null for C(merged), C(replaced), and C(overridden).
+    - Use C(config=[]) only to request an intentional empty desired set. With
+      C(replaced) or C(overridden), it removes all managed VRF Lite attachments
+      in the fabric. To remove every attachment for only one VRF with
+      C(replaced), list that VRF with C(attach=[]).
+    type: list
+    elements: dict
+    suboptions:
+      vrf_name:
+        description:
+        - VRF name.
+        type: str
+        required: true
+      vlan_id:
+        description:
+        - VRF VLAN id.
+        type: int
+      deploy:
+        description:
+        - Per-VRF deploy intent used by deploy planning.
+        type: bool
+      attach:
+        description:
+        - Per-switch attachment list.
+        type: list
+        elements: dict
+        suboptions:
+          ip_address:
+            description:
+            - Switch management IP or serial number.
+            type: str
+            required: true
+          deploy:
+            description:
+            - Per-attachment deploy intent used by deploy planning.
+            - Per-switch exclusion applies when O(config_actions.type=switch).
+              A global deployment targets the whole changed VRF when at least
+              one of its changed attachments is deploy-enabled.
+            type: bool
+          import_evpn_rt:
+            description:
+            - EVPN route-target to import, in ASN:NN format.
+            type: str
+          export_evpn_rt:
+            description:
+            - EVPN route-target to export, in ASN:NN format.
+            type: str
+          vrf_lite:
+            description:
+            - VRF Lite extension entries for the attachment.
+            type: list
+            elements: dict
+            suboptions:
+              interface:
+                description:
+                - Layer-3 interface used for the VRF Lite extension (e.g. C(Ethernet1/20)).
+                type: str
+                required: true
+              dot1q:
+                description:
+                - 802.1Q VLAN tag for the sub-interface.
+                type: int
+              ipv4_addr:
+                description:
+                - IPv4 address with prefix length for the extension interface (e.g. C(10.0.0.1/30)).
+                type: str
+              neighbor_ipv4:
+                description:
+                - Peer IPv4 address for the VRF Lite BGP or static-route neighbour.
+                type: str
+              ipv6_addr:
+                description:
+                - IPv6 address with prefix length for the extension interface.
+                type: str
+              neighbor_ipv6:
+                description:
+                - Peer IPv6 address for the VRF Lite BGP or static-route neighbour.
+                type: str
+              peer_vrf:
+                description:
+                - Name of the peer VRF for the VRF Lite extension.
+                type: str
+
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+"""
+
+EXAMPLES = r"""
+- name: Gather VRF Lite state
+  cisco.nd.nd_manage_vrf_lite:
+    fabric_name: my_fabric
+    state: gathered
+
+- name: Merge VRF Lite attachment and stage only (save without deploy)
+  cisco.nd.nd_manage_vrf_lite:
+    fabric_name: my_fabric
+    state: merged
+    # Save the staged intent on the controller but do not push it to the
+    # switches yet. A later run (or another tool) can deploy it.
+    config_actions:
+      save: true
+      deploy: false
+    config:
+      - vrf_name: TENANT_A
+        vlan_id: 500
+        attach:
+          - ip_address: 10.10.10.11
+            import_evpn_rt: ""
+            export_evpn_rt: ""
+            vrf_lite:
+              - interface: Ethernet1/20
+                dot1q: 500
+                ipv4_addr: 10.33.0.2/24
+                neighbor_ipv4: 10.33.0.1
+                peer_vrf: TENANT_A
+
+- name: Replace VRF Lite attachments for the listed VRFs and deploy affected switches
+  cisco.nd.nd_manage_vrf_lite:
+    fabric_name: my_fabric
+    state: replaced
+    # 'replaced' rewrites the attachment set for the VRFs you list; VRFs that
+    # are not listed are left untouched. type=switch deploys only the switches
+    # affected by the changed VRFs.
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config:
+      - vrf_name: TENANT_A
+        vlan_id: 500
+        attach:
+          - ip_address: 10.10.10.11
+            vrf_lite:
+              - interface: Ethernet1/20
+                dot1q: 500
+                ipv4_addr: 10.33.0.2/24
+                neighbor_ipv4: 10.33.0.1
+                peer_vrf: TENANT_A
+
+- name: Override fabric VRF Lite to match config exactly and deploy fabric-wide
+  cisco.nd.nd_manage_vrf_lite:
+    fabric_name: my_fabric
+    state: overridden
+    # 'overridden' makes the fabric match this config exactly; any VRF Lite
+    # attachment not listed below is removed. type=global performs a
+    # fabric-wide deploy of the changed VRFs.
+    config_actions:
+      save: true
+      deploy: true
+      type: global
+    config:
+      - vrf_name: TENANT_A
+        vlan_id: 500
+        attach:
+          - ip_address: 10.10.10.11
+            vrf_lite:
+              - interface: Ethernet1/20
+                dot1q: 500
+                ipv4_addr: 10.33.0.2/24
+                neighbor_ipv4: 10.33.0.1
+                peer_vrf: TENANT_A
+
+- name: Delete all attachments for a VRF
+  cisco.nd.nd_manage_vrf_lite:
+    fabric_name: my_fabric
+    state: deleted
+    config:
+      - vrf_name: TENANT_A
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the VRF Lite configuration.
+  type: bool
+  returned: always
+output_level:
+  description: The output verbosity level in effect for the run, echoing O(output_level).
+  type: str
+  returned: always
+before:
+  description: VRF Lite configuration present on ND before the operation.
+  type: list
+  elements: dict
+  returned: always
+after:
+  description:
+  - VRF Lite configuration returned after the operation.
+  - For write states in check mode, this is the projected state and is not written to ND.
+  - For gathered state, this is the same read-only state exposed through C(gathered).
+  type: list
+  elements: dict
+  returned: always
+current:
+  description: Alias for C(after).
+  type: list
+  elements: dict
+  returned: always
+diff:
+  description:
+  - Configuration-difference collection exposed for output compatibility.
+  - The current VRF Lite workflow returns an empty list.
+  type: list
+  elements: dict
+  returned: always
+proposed:
+  description: VRF Lite configuration proposed before reconciliation with existing state.
+  type: list
+  elements: dict
+  returned: when O(output_level) is V(info) or V(debug) for a write-state operation
+logs:
+  description:
+  - Internal diagnostic-message collection exposed for debug-output compatibility.
+  - The current VRF Lite workflow returns an empty list.
+  type: list
+  elements: str
+  returned: when O(output_level) is V(debug) for a write-state operation
+gathered:
+  description: VRF Lite configuration returned by a read-only gathered operation.
+  type: list
+  elements: dict
+  returned: when O(state) is V(gathered)
+warnings:
+  description: Runtime warnings collected by validation and deployment helpers.
+  type: list
+  elements: str
+  returned: when warnings are present
+deployment:
+  description: Detailed save and deploy action output.
+  type: dict
+  returned: when O(config_actions.save) is V(true) for a successful write-state operation
+  contains:
+    msg:
+      description: Human-readable summary of the deployment decision or completed actions.
+      type: str
+      returned: always
+    deployment_needed:
+      description: Whether save or deploy actions are needed.
+      type: bool
+      returned: always
+    changed:
+      description: Whether the deployment phase changed, or in check mode would change, controller state.
+      type: bool
+      returned: always
+    config_actions:
+      description: Effective save and deploy controls used by the operation.
+      type: dict
+      returned: always
+      contains:
+        save:
+          description: Whether the fabric configuration-save action is enabled.
+          type: bool
+          returned: always
+        deploy:
+          description: Whether deployment of affected VRFs is enabled after configuration save.
+          type: bool
+          returned: always
+        type:
+          description: Deployment scope, either C(switch) or C(global).
+          type: str
+          returned: always
+    target_vrfs:
+      description:
+      - Changed VRFs eligible for VRF deployment.
+      - This can be empty when only the fabric-wide configuration-save action is planned.
+      type: list
+      elements: str
+      returned: when configuration save or deployment actions are needed
+    planned_actions:
+      description: REST actions planned or executed by the deployment phase.
+      type: list
+      elements: str
+      returned: when configuration save or deployment actions are needed
+    response:
+      description: Per-action controller responses collected by the deployment phase.
+      type: list
+      elements: dict
+      returned: always
+deployment_needed:
+  description: Whether the reconciled VRF Lite changes require configuration save or deployment actions.
+  type: bool
+  returned: when O(config_actions.save) is V(true) for a successful write-state operation
+ip_to_sn_mapping:
+  description: Mapping of fabric switch management IP addresses to controller serial numbers.
+  type: dict
+  returned: when the fabric switch query returns a non-empty mapping
+response:
+  description:
+  - Controller-response collection reserved for gathered-output compatibility.
+  - The current gathered workflow returns an empty list.
+  type: list
+  elements: dict
+  returned: when O(state) is V(gathered)
+result:
+  description:
+  - Normalized-result collection reserved for gathered-output compatibility.
+  - The current gathered workflow returns an empty list.
+  type: list
+  elements: dict
+  returned: when O(state) is V(gathered)
+"""
+
+import json
+import logging
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    ValidationError,
+    require_pydantic,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_vrf_lite.vrf_lite_model import (
+    VrfLiteModel,
+    VrfLitePlaybookConfigModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.exceptions import (
+    VrfLiteResourceError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.deploy import (
+    _changed_entries_from_preview,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite import (
+    ManageVrfLiteOrchestrator,
+)
+
+
+def _validate_config_presence(state: str, config: object) -> None:
+    """Reject omitted/null write config before runtime normalization."""
+    if state in {"merged", "replaced", "overridden"} and config is None:
+        raise VrfLiteResourceError(
+            msg="config must be provided and cannot be null for state '{0}'. "
+            "Use config: [] only when intentionally managing an explicit empty set.".format(state)
+        )
+
+
+def main() -> None:
+    """Entry point for nd_manage_vrf_lite.
+
+    Follows the 'declare, don't implement' pattern:
+    - Validate input
+    - Delegate state reconciliation to NDStateMachine + orchestrator
+    - Delegate deploy/gather to orchestrator methods
+    """
+    argument_spec = nd_argument_spec()
+    argument_spec.update(VrfLiteModel.get_argument_spec())
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    require_pydantic(module)
+
+    setup_logging(module)
+    log = logging.getLogger("nd.nd_manage_vrf_lite")
+
+    try:
+        module_config = VrfLitePlaybookConfigModel.model_validate(module.params, by_alias=True, by_name=True)
+    except ValidationError as error:
+        validation_errors = []
+        detail_msg = str(error)
+        try:
+            validation_errors = json.loads(error.json())
+            if validation_errors and isinstance(validation_errors[0], dict):
+                detail_msg = validation_errors[0].get("msg", detail_msg)
+        except Exception:
+            validation_errors = [{"msg": str(error)}]
+
+        module.fail_json(
+            msg="Invalid nd_manage_vrf_lite playbook configuration: {0}".format(detail_msg),
+            validation_errors=validation_errors,
+        )
+
+    state = module_config.state
+    log.info("nd_manage_vrf_lite invoked: state=%s, fabric=%s, check_mode=%s", state, module_config.fabric_name, module.check_mode)
+
+    try:
+        # Validate the original playbook value before prepare_module_params()
+        # normalizes omitted/null config to an empty runtime list. This keeps an
+        # accidental missing write configuration distinct from an intentional
+        # ``config: []`` request.
+        _validate_config_presence(state, module_config.config)
+        ManageVrfLiteOrchestrator.prepare_module_params(module, module_config)
+
+        if state == "gathered":
+            log.debug("Dispatching read-only gathered workflow for fabric %s", module_config.fabric_name)
+            nd_state_machine = NDStateMachine(module=module, model_orchestrator=ManageVrfLiteOrchestrator)
+            result = nd_state_machine.model_orchestrator.gather()
+            module.exit_json(**result)
+
+        module.params["state"] = "overridden" if state == "replaced" else state
+        nd_state_machine = NDStateMachine(module=module, model_orchestrator=ManageVrfLiteOrchestrator)
+        # Preflight the proposed attachments before reconciliation. In check mode the
+        # state machine skips all write methods (and their inline guardrails), so this
+        # runs the same read-only VRF-existence/switch-support validation to avoid a
+        # false-green plan that a real run would reject. Scope it to the entries a real
+        # run would actually create or update (skipping idempotent no-op rows) so check
+        # mode validates exactly the same set as the execution path (PR #281 review).
+        nd_state_machine.model_orchestrator.preflight_validate_check_mode(nd_state_machine.pending_create_update_items())
+        nd_state_machine.manage_state()
+        module.params["state"] = state
+
+        change_entries = list(nd_state_machine.sent)
+        if module.check_mode and not change_entries:
+            # sent is intentionally empty in check mode; recover the change set from
+            # the before/after preview so the plan reports the VRFs a real run would
+            # deploy while save and deploy stay suppressed.
+            change_entries = _changed_entries_from_preview(nd_state_machine.before, nd_state_machine.existing)
+        module.params["_changed_vrfs"] = sorted({item.vrf_name for item in change_entries})
+        # Operation journal: every (vrf, switch) pair attached OR detached this run.
+        # Deletes are included (track_deletes_in_sent=True), so the deploy scope can
+        # cover switches whose attachment was removed by replaced/overridden/deleted
+        # and are therefore absent from the retained desired config.
+        after_identifiers = set(nd_state_machine.existing.keys())
+        module.params["_deploy_targets"] = [
+            {
+                "vrf_name": item.vrf_name,
+                "switch_ip": getattr(item, "switch_ip", None),
+                "operation": "write" if item.get_identifier_value() in after_identifiers else "delete",
+            }
+            for item in change_entries
+            if getattr(item, "vrf_name", None) and getattr(item, "switch_ip", None)
+        ]
+        log.info("state=%s: reconciliation complete, changed_vrfs=%s", state, module.params["_changed_vrfs"])
+
+        result = nd_state_machine.output.format()
+        result.setdefault("current", result.get("after", []))
+        result = nd_state_machine.model_orchestrator.format_public_output(result)
+
+        deploy_result = nd_state_machine.model_orchestrator.deploy_pending(result)
+        if deploy_result:
+            log.info(
+                "state=%s: config actions executed, deployment_needed=%s, changed=%s",
+                state,
+                deploy_result.get("deployment_needed", False),
+                deploy_result.get("changed", False),
+            )
+            result["deployment"] = deploy_result
+            result["deployment_needed"] = deploy_result.get("deployment_needed", False)
+            if deploy_result.get("changed"):
+                result["changed"] = True
+
+        result = nd_state_machine.model_orchestrator.refresh_verified_state(result)
+        result = nd_state_machine.model_orchestrator.inject_runtime_metadata(result)
+        module.exit_json(**result)
+
+    except VrfLiteResourceError as error:
+        module.params["state"] = state
+        log.error("nd_manage_vrf_lite failed (state=%s): %s", state, error.msg)
+        module.fail_json(msg=error.msg, **error.details)
+    except Exception as error:
+        module.params["state"] = state
+        log.exception("nd_manage_vrf_lite unexpected error (state=%s)", state)
+        module.fail_json(msg=str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_delete_setup_conf.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_delete_setup_conf.yaml
@@ -1,0 +1,17 @@
+---
+# This nd_manage_vrf_lite test data structure is auto-generated
+# DO NOT EDIT MANUALLY
+#
+# Template: nd_manage_vrf_lite_conf.j2
+# Variables: vrf_lite_conf (list of dicts)
+
+- attach:
+  - ip_address: 10.122.84.55
+    vrf_lite:
+    - dot1q: '2001'
+      interface: Ethernet1/20
+      ipv4_addr: 10.33.0.2/24
+      neighbor_ipv4: 10.33.0.1
+      peer_vrf: VRF_LITE_IT_50001
+  vlan_id: '2001'
+  vrf_name: VRF_LITE_IT_50001

--- a/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_merge_full_conf.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_merge_full_conf.yaml
@@ -1,0 +1,19 @@
+---
+# This nd_manage_vrf_lite test data structure is auto-generated
+# DO NOT EDIT MANUALLY
+#
+# Template: nd_manage_vrf_lite_conf.j2
+# Variables: vrf_lite_conf (list of dicts)
+
+- attach:
+  - export_evpn_rt: ''
+    import_evpn_rt: ''
+    ip_address: 10.122.84.55
+    vrf_lite:
+    - dot1q: '2001'
+      interface: Ethernet1/20
+      ipv4_addr: 10.33.0.2/24
+      neighbor_ipv4: 10.33.0.1
+      peer_vrf: VRF_LITE_IT_50001
+  vlan_id: '2001'
+  vrf_name: VRF_LITE_IT_50001

--- a/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_merge_minimal_conf.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_merge_minimal_conf.yaml
@@ -1,0 +1,10 @@
+---
+# This nd_manage_vrf_lite test data structure is auto-generated
+# DO NOT EDIT MANUALLY
+#
+# Template: nd_manage_vrf_lite_conf.j2
+# Variables: vrf_lite_conf (list of dicts)
+
+- attach:
+  - ip_address: 10.122.84.55
+  vrf_name: VRF_LITE_IT_50001

--- a/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_merge_modified_conf.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_merge_modified_conf.yaml
@@ -1,0 +1,19 @@
+---
+# This nd_manage_vrf_lite test data structure is auto-generated
+# DO NOT EDIT MANUALLY
+#
+# Template: nd_manage_vrf_lite_conf.j2
+# Variables: vrf_lite_conf (list of dicts)
+
+- attach:
+  - export_evpn_rt: ''
+    import_evpn_rt: ''
+    ip_address: 10.122.84.55
+    vrf_lite:
+    - dot1q: '2001'
+      interface: Ethernet1/20
+      ipv4_addr: 10.33.0.10/24
+      neighbor_ipv4: 10.33.0.9
+      peer_vrf: VRF_LITE_IT_50001
+  vlan_id: '2001'
+  vrf_name: VRF_LITE_IT_50001

--- a/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_merge_no_deploy_conf.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/files/nd_manage_vrf_lite_merge_no_deploy_conf.yaml
@@ -1,0 +1,17 @@
+---
+# This nd_manage_vrf_lite test data structure is auto-generated
+# DO NOT EDIT MANUALLY
+#
+# Template: nd_manage_vrf_lite_conf.j2
+# Variables: vrf_lite_conf (list of dicts)
+
+- attach:
+  - ip_address: 10.122.84.55
+    vrf_lite:
+    - dot1q: '2001'
+      interface: Ethernet1/20
+      ipv4_addr: 10.33.0.2/24
+      neighbor_ipv4: 10.33.0.1
+      peer_vrf: VRF_LITE_IT_50001
+  vlan_id: '2001'
+  vrf_name: VRF_LITE_IT_50001

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/assert_vrf_lite_attachment.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/assert_vrf_lite_attachment.yaml
@@ -1,0 +1,54 @@
+---
+- name: ASSERT - Reset VRF Lite assertion selections
+  ansible.builtin.set_fact:
+    vrf_lite_assert_entries: []
+    vrf_lite_assert_attach_entries: []
+    vrf_lite_assert_lite_entries: []
+
+- name: ASSERT - Select gathered VRF Lite entry
+  ansible.builtin.set_fact:
+    vrf_lite_assert_entries: >-
+      {{
+        (vrf_lite_assert_result.gathered | default([]))
+        | selectattr('vrf_name', 'equalto', vrf_lite_assert_vrf_name)
+        | list
+      }}
+
+- name: ASSERT - Select gathered VRF Lite attachment
+  ansible.builtin.set_fact:
+    vrf_lite_assert_attach_entries: >-
+      {{
+        (vrf_lite_assert_entries[0].attach | default([]))
+        | selectattr('ip_address', 'equalto', vrf_lite_assert_switch)
+        | list
+      }}
+  when: vrf_lite_assert_entries | length == 1
+
+- name: ASSERT - Select gathered VRF Lite interface
+  ansible.builtin.set_fact:
+    vrf_lite_assert_lite_entries: >-
+      {{
+        (vrf_lite_assert_attach_entries[0].vrf_lite | default([]))
+        | selectattr('interface', 'equalto', vrf_lite_assert_interface)
+        | selectattr('dot1q', 'equalto', vrf_lite_assert_dot1q | int)
+        | list
+      }}
+  when:
+    - vrf_lite_assert_entries | length == 1
+    - vrf_lite_assert_attach_entries | length == 1
+
+- name: ASSERT - Verify gathered VRF Lite attachment content
+  ansible.builtin.assert:
+    that:
+      - vrf_lite_assert_result.failed == false
+      - vrf_lite_assert_result.gathered is defined
+      - vrf_lite_assert_entries | length == 1
+      - (vrf_lite_assert_entries[0].vlan_id | int) == (vrf_lite_assert_vlan_id | int)
+      - (vrf_lite_assert_entries[0].attach | default([]) | length) == (vrf_lite_assert_attach_count | default(1) | int)
+      - vrf_lite_assert_attach_entries | length == 1
+      - (vrf_lite_assert_attach_entries[0].vrf_lite | default([]) | length) == (vrf_lite_assert_connection_count | default(1) | int)
+      - vrf_lite_assert_lite_entries | length == 1
+      - (vrf_lite_assert_lite_entries[0].dot1q | int) == (vrf_lite_assert_dot1q | int)
+      - vrf_lite_assert_lite_entries[0].ipv4_addr == vrf_lite_assert_ipv4_addr
+      - vrf_lite_assert_lite_entries[0].neighbor_ipv4 == vrf_lite_assert_neighbor_ipv4
+      - vrf_lite_assert_lite_entries[0].peer_vrf == vrf_lite_assert_peer_vrf

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/base_tasks.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/base_tasks.yaml
@@ -1,0 +1,118 @@
+---
+# Shared base tasks for nd_manage_vrf_lite integration tests.
+# Import this at the top of each test file:
+#   - import_tasks: base_tasks.yaml
+#     tags: <test_tag>
+
+- name: BASE - Test Entry Point - [nd_manage_vrf_lite]
+  ansible.builtin.debug:
+    msg:
+      - "----------------------------------------------------------------"
+      - "+    nd_manage_vrf_lite Integration Test Base Setup            +"
+      - "----------------------------------------------------------------"
+
+- name: BASE - Set nd_info defaults
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+# --------------------------------
+# Create Dictionary of Test Data
+# --------------------------------
+- name: BASE - Setup Internal TestCase Variables
+  ansible.builtin.set_fact:
+    test_fabric: "{{ fabric_name }}"
+    test_switch1: "{{ switch1_ip | default(switch_id | default(switch1_serial)) }}"
+    test_switch1_serial: "{{ switch1_serial | default(switch1_ip | default(switch_id)) }}"
+    test_switch2: "{{ switch2_ip | default(switch2_serial | default('')) }}"
+    test_switch2_serial: "{{ switch2_serial | default(switch2_ip | default('')) }}"
+    test_vrf: "{{ vrf_name | default('TENANT_A') }}"
+    test_vlan_id: "{{ vrf_vlan_id | default(500) }}"
+    test_interface: "{{ vrf_lite_interface | default('Ethernet1/20') }}"
+    test_dot1q: "{{ vrf_lite_dot1q | default(500) }}"
+    test_ipv4_addr: "{{ vrf_lite_ipv4_addr | default('10.33.0.2/24') }}"
+    test_neighbor_ipv4: "{{ vrf_lite_neighbor_ipv4 | default('10.33.0.1') }}"
+    test_interface2: "{{ vrf_lite_interface2 | default('Ethernet1/21') }}"
+    test_dot1q2: "{{ vrf_lite_dot1q2 | default((vrf_lite_dot1q | default(500) | int) + 1) }}"
+    test_ipv4_addr2: "{{ vrf_lite_ipv4_addr2 | default('10.33.1.2/24') }}"
+    test_neighbor_ipv4_2: "{{ vrf_lite_neighbor_ipv4_2 | default('10.33.1.1') }}"
+    test_peer_vrf: "{{ vrf_lite_peer_vrf | default(vrf_name | default('TENANT_A')) }}"
+    deploy_local: true
+  delegate_to: localhost
+
+- name: BASE - Setup extended VRF Lite attachment payload for coverage
+  ansible.builtin.set_fact:
+    vrf_lite_attach_extended:
+      - ip_address: "{{ test_switch1 }}"
+        import_evpn_rt: ""
+        export_evpn_rt: ""
+        vrf_lite:
+          - interface: "{{ vrf_lite_interface | default('Ethernet1/20') }}"
+            dot1q: "{{ vrf_lite_dot1q | default(500) }}"
+            ipv4_addr: "{{ vrf_lite_ipv4_addr | default('10.33.0.2/24') }}"
+            neighbor_ipv4: "{{ vrf_lite_neighbor_ipv4 | default('10.33.0.1') }}"
+            ipv6_addr: ""
+            neighbor_ipv6: ""
+            peer_vrf: "{{ vrf_lite_peer_vrf | default('TENANT_A') }}"
+  delegate_to: localhost
+
+# ------------------------------------------
+# Query Fabric Reachability
+# ------------------------------------------
+- name: BASE - Verify fabric is reachable via VRF Lite gather API
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    verify:
+      timeout: 60
+      retries: 3
+  register: fabric_query
+  failed_when: false
+
+- name: BASE - Assert fabric exists
+  ansible.builtin.assert:
+    that:
+      - fabric_query.failed == false
+    fail_msg: "Fabric '{{ test_fabric }}' not found or VRF Lite API unreachable."
+
+- name: BASE - Reset HTTPAPI socket before cleanup
+  ansible.builtin.meta: reset_connection
+
+# ------------------------------------------
+# Clean up existing VRF Lite attachments
+# ------------------------------------------
+- name: BASE - Clean up existing VRF Lite attachments for test VRF
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+
+- name: BASE - Clean up existing secondary VRF Lite attachment for test VRF
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch2 }}"
+  failed_when: false
+  when: test_switch2 | length > 0

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/conf_prep_tasks.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/conf_prep_tasks.yaml
@@ -1,0 +1,21 @@
+---
+# Shared configuration preparation tasks for nd_manage_vrf_lite integration tests.
+#
+# Usage:
+#   - name: Import Configuration Prepare Tasks
+#     vars:
+#       file: merge  # output variable identifier
+#     import_tasks: conf_prep_tasks.yaml
+#
+# Requires: vrf_lite_conf variable to be set before importing.
+
+- name: Render Configuration Data into Variable
+  ansible.builtin.set_fact:
+    "{{ 'nd_manage_vrf_lite_' + file + '_conf' }}": >-
+      {{
+        lookup(
+          'ansible.builtin.template',
+          (nd_vrf_lite_root | default(playbook_dir | dirname)) + '/templates/nd_manage_vrf_lite_conf.j2'
+        ) | from_yaml
+      }}
+  delegate_to: localhost

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/main.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/main.yaml
@@ -1,0 +1,60 @@
+---
+# Test discovery and execution for nd_manage_vrf_lite integration tests.
+#
+# Usage:
+#   ansible-playbook -i hosts.yaml tasks/main.yaml                 # run all tests
+#   ansible-playbook -i hosts.yaml tasks/main.yaml -e testcase=nd_manage_vrf_lite_merge  # run one
+#   ansible-playbook -i hosts.yaml tasks/main.yaml --tags merge    # run by tag
+
+- name: nd_manage_vrf_lite integration tests
+  hosts: nd
+  gather_facts: false
+  vars:
+    nd_vrf_lite_root: "{{ playbook_dir | dirname }}"
+    nd_vrf_lite_tasks_dir: "{{ playbook_dir }}"
+  tasks:
+    - name: Test that we have a Nexus Dashboard host, username and password
+      tags: always
+      ansible.builtin.assert:
+        that:
+          - ansible_host is defined
+          - ansible_user is defined
+          - ansible_password is defined
+        fail_msg: "Please define the following variables: ansible_host, ansible_user and ansible_password."
+
+    - name: Discover nd_manage_vrf_lite test cases
+      tags: always
+      ansible.builtin.find:
+        paths: "{{ nd_vrf_lite_tasks_dir }}"
+        patterns: "{{ testcase | default('nd_manage_vrf_lite_*') }}.yaml"
+        file_type: file
+      delegate_to: localhost
+      run_once: true
+      connection: local
+      register: nd_vrf_lite_testcases
+
+    - name: Build list of test items
+      tags: always
+      ansible.builtin.set_fact:
+        test_items: "{{ nd_vrf_lite_testcases.files | map(attribute='path') | sort | list }}"
+
+    - name: Assert nd_manage_vrf_lite test discovery has matches
+      tags: always
+      ansible.builtin.assert:
+        that:
+          - test_items | length > 0
+        fail_msg: >-
+          No nd_manage_vrf_lite test cases matched pattern
+          '{{ testcase | default("nd_manage_vrf_lite_*") }}.yaml' under '{{ nd_vrf_lite_tasks_dir }}'.
+
+    - name: Display discovered tests
+      tags: always
+      ansible.builtin.debug:
+        msg: "Discovered {{ test_items | length }} test file(s): {{ test_items | map('basename') | list }}"
+
+    - name: Run nd_manage_vrf_lite test cases
+      tags: always
+      ansible.builtin.include_tasks: "{{ test_case_to_run }}"
+      loop: "{{ test_items }}"
+      loop_control:
+        loop_var: test_case_to_run

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_bulk.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_bulk.yaml
@@ -1,0 +1,269 @@
+##############################################
+##                 SETUP                    ##
+##############################################
+
+- name: Import nd_manage_vrf_lite Base Tasks
+  ansible.builtin.import_tasks: base_tasks.yaml
+  tags: bulk
+
+- name: BULK - Set nd_info defaults
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+      timeout: "{{ nd_vrf_lite_module_timeout | default(600) }}"
+  tags: bulk
+
+##############################################
+##       Setup Bulk TestCase Variables      ##
+##############################################
+
+- name: BULK - Setup multi-link VRF Lite config
+  ansible.builtin.set_fact:
+    bulk_vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q2 | int }}"
+                ipv4_addr: "{{ test_ipv4_addr2 }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4_2 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: bulk
+
+##############################################
+##                 BULK                     ##
+##############################################
+
+# TC1 - Create two VRF Lite links in one module call.
+- name: BULK - TC1 - MERGE - Bulk create two VRF Lite links
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ bulk_vrf_lite_conf }}"
+  register: bulk_create_result
+  tags: bulk
+
+- name: BULK - TC1 - ASSERT - Verify bulk create changed
+  ansible.builtin.assert:
+    that:
+      - bulk_create_result.failed == false
+      - bulk_create_result.changed == true
+      - bulk_create_result.deployment is not defined
+  tags: bulk
+
+- name: BULK - TC1 - GATHER - Verify bulk create result in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: bulk_create_verify_result
+  tags: bulk
+
+- name: BULK - TC1 - ASSERT - Verify first bulk-created link
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ bulk_create_verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_attach_count: 1
+    vrf_lite_assert_connection_count: 2
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: bulk
+
+- name: BULK - TC1 - ASSERT - Verify second bulk-created link
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ bulk_create_verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_attach_count: 1
+    vrf_lite_assert_connection_count: 2
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q2 }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr2 }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4_2 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: bulk
+
+# TC2 - Query the two links with one gathered call.
+- name: BULK - TC2 - GATHER - Bulk query VRF Lite links
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  register: bulk_query_result
+  tags: bulk
+
+- name: BULK - TC2 - ASSERT - Verify bulk query output
+  ansible.builtin.assert:
+    that:
+      - bulk_query_result.failed == false
+      - bulk_query_result.changed == false
+      - bulk_query_result.gathered is defined
+      - bulk_query_result.gathered | length == 1
+      - bulk_query_result.gathered[0].vrf_name == test_vrf
+      - bulk_query_result.gathered[0].attach | default([]) | length == 1
+      - bulk_query_result.gathered[0].attach[0].vrf_lite | default([]) | length == 2
+      - >
+        (
+          bulk_query_result.gathered[0].attach[0].vrf_lite
+          | selectattr('interface', 'equalto', test_interface)
+          | list
+          | length
+        ) == 2
+      - >
+        (
+          bulk_query_result.gathered[0].attach[0].vrf_lite
+          | selectattr('dot1q', 'equalto', test_dot1q | int)
+          | list
+          | length
+        ) == 1
+      - >
+        (
+          bulk_query_result.gathered[0].attach[0].vrf_lite
+          | selectattr('dot1q', 'equalto', test_dot1q2 | int)
+          | list
+          | length
+        ) == 1
+  tags: bulk
+
+# TC3 - Delete the bulk-created attachment in one module call.
+- name: BULK - TC3 - DELETE - Bulk delete VRF Lite links
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ bulk_vrf_lite_conf }}"
+  register: bulk_delete_result
+  tags: bulk
+
+- name: BULK - TC3 - ASSERT - Verify bulk delete changed
+  ansible.builtin.assert:
+    that:
+      - bulk_delete_result.failed == false
+      - bulk_delete_result.changed == true
+      - bulk_delete_result.deployment is not defined
+  tags: bulk
+
+- name: BULK - TC3 - GATHER - Verify bulk delete result in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: bulk_delete_verify_result
+  tags: bulk
+
+- name: BULK - TC3 - ASSERT - Verify attachments are deleted
+  ansible.builtin.assert:
+    that:
+      - bulk_delete_verify_result.failed == false
+      - bulk_delete_verify_result.gathered is defined
+      - bulk_delete_verify_result.gathered | length == 1
+      - bulk_delete_verify_result.gathered[0].vrf_name == test_vrf
+      - bulk_delete_verify_result.gathered[0].attach | default([]) | length == 0
+  tags: bulk
+
+# TC4 - Re-run bulk delete to verify idempotence.
+- name: BULK - TC4 - DELETE - Re-run bulk delete
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ bulk_vrf_lite_conf }}"
+  register: bulk_delete_idempotent_result
+  tags: bulk
+
+- name: BULK - TC4 - ASSERT - Verify bulk delete idempotence
+  ansible.builtin.assert:
+    that:
+      - bulk_delete_idempotent_result.failed == false
+      - bulk_delete_idempotent_result.changed == false
+      - bulk_delete_idempotent_result.deployment is not defined
+  tags: bulk
+
+##############################################
+##                 CLEAN-UP                 ##
+##############################################
+
+- name: BULK - END - ensure primary clean state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  when: cleanup_at_end | default(true)
+  tags: bulk
+
+- name: BULK - END - ensure secondary clean state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch2 }}"
+  failed_when: false
+  when:
+    - cleanup_at_end | default(true)
+    - test_switch2 | length > 0
+  tags: bulk

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_delete.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_delete.yaml
@@ -1,0 +1,665 @@
+##############################################
+##                 SETUP                    ##
+##############################################
+
+- name: Import nd_manage_vrf_lite Base Tasks
+  ansible.builtin.import_tasks: base_tasks.yaml
+  tags: delete
+
+- name: DELETE - Set nd_info defaults
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+      timeout: "{{ nd_vrf_lite_module_timeout | default(600) }}"
+  tags: delete
+
+##############################################
+##      Setup Delete TestCase Variables    ##
+##############################################
+
+- name: DELETE - Setup config
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: delete
+
+- name: Import Configuration Prepare Tasks - delete_setup
+  vars:
+    file: delete_setup
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: delete
+
+##############################################
+##                DELETE                   ##
+##############################################
+
+# TC1 - Setup: Create VRF Lite attachment for deletion tests
+- name: DELETE - TC1 - MERGE - Create VRF Lite attachment for deletion testing
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_delete_setup_conf }}"
+  register: result
+  tags: delete
+
+- name: DELETE - TC1 - ASSERT - Check if creation successful
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+  tags: delete
+
+- name: DELETE - TC1 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: delete
+
+- name: DELETE - TC1 - ASSERT - Verify VRF Lite state in ND
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: delete
+
+# TC2 - Delete VRF Lite with specific config (without deploy)
+- name: DELETE - TC2 - DELETE - Delete VRF Lite with specific config (no deploy)
+  cisco.nd.nd_manage_vrf_lite: &delete_specific
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  register: result
+  tags: delete
+
+- name: DELETE - TC2 - ASSERT - Check if deletion successful
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.deployment is not defined
+  tags: delete
+
+- name: DELETE - TC2 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: delete
+
+- name: DELETE - TC2 - ASSERT - Verify VRF Lite deletion
+  ansible.builtin.assert:
+    that:
+      - verify_result.failed == false
+      - verify_result.gathered is defined
+      - verify_result.gathered | length == 1
+      - verify_result.gathered[0].vrf_name == test_vrf
+      - verify_result.gathered[0].attach | default([]) | length == 0
+  tags: delete
+
+# TC2b - Delete VRF Lite with deploy=true path
+- name: DELETE - TC2b - MERGE - Recreate VRF Lite for deploy-delete path
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_delete_setup_conf }}"
+  register: result
+  tags: delete
+
+- name: DELETE - TC2b - ASSERT - Verify setup creation for deploy-delete
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: delete
+
+- name: DELETE - TC2b - DELETE - Delete VRF Lite with deploy enabled
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  register: result
+  tags: delete
+
+- name: DELETE - TC2b - ASSERT - Verify deploy delete execution
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is defined
+      - (result.deployment_needed | default(result.deployment.deployment_needed | default(false))) | bool == true
+  tags: delete
+
+- name: DELETE - TC2b - ASSERT - Verify config-save and deploy API traces
+  ansible.builtin.assert:
+    that:
+      - result.deployment.response is defined
+      - (result.deployment.response | length) >= 2
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'config_save')
+          | list
+          | length
+        ) > 0
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'vrf_deploy')
+          | list
+          | length
+        ) > 0
+  tags: delete
+
+- name: DELETE - TC2b - GATHER - Verify deploy delete result in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: delete
+
+- name: DELETE - TC2b - ASSERT - Verify VRF Lite deleted after deploy
+  ansible.builtin.assert:
+    that:
+      - verify_result.failed == false
+      - verify_result.gathered is defined
+      - verify_result.gathered | length == 1
+      - verify_result.gathered[0].vrf_name == test_vrf
+      - verify_result.gathered[0].attach | default([]) | length == 0
+  tags: delete
+
+# TC3 - Idempotence test for deletion (no deploy)
+- name: DELETE - TC3 - conf - Idempotence
+  cisco.nd.nd_manage_vrf_lite: *delete_specific
+  register: result
+  tags: delete
+
+- name: DELETE - TC3 - ASSERT - Check if changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+  tags: delete
+
+# TC5 - Delete with config_actions save+deploy
+- name: DELETE - TC5 - MERGE - Recreate VRF Lite for config_actions delete path
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_delete_setup_conf }}"
+  register: result
+  tags: delete
+
+- name: DELETE - TC5 - DELETE - Delete VRF Lite with config_actions save+deploy
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  register: tc5_delete_result
+  tags: delete
+
+- name: DELETE - TC5 - ASSERT - Verify config_actions save+deploy execution in delete flow
+  ansible.builtin.assert:
+    that:
+      - tc5_delete_result.failed == false
+      - tc5_delete_result.changed == true
+      - tc5_delete_result.deployment is defined
+      - tc5_delete_result.deployment.config_actions is defined
+      - tc5_delete_result.deployment.config_actions.save == true
+      - tc5_delete_result.deployment.config_actions.deploy == true
+      - tc5_delete_result.deployment.config_actions.type == "switch"
+      - tc5_delete_result.deployment.response is defined
+      - (tc5_delete_result.deployment.response | length) >= 2
+      - >
+        (
+          tc5_delete_result.deployment.response
+          | selectattr('operation', 'equalto', 'config_save')
+          | list
+          | length
+        ) > 0
+      - >
+        (
+          tc5_delete_result.deployment.response
+          | selectattr('operation', 'equalto', 'vrf_deploy')
+          | list
+          | length
+        ) > 0
+  tags: delete
+
+- name: DELETE - TC5 - GATHER - Verify config_actions delete result in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: tc5_verify_result
+  tags: delete
+
+- name: DELETE - TC5 - ASSERT - Verify VRF Lite deleted after config_actions delete
+  ansible.builtin.assert:
+    that:
+      - tc5_verify_result.failed == false
+      - tc5_verify_result.gathered is defined
+      - tc5_verify_result.gathered | length == 1
+      - tc5_verify_result.gathered[0].vrf_name == test_vrf
+      - tc5_verify_result.gathered[0].attach | default([]) | length == 0
+  tags: delete
+
+# TC6 - check_mode should not apply delete configuration changes
+- name: DELETE - TC6 - MERGE - Ensure VRF Lite exists before check_mode delete test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_delete_setup_conf }}"
+  register: tc6_setup_result
+  tags: delete
+
+- name: DELETE - TC6 - ASSERT - Verify setup creation for check_mode delete
+  ansible.builtin.assert:
+    that:
+      - tc6_setup_result.failed == false
+      - tc6_setup_result.changed in [true, false]
+  tags: delete
+
+- name: DELETE - TC6 - DELETE - Run check_mode delete for existing VRF Lite
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  check_mode: true
+  register: tc6_delete_result
+  tags: delete
+
+- name: DELETE - TC6 - ASSERT - Verify check_mode delete preview behavior
+  ansible.builtin.assert:
+    that:
+      - tc6_delete_result.failed == false
+      - tc6_delete_result.changed == true
+      - tc6_delete_result.deployment is not defined
+  tags: delete
+
+- name: DELETE - TC6 - GATHER - Verify check_mode delete did not remove VRF Lite
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: tc6_verify_result
+  tags: delete
+
+- name: DELETE - TC6 - ASSERT - Verify VRF Lite still exists after check_mode delete
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ tc6_verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: delete
+
+# TC7 - Delete with empty config must be rejected (guard against accidental purge)
+- name: DELETE - TC7 - DELETE - Validate empty config is rejected
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: []
+  register: result
+  failed_when: false
+  tags: delete
+
+- name: DELETE - TC7 - ASSERT - Verify empty delete config rejected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.msg is defined
+      - result.msg is search("Config parameter is required for state 'deleted'")
+  tags: delete
+
+# TC8 - Unknown attachment delete must be a no-op and preserve existing attachment
+- name: DELETE - TC8 - MERGE - Ensure original VRF Lite exists before no-op delete
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_delete_setup_conf }}"
+  register: tc8_setup_result
+  when: test_switch2 | length > 0
+  tags: delete
+
+- name: DELETE - TC8 - ASSERT - Verify setup for no-op delete
+  ansible.builtin.assert:
+    that:
+      - tc8_setup_result.failed == false
+      - tc8_setup_result.changed in [true, false]
+  when: test_switch2 | length > 0
+  tags: delete
+
+- name: DELETE - TC8 - DELETE - Delete with unattached switch
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch2 }}"
+  register: tc8_delete_result
+  failed_when: false
+  when: test_switch2 | length > 0
+  tags: delete
+
+- name: DELETE - TC8 - ASSERT - Verify unknown attachment delete is no-op
+  ansible.builtin.assert:
+    that:
+      - tc8_delete_result.failed == false
+      - tc8_delete_result.changed == false
+      - tc8_delete_result.deployment is not defined
+      - >
+        (
+          (tc8_delete_result.warnings | default([]) | join(' ')) is search('No matching VRF Lite attachment')
+          or
+          (tc8_delete_result.msg | default('')) is search('No matching VRF Lite attachment')
+        )
+  when: test_switch2 | length > 0
+  tags: delete
+
+- name: DELETE - TC8 - GATHER - Verify original attachment remains after no-op delete
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: tc8_verify_result
+  when: test_switch2 | length > 0
+  tags: delete
+
+- name: DELETE - TC8 - ASSERT - Verify original attachment content remains
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ tc8_verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  when: test_switch2 | length > 0
+  tags: delete
+
+# TC9 - Delete with verify.enabled=false clears a multi-link VRF Lite attachment
+- name: DELETE - TC9 - MERGE - Create two VRF Lite links for verify-disabled delete
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q2 | int }}"
+                ipv4_addr: "{{ test_ipv4_addr2 }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4_2 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  register: tc9_setup_result
+  tags: delete
+
+- name: DELETE - TC9 - ASSERT - Verify two-link setup
+  ansible.builtin.assert:
+    that:
+      - tc9_setup_result.failed == false
+      - tc9_setup_result.changed == true
+  tags: delete
+
+- name: DELETE - TC9 - DELETE - Delete multi-link attachment with verify disabled
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    verify:
+      enabled: false
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  register: tc9_delete_result
+  tags: delete
+
+- name: DELETE - TC9 - ASSERT - Verify delete output clears attachment
+  vars:
+    tc9_after_vrf: >-
+      {{
+        (tc9_delete_result.after | default([]))
+        | selectattr('vrf_name', 'equalto', test_vrf)
+        | list
+      }}
+    tc9_current_vrf: >-
+      {{
+        (tc9_delete_result.current | default([]))
+        | selectattr('vrf_name', 'equalto', test_vrf)
+        | list
+      }}
+  ansible.builtin.assert:
+    that:
+      - tc9_delete_result.failed == false
+      - tc9_delete_result.changed == true
+      - tc9_after_vrf | length == 1
+      - tc9_current_vrf | length == 1
+      - >
+        (
+          tc9_after_vrf[0].attach | default([])
+          | selectattr('ip_address', 'equalto', test_switch1)
+          | list
+          | length
+        ) == 0
+      - >
+        (
+          tc9_current_vrf[0].attach | default([])
+          | selectattr('ip_address', 'equalto', test_switch1)
+          | list
+          | length
+        ) == 0
+  tags: delete
+
+- name: DELETE - TC9 - GATHER - Verify multi-link attachment removed after verify-disabled delete
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: tc9_verify_result
+  tags: delete
+
+- name: DELETE - TC9 - ASSERT - Verify gathered has no attachment
+  ansible.builtin.assert:
+    that:
+      - tc9_verify_result.failed == false
+      - tc9_verify_result.gathered is defined
+      - tc9_verify_result.gathered | length == 1
+      - tc9_verify_result.gathered[0].vrf_name == test_vrf
+      - tc9_verify_result.gathered[0].attach | default([]) | length == 0
+  tags: delete
+
+##############################################
+##                 CLEAN-UP                 ##
+##############################################
+
+- name: DELETE - END - ensure clean state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  when: cleanup_at_end | default(true)
+  tags: delete
+
+- name: DELETE - END - ensure secondary clean state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch2 }}"
+  failed_when: false
+  when:
+    - cleanup_at_end | default(true)
+    - test_switch2 | length > 0
+  tags: delete

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_gather.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_gather.yaml
@@ -1,0 +1,352 @@
+##############################################
+##                 SETUP                    ##
+##############################################
+
+- name: Import nd_manage_vrf_lite Base Tasks
+  ansible.builtin.import_tasks: base_tasks.yaml
+  tags: gather
+
+- name: GATHER - Set nd_info defaults
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+      timeout: "{{ nd_vrf_lite_module_timeout | default(600) }}"
+  tags: gather
+
+##############################################
+##      Setup Gather TestCase Variables    ##
+##############################################
+
+- name: GATHER - Setup config
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: gather
+
+- name: Import Configuration Prepare Tasks - gather_setup
+  vars:
+    file: gather_setup
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: gather
+
+##############################################
+##                GATHER                    ##
+##############################################
+
+# TC1 - Setup: Create VRF Lite attachment for gather tests
+- name: GATHER - TC1 - MERGE - Create VRF Lite attachment for testing
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_gather_setup_conf }}"
+  register: result
+  tags: gather
+
+- name: GATHER - TC1 - ASSERT - Check if creation successful
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: gather
+
+- name: GATHER - TC1 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    fabric_name: "{{ test_fabric }}"
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+  register: verify_result
+  tags: gather
+
+- name: GATHER - TC1 - ASSERT - Verify gathered data is returned
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: gather
+
+- name: GATHER - TC1 - ASSERT - Verify gathered output shape
+  ansible.builtin.assert:
+    that:
+      - verify_result.changed == false
+      - verify_result.gathered | type_debug == "list"
+      - verify_result.gathered.vrf_lite is not defined
+  tags: gather
+
+# TC2 - Gather with no filters
+- name: GATHER - TC2 - GATHER - Gather all VRF Lite attachments with no filters
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+  register: result
+  tags: gather
+
+- name: GATHER - TC2 - ASSERT - Check gather results
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: gather
+
+- name: GATHER - TC2 - ASSERT - Verify gather is read-only
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+  tags: gather
+
+# TC3 - Gather with VRF name filter
+- name: GATHER - TC3 - GATHER - Gather VRF Lite with VRF name filter
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: result
+  tags: gather
+
+- name: GATHER - TC3 - ASSERT - Check gather results with VRF filter
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == false
+      - result.gathered is defined
+      - result.gathered | length == 1
+      - result.gathered[0].vrf_name == test_vrf
+  tags: gather
+
+- name: GATHER - TC3 - ASSERT - Verify VRF-filtered attachment content
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: gather
+
+# TC4 - Gather with non-existent VRF
+- name: GATHER - TC4 - GATHER - Gather VRF Lite with non-existent VRF
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "NONEXISTENT_VRF_12345"
+  register: result
+  failed_when: false
+  tags: gather
+
+- name: GATHER - TC4 - ASSERT - Check gather results with non-existent VRF
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == false
+      - result.gathered is defined
+      - result.gathered == []
+  tags: gather
+
+# TC5 - Gather with custom verify timeout/retries
+- name: GATHER - TC5 - GATHER - Gather with verify override
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    verify:
+      timeout: 20
+      retries: 3
+  register: result
+  tags: gather
+
+- name: GATHER - TC5 - ASSERT - Verify verify path execution
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: gather
+
+- name: GATHER - TC5 - ASSERT - Verify gather with verify override is read-only
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+  tags: gather
+
+# TC6 - gathered + deploy validation (must fail)
+- name: GATHER - TC6 - GATHER - Gather with deploy enabled (invalid)
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+  register: result
+  failed_when: false
+  tags: gather
+
+- name: GATHER - TC6 - ASSERT - Verify gathered+deploy validation
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.gathered is not defined
+      - result.msg is defined
+  tags: gather
+
+# TC7 - gathered + native check_mode validation
+- name: GATHER - TC7 - GATHER - Gather with native check_mode enabled
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+  check_mode: true
+  register: result
+  tags: gather
+
+- name: GATHER - TC7 - ASSERT - Verify gathered+check_mode behavior
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: gather
+
+- name: GATHER - TC7 - ASSERT - Verify check_mode gather is read-only
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+  tags: gather
+
+# TC8 - Gather with VRF name + switch filter
+- name: GATHER - TC8 - GATHER - Gather VRF Lite with VRF and switch filter
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  register: result
+  tags: gather
+
+- name: GATHER - TC8 - ASSERT - Check gather results with VRF and switch filter
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == false
+      - result.gathered is defined
+      - result.gathered | length == 1
+      - result.gathered[0].vrf_name == test_vrf
+      - result.gathered[0].attach | default([]) | length == 1
+      - result.gathered[0].attach[0].ip_address == test_switch1
+  tags: gather
+
+- name: GATHER - TC8 - ASSERT - Verify VRF and switch filtered attachment content
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: gather
+
+##############################################
+##                 CLEAN-UP                 ##
+##############################################
+
+- name: GATHER - END - ensure clean state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  when: cleanup_at_end | default(true)
+  tags: gather

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_merge.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_merge.yaml
@@ -120,7 +120,7 @@
     fabric_name: "{{ test_fabric }}"
     state: merged
     config_actions:
-      save: false
+      save: true
       deploy: false
       type: switch
     config: "{{ nd_manage_vrf_lite_merge_full_conf }}"
@@ -395,7 +395,7 @@
     fabric_name: "{{ test_fabric }}"
     state: merged
     config_actions:
-      save: false
+      save: true
       deploy: false
       type: switch
     config: "{{ nd_manage_vrf_lite_merge_no_deploy_conf }}"
@@ -407,7 +407,10 @@
     that:
       - result.failed == false
       - result.changed == true
-      - result.deployment is not defined
+      - result.deployment is defined
+      - result.deployment.deployment_needed == true
+      - (result.deployment.response | selectattr('operation', 'equalto', 'config_save') | list | length) == 1
+      - (result.deployment.response | selectattr('operation', 'equalto', 'vrf_deploy') | list | length) == 0
   tags: merge
 
 - name: MERGE - TC6 - GATHER - Get VRF Lite state in ND
@@ -453,24 +456,47 @@
   tags: merge
 
 - name: MERGE - TC6b - ASSERT - Verify deployment decision after non-deploy config
-  vars:
-    tc6b_deployment_needed: >-
-      {{
-        (result.deployment_needed | default(result.deployment.deployment_needed | default(false)))
-        | bool
-      }}
   ansible.builtin.assert:
     that:
       - result.failed == false
+      - result.changed == true
       - result.deployment is defined
-      - >
-        (
-          (tc6b_deployment_needed and (result.deployment.response is defined)
-           and ((result.deployment.response | selectattr('operation', 'equalto', 'config_save') | list | length) > 0)
-           and ((result.deployment.response | selectattr('operation', 'equalto', 'vrf_deploy') | list | length) > 0))
-          or
-          ((not tc6b_deployment_needed) and (result.deployment.msg | default('') is search('skipping')))
-        )
+      - result.deployment_needed == true
+      - result.deployment.deployment_needed == true
+      - (result.deployment.response | selectattr('operation', 'equalto', 'config_save') | list | length) == 1
+      - (result.deployment.response | selectattr('operation', 'equalto', 'vrf_deploy') | list | length) == 1
+      - result.deployment.target_vrfs == [test_vrf]
+  tags: merge
+
+# A single vrf_deploy can race the preceding config_save ("No switches pending
+# for deployment"), leaving the switch OUT-OF-SYNC. Per #468 each deploy run
+# re-pushes the owned pending intent, so re-run deploy until it converges and
+# reports no change; this both drives convergence and proves idempotency (a
+# passive gather-wait cannot recover from the raced deploy).
+- name: MERGE - TC6c - MERGE - Re-deploy until the fully deployed intent is idempotent
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_no_deploy_conf }}"
+  register: result
+  until: result.changed == false
+  retries: 20
+  delay: 10
+  tags: merge
+
+- name: MERGE - TC6c - ASSERT - Verify no save or deployment is repeated
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == false
+      - result.deployment_needed == false
+      - result.deployment is defined
+      - result.deployment.response == []
   tags: merge
 
 # TC7 - Test invalid configurations (non-existent switch)
@@ -575,7 +601,11 @@
   tags: merge
 
 # TC9 - Idempotent deploy skip
-- name: MERGE - TC9 - MERGE - Re-run same deploy-enabled config
+# A single vrf_deploy can race the config_save ("No switches pending for
+# deployment") and leave the switch OUT-OF-SYNC. Per #468 each deploy run
+# re-pushes owned pending intent, so re-run deploy until it converges and
+# reports no change; the assert then validates the final idempotent result.
+- name: MERGE - TC9 - MERGE - Re-deploy same config until idempotent
   cisco.nd.nd_manage_vrf_lite:
     <<: *nd_info
     fabric_name: "{{ test_fabric }}"
@@ -586,6 +616,9 @@
       type: switch
     config: "{{ nd_manage_vrf_lite_merge_full_conf }}"
   register: result
+  until: result.changed == false
+  retries: 20
+  delay: 10
   tags: merge
 
 - name: MERGE - TC9 - ASSERT - Verify idempotent deploy skip

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_merge.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_merge.yaml
@@ -1,0 +1,899 @@
+##############################################
+##                 SETUP                    ##
+##############################################
+
+- name: Import nd_manage_vrf_lite Base Tasks
+  ansible.builtin.import_tasks: base_tasks.yaml
+  tags: merge
+
+- name: MERGE - Set nd_info defaults
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+      timeout: "{{ nd_vrf_lite_module_timeout | default(600) }}"
+  tags: merge
+
+##############################################
+##      Setup Merge TestCase Variables     ##
+##############################################
+
+- name: MERGE - Setup full config
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            import_evpn_rt: ""
+            export_evpn_rt: ""
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: merge
+
+- name: Import Configuration Prepare Tasks - merge_full
+  vars:
+    file: merge_full
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: merge
+
+- name: MERGE - Setup modified config (changed ipv4 addr)
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            import_evpn_rt: ""
+            export_evpn_rt: ""
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "10.33.0.10/24"
+                neighbor_ipv4: "10.33.0.9"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: merge
+
+- name: Import Configuration Prepare Tasks - merge_modified
+  vars:
+    file: merge_modified
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: merge
+
+- name: MERGE - Setup minimal config (VRF name + switch only)
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: merge
+
+- name: Import Configuration Prepare Tasks - merge_minimal
+  vars:
+    file: merge_minimal
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: merge
+
+- name: MERGE - Setup no-deploy config
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: merge
+
+- name: Import Configuration Prepare Tasks - merge_no_deploy
+  vars:
+    file: merge_no_deploy
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: merge
+
+##############################################
+##                MERGE                    ##
+##############################################
+
+# TC1 - Create VRF Lite attachment with full configuration
+- name: MERGE - TC1 - MERGE - Create VRF Lite with full configuration
+  cisco.nd.nd_manage_vrf_lite: &conf_full
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_full_conf }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC1 - ASSERT - Check if changed flag is true
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: merge
+
+- name: MERGE - TC1 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: merge
+
+- name: MERGE - TC1 - ASSERT - Verify VRF Lite state in ND
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: merge
+
+- name: MERGE - TC1 - conf - Idempotence
+  cisco.nd.nd_manage_vrf_lite: *conf_full
+  register: result
+  tags: merge
+
+- name: MERGE - TC1 - ASSERT - Check if changed flag is false (idempotence)
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == false
+      - result.class_diff.created | default([]) | length == 0
+      - result.class_diff.deleted | default([]) | length == 0
+  tags: merge
+
+# TC2 - Modify existing VRF Lite configuration
+- name: MERGE - TC2 - MERGE - Modify VRF Lite configuration (change IP)
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_modified_conf }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC2 - ASSERT - Check if changed flag is true
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: merge
+
+- name: MERGE - TC2 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: merge
+
+- name: MERGE - TC2 - ASSERT - Verify modified VRF Lite state
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "10.33.0.10/24"
+    vrf_lite_assert_neighbor_ipv4: "10.33.0.9"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: merge
+
+# TC3 - Delete VRF Lite attachment
+- name: MERGE - TC3 - DELETE - Delete VRF Lite attachment
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC3 - ASSERT - Check if delete successful
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: merge
+
+- name: MERGE - TC3 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: merge
+
+- name: MERGE - TC3 - ASSERT - Verify VRF Lite deletion
+  ansible.builtin.assert:
+    that:
+      - verify_result.failed == false
+      - verify_result.gathered is defined
+      - verify_result.gathered | length == 1
+      - verify_result.gathered[0].vrf_name == test_vrf
+      - verify_result.gathered[0].attach | default([]) | length == 0
+  tags: merge
+
+# TC4 - Create VRF Lite with minimal configuration
+- name: MERGE - TC4 - MERGE - Create VRF Lite with minimal configuration
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_minimal_conf }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC4 - ASSERT - Check if changed flag is true
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: merge
+
+- name: MERGE - TC4 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: merge
+
+- name: MERGE - TC4 - ASSERT - Verify minimal VRF Lite state
+  ansible.builtin.assert:
+    that:
+      - verify_result.failed == false
+      - verify_result.gathered is defined
+      - verify_result.gathered | length == 1
+      - verify_result.gathered[0].vrf_name == test_vrf
+      - verify_result.gathered[0].attach | default([]) | length == 1
+      - verify_result.gathered[0].attach[0].ip_address == test_switch1
+  tags: merge
+
+# TC4b - Delete VRF Lite after minimal test
+- name: MERGE - TC4b - DELETE - Delete VRF Lite after minimal test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC4b - ASSERT - Check if delete successful
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: merge
+
+# TC5 - Create VRF Lite with defaults (state omitted)
+- name: MERGE - TC5 - MERGE - Create VRF Lite with defaults
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_minimal_conf }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC5 - ASSERT - Check if changed flag is true
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.diff is defined
+  tags: merge
+
+# TC5b - Delete VRF Lite after defaults test
+- name: MERGE - TC5b - DELETE - Delete VRF Lite after defaults test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC5b - ASSERT - Check if delete successful
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: merge
+
+# TC6 - Create VRF Lite with deploy flag false
+- name: MERGE - TC6 - MERGE - Create VRF Lite with deploy false
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_no_deploy_conf }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC6 - ASSERT - Check if changed flag is true and no deploy
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is not defined
+  tags: merge
+
+- name: MERGE - TC6 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: merge
+
+- name: MERGE - TC6 - ASSERT - Verify VRF Lite state after no-deploy merge
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: merge
+
+# TC6b - Re-run same config with deploy=true after non-deploy create
+- name: MERGE - TC6b - MERGE - Re-run same config with deploy true
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_no_deploy_conf }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC6b - ASSERT - Verify deployment decision after non-deploy config
+  vars:
+    tc6b_deployment_needed: >-
+      {{
+        (result.deployment_needed | default(result.deployment.deployment_needed | default(false)))
+        | bool
+      }}
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.deployment is defined
+      - >
+        (
+          (tc6b_deployment_needed and (result.deployment.response is defined)
+           and ((result.deployment.response | selectattr('operation', 'equalto', 'config_save') | list | length) > 0)
+           and ((result.deployment.response | selectattr('operation', 'equalto', 'vrf_deploy') | list | length) > 0))
+          or
+          ((not tc6b_deployment_needed) and (result.deployment.msg | default('') is search('skipping')))
+        )
+  tags: merge
+
+# TC7 - Test invalid configurations (non-existent switch)
+- name: MERGE - TC7 - MERGE - Create VRF Lite with invalid switch IP
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "192.168.255.255"
+            vrf_lite:
+              - interface: "Ethernet1/20"
+                dot1q: 500
+                ipv4_addr: "10.33.0.2/24"
+                neighbor_ipv4: "10.33.0.1"
+                peer_vrf: "{{ test_peer_vrf }}"
+  register: result
+  failed_when: false
+  tags: merge
+
+- name: MERGE - TC7 - ASSERT - Check invalid switch error
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.msg is defined
+      - >
+        (
+          (result.msg is search("192.168.255.255"))
+          or
+          (result.msg is search("not found"))
+          or
+          (result.msg is search("do not exist"))
+          or
+          (result.msg is search("Switch validation failed"))
+        )
+  tags: merge
+
+# TC8 - Create VRF Lite with deploy enabled (actual deployment path)
+- name: MERGE - TC8 - DELETE - Ensure VRF Lite is absent before deploy test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: merge
+
+- name: MERGE - TC8 - MERGE - Create VRF Lite with deploy true
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_full_conf }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC8 - ASSERT - Verify deploy path execution
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is defined
+      - (result.deployment_needed | default(result.deployment.deployment_needed | default(false))) | bool == true
+  tags: merge
+
+- name: MERGE - TC8 - ASSERT - Verify config-save and deploy API traces
+  ansible.builtin.assert:
+    that:
+      - result.deployment.response is defined
+      - (result.deployment.response | length) >= 2
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'config_save')
+          | list
+          | length
+        ) > 0
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'vrf_deploy')
+          | list
+          | length
+        ) > 0
+  tags: merge
+
+# TC9 - Idempotent deploy skip
+- name: MERGE - TC9 - MERGE - Re-run same deploy-enabled config
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_full_conf }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC9 - ASSERT - Verify idempotent deploy skip
+  vars:
+    tc9_deployment_needed: >-
+      {{
+        (result.deployment_needed | default(result.deployment.deployment_needed | default(false)))
+        | bool
+      }}
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == false
+      - tc9_deployment_needed == false
+  tags: merge
+
+# TC10 - check_mode should not apply configuration changes
+- name: MERGE - TC10 - DELETE - Ensure VRF Lite absent before check_mode test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: merge
+
+- name: MERGE - TC10 - MERGE - Run check_mode create for VRF Lite
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_full_conf }}"
+  check_mode: true
+  register: result
+  tags: merge
+
+- name: MERGE - TC10 - ASSERT - Verify check_mode invocation succeeded
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is not defined
+  tags: merge
+
+- name: MERGE - TC10 - GATHER - Verify check_mode flow did not create VRF Lite
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: merge
+
+- name: MERGE - TC10 - ASSERT - Verify gathered after check_mode
+  ansible.builtin.assert:
+    that:
+      - verify_result.failed == false
+      - verify_result.gathered is defined
+      - verify_result.gathered | length == 1
+      - verify_result.gathered[0].vrf_name == test_vrf
+      - verify_result.gathered[0].attach | default([]) | length == 0
+  tags: merge
+
+# TC11 - Validate invalid config_actions (save: false, deploy: true)
+- name: MERGE - TC11 - MERGE - Invalid config_actions (save false, deploy true)
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: true
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_full_conf }}"
+  register: result
+  failed_when: false
+  tags: merge
+
+- name: MERGE - TC11 - ASSERT - Verify invalid config_actions rejected
+  ansible.builtin.assert:
+    that:
+      - result.msg is defined
+      - result.msg is search("deploy.*requires.*save")
+  tags: merge
+
+# TC12 - config_actions with save only (no deploy)
+- name: MERGE - TC12 - DELETE - Ensure VRF Lite absent before config_actions test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: merge
+
+- name: MERGE - TC12 - MERGE - Create VRF Lite with save only
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: true
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_merge_full_conf }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC12 - ASSERT - Verify save-only behavior
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: merge
+
+# TC13 - Extended VRF Lite attachment payload coverage
+- name: MERGE - TC13 - MERGE - Apply extended VRF Lite attachment payload
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach: "{{ vrf_lite_attach_extended }}"
+  register: result
+  tags: merge
+
+- name: MERGE - TC13 - ASSERT - Verify extended payload applied
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: merge
+
+- name: MERGE - TC13 - GATHER - Get VRF Lite state after extended payload
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: merge
+
+- name: MERGE - TC13 - ASSERT - Verify extended state
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: merge
+
+# TC14 - Multi-link coverage for one VRF attachment
+- name: MERGE - TC14 - MERGE - Create two VRF Lite links for one VRF attachment
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q2 | int }}"
+                ipv4_addr: "{{ test_ipv4_addr2 }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4_2 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  register: tc14_result
+  tags: merge
+
+- name: MERGE - TC14 - ASSERT - Verify two-link merge changed
+  ansible.builtin.assert:
+    that:
+      - tc14_result.failed == false
+      - tc14_result.changed == true
+  tags: merge
+
+- name: MERGE - TC14 - GATHER - Get two-link VRF Lite state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: tc14_verify_result
+  tags: merge
+
+- name: MERGE - TC14 - ASSERT - Verify first VRF Lite link remains
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ tc14_verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_attach_count: 1
+    vrf_lite_assert_connection_count: 2
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: merge
+
+- name: MERGE - TC14 - ASSERT - Verify second VRF Lite link exists
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ tc14_verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_attach_count: 1
+    vrf_lite_assert_connection_count: 2
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q2 }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr2 }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4_2 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: merge
+
+##############################################
+##                 CLEAN-UP                 ##
+##############################################
+
+- name: MERGE - END - ensure clean state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  when: cleanup_at_end | default(true)
+  tags: merge
+
+- name: MERGE - END - ensure secondary clean state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch2 }}"
+  failed_when: false
+  when:
+    - cleanup_at_end | default(true)
+    - test_switch2 | length > 0
+  tags: merge

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_override.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_override.yaml
@@ -1,0 +1,491 @@
+##############################################
+##                 SETUP                    ##
+##############################################
+
+- name: Import nd_manage_vrf_lite Base Tasks
+  ansible.builtin.import_tasks: base_tasks.yaml
+  tags: override
+
+- name: OVERRIDE - Set nd_info defaults
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+      timeout: "{{ nd_vrf_lite_module_timeout | default(600) }}"
+  tags: override
+
+##############################################
+##      Setup Override TestCase Variables  ##
+##############################################
+
+- name: OVERRIDE - Setup initial config
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: override
+
+- name: Import Configuration Prepare Tasks - override_initial
+  vars:
+    file: override_initial
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: override
+
+- name: OVERRIDE - Setup overridden config (changed IP address)
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "10.33.0.30/24"
+                neighbor_ipv4: "10.33.0.29"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: override
+
+- name: Import Configuration Prepare Tasks - override_overridden
+  vars:
+    file: override_overridden
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: override
+
+##############################################
+##               OVERRIDE                 ##
+##############################################
+
+# TC1 - Override with a new VRF Lite attachment
+- name: OVERRIDE - TC1 - OVERRIDE - Create VRF Lite using override state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: overridden
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_override_initial_conf }}"
+  register: result
+  tags: override
+
+- name: OVERRIDE - TC1 - ASSERT - Check if changed flag is true
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: override
+
+- name: OVERRIDE - TC1 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    fabric_name: "{{ test_fabric }}"
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: override
+
+- name: OVERRIDE - TC1 - ASSERT - Verify VRF Lite state in ND
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: override
+
+# TC2 - Override with same VRF Lite with changes
+- name: OVERRIDE - TC2 - OVERRIDE - Override VRF Lite with changes
+  cisco.nd.nd_manage_vrf_lite: &conf_overridden
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: overridden
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_override_overridden_conf }}"
+  register: result
+  tags: override
+
+- name: OVERRIDE - TC2 - ASSERT - Check if changed flag is true
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: override
+
+- name: OVERRIDE - TC2 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    fabric_name: "{{ test_fabric }}"
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: override
+
+- name: OVERRIDE - TC2 - ASSERT - Verify overridden VRF Lite state
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "10.33.0.30/24"
+    vrf_lite_assert_neighbor_ipv4: "10.33.0.29"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: override
+
+# TC3 - Idempotence test
+- name: OVERRIDE - TC3 - conf - Idempotence
+  cisco.nd.nd_manage_vrf_lite: *conf_overridden
+  register: result
+  tags: override
+
+- name: OVERRIDE - TC3 - ASSERT - Check if changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+  tags: override
+
+# TC4 - Override with empty config should delete all VRF Lite for the fabric (purge-all)
+- name: OVERRIDE - TC4 - SETUP - Ensure at least one VRF Lite exists
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: merged
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: override
+
+- name: OVERRIDE - TC4 - OVERRIDE - Purge all VRF Lite with empty config
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: overridden
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: []
+  register: result
+  tags: override
+
+- name: OVERRIDE - TC4 - ASSERT - Verify all attachments deleted
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: override
+
+- name: OVERRIDE - TC4 - GATHER - Verify no VRF Lite remain
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+  register: verify_result
+  tags: override
+
+- name: OVERRIDE - TC4 - ASSERT - Confirm gathered is empty or minimal
+  ansible.builtin.assert:
+    that:
+      - verify_result.failed == false
+      - verify_result.gathered is defined
+      - >
+        (
+          verify_result.gathered
+          | selectattr('attach', 'defined')
+          | selectattr('attach')
+          | list
+          | length
+        ) == 0
+  tags: override
+
+# TC5 - Override with deploy enabled
+- name: OVERRIDE - TC5 - DELETE - Ensure VRF Lite absent before deploy test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: override
+
+- name: OVERRIDE - TC5 - OVERRIDE - Create VRF Lite with deploy true
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: overridden
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config: "{{ nd_manage_vrf_lite_override_initial_conf }}"
+  register: result
+  tags: override
+
+- name: OVERRIDE - TC5 - ASSERT - Verify deploy path execution
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is defined
+      - (result.deployment_needed | default(result.deployment.deployment_needed | default(false))) | bool == true
+  tags: override
+
+- name: OVERRIDE - TC5 - ASSERT - Verify config-save and deploy API traces
+  ansible.builtin.assert:
+    that:
+      - result.deployment.response is defined
+      - (result.deployment.response | length) >= 2
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'config_save')
+          | list
+          | length
+        ) > 0
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'vrf_deploy')
+          | list
+          | length
+        ) > 0
+  tags: override
+
+- name: OVERRIDE - TC5 - GATHER - Verify VRF Lite exists after deploy flow
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    fabric_name: "{{ test_fabric }}"
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: override
+
+- name: OVERRIDE - TC5 - ASSERT - Verify deployed override config
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: override
+
+# TC6 - Override with config_actions save+deploy (global scope)
+- name: OVERRIDE - TC6 - DELETE - Ensure VRF Lite absent before config_actions test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: override
+
+- name: OVERRIDE - TC6 - OVERRIDE - Create VRF Lite with config_actions save+deploy global
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: overridden
+    config_actions:
+      save: true
+      deploy: true
+      type: global
+    config: "{{ nd_manage_vrf_lite_override_initial_conf }}"
+  register: result
+  tags: override
+
+- name: OVERRIDE - TC6 - ASSERT - Verify config_actions save+deploy execution
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is defined
+      - result.deployment.config_actions is defined
+      - result.deployment.config_actions.save == true
+      - result.deployment.config_actions.deploy == true
+      - result.deployment.config_actions.type == "global"
+      - result.deployment.response is defined
+      - (result.deployment.response | length) >= 2
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'config_save')
+          | list
+          | length
+        ) > 0
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'vrf_deploy')
+          | list
+          | length
+        ) > 0
+      # type=global performs a fabric-wide deploy and must not pin switchIds.
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'vrf_deploy')
+          | map(attribute='payload')
+          | selectattr('switchIds', 'defined')
+          | list
+          | length
+        ) == 0
+      # config save is a body-less fabric trigger; it must not carry a deploy-scope 'type'.
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'config_save')
+          | map(attribute='payload')
+          | selectattr('type', 'defined')
+          | list
+          | length
+        ) == 0
+  tags: override
+
+# TC7 - check_mode should not apply override configuration changes
+- name: OVERRIDE - TC7 - DELETE - Ensure VRF Lite is absent before check_mode test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: override
+
+- name: OVERRIDE - TC7 - OVERRIDE - Run check_mode create for VRF Lite
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: overridden
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_override_initial_conf }}"
+  check_mode: true
+  register: result
+  tags: override
+
+- name: OVERRIDE - TC7 - ASSERT - Verify check_mode invocation succeeded
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is not defined
+  tags: override
+
+- name: OVERRIDE - TC7 - GATHER - Verify check_mode flow did not create VRF Lite
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: override
+
+- name: OVERRIDE - TC7 - ASSERT - Verify gathered after check_mode
+  ansible.builtin.assert:
+    that:
+      - verify_result.failed == false
+      - verify_result.gathered is defined
+      - verify_result.gathered | length == 1
+      - verify_result.gathered[0].vrf_name == test_vrf
+      - verify_result.gathered[0].attach | default([]) | length == 0
+  tags: override
+
+##############################################
+##                 CLEAN-UP                 ##
+##############################################
+
+- name: OVERRIDE - END - ensure clean state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  when: cleanup_at_end | default(true)
+  tags: override

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_replace.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_replace.yaml
@@ -1,0 +1,427 @@
+##############################################
+##                 SETUP                    ##
+##############################################
+
+- name: Import nd_manage_vrf_lite Base Tasks
+  ansible.builtin.import_tasks: base_tasks.yaml
+  tags: replace
+
+- name: REPLACE - Set nd_info defaults
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+      timeout: "{{ nd_vrf_lite_module_timeout | default(600) }}"
+  tags: replace
+
+##############################################
+##      Setup Replace TestCase Variables   ##
+##############################################
+
+- name: REPLACE - Setup initial config
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "{{ test_ipv4_addr }}"
+                neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: replace
+
+- name: Import Configuration Prepare Tasks - replace_initial
+  vars:
+    file: replace_initial
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: replace
+
+- name: REPLACE - Setup replaced config (changed IP address)
+  ansible.builtin.set_fact:
+    vrf_lite_conf:
+      - vrf_name: "{{ test_vrf }}"
+        vlan_id: "{{ test_vlan_id | int }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+            vrf_lite:
+              - interface: "{{ test_interface }}"
+                dot1q: "{{ test_dot1q | int }}"
+                ipv4_addr: "10.33.0.20/24"
+                neighbor_ipv4: "10.33.0.19"
+                peer_vrf: "{{ test_peer_vrf }}"
+  delegate_to: localhost
+  tags: replace
+
+- name: Import Configuration Prepare Tasks - replace_replaced
+  vars:
+    file: replace_replaced
+  ansible.builtin.import_tasks: conf_prep_tasks.yaml
+  tags: replace
+
+##############################################
+##                REPLACE                  ##
+##############################################
+
+# TC1 - Create initial VRF Lite using replace state
+- name: REPLACE - TC1 - REPLACE - Create VRF Lite using replace state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: replaced
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_replace_initial_conf }}"
+  register: result
+  tags: replace
+
+- name: REPLACE - TC1 - ASSERT - Check if changed flag is true
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: replace
+
+- name: REPLACE - TC1 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    fabric_name: "{{ test_fabric }}"
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: replace
+
+- name: REPLACE - TC1 - ASSERT - Verify VRF Lite state in ND
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: replace
+
+# TC2 - Replace VRF Lite configuration
+- name: REPLACE - TC2 - REPLACE - Replace VRF Lite configuration
+  cisco.nd.nd_manage_vrf_lite: &conf_replaced
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: replaced
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_replace_replaced_conf }}"
+  register: result
+  tags: replace
+
+- name: REPLACE - TC2 - ASSERT - Check if changed flag is true
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+  tags: replace
+
+- name: REPLACE - TC2 - GATHER - Get VRF Lite state in ND
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    fabric_name: "{{ test_fabric }}"
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: replace
+
+- name: REPLACE - TC2 - ASSERT - Verify replaced VRF Lite state
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "10.33.0.20/24"
+    vrf_lite_assert_neighbor_ipv4: "10.33.0.19"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: replace
+
+# TC3 - Idempotence test
+- name: REPLACE - TC3 - conf - Idempotence
+  cisco.nd.nd_manage_vrf_lite: *conf_replaced
+  register: result
+  tags: replace
+
+- name: REPLACE - TC3 - ASSERT - Check if changed flag is false
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+  tags: replace
+
+# TC4 - Replace with deploy enabled
+- name: REPLACE - TC4 - DELETE - Ensure VRF Lite absent before deploy test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: replace
+
+- name: REPLACE - TC4 - REPLACE - Create VRF Lite with deploy true
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: replaced
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config: "{{ nd_manage_vrf_lite_replace_initial_conf }}"
+  register: result
+  tags: replace
+
+- name: REPLACE - TC4 - ASSERT - Verify deploy path execution
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is defined
+      - (result.deployment_needed | default(result.deployment.deployment_needed | default(false))) | bool == true
+  tags: replace
+
+- name: REPLACE - TC4 - ASSERT - Verify config-save and deploy API traces
+  ansible.builtin.assert:
+    that:
+      - result.deployment.response is defined
+      - (result.deployment.response | length) >= 2
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'config_save')
+          | list
+          | length
+        ) > 0
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'vrf_deploy')
+          | list
+          | length
+        ) > 0
+  tags: replace
+
+- name: REPLACE - TC4 - GATHER - Verify VRF Lite exists after deploy flow
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    fabric_name: "{{ test_fabric }}"
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: replace
+
+- name: REPLACE - TC4 - ASSERT - Verify deployed replace config
+  ansible.builtin.include_tasks: assert_vrf_lite_attachment.yaml
+  vars:
+    vrf_lite_assert_result: "{{ verify_result }}"
+    vrf_lite_assert_vrf_name: "{{ test_vrf }}"
+    vrf_lite_assert_vlan_id: "{{ test_vlan_id }}"
+    vrf_lite_assert_switch: "{{ test_switch1 }}"
+    vrf_lite_assert_interface: "{{ test_interface }}"
+    vrf_lite_assert_dot1q: "{{ test_dot1q }}"
+    vrf_lite_assert_ipv4_addr: "{{ test_ipv4_addr }}"
+    vrf_lite_assert_neighbor_ipv4: "{{ test_neighbor_ipv4 }}"
+    vrf_lite_assert_peer_vrf: "{{ test_peer_vrf }}"
+  tags: replace
+
+# TC5 - Replace with config_actions save+deploy
+- name: REPLACE - TC5 - DELETE - Ensure VRF Lite absent before config_actions test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: replace
+
+- name: REPLACE - TC5 - REPLACE - Create VRF Lite with config_actions save+deploy
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: replaced
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config: "{{ nd_manage_vrf_lite_replace_initial_conf }}"
+  register: result
+  tags: replace
+
+- name: REPLACE - TC5 - ASSERT - Verify config_actions save+deploy execution
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is defined
+      - result.deployment.config_actions is defined
+      - result.deployment.config_actions.save == true
+      - result.deployment.config_actions.deploy == true
+      - result.deployment.config_actions.type == "switch"
+      - result.deployment.response is defined
+      - (result.deployment.response | length) >= 2
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'config_save')
+          | list
+          | length
+        ) > 0
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'vrf_deploy')
+          | list
+          | length
+        ) > 0
+      # type=switch scopes the VRF deploy to only the affected switches (switchIds present).
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'vrf_deploy')
+          | map(attribute='payload')
+          | selectattr('switchIds', 'defined')
+          | list
+          | length
+        ) > 0
+      # config save is a body-less fabric trigger; it must not carry a deploy-scope 'type'.
+      - >
+        (
+          result.deployment.response
+          | selectattr('operation', 'equalto', 'config_save')
+          | map(attribute='payload')
+          | selectattr('type', 'defined')
+          | list
+          | length
+        ) == 0
+  tags: replace
+
+# TC6 - check_mode should not apply replace configuration changes
+- name: REPLACE - TC6 - DELETE - Ensure VRF Lite is absent before check_mode test
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  tags: replace
+
+- name: REPLACE - TC6 - REPLACE - Run check_mode create for VRF Lite
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: replaced
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    config: "{{ nd_manage_vrf_lite_replace_initial_conf }}"
+  check_mode: true
+  register: result
+  tags: replace
+
+- name: REPLACE - TC6 - ASSERT - Verify check_mode invocation succeeded
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.deployment is not defined
+  tags: replace
+
+- name: REPLACE - TC6 - GATHER - Verify check_mode flow did not create VRF Lite
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    state: gathered
+    config_actions:
+      save: false
+      deploy: false
+      type: switch
+    fabric_name: "{{ test_fabric }}"
+    config:
+      - vrf_name: "{{ test_vrf }}"
+  register: verify_result
+  tags: replace
+
+- name: REPLACE - TC6 - ASSERT - Verify gathered after check_mode
+  ansible.builtin.assert:
+    that:
+      - verify_result.failed == false
+      - verify_result.gathered is defined
+      - verify_result.gathered | length == 1
+      - verify_result.gathered[0].vrf_name == test_vrf
+      - verify_result.gathered[0].attach | default([]) | length == 0
+  tags: replace
+
+##############################################
+##                 CLEAN-UP                 ##
+##############################################
+
+- name: REPLACE - END - ensure clean state
+  cisco.nd.nd_manage_vrf_lite:
+    <<: *nd_info
+    fabric_name: "{{ test_fabric }}"
+    state: deleted
+    config_actions:
+      save: true
+      deploy: true
+      type: switch
+    config:
+      - vrf_name: "{{ test_vrf }}"
+        attach:
+          - ip_address: "{{ test_switch1 }}"
+  failed_when: false
+  when: cleanup_at_end | default(true)
+  tags: replace

--- a/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_scale.yaml
+++ b/tests/integration/targets/nd_manage_vrf_lite/tasks/nd_manage_vrf_lite_scale.yaml
@@ -1,0 +1,816 @@
+---
+# Opt-in scale tests for nd_manage_vrf_lite.
+#
+# Example:
+#   ansible-playbook -i hosts.yaml tasks/main.yaml \
+#     -e testcase=nd_manage_vrf_lite_scale \
+#     -e nd_vrf_lite_run_scale=true \
+#     -e nd_vrf_lite_scale_count=200
+
+- name: SCALE - Skip unless explicitly enabled
+  ansible.builtin.debug:
+    msg: "Skipping VRF Lite scale test. Set nd_vrf_lite_run_scale=true to run it."
+  when: not (nd_vrf_lite_run_scale | default(false) | bool)
+  tags: scale
+
+- name: SCALE - Run opt-in VRF Lite scale test
+  when: nd_vrf_lite_run_scale | default(false) | bool
+  tags: scale
+  block:
+    - name: SCALE - Import nd_manage_vrf_lite base tasks
+      ansible.builtin.import_tasks: base_tasks.yaml
+      tags:
+        - scale_single_switch
+        - scale_two_switch
+        - scale_many_vrfs
+
+    - name: SCALE - Set nd_info defaults
+      ansible.builtin.set_fact:
+        nd_info: &nd_info
+          output_level: '{{ api_key_output_level | default("debug") }}'
+      tags:
+        - scale_single_switch
+        - scale_two_switch
+        - scale_many_vrfs
+
+    - name: SCALE - Set scale defaults
+      ansible.builtin.set_fact:
+        scale_vrf_name: "{{ nd_vrf_lite_scale_vrf_name | default(test_vrf) }}"
+        scale_peer_vrf_name: "{{ nd_vrf_lite_scale_peer_vrf | default(test_peer_vrf) }}"
+        scale_vlan_id: "{{ nd_vrf_lite_scale_vlan_id | default(test_vlan_id) | int }}"
+        scale_link_count: "{{ nd_vrf_lite_scale_count | default(200) | int }}"
+        scale_dot1q_start: "{{ nd_vrf_lite_scale_dot1q_start | default(test_dot1q) | int }}"
+        scale_interface: "{{ nd_vrf_lite_scale_interface | default(test_interface) }}"
+        scale_timeout: "{{ nd_vrf_lite_scale_timeout | default(1800) | int }}"
+        scale_two_switch_enabled: >-
+          {{
+            (nd_vrf_lite_scale_two_switch_enabled | default(switch2_vrf_lite_enabled | default(false)) | bool)
+            and (test_switch2 | default('') | length > 0)
+          }}
+        scale_two_switch_count: "{{ nd_vrf_lite_scale_two_switch_count | default(nd_vrf_lite_scale_count | default(200)) | int }}"
+        scale_many_vrfs_enabled: "{{ nd_vrf_lite_scale_many_vrfs_enabled | default(false) | bool }}"
+        scale_many_vrfs_count: "{{ nd_vrf_lite_scale_many_vrfs_count | default(50) | int }}"
+        scale_many_vrfs_prefix: "{{ nd_vrf_lite_scale_many_vrfs_prefix | default('VRF_LITE_SCALE_') }}"
+      delegate_to: localhost
+      tags:
+        - scale_single_switch
+        - scale_two_switch
+        - scale_many_vrfs
+
+    - name: SCALE - Validate scale input ranges
+      ansible.builtin.assert:
+        that:
+          - scale_link_count | int > 0
+          - scale_two_switch_count | int > 0
+          - scale_dot1q_start | int >= 2
+          - (scale_dot1q_start | int + scale_link_count | int - 1) <= 4093
+          - (scale_dot1q_start | int + scale_two_switch_count | int - 1) <= 4093
+          - scale_vlan_id | int >= 1
+          - scale_vlan_id | int <= 4094
+        fail_msg: >-
+          Invalid scale values. Keep dot1q values inside 2-4093 and VLAN
+          inside 1-4094. Current start={{ scale_dot1q_start }},
+          count={{ scale_link_count }}, two_switch_count={{ scale_two_switch_count }},
+          vlan={{ scale_vlan_id }}.
+      tags:
+        - scale_single_switch
+        - scale_two_switch
+        - scale_many_vrfs
+
+    - name: SCALE - Initialize generated payload lists
+      ansible.builtin.set_fact:
+        scale_switch1_links: []
+        scale_switch2_links: []
+        scale_single_link_conf: []
+        scale_single_switch_conf: []
+        scale_two_switch_conf: []
+        scale_many_vrfs_conf: []
+      delegate_to: localhost
+      tags:
+        - scale_single_switch
+        - scale_two_switch
+        - scale_many_vrfs
+
+    - name: SCALE - Generate single-switch VRF Lite rows
+      ansible.builtin.set_fact:
+        scale_switch1_links: >-
+          {{
+            scale_switch1_links
+            + [
+              {
+                'interface': scale_interface,
+                'dot1q': scale_dot1q_start | int + item,
+                'ipv4_addr': '10.250.' ~ ((item // 64) | int) ~ '.' ~ (((item % 64) * 4 + 2) | int) ~ '/30',
+                'neighbor_ipv4': '10.250.' ~ ((item // 64) | int) ~ '.' ~ (((item % 64) * 4 + 1) | int),
+                'peer_vrf': scale_peer_vrf_name
+              }
+            ]
+          }}
+      loop: "{{ range(0, scale_link_count | int) | list }}"
+      delegate_to: localhost
+      tags:
+        - scale_single_switch
+        - scale_two_switch
+
+    - name: SCALE - Generate second-switch VRF Lite rows
+      ansible.builtin.set_fact:
+        scale_switch2_links: >-
+          {{
+            scale_switch2_links
+            + [
+              {
+                'interface': scale_interface,
+                'dot1q': scale_dot1q_start | int + item,
+                'ipv4_addr': '10.251.' ~ ((item // 64) | int) ~ '.' ~ (((item % 64) * 4 + 2) | int) ~ '/30',
+                'neighbor_ipv4': '10.251.' ~ ((item // 64) | int) ~ '.' ~ (((item % 64) * 4 + 1) | int),
+                'peer_vrf': scale_peer_vrf_name
+              }
+            ]
+          }}
+      loop: "{{ (range(0, scale_two_switch_count | int) | list) if (scale_two_switch_enabled | bool) else [] }}"
+      delegate_to: localhost
+      tags: scale_two_switch
+
+    - name: SCALE - Build single-switch config
+      ansible.builtin.set_fact:
+        scale_single_switch_conf:
+          - vrf_name: "{{ scale_vrf_name }}"
+            vlan_id: "{{ scale_vlan_id | int }}"
+            attach:
+              - ip_address: "{{ test_switch1 }}"
+                deploy: true
+                vrf_lite: "{{ scale_switch1_links }}"
+      delegate_to: localhost
+      tags:
+        - scale_single_switch
+        - scale_two_switch
+
+    - name: SCALE - Build single-link timing config
+      ansible.builtin.set_fact:
+        scale_single_link_conf:
+          - vrf_name: "{{ scale_vrf_name }}"
+            vlan_id: "{{ scale_vlan_id | int }}"
+            attach:
+              - ip_address: "{{ test_switch1 }}"
+                deploy: true
+                vrf_lite: "{{ [scale_switch1_links[0]] }}"
+      delegate_to: localhost
+      tags: scale_single_switch
+
+    - name: SCALE - Build two-switch config
+      ansible.builtin.set_fact:
+        scale_two_switch_conf:
+          - vrf_name: "{{ scale_vrf_name }}"
+            vlan_id: "{{ scale_vlan_id | int }}"
+            attach:
+              - ip_address: "{{ test_switch1 }}"
+                deploy: false
+                vrf_lite: "{{ scale_switch1_links }}"
+              - ip_address: "{{ test_switch2 }}"
+                deploy: false
+                vrf_lite: "{{ scale_switch2_links }}"
+      when: scale_two_switch_enabled | bool
+      delegate_to: localhost
+      tags: scale_two_switch
+
+    - name: SCALE - Generate many-VRF one-link config
+      ansible.builtin.set_fact:
+        scale_many_vrfs_conf: >-
+          {{
+            scale_many_vrfs_conf
+            + [
+              {
+                'vrf_name': scale_many_vrfs_prefix ~ ('%03d' | format(item + 1)),
+                'vlan_id': scale_vlan_id | int + item,
+                'attach': [
+                  {
+                    'ip_address': test_switch1,
+                    'deploy': false,
+                    'vrf_lite': [
+                      {
+                        'interface': scale_interface,
+                        'dot1q': scale_dot1q_start | int + item,
+                        'ipv4_addr': '10.252.' ~ ((item // 64) | int) ~ '.' ~ (((item % 64) * 4 + 2) | int) ~ '/30',
+                        'neighbor_ipv4': '10.252.' ~ ((item // 64) | int) ~ '.' ~ (((item % 64) * 4 + 1) | int),
+                        'peer_vrf': scale_peer_vrf_name
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }}
+      loop: "{{ (range(0, scale_many_vrfs_count | int) | list) if (scale_many_vrfs_enabled | bool) else [] }}"
+      delegate_to: localhost
+      tags: scale_many_vrfs
+
+    - name: SCALE - Display scale plan
+      ansible.builtin.debug:
+        msg:
+          - "VRF={{ scale_vrf_name }}"
+          - "switch1={{ test_switch1 }}, links={{ scale_switch1_links | length }}"
+          - "switch2={{ test_switch2 | default('') }}, enabled={{ scale_two_switch_enabled }}, links={{ scale_switch2_links | length }}"
+          - "many_vrfs_enabled={{ scale_many_vrfs_enabled }}, many_vrfs={{ scale_many_vrfs_conf | length }}"
+          - "dot1q={{ scale_dot1q_start }}-{{ (scale_dot1q_start | int) + (scale_link_count | int) - 1 }}"
+      tags:
+        - scale_single_switch
+        - scale_two_switch
+        - scale_many_vrfs
+
+    - name: SCALE - Execute single-switch scale scenario
+      tags: scale_single_switch
+      block:
+        - name: SCALE - TC1 - CHECK MODE - Plan single-switch scale create
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: merged
+            config_actions:
+              save: true
+              deploy: true
+              type: switch
+            verify:
+              enabled: false
+            config: "{{ scale_single_switch_conf }}"
+          check_mode: true
+          register: scale_single_check
+
+        - name: SCALE - TC1 - ASSERT - Check mode planned single-switch scale
+          ansible.builtin.assert:
+            that:
+              - scale_single_check.failed == false
+              - scale_single_check.changed == true
+
+        - name: SCALE TIMING - Mark single-link create/deploy start
+          ansible.builtin.set_fact:
+            scale_timing_single_create_deploy_start: "{{ lookup('pipe', 'date +%s') | int }}"
+
+        - name: SCALE - TC2 - MERGE - Create and deploy one VRF Lite row on one switch
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: merged
+            config_actions:
+              save: true
+              deploy: true
+              type: switch
+            verify:
+              enabled: false
+            config: "{{ scale_single_link_conf }}"
+          register: scale_single_link_create_deploy
+
+        - name: SCALE TIMING - Record single-link create/deploy seconds
+          ansible.builtin.set_fact:
+            scale_timing_single_create_deploy_end: "{{ lookup('pipe', 'date +%s') | int }}"
+
+        - name: SCALE TIMING - Calculate single-link create/deploy seconds
+          ansible.builtin.set_fact:
+            scale_timing_single_create_deploy_seconds: >-
+              {{
+                (scale_timing_single_create_deploy_end | int)
+                - (scale_timing_single_create_deploy_start | int)
+              }}
+
+        - name: SCALE - TC2 - ASSERT - Single-link create and deploy changed
+          ansible.builtin.assert:
+            that:
+              - scale_single_link_create_deploy.failed == false
+              - scale_single_link_create_deploy.changed == true
+
+        - name: SCALE - TC2 - GATHER - Query single-link VRF Lite row
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: gathered
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+          register: scale_single_link_gather
+
+        - name: SCALE - TC2 - Select gathered single-link attachment
+          ansible.builtin.set_fact:
+            scale_single_link_attach_entries: >-
+              {{
+                (
+                  scale_single_link_gather.gathered | default([])
+                  | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                  | list
+                  | first
+                  | default({})
+                ).attach | default([])
+                | selectattr('ip_address', 'equalto', test_switch1)
+                | list
+              }}
+
+        - name: SCALE - TC2 - ASSERT - Gathered single-link count matches
+          ansible.builtin.assert:
+            that:
+              - scale_single_link_gather.failed == false
+              - scale_single_link_attach_entries | length == 1
+              - (scale_single_link_attach_entries[0].vrf_lite | default([]) | length) == 1
+
+        - name: SCALE TIMING - Mark single-link delete/deploy start
+          ansible.builtin.set_fact:
+            scale_timing_single_delete_deploy_start: "{{ lookup('pipe', 'date +%s') | int }}"
+
+        - name: SCALE - TC2b - DELETE - Remove and deploy one VRF Lite row on one switch
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: deleted
+            config_actions:
+              save: true
+              deploy: true
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+                attach:
+                  - ip_address: "{{ test_switch1 }}"
+                    deploy: true
+          register: scale_single_link_delete_deploy
+
+        - name: SCALE TIMING - Record single-link delete/deploy seconds
+          ansible.builtin.set_fact:
+            scale_timing_single_delete_deploy_end: "{{ lookup('pipe', 'date +%s') | int }}"
+
+        - name: SCALE TIMING - Calculate single-link delete/deploy seconds
+          ansible.builtin.set_fact:
+            scale_timing_single_delete_deploy_seconds: >-
+              {{
+                (scale_timing_single_delete_deploy_end | int)
+                - (scale_timing_single_delete_deploy_start | int)
+              }}
+
+        - name: SCALE - TC2b - ASSERT - Single-link delete and deploy changed
+          ansible.builtin.assert:
+            that:
+              - scale_single_link_delete_deploy.failed == false
+              - scale_single_link_delete_deploy.changed == true
+
+        - name: SCALE TIMING - Mark scaled create/deploy start
+          ansible.builtin.set_fact:
+            scale_timing_scaled_create_deploy_start: "{{ lookup('pipe', 'date +%s') | int }}"
+
+        - name: SCALE - TC3 - MERGE - Create and deploy scaled VRF Lite rows on one switch
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: merged
+            config_actions:
+              save: true
+              deploy: true
+              type: switch
+            verify:
+              enabled: false
+            config: "{{ scale_single_switch_conf }}"
+          register: scale_single_create
+
+        - name: SCALE TIMING - Record scaled create/deploy seconds
+          ansible.builtin.set_fact:
+            scale_timing_scaled_create_deploy_end: "{{ lookup('pipe', 'date +%s') | int }}"
+
+        - name: SCALE TIMING - Calculate scaled create/deploy seconds
+          ansible.builtin.set_fact:
+            scale_timing_scaled_create_deploy_seconds: >-
+              {{
+                (scale_timing_scaled_create_deploy_end | int)
+                - (scale_timing_scaled_create_deploy_start | int)
+              }}
+
+        - name: SCALE - TC3 - ASSERT - Single-switch scale create and deploy changed
+          ansible.builtin.assert:
+            that:
+              - scale_single_create.failed == false
+              - scale_single_create.changed == true
+
+        - name: SCALE - TC3 - GATHER - Query scaled VRF Lite rows
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: gathered
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+          register: scale_single_gather
+
+        - name: SCALE - TC3 - Select gathered single-switch attachment
+          ansible.builtin.set_fact:
+            scale_single_vrf_entries: >-
+              {{
+                scale_single_gather.gathered | default([])
+                | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                | list
+              }}
+            scale_single_attach_entries: >-
+              {{
+                (
+                  scale_single_gather.gathered | default([])
+                  | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                  | list
+                  | first
+                  | default({})
+                ).attach | default([])
+                | selectattr('ip_address', 'equalto', test_switch1)
+                | list
+              }}
+
+        - name: SCALE - TC3 - ASSERT - Gathered single-switch count matches
+          ansible.builtin.assert:
+            that:
+              - scale_single_gather.failed == false
+              - scale_single_vrf_entries | length == 1
+              - scale_single_attach_entries | length == 1
+              - (scale_single_attach_entries[0].vrf_lite | default([]) | length) == (scale_link_count | int)
+
+        - name: SCALE - TC4 - MERGE - Re-run single-switch scale for idempotence
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: merged
+            config_actions:
+              save: true
+              deploy: true
+              type: switch
+            verify:
+              enabled: false
+            config: "{{ scale_single_switch_conf }}"
+          register: scale_single_idempotent
+
+        - name: SCALE - TC4 - ASSERT - Single-switch scale is idempotent
+          ansible.builtin.assert:
+            that:
+              - scale_single_idempotent.failed == false
+              - scale_single_idempotent.changed == false
+
+        - name: SCALE TIMING - Mark scaled delete/deploy start
+          ansible.builtin.set_fact:
+            scale_timing_scaled_delete_deploy_start: "{{ lookup('pipe', 'date +%s') | int }}"
+
+        - name: SCALE - TC5 - DELETE - Remove and deploy scaled VRF Lite rows on one switch
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: deleted
+            config_actions:
+              save: true
+              deploy: true
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+                attach:
+                  - ip_address: "{{ test_switch1 }}"
+                    deploy: true
+          register: scale_single_delete
+
+        - name: SCALE TIMING - Record scaled delete/deploy seconds
+          ansible.builtin.set_fact:
+            scale_timing_scaled_delete_deploy_end: "{{ lookup('pipe', 'date +%s') | int }}"
+
+        - name: SCALE TIMING - Calculate scaled delete/deploy seconds
+          ansible.builtin.set_fact:
+            scale_timing_scaled_delete_deploy_seconds: >-
+              {{
+                (scale_timing_scaled_delete_deploy_end | int)
+                - (scale_timing_scaled_delete_deploy_start | int)
+              }}
+
+        - name: SCALE - TC5 - ASSERT - Single-switch scale delete and deploy changed
+          ansible.builtin.assert:
+            that:
+              - scale_single_delete.failed == false
+              - scale_single_delete.changed == true
+
+        - name: SCALE - TC5 - GATHER - Query after single-switch scale delete
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: gathered
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+          register: scale_single_delete_gather
+
+        - name: SCALE - TC5 - Select gathered single-switch attachment after delete
+          ansible.builtin.set_fact:
+            scale_single_delete_vrf_entries: >-
+              {{
+                scale_single_delete_gather.gathered | default([])
+                | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                | list
+              }}
+            scale_single_delete_attach_entries: >-
+              {{
+                (
+                  scale_single_delete_gather.gathered | default([])
+                  | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                  | list
+                  | first
+                  | default({})
+                ).attach | default([])
+                | selectattr('ip_address', 'equalto', test_switch1)
+                | list
+              }}
+
+        - name: SCALE - TC5 - ASSERT - Single-switch scale delete removed attachment
+          ansible.builtin.assert:
+            that:
+              - scale_single_delete_gather.failed == false
+              - scale_single_delete_vrf_entries | length == 1
+              - scale_single_delete_attach_entries | length == 0
+      always:
+        - name: SCALE - TC CLEANUP - Remove single-switch scaled VRF Lite rows
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: deleted
+            config_actions:
+              save: true
+              deploy: true
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+                attach:
+                  - ip_address: "{{ test_switch1 }}"
+                    deploy: true
+          failed_when: false
+
+    - name: SCALE TIMING - Calculate total measured single-switch deploy seconds
+      ansible.builtin.set_fact:
+        scale_timing_total_deploy_seconds: >-
+          {{
+            (scale_timing_single_create_deploy_seconds | default(0) | int)
+            + (scale_timing_single_delete_deploy_seconds | default(0) | int)
+            + (scale_timing_scaled_create_deploy_seconds | default(0) | int)
+            + (scale_timing_scaled_delete_deploy_seconds | default(0) | int)
+          }}
+      tags: scale_single_switch
+
+    - name: SCALE TIMING - SUMMARY - Single-switch create/deploy/delete/deploy
+      ansible.builtin.debug:
+        msg:
+          - "TIMING SUMMARY: VRF Lite single-switch create/deploy/delete/deploy"
+          - "fabric={{ test_fabric }}"
+          - "vrf={{ scale_vrf_name }}"
+          - "switch={{ test_switch1 }}"
+          - "single_rows=1 create_deploy_seconds={{ scale_timing_single_create_deploy_seconds | default('not_run') }}"
+          - "single_rows=1 delete_deploy_seconds={{ scale_timing_single_delete_deploy_seconds | default('not_run') }}"
+          - "scale_rows={{ scale_link_count }} create_deploy_seconds={{ scale_timing_scaled_create_deploy_seconds | default('not_run') }}"
+          - "scale_rows={{ scale_link_count }} delete_deploy_seconds={{ scale_timing_scaled_delete_deploy_seconds | default('not_run') }}"
+          - "total_measured_seconds={{ scale_timing_total_deploy_seconds | default('not_run') }}"
+      tags: scale_single_switch
+
+    - name: SCALE - Execute two-switch scale scenario
+      when: scale_two_switch_enabled | bool
+      tags: scale_two_switch
+      block:
+        - name: SCALE - TC4 - MERGE - Create scaled VRF Lite rows on two switches
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: merged
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config: "{{ scale_two_switch_conf }}"
+          register: scale_two_switch_create
+
+        - name: SCALE - TC4 - ASSERT - Two-switch scale create changed
+          ansible.builtin.assert:
+            that:
+              - scale_two_switch_create.failed == false
+              - scale_two_switch_create.changed == true
+
+        - name: SCALE - TC4 - GATHER - Query two-switch scale rows
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: gathered
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+          register: scale_two_switch_gather
+
+        - name: SCALE - TC4 - Select gathered two-switch attachments
+          ansible.builtin.set_fact:
+            scale_two_switch_vrf_entries: >-
+              {{
+                scale_two_switch_gather.gathered | default([])
+                | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                | list
+              }}
+            scale_two_switch_attach1_entries: >-
+              {{
+                (
+                  scale_two_switch_gather.gathered | default([])
+                  | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                  | list
+                  | first
+                  | default({})
+                ).attach | default([])
+                | selectattr('ip_address', 'equalto', test_switch1)
+                | list
+              }}
+            scale_two_switch_attach2_entries: >-
+              {{
+                (
+                  scale_two_switch_gather.gathered | default([])
+                  | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                  | list
+                  | first
+                  | default({})
+                ).attach | default([])
+                | selectattr('ip_address', 'equalto', test_switch2)
+                | list
+              }}
+
+        - name: SCALE - TC4 - ASSERT - Gathered two-switch counts match
+          ansible.builtin.assert:
+            that:
+              - scale_two_switch_gather.failed == false
+              - scale_two_switch_vrf_entries | length == 1
+              - scale_two_switch_attach1_entries | length == 1
+              - scale_two_switch_attach2_entries | length == 1
+              - (scale_two_switch_attach1_entries[0].vrf_lite | default([]) | length) == (scale_link_count | int)
+              - (scale_two_switch_attach2_entries[0].vrf_lite | default([]) | length) == (scale_two_switch_count | int)
+
+        - name: SCALE - TC4b - DELETE - Remove scaled VRF Lite rows on two switches
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: deleted
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+                attach:
+                  - ip_address: "{{ test_switch1 }}"
+                  - ip_address: "{{ test_switch2 }}"
+          register: scale_two_switch_delete
+
+        - name: SCALE - TC4b - ASSERT - Two-switch scale delete changed
+          ansible.builtin.assert:
+            that:
+              - scale_two_switch_delete.failed == false
+              - scale_two_switch_delete.changed == true
+
+        - name: SCALE - TC4b - GATHER - Query after two-switch scale delete
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: gathered
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+          register: scale_two_switch_delete_gather
+
+        - name: SCALE - TC4b - Select gathered two-switch attachments after delete
+          ansible.builtin.set_fact:
+            scale_two_switch_delete_vrf_entries: >-
+              {{
+                scale_two_switch_delete_gather.gathered | default([])
+                | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                | list
+              }}
+            scale_two_switch_delete_attach1_entries: >-
+              {{
+                (
+                  scale_two_switch_delete_gather.gathered | default([])
+                  | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                  | list
+                  | first
+                  | default({})
+                ).attach | default([])
+                | selectattr('ip_address', 'equalto', test_switch1)
+                | list
+              }}
+            scale_two_switch_delete_attach2_entries: >-
+              {{
+                (
+                  scale_two_switch_delete_gather.gathered | default([])
+                  | selectattr('vrf_name', 'equalto', scale_vrf_name)
+                  | list
+                  | first
+                  | default({})
+                ).attach | default([])
+                | selectattr('ip_address', 'equalto', test_switch2)
+                | list
+              }}
+
+        - name: SCALE - TC4b - ASSERT - Two-switch scale delete removed attachments
+          ansible.builtin.assert:
+            that:
+              - scale_two_switch_delete_gather.failed == false
+              - scale_two_switch_delete_vrf_entries | length == 1
+              - scale_two_switch_delete_attach1_entries | length == 0
+              - scale_two_switch_delete_attach2_entries | length == 0
+      always:
+        - name: SCALE - TC CLEANUP - Remove two-switch scaled VRF Lite rows
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: deleted
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config:
+              - vrf_name: "{{ scale_vrf_name }}"
+                attach:
+                  - ip_address: "{{ test_switch1 }}"
+                  - ip_address: "{{ test_switch2 }}"
+          failed_when: false
+
+    - name: SCALE - Execute many-VRF one-link scenario
+      when: scale_many_vrfs_enabled | bool
+      tags: scale_many_vrfs
+      block:
+        - name: SCALE - TC5 - MERGE - Create one VRF Lite row across many pre-created VRFs
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: merged
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config: "{{ scale_many_vrfs_conf }}"
+          register: scale_many_vrfs_create
+
+        - name: SCALE - TC5 - ASSERT - Many-VRF create changed
+          ansible.builtin.assert:
+            that:
+              - scale_many_vrfs_create.failed == false
+              - scale_many_vrfs_create.changed == true
+      always:
+        - name: SCALE - TC CLEANUP - Remove many-VRF scaled rows
+          cisco.nd.nd_manage_vrf_lite:
+            <<: *nd_info
+            timeout: "{{ scale_timeout }}"
+            fabric_name: "{{ test_fabric }}"
+            state: deleted
+            config_actions:
+              save: false
+              deploy: false
+              type: switch
+            verify:
+              enabled: false
+            config: "{{ scale_many_vrfs_conf }}"
+          failed_when: false

--- a/tests/integration/targets/nd_manage_vrf_lite/templates/nd_manage_vrf_lite_conf.j2
+++ b/tests/integration/targets/nd_manage_vrf_lite/templates/nd_manage_vrf_lite_conf.j2
@@ -1,0 +1,73 @@
+---
+# This nd_manage_vrf_lite test data structure is auto-generated
+# DO NOT EDIT MANUALLY
+#
+# Template: nd_manage_vrf_lite_conf.j2
+# Variables: vrf_lite_conf (list of dicts)
+
+{% if vrf_lite_conf is iterable %}
+{% set vrf_list = [] %}
+{% for vrf in vrf_lite_conf %}
+{% set vrf_item = {} %}
+{% if vrf.vrf_name is defined %}
+{% set _ = vrf_item.update({'vrf_name': vrf.vrf_name}) %}
+{% endif %}
+{% if vrf.vlan_id is defined %}
+{% set _ = vrf_item.update({'vlan_id': vrf.vlan_id}) %}
+{% endif %}
+{% if vrf.deploy is defined %}
+{% set _ = vrf_item.update({'deploy': vrf.deploy}) %}
+{% endif %}
+{% if vrf.attach is defined %}
+{% set attach_list = [] %}
+{% for att in vrf.attach %}
+{% set att_item = {} %}
+{% if att.ip_address is defined %}
+{% set _ = att_item.update({'ip_address': att.ip_address}) %}
+{% endif %}
+{% if att.deploy is defined %}
+{% set _ = att_item.update({'deploy': att.deploy}) %}
+{% endif %}
+{% if att.import_evpn_rt is defined %}
+{% set _ = att_item.update({'import_evpn_rt': att.import_evpn_rt}) %}
+{% endif %}
+{% if att.export_evpn_rt is defined %}
+{% set _ = att_item.update({'export_evpn_rt': att.export_evpn_rt}) %}
+{% endif %}
+{% if att.vrf_lite is defined %}
+{% set lite_list = [] %}
+{% for lite in att.vrf_lite %}
+{% set lite_item = {} %}
+{% if lite.interface is defined %}
+{% set _ = lite_item.update({'interface': lite.interface}) %}
+{% endif %}
+{% if lite.dot1q is defined %}
+{% set _ = lite_item.update({'dot1q': lite.dot1q}) %}
+{% endif %}
+{% if lite.ipv4_addr is defined %}
+{% set _ = lite_item.update({'ipv4_addr': lite.ipv4_addr}) %}
+{% endif %}
+{% if lite.neighbor_ipv4 is defined %}
+{% set _ = lite_item.update({'neighbor_ipv4': lite.neighbor_ipv4}) %}
+{% endif %}
+{% if lite.ipv6_addr is defined %}
+{% set _ = lite_item.update({'ipv6_addr': lite.ipv6_addr}) %}
+{% endif %}
+{% if lite.neighbor_ipv6 is defined %}
+{% set _ = lite_item.update({'neighbor_ipv6': lite.neighbor_ipv6}) %}
+{% endif %}
+{% if lite.peer_vrf is defined %}
+{% set _ = lite_item.update({'peer_vrf': lite.peer_vrf}) %}
+{% endif %}
+{% set _ = lite_list.append(lite_item) %}
+{% endfor %}
+{% set _ = att_item.update({'vrf_lite': lite_list}) %}
+{% endif %}
+{% set _ = attach_list.append(att_item) %}
+{% endfor %}
+{% set _ = vrf_item.update({'attach': attach_list}) %}
+{% endif %}
+{% set _ = vrf_list.append(vrf_item) %}
+{% endfor %}
+{{ vrf_list | to_nice_yaml(indent=2) | trim }}
+{% endif %}

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_vrf_lite.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_vrf_lite.py
@@ -1,0 +1,30 @@
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.runtime_endpoints import (
+    VrfLiteEndpoints,
+)
+
+
+def test_endpoints_api_v1_vrf_lite_00100_runtime_endpoints_use_required_api_contracts():
+    # Legacy top-down paths are hand-built in this module and percent-encode the
+    # fabric name, so a spaced name exercises that encoding.
+    assert (
+        VrfLiteEndpoints.vrf_attachments_query("Fab A", "BLUE,GREEN")
+        == "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/Fab%20A/vrfs/attachments?vrf-names=BLUE,GREEN"
+    )
+    assert VrfLiteEndpoints.vrf_attachments_post("Fab A") == "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/Fab%20A/vrfs/attachments"
+    assert (
+        VrfLiteEndpoints.vrf_switch("Fab A", "BLUE", "SN1,SN2")
+        == "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/Fab%20A/vrfs/switches?vrf-names=BLUE&serial-numbers=SN1,SN2"
+    )
+    assert VrfLiteEndpoints.reserve_id("Fab A") == "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/reserve-id"
+
+    # Manage-API paths delegate to the canonical endpoint models, which own their
+    # own path formatting; assert the contract with a plain fabric name.
+    assert VrfLiteEndpoints.vrfs("FABRIC1") == "/api/v1/manage/fabrics/FABRIC1/vrfs"
+    assert VrfLiteEndpoints.vrf_deployments("FABRIC1") == "/api/v1/manage/fabrics/FABRIC1/vrfActions/deploy"
+    assert VrfLiteEndpoints.config_save("FABRIC1") == "/api/v1/manage/fabrics/FABRIC1/actions/configSave"

--- a/tests/unit/module_utils/test_manage_vrf_lite.py
+++ b/tests/unit/module_utils/test_manage_vrf_lite.py
@@ -32,9 +32,11 @@ from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.deploy im
     _changed_entries_from_preview,
     _deployment_intent,
     _needs_deployment,
+    _scoped_pending_deploy_targets,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query import (
     _coerce_vlan,
+    _has_vrf_lite_extension_marker,
     _query_fabric_switches,
     _query_vrf_attachments,
     _query_vrf_switch_details,
@@ -711,6 +713,104 @@ def test_manage_vrf_lite_00481_query_enriches_pending_attachment_from_switch_det
     assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["extension_values"] == extension_values
     assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["freeform_config"] == "router ospf 100"
     assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["vlan"] == 2
+    assert module.params["_pending_deploy_targets"] == [
+        {"vrf_name": "BLUE", "switch_ip": "SN1", "operation": "write"}
+    ]
+
+
+def test_manage_vrf_lite_00481aa_query_preserves_pending_empty_removal_marker(monkeypatch):
+    module = _DummyModule({})
+    empty_vrf_lite = json.dumps(
+        {
+            "VRF_LITE_CONN": json.dumps({"VRF_LITE_CONN": []}, separators=(",", ":")),
+            "MULTISITE_CONN": json.dumps({"MULTISITE_CONN": []}, separators=(",", ":")),
+        },
+        separators=(",", ":"),
+    )
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_fabric_switches",
+        lambda _module, _rest_send, _fabric_name: {"SN1": "10.0.0.1"},
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrfs",
+        lambda _module, _rest_send, _fabric_name: [{"vrfName": "BLUE", "vlanId": 500}],
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrf_attachments",
+        lambda **_kwargs: [
+            {
+                "vrfName": "BLUE",
+                "lanAttachList": [
+                    {
+                        "serialNumber": "SN1",
+                        "isLanAttached": True,
+                        "lanAttachState": "PENDING",
+                        "vlanId": 500,
+                        "extensionValues": empty_vrf_lite,
+                        "instanceValues": "{}",
+                    }
+                ],
+            }
+        ],
+    )
+
+    result = query_vrf_lite_state(module=module, rest_send=object(), fabric_name="FABRIC1", filter_vrfs={"BLUE"})
+
+    assert result == [{"vrf_name": "BLUE", "vlan_id": 500, "deploy": False, "attach": []}]
+    assert module.params["_not_in_sync_vrfs"] == ["BLUE"]
+    assert module.params["_pending_deploy_targets"] == [
+        {"vrf_name": "BLUE", "switch_ip": "SN1", "operation": "delete"}
+    ]
+
+
+def test_manage_vrf_lite_00481ab_query_does_not_claim_unrelated_pending_extension(monkeypatch):
+    module = _DummyModule({})
+    unrelated_extension = json.dumps({"MULTISITE_CONN": json.dumps({"MULTISITE_CONN": []})})
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_fabric_switches",
+        lambda _module, _rest_send, _fabric_name: {"SN1": "10.0.0.1"},
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrfs",
+        lambda _module, _rest_send, _fabric_name: [{"vrfName": "BLUE", "vlanId": 500}],
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrf_attachments",
+        lambda **_kwargs: [
+            {
+                "vrfName": "BLUE",
+                "lanAttachList": [
+                    {
+                        "serialNumber": "SN1",
+                        "isLanAttached": True,
+                        "lanAttachState": "PENDING",
+                        "vlanId": 500,
+                        "extensionValues": unrelated_extension,
+                    }
+                ],
+            }
+        ],
+    )
+
+    query_vrf_lite_state(module=module, rest_send=object(), fabric_name="FABRIC1", filter_vrfs={"BLUE"})
+
+    assert module.params["_pending_deploy_targets"] == []
+    assert module.params["_not_in_sync_vrfs"] == []
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param('{"VRF_LITE_CONN":"{\\"VRF_LITE_CONN\\":[]}"}', True, id="empty-marker"),
+        pytest.param({"VRF_LITE_CONN": {"VRF_LITE_CONN": []}}, True, id="dict-marker"),
+        pytest.param('{"MULTISITE_CONN":"{}"}', False, id="unrelated"),
+        pytest.param("", False, id="empty"),
+    ],
+)
+def test_manage_vrf_lite_00481ac_extension_marker_detection(value, expected):
+    assert _has_vrf_lite_extension_marker(value) is expected
 
 
 def test_manage_vrf_lite_00481a_attachment_query_uses_lossless_top_down_get():
@@ -888,6 +988,128 @@ def test_manage_vrf_lite_00490_deploy_needed_when_state_machine_changed_without_
     module = _DummyModule({})
 
     assert _needs_deployment({"changed": True}, module) is True
+
+
+@pytest.mark.parametrize(
+    ("state", "config", "expected"),
+    [
+        pytest.param(
+            "merged",
+            [{"vrf_name": "BLUE", "attach": [{"ip_address": "SN1"}]}],
+            {("BLUE", "SN1", "write")},
+            id="merged-exact-pair",
+        ),
+        pytest.param(
+            "replaced",
+            [{"vrf_name": "BLUE", "attach": [{"ip_address": "SN1"}]}],
+            {("BLUE", "SN1", "write"), ("BLUE", "SN2", "delete")},
+            id="replaced-listed-vrf",
+        ),
+        pytest.param(
+            "overridden",
+            [{"vrf_name": "BLUE", "attach": [{"ip_address": "SN1"}]}],
+            {
+                ("BLUE", "SN1", "write"),
+                ("BLUE", "SN2", "delete"),
+                ("GREEN", "SN3", "delete"),
+            },
+            id="overridden-fabric-intent",
+        ),
+        pytest.param(
+            "deleted",
+            [{"vrf_name": "BLUE", "attach": [{"ip_address": "SN2"}]}],
+            {("BLUE", "SN2", "delete")},
+            id="deleted-specific-pair",
+        ),
+        pytest.param(
+            "deleted",
+            [{"vrf_name": "BLUE"}],
+            {("BLUE", "SN2", "delete")},
+            id="deleted-whole-vrf",
+        ),
+    ],
+)
+def test_manage_vrf_lite_00490a_pending_targets_are_scoped_by_requested_state(state, config, expected):
+    module = _DummyModule(
+        {
+            "state": state,
+            "_vrf_lite_requested_state": state,
+            "_vrf_lite_nested_config": config,
+            "config_actions": {"save": True, "deploy": True, "type": "switch"},
+            "_pending_deploy_targets": [
+                {"vrf_name": "BLUE", "switch_ip": "SN1", "operation": "write"},
+                {"vrf_name": "BLUE", "switch_ip": "SN2", "operation": "delete"},
+                {"vrf_name": "GREEN", "switch_ip": "SN3", "operation": "delete"},
+            ],
+        }
+    )
+
+    targets = _scoped_pending_deploy_targets(module)
+
+    assert {(target["vrf_name"], target["switch_ip"], target["operation"]) for target in targets} == expected
+
+
+def test_manage_vrf_lite_00490b_pending_target_requires_final_deploy_request():
+    params = {
+        "_vrf_lite_requested_state": "merged",
+        "_vrf_lite_nested_config": [{"vrf_name": "BLUE", "attach": [{"ip_address": "SN1"}]}],
+        "_pending_deploy_targets": [{"vrf_name": "BLUE", "switch_ip": "SN1", "operation": "write"}],
+        "_changed_vrfs": [],
+    }
+    module = _DummyModule({**params, "config_actions": {"save": True, "deploy": False, "type": "switch"}})
+    assert _needs_deployment({"changed": False}, module) is False
+
+    module = _DummyModule({**params, "config_actions": {"save": True, "deploy": True, "type": "switch"}})
+    assert _needs_deployment({"changed": False}, module) is True
+
+
+def test_manage_vrf_lite_00490c_later_identical_run_deploys_pending_target_once(monkeypatch):
+    captured = _capture_config_action_requests(monkeypatch)
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "_vrf_lite_requested_state": "merged",
+            "_vrf_lite_nested_config": [{"vrf_name": "BLUE", "attach": [{"ip_address": "SN1"}]}],
+            "config_actions": {"save": True, "deploy": True, "type": "switch"},
+            "_changed_vrfs": [],
+            "_deploy_targets": [],
+            "_pending_deploy_targets": [{"vrf_name": "BLUE", "switch_ip": "SN1", "operation": "write"}],
+        }
+    )
+
+    result = _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": False})
+
+    assert result["changed"] is True
+    assert result["deployment_needed"] is True
+    assert result["target_vrfs"] == ["BLUE"]
+    assert captured == [
+        {"path": VrfLiteEndpoints.config_save("FABRIC1"), "payload": {}},
+        {
+            "path": VrfLiteEndpoints.vrf_deployments("FABRIC1"),
+            "payload": {"vrfNames": ["BLUE"], "switchIds": ["SN1"]},
+        },
+    ]
+
+
+def test_manage_vrf_lite_00490d_in_sync_identical_run_remains_idempotent(monkeypatch):
+    captured = _capture_config_action_requests(monkeypatch)
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "_vrf_lite_requested_state": "merged",
+            "_vrf_lite_nested_config": [{"vrf_name": "BLUE", "attach": [{"ip_address": "SN1"}]}],
+            "config_actions": {"save": True, "deploy": True, "type": "switch"},
+            "_changed_vrfs": [],
+            "_deploy_targets": [],
+            "_pending_deploy_targets": [],
+        }
+    )
+
+    result = _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": False})
+
+    assert result["changed"] is False
+    assert result["deployment_needed"] is False
+    assert captured == []
 
 
 def test_manage_vrf_lite_00491_deploy_targets_honor_vrf_and_attachment_intent():

--- a/tests/unit/module_utils/test_manage_vrf_lite.py
+++ b/tests/unit/module_utils/test_manage_vrf_lite.py
@@ -713,9 +713,7 @@ def test_manage_vrf_lite_00481_query_enriches_pending_attachment_from_switch_det
     assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["extension_values"] == extension_values
     assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["freeform_config"] == "router ospf 100"
     assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["vlan"] == 2
-    assert module.params["_pending_deploy_targets"] == [
-        {"vrf_name": "BLUE", "switch_ip": "SN1", "operation": "write"}
-    ]
+    assert module.params["_pending_deploy_targets"] == [{"vrf_name": "BLUE", "switch_ip": "SN1", "operation": "write"}]
 
 
 def test_manage_vrf_lite_00481aa_query_preserves_pending_empty_removal_marker(monkeypatch):
@@ -759,9 +757,7 @@ def test_manage_vrf_lite_00481aa_query_preserves_pending_empty_removal_marker(mo
 
     assert result == [{"vrf_name": "BLUE", "vlan_id": 500, "deploy": False, "attach": []}]
     assert module.params["_not_in_sync_vrfs"] == ["BLUE"]
-    assert module.params["_pending_deploy_targets"] == [
-        {"vrf_name": "BLUE", "switch_ip": "SN1", "operation": "delete"}
-    ]
+    assert module.params["_pending_deploy_targets"] == [{"vrf_name": "BLUE", "switch_ip": "SN1", "operation": "delete"}]
 
 
 def test_manage_vrf_lite_00481ab_query_does_not_claim_unrelated_pending_extension(monkeypatch):

--- a/tests/unit/module_utils/test_manage_vrf_lite.py
+++ b/tests/unit/module_utils/test_manage_vrf_lite.py
@@ -1,0 +1,2647 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for nd_manage_vrf_lite merge/payload/config-actions behavior."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDModuleError
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions import (
+    _ensure_vrf_exists,
+    _request_vrf_lite_payload,
+    build_attach_payload_for_entry,
+    build_detach_payload_for_entry,
+    _post_attachment_payload,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.common import (
+    _VrfLiteListPayloadRestSend,
+    get_config_actions,
+    request_with_rest_send,
+    request_with_verify_settings,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.deploy import (
+    _changed_entries_from_preview,
+    _deployment_intent,
+    _needs_deployment,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query import (
+    _coerce_vlan,
+    _query_fabric_switches,
+    _query_vrf_attachments,
+    _query_vrf_switch_details,
+    _resolve_vrf_vlan,
+    query_vrf_lite_state,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.runtime_payloads import (
+    build_vrf_lite_extension_values,
+    parse_vrf_lite_extension_values,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.runtime_endpoints import (
+    VrfLiteEndpoints,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation import (
+    _extract_vrf_lite_prototypes,
+    _load_switch_inventory,
+    _vrf_lite_cache_key,
+    validate_vrf_lite_write_guardrails,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.exceptions import (
+    VrfLiteResourceError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.config_transform import (
+    explode_playbook_to_entries,
+    group_attachment_entries_to_vrfs,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_vrf_lite.vrf_lite_attachment_entry import (
+    VrfLiteAttachmentEntry,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+    NDConfigCollection,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_vrf_lite.vrf_lite_model import (
+    VrfLiteModel,
+    VrfLitePlaybookConfigModel,
+    VrfLitePlaybookItemModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite import (
+    ManageVrfLiteOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
+
+
+class _DummyModule:
+    def __init__(self, params):
+        self.params = params
+        self._debug = False
+        self.check_mode = bool(params.get("check_mode", False))
+
+
+class _DummyWarnModule(_DummyModule):
+    def __init__(self, params):
+        super().__init__(params)
+        self.warnings = []
+
+    def warn(self, msg):
+        self.warnings.append(msg)
+
+
+class _StubEntry:
+    """Minimal attachment-entry stand-in for preflight validation tests."""
+
+    def __init__(self, vrf_name, switch_ip, extensions=None):
+        self.vrf_name = vrf_name
+        self.switch_ip = switch_ip
+        self.extensions = extensions
+
+
+def _vrf_lite_orchestrator(module):
+    sender = Sender()
+    sender.ansible_module = module
+    rest_send = RestSend(
+        {
+            "check_mode": module.check_mode,
+            "state": module.params.get("state"),
+        }
+    )
+    rest_send.sender = sender
+    rest_send.response_handler = ResponseHandler()
+    return ManageVrfLiteOrchestrator(rest_send=rest_send)
+
+
+def _vrf_lite_prototype(interface="Ethernet1/10", extension_values=None):
+    values = {
+        "PEER_VRF_NAME": "",
+        "NEIGHBOR_IP": "192.0.2.1",
+        "VRF_LITE_JYTHON_TEMPLATE": "Ext_VRF_Lite_Jython",
+        "enableBorderExtension": "VRF_LITE",
+        "AUTO_VRF_LITE_FLAG": "false",
+        "IP_MASK": "192.0.2.2/31",
+        "MTU": "9216",
+        "NEIGHBOR_ASN": "65001",
+        "IF_NAME": interface,
+        "IPV6_NEIGHBOR": "",
+        "IPV6_MASK": "",
+        "DOT1Q_ID": "2",
+        "asn": "65000",
+    }
+    if extension_values is not None:
+        values = extension_values
+    return {
+        "interfaceName": interface,
+        "extensionType": "VRF_LITE",
+        "extensionValues": json.dumps(values) if isinstance(values, dict) else values,
+    }
+
+
+def _vrf_lite_switch_detail(serial_number="SN1", prototypes=None, **extra):
+    detail = {
+        "serialNumber": serial_number,
+        "role": "border gateway",
+        "extensionPrototypeValues": [_vrf_lite_prototype()] if prototypes is None else prototypes,
+        "islanAttached": False,
+    }
+    detail.update(extra)
+    return detail
+
+
+def _vrf_lite_guardrail_model(interface="Ethernet1/10"):
+    return VrfLiteModel.from_config(
+        {
+            "vrf_name": "BLUE",
+            "attach": [
+                {
+                    "ip_address": "10.0.0.1",
+                    "vrf_lite": [
+                        {
+                            "interface": interface,
+                            "neighbor_ipv4": "192.0.2.9",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+def _mock_guardrail_inventory(monkeypatch, role="border", fabric_type=None):
+    switch_data = {
+        "role": role,
+        "ip_address": "10.0.0.1",
+        "raw": {},
+    }
+    if fabric_type is not None:
+        switch_data["fabric_type"] = fabric_type
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation._load_switch_inventory",
+        lambda _module, _fabric_name, _rest_send: {"SN1": switch_data},
+    )
+
+
+def test_manage_vrf_lite_00050_model_exposes_module_argspec():
+    assert VrfLiteModel.get_argument_spec() == VrfLitePlaybookConfigModel.get_argument_spec()
+
+
+@pytest.mark.parametrize("model_class", [VrfLiteModel, VrfLitePlaybookItemModel])
+def test_manage_vrf_lite_00052_plain_vrf_name_accepts_nd_maximum(model_class):
+    """The module field carries a plain VRF name, whose ND limit is 32."""
+    model = model_class(vrf_name="v" * 32)
+
+    assert model.vrf_name == "v" * 32
+
+
+@pytest.mark.parametrize("model_class", [VrfLiteModel, VrfLitePlaybookItemModel])
+def test_manage_vrf_lite_00053_plain_vrf_name_rejects_above_nd_maximum(model_class):
+    """Reject names that ND's plain VRF schema cannot accept on create."""
+    with pytest.raises(ValidationError):
+        model_class(vrf_name="v" * 33)
+
+
+def test_manage_vrf_lite_00060_existing_empty_vrf_passes_existence_check(monkeypatch):
+    """An existing VRF with no attachment rows must not be reported missing."""
+    module = _DummyModule({"fabric_name": "FABRIC1", "_known_vrfs": []})
+
+    def _query(**kwargs):
+        del kwargs
+        module.params["_known_vrfs"] = ["BLUE"]
+        return []
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions.query_vrf_lite_state",
+        _query,
+    )
+
+    _ensure_vrf_exists(module, rest_send=object(), vrf_name="BLUE")
+
+
+def test_manage_vrf_lite_00065_missing_vrf_fails_existence_check(monkeypatch):
+    """A VRF absent from the refreshed authoritative inventory is rejected."""
+    module = _DummyModule({"fabric_name": "FABRIC1", "_known_vrfs": []})
+
+    def _query(**kwargs):
+        del kwargs
+        module.params["_known_vrfs"] = ["GREEN"]
+        return []
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions.query_vrf_lite_state",
+        _query,
+    )
+
+    with pytest.raises(VrfLiteResourceError, match="does not exist"):
+        _ensure_vrf_exists(module, rest_send=object(), vrf_name="BLUE")
+
+
+@pytest.mark.parametrize("known_vrfs", [[], ["GREEN"]], ids=["empty-inventory", "different-vrf"])
+def test_manage_vrf_lite_00067_loaded_missing_vrf_fails_without_refresh(monkeypatch, known_vrfs):
+    """A cached absence is authoritative and fails without two more controller reads."""
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "_known_vrfs": known_vrfs,
+            "_known_vrfs_loaded": True,
+        }
+    )
+
+    def _unexpected_query(**kwargs):
+        pytest.fail("loaded VRF inventory must not be refreshed: {0}".format(kwargs))
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions.query_vrf_lite_state",
+        _unexpected_query,
+    )
+
+    with pytest.raises(VrfLiteResourceError, match="VRF 'BLUE' does not exist"):
+        _ensure_vrf_exists(module, rest_send=object(), vrf_name="BLUE")
+
+
+def test_manage_vrf_lite_00075_orchestrator_prepares_runtime_params():
+    module = _DummyModule(
+        {
+            "fabric_name": "F1",
+            "state": "merged",
+            "config_actions": {"save": True, "deploy": False, "type": "global"},
+            "verify": {"enabled": True, "retries": 2, "timeout": 9},
+        }
+    )
+    module_config = VrfLitePlaybookConfigModel.model_validate(
+        {
+            "fabric_name": "F1",
+            "state": "merged",
+            "config": [{"vrf_name": "BLUE", "vlan_id": 500}],
+        },
+        by_alias=True,
+        by_name=True,
+    )
+
+    ManageVrfLiteOrchestrator.prepare_module_params(module, module_config)
+
+    assert module.params["config"] == [{"vrf_name": "BLUE", "vlan_id": 500}]
+    assert module.params["config_actions"] == {
+        "save": True,
+        "deploy": False,
+        "type": "global",
+    }
+    assert module.params["verify"] == {"enabled": True, "retries": 2, "timeout": 9}
+    assert module.params["_changed_vrfs"] == []
+    assert module.params["_gather_filter_config"] == []
+    assert module.params["_known_vrfs"] == []
+    assert module.params["_known_vrfs_loaded"] is False
+    assert module.params["_fabric_switch_inventory"] == {}
+    assert module.params["_fabric_switch_inventory_loaded"] is False
+    assert module.params["_fabric_switch_inventory_normalized"] is False
+
+
+def test_manage_vrf_lite_00080_query_reuses_cached_gathered_have(monkeypatch):
+    cached_have = [{"vrf_name": "BLUE", "vlan_id": 500, "attach": []}]
+    module = _DummyModule(
+        {
+            "state": "gathered",
+            "fabric_name": "FABRIC1",
+            "_have": cached_have,
+            "_have_loaded": True,
+        }
+    )
+
+    def _fail_query(**kwargs):
+        del kwargs
+        pytest.fail("gathered query should reuse the state machine query result")
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.query_vrf_lite_state",
+        _fail_query,
+    )
+
+    assert _vrf_lite_orchestrator(module)._query_current_state() == cached_have
+
+
+def test_manage_vrf_lite_00100_merge_preserves_unmentioned_switch_and_interface_data():
+    have = VrfLiteModel.from_config(
+        {
+            "vrf_name": "BLUE",
+            "vlan_id": 500,
+            "attach": [
+                {
+                    "ip_address": "10.0.0.1",
+                    "import_evpn_rt": "100:1",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/10",
+                            "dot1q": 100,
+                            "ipv4_addr": "192.0.2.2/30",
+                            "neighbor_ipv4": "192.0.2.1",
+                        },
+                        {
+                            "interface": "Ethernet1/11",
+                            "dot1q": 101,
+                            "ipv4_addr": "192.0.2.6/30",
+                            "neighbor_ipv4": "192.0.2.5",
+                        },
+                    ],
+                },
+                {
+                    "ip_address": "10.0.0.2",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/12",
+                            "dot1q": 102,
+                            "ipv4_addr": "192.0.2.10/30",
+                            "neighbor_ipv4": "192.0.2.9",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    want = VrfLiteModel.from_config(
+        {
+            "vrf_name": "BLUE",
+            "attach": [
+                {
+                    "ip_address": "10.0.0.1",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/10",
+                            "neighbor_ipv4": "192.0.2.9",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    merged = have.merge(want)
+
+    assert merged.attach is not None
+    assert len(merged.attach) == 2
+
+    first_attach = {item.ip_address: item for item in merged.attach}["10.0.0.1"]
+    assert first_attach.vrf_lite is not None
+
+    merged_lite_map = {item.interface.lower(): item for item in first_attach.vrf_lite}
+    assert set(merged_lite_map.keys()) == {"ethernet1/10", "ethernet1/11"}
+
+    # Updated field from incoming payload
+    assert merged_lite_map["ethernet1/10"].neighbor_ipv4 == "192.0.2.9"
+    # Preserved field from existing payload
+    assert merged_lite_map["ethernet1/10"].dot1q == 100
+    # Preserved untouched interface
+    assert merged_lite_map["ethernet1/11"].dot1q == 101
+
+    # Preserved second switch attachment (not in incoming payload)
+    assert {item.ip_address for item in merged.attach} == {"10.0.0.1", "10.0.0.2"}
+
+
+def test_manage_vrf_lite_00200_extension_values_preserve_non_vrf_lite_keys():
+    existing_outer = {
+        "VRF_LITE_CONN": json.dumps({"VRF_LITE_CONN": [{"IF_NAME": "Ethernet1/1"}]}, separators=(",", ":")),
+        "MULTISITE_CONN": json.dumps({"MULTISITE_CONN": [{"site": "A"}]}, separators=(",", ":")),
+        "CUSTOM_EXTENSION": "keep-me",
+    }
+
+    rendered = build_vrf_lite_extension_values(
+        vrf_lite_items=[
+            {
+                "interface": "Ethernet1/20",
+                "dot1q": 500,
+                "ipv4_addr": "10.10.10.2/30",
+                "neighbor_ipv4": "10.10.10.1",
+            }
+        ],
+        existing_extension_values=json.dumps(existing_outer, separators=(",", ":")),
+    )
+
+    outer = json.loads(rendered)
+    assert outer["MULTISITE_CONN"] == existing_outer["MULTISITE_CONN"]
+    assert outer["CUSTOM_EXTENSION"] == "keep-me"
+
+    vrf_lite_inner = json.loads(outer["VRF_LITE_CONN"])
+    rows = vrf_lite_inner.get("VRF_LITE_CONN") or []
+    assert len(rows) == 1
+    assert rows[0]["IF_NAME"] == "Ethernet1/20"
+    assert rows[0]["DOT1Q_ID"] == "500"
+
+
+def test_manage_vrf_lite_00300_extension_values_clear_only_vrf_lite_section():
+    existing_outer = {
+        "VRF_LITE_CONN": json.dumps({"VRF_LITE_CONN": [{"IF_NAME": "Ethernet1/1"}]}, separators=(",", ":")),
+        "MULTISITE_CONN": json.dumps({"MULTISITE_CONN": [{"site": "A"}]}, separators=(",", ":")),
+        "OTHER": "preserve",
+    }
+
+    rendered = build_vrf_lite_extension_values(
+        vrf_lite_items=[],
+        existing_extension_values=json.dumps(existing_outer, separators=(",", ":")),
+    )
+
+    outer = json.loads(rendered)
+    assert outer["MULTISITE_CONN"] == existing_outer["MULTISITE_CONN"]
+    assert outer["OTHER"] == "preserve"
+
+    vrf_lite_inner = json.loads(outer["VRF_LITE_CONN"])
+    assert vrf_lite_inner == {"VRF_LITE_CONN": []}
+
+    # No pre-existing extension block + empty input should stay empty for detach payloads.
+    assert build_vrf_lite_extension_values(vrf_lite_items=[], existing_extension_values=None) == ""
+
+
+def test_manage_vrf_lite_00325_extension_values_does_not_mutate_existing_dict():
+    existing_outer = {
+        "VRF_LITE_CONN": json.dumps({"VRF_LITE_CONN": [{"IF_NAME": "Ethernet1/1"}]}, separators=(",", ":")),
+        "MULTISITE_CONN": json.dumps({"MULTISITE_CONN": [{"site": "A"}]}, separators=(",", ":")),
+    }
+    original = dict(existing_outer)
+
+    rendered = build_vrf_lite_extension_values(
+        vrf_lite_items=[],
+        existing_extension_values=existing_outer,
+    )
+
+    assert existing_outer == original
+    assert json.loads(json.loads(rendered)["VRF_LITE_CONN"]) == {"VRF_LITE_CONN": []}
+
+
+def test_manage_vrf_lite_00400_config_actions_ignore_legacy_top_level_deploy():
+    module_with_legacy_field_only = _DummyModule({"deploy": False})
+    actions = get_config_actions(module_with_legacy_field_only)
+    assert actions == {"save": True, "deploy": True, "type": "switch"}
+    assert get_config_actions({"deploy": False}) == {
+        "save": True,
+        "deploy": True,
+        "type": "switch",
+    }
+
+    module_with_config_actions = _DummyModule(
+        {
+            "deploy": False,
+            "config_actions": {
+                "save": True,
+                "deploy": False,
+                "type": "global",
+            },
+        }
+    )
+
+    configured_actions = get_config_actions(module_with_config_actions)
+    assert configured_actions == {"save": True, "deploy": False, "type": "global"}
+
+
+def test_manage_vrf_lite_00470_empty_fabric_switch_inventory_is_marked_loaded(monkeypatch):
+    class _EmptyFabricContext:
+        def __init__(self, rest_send, fabric_name):
+            del rest_send, fabric_name
+            self.switch_inventory_by_id = {}
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query.FabricContext",
+        _EmptyFabricContext,
+    )
+    module = _DummyModule({})
+
+    result = _query_fabric_switches(module, rest_send=object(), fabric_name="FABRIC1")
+
+    assert result == {}
+    assert module.params["_fabric_switch_inventory"] == {}
+    assert module.params["_fabric_switch_inventory_loaded"] is True
+    assert module.params["_fabric_switch_inventory_normalized"] is False
+
+
+def test_manage_vrf_lite_00475_query_ignores_detached_attachment_rows(monkeypatch):
+    module = _DummyModule({})
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_fabric_switches",
+        lambda _module, _rest_send, _fabric_name: {"SN1": "10.0.0.1"},
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrfs",
+        lambda _module, _rest_send, _fabric_name: [
+            {
+                "vrfName": "BLUE",
+                "vrfTemplateConfig": '{"vrfVlanId":500}',
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrf_attachments",
+        lambda **_kwargs: [
+            {
+                "vrfName": "BLUE",
+                "lanAttachList": [
+                    {
+                        "serialNumber": "SN1",
+                        "isLanAttached": False,
+                        "vlanId": 500,
+                    }
+                ],
+            }
+        ],
+    )
+
+    result = query_vrf_lite_state(module=module, rest_send=object(), fabric_name="FABRIC1", filter_vrfs={"BLUE"})
+
+    assert result == [{"vrf_name": "BLUE", "vlan_id": 500, "deploy": False, "attach": []}]
+    assert module.params["_raw_vrf_attachment_map"] == {}
+    assert module.params["_known_vrfs"] == ["BLUE"]
+    assert module.params["_known_vrfs_loaded"] is True
+
+
+def test_manage_vrf_lite_00480_query_ignores_base_vrf_attachments_without_vrf_lite(
+    monkeypatch,
+):
+    module = _DummyModule({})
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_fabric_switches",
+        lambda _module, _rest_send, _fabric_name: {"SN1": "10.0.0.1"},
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrfs",
+        lambda _module, _rest_send, _fabric_name: [
+            {
+                "vrfName": "BLUE",
+                "vrfTemplateConfig": '{"vrfVlanId":500}',
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrf_attachments",
+        lambda **_kwargs: [
+            {
+                "vrfName": "BLUE",
+                "lanAttachList": [
+                    {
+                        "serialNumber": "SN1",
+                        "isLanAttached": True,
+                        "lanAttachState": "DEPLOYED",
+                        "vlanId": 500,
+                        "extensionValues": "",
+                        "instanceValues": "",
+                        "freeformConfig": "router ospf 100",
+                    }
+                ],
+            }
+        ],
+    )
+
+    result = query_vrf_lite_state(module=module, rest_send=object(), fabric_name="FABRIC1", filter_vrfs={"BLUE"})
+
+    assert result == [{"vrf_name": "BLUE", "vlan_id": 500, "deploy": False, "attach": []}]
+    assert module.params["_raw_vrf_attachment_map"] == {
+        "BLUE": {
+            "SN1": {
+                "extension_values": "",
+                "instance_values": "",
+                "freeform_config": "router ospf 100",
+                "vlan": 500,
+            }
+        }
+    }
+
+
+def test_manage_vrf_lite_00481_query_enriches_pending_attachment_from_switch_details(
+    monkeypatch,
+):
+    module = _DummyModule({})
+    extension_values = json.dumps(
+        {
+            "VRF_LITE_CONN": json.dumps(
+                {
+                    "VRF_LITE_CONN": [
+                        {
+                            "IF_NAME": "Ethernet1/2",
+                            "DOT1Q_ID": "2",
+                            "IP_MASK": "10.33.0.2/24",
+                            "NEIGHBOR_IP": "10.33.0.1",
+                            "PEER_VRF_NAME": "GREEN",
+                            "VRF_LITE_JYTHON_TEMPLATE": "Ext_VRF_Lite_Jython",
+                        }
+                    ]
+                },
+                separators=(",", ":"),
+            ),
+            "MULTISITE_CONN": json.dumps({"MULTISITE_CONN": []}, separators=(",", ":")),
+        },
+        separators=(",", ":"),
+    )
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_fabric_switches",
+        lambda _module, _rest_send, _fabric_name: {"SN1": "10.0.0.1"},
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrfs",
+        lambda _module, _rest_send, _fabric_name: [
+            {
+                "vrfName": "BLUE",
+                "vrfTemplateConfig": '{"vrfVlanId":500}',
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrf_attachments",
+        lambda **_kwargs: [
+            {
+                "vrfName": "BLUE",
+                "lanAttachList": [
+                    {
+                        "serialNumber": "SN1",
+                        "isLanAttached": False,
+                        "lanAttachState": "PENDING",
+                        "vlanId": 500,
+                    }
+                ],
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrf_switch_details_bulk",
+        lambda **_kwargs: {
+            ("BLUE", "SN1"): {
+                "serialNumber": "SN1",
+                "extensionValues": extension_values,
+                "instanceValues": "",
+                "freeformConfig": "router ospf 100",
+                "islanAttached": False,
+                "lanAttachedState": "PENDING",
+                "vlan": 2,
+            }
+        },
+    )
+
+    result = query_vrf_lite_state(module=module, rest_send=object(), fabric_name="FABRIC1", filter_vrfs={"BLUE"})
+
+    assert result == [
+        {
+            "vrf_name": "BLUE",
+            "vlan_id": 500,
+            "deploy": False,
+            "attach": [
+                {
+                    "ip_address": "10.0.0.1",
+                    "deploy": False,
+                    "import_evpn_rt": "",
+                    "export_evpn_rt": "",
+                    "vrf_lite": [
+                        {
+                            "interface": "Ethernet1/2",
+                            "dot1q": 2,
+                            "ipv4_addr": "10.33.0.2/24",
+                            "neighbor_ipv4": "10.33.0.1",
+                            "peer_vrf": "GREEN",
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["extension_values"] == extension_values
+    assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["freeform_config"] == "router ospf 100"
+    assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["vlan"] == 2
+
+
+def test_manage_vrf_lite_00481a_attachment_query_uses_lossless_top_down_get():
+    class _FakeRestSend:
+        timeout = 30
+        check_mode = False
+        response_handler = None
+
+        def __init__(self):
+            self.path = None
+            self.verb = None
+            self.response_current = {}
+            self.result_current = {}
+            self.payload = None
+
+        def save_settings(self):
+            pass
+
+        def restore_settings(self):
+            pass
+
+        def commit(self):
+            assert self.path == VrfLiteEndpoints.vrf_attachments_query("FABRIC1", "BLUE,GREEN")
+            assert self.verb == HttpVerbEnum.GET
+            assert self.payload is None
+            self.response_current = {
+                "DATA": [
+                    {
+                        "vrfName": "BLUE",
+                        "lanAttachList": [
+                            {
+                                "serialNumber": "SN1",
+                                "extensionValues": '{"UNMANAGED_EXTENSION":"preserve-me"}',
+                            }
+                        ],
+                    }
+                ]
+            }
+            self.result_current = {"success": True}
+
+    result = _query_vrf_attachments(
+        module=_DummyModule({}),
+        rest_send=_FakeRestSend(),
+        fabric_name="FABRIC1",
+        vrf_names=["BLUE", "GREEN"],
+    )
+
+    assert result[0]["lanAttachList"][0]["extensionValues"] == '{"UNMANAGED_EXTENSION":"preserve-me"}'
+
+
+def test_manage_vrf_lite_00481b_query_batches_switch_detail_enrichment_across_vrfs(monkeypatch):
+    """PENDING rows missing ``extensionValues`` across several VRFs are enriched
+    with a single cross-VRF ``vrf_switch`` GET (plural ``vrf-names``), not one
+    request per VRF."""
+    ext_blue = json.dumps(
+        {
+            "VRF_LITE_CONN": json.dumps({"VRF_LITE_CONN": []}, separators=(",", ":")),
+            "MULTISITE_CONN": json.dumps({"MULTISITE_CONN": [{"MARK": "blue"}]}, separators=(",", ":")),
+        },
+        separators=(",", ":"),
+    )
+    ext_green = json.dumps(
+        {
+            "VRF_LITE_CONN": json.dumps({"VRF_LITE_CONN": []}, separators=(",", ":")),
+            "MULTISITE_CONN": json.dumps({"MULTISITE_CONN": [{"MARK": "green"}]}, separators=(",", ":")),
+        },
+        separators=(",", ":"),
+    )
+
+    class _FakeRestSend:
+        timeout = 30
+        check_mode = False
+        response_handler = None
+
+        def __init__(self):
+            self.path = None
+            self.verb = None
+            self.response_current = {}
+            self.result_current = {}
+            self.calls = []
+
+        def save_settings(self):
+            pass
+
+        def restore_settings(self):
+            pass
+
+        def commit(self):
+            self.calls.append(self.path)
+            self.response_current = {
+                "DATA": [
+                    {
+                        "vrfName": "BLUE",
+                        "switchDetailsList": [{"serialNumber": "SN1", "extensionValues": ext_blue}],
+                    },
+                    {
+                        "vrfName": "GREEN",
+                        "switchDetailsList": [{"serialNumber": "SN2", "extensionValues": ext_green}],
+                    },
+                ]
+            }
+            self.result_current = {"success": True}
+
+    module = _DummyModule({"_vrf_lite_switch_detail_cache": {}})
+    rest_send = _FakeRestSend()
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_fabric_switches",
+        lambda _module, _rest_send, _fabric_name: {"SN1": "10.0.0.1", "SN2": "10.0.0.2"},
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrfs",
+        lambda _module, _rest_send, _fabric_name: [
+            {"vrfName": "BLUE", "vrfTemplateConfig": '{"vrfVlanId":500}'},
+            {"vrfName": "GREEN", "vrfTemplateConfig": '{"vrfVlanId":600}'},
+        ],
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query._query_vrf_attachments",
+        lambda **_kwargs: [
+            {
+                "vrfName": "BLUE",
+                "lanAttachList": [{"serialNumber": "SN1", "isLanAttached": False, "lanAttachState": "PENDING", "vlanId": 500}],
+            },
+            {
+                "vrfName": "GREEN",
+                "lanAttachList": [{"serialNumber": "SN2", "isLanAttached": False, "lanAttachState": "PENDING", "vlanId": 600}],
+            },
+        ],
+    )
+
+    query_vrf_lite_state(module=module, rest_send=rest_send, fabric_name="FABRIC1", filter_vrfs={"BLUE", "GREEN"})
+
+    # Exactly one switch-detail request for both VRFs, carrying plural vrf-names.
+    assert rest_send.calls == [VrfLiteEndpoints.vrf_switch("FABRIC1", "BLUE,GREEN", "SN1,SN2")]
+    # Each VRF's PENDING row is enriched from the batched response by ``vrfName``.
+    assert module.params["_raw_vrf_attachment_map"]["BLUE"]["SN1"]["extension_values"] == ext_blue
+    assert module.params["_raw_vrf_attachment_map"]["GREEN"]["SN2"]["extension_values"] == ext_green
+
+
+def test_manage_vrf_lite_00482_vlan_prefers_top_level_vlanid():
+    """The current OpenAPI VRF object exposes the VLAN at top-level ``vlanId``."""
+    vrf_object = {"vlanId": 500, "vrfTemplateConfig": '{"vrfVlanId":999}'}
+    # Top-level wins even when the legacy serialized value disagrees.
+    assert _resolve_vrf_vlan(vrf_object) == 500
+
+
+def test_manage_vrf_lite_00483_vlan_falls_back_to_legacy_template_config():
+    """Older controller shapes omit ``vlanId`` and carry the VLAN inside the
+    serialized ``vrfTemplateConfig.vrfVlanId``."""
+    assert _resolve_vrf_vlan({"vrfTemplateConfig": '{"vrfVlanId":777}'}) == 777
+    assert _resolve_vrf_vlan({"vrfTemplateConfig": {"vrfVlanId": 888}}) == 888
+
+
+def test_manage_vrf_lite_00484_vlan_top_level_unassigned_falls_back():
+    """A top-level ``vlanId`` of 0 means unassigned, so fall back to the legacy value."""
+    assert _resolve_vrf_vlan({"vlanId": 0, "vrfTemplateConfig": '{"vrfVlanId":123}'}) == 123
+
+
+def test_manage_vrf_lite_00485_vlan_absent_resolves_to_none():
+    assert _resolve_vrf_vlan({}) is None
+    assert _resolve_vrf_vlan({"vrfTemplateConfig": "{}"}) is None
+    assert _resolve_vrf_vlan({"vlanId": "", "vrfTemplateConfig": ""}) is None
+
+
+def test_manage_vrf_lite_00486_coerce_vlan_normalizes_values():
+    assert _coerce_vlan(None) is None
+    assert _coerce_vlan("") is None
+    assert _coerce_vlan(0) is None
+    assert _coerce_vlan("500") == 500
+    assert _coerce_vlan(500) == 500
+
+
+def test_manage_vrf_lite_00490_deploy_needed_when_state_machine_changed_without_changed_vrf_marker():
+    module = _DummyModule({})
+
+    assert _needs_deployment({"changed": True}, module) is True
+
+
+def test_manage_vrf_lite_00491_deploy_targets_honor_vrf_and_attachment_intent():
+    module = _DummyModule(
+        {
+            "config": [
+                {
+                    "vrf_name": "BLUE",
+                    "attach": [{"ip_address": "SN1", "deploy": False}],
+                },
+                {
+                    "vrf_name": "GREEN",
+                    "attach": [
+                        {"ip_address": "SN2", "deploy": False},
+                        {"ip_address": "SN3"},
+                    ],
+                },
+                {
+                    "vrf_name": "RED",
+                    "deploy": False,
+                    "attach": [{"ip_address": "SN4", "deploy": True}],
+                },
+                {
+                    "vrf_name": "YELLOW",
+                    "deploy": True,
+                    "attach": [{"ip_address": "SN5", "deploy": False}],
+                },
+            ]
+        }
+    )
+
+    assert _deployment_intent(module) == (
+        {("GREEN", "SN3"), ("YELLOW", "SN5")},
+        {("BLUE", "SN1"), ("GREEN", "SN2")},
+        {"RED"},
+    )
+
+
+def test_manage_vrf_lite_00492_deploy_filters_changed_vrfs_by_deploy_intent():
+    nested_config = [
+        {
+            "vrf_name": "BLUE",
+            "attach": [{"ip_address": "10.0.0.1", "deploy": False}],
+        },
+        {"vrf_name": "GREEN", "attach": [{"ip_address": "10.0.0.2"}]},
+        {
+            "vrf_name": "RED",
+            "deploy": False,
+            "attach": [{"ip_address": "10.0.0.3"}],
+        },
+    ]
+    module = _DummyModule(
+        {
+            "check_mode": True,
+            "fabric_name": "FABRIC1",
+            "_changed_vrfs": ["BLUE", "GREEN", "RED"],
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1", "10.0.0.2": "SN2", "10.0.0.3": "SN3"},
+            "config_actions": {"save": True, "deploy": True, "type": "switch"},
+            "_vrf_lite_nested_config": nested_config,
+            "config": [
+                {"vrf_name": "BLUE", "switch_ip": "10.0.0.1", "deploy": False},
+                {"vrf_name": "GREEN", "switch_ip": "10.0.0.2"},
+                {"vrf_name": "RED", "switch_ip": "10.0.0.3", "deploy": False},
+            ],
+            "_deploy_targets": [
+                {"vrf_name": "BLUE", "switch_ip": "10.0.0.1", "operation": "write"},
+                {"vrf_name": "GREEN", "switch_ip": "10.0.0.2", "operation": "write"},
+                {"vrf_name": "RED", "switch_ip": "10.0.0.3", "operation": "write"},
+            ],
+        }
+    )
+
+    result = _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": True})
+
+    assert result["target_vrfs"] == ["GREEN"]
+    assert result["planned_actions"] == [
+        "POST {0}".format(VrfLiteEndpoints.config_save("FABRIC1")),
+        "POST {0} vrfNames=GREEN switchIds=SN2".format(VrfLiteEndpoints.vrf_deployments("FABRIC1")),
+    ]
+
+
+def _capture_config_action_requests(monkeypatch):
+    """Patch the orchestrator transport and return a list capturing each request."""
+    captured: list[dict] = []
+
+    def _fake_request(module, rest_send, path, verb, data=None, timeout=None, force_check_mode=False):
+        del module, rest_send, verb, timeout, force_check_mode
+        captured.append({"path": path, "payload": data})
+        return {}
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.request_with_rest_send",
+        _fake_request,
+    )
+    return captured
+
+
+def test_manage_vrf_lite_00492a_config_save_omits_type_and_switch_scope_targets_switch_ids(
+    monkeypatch,
+):
+    captured = _capture_config_action_requests(monkeypatch)
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "_changed_vrfs": ["GREEN"],
+            "_ip_to_sn_mapping": {"10.0.0.2": "SN2"},
+            "config_actions": {"save": True, "deploy": True, "type": "switch"},
+            "_vrf_lite_nested_config": [{"vrf_name": "GREEN", "attach": [{"ip_address": "10.0.0.2"}]}],
+            "config": [{"vrf_name": "GREEN", "switch_ip": "10.0.0.2"}],
+            "_deploy_targets": [{"vrf_name": "GREEN", "switch_ip": "SN2", "operation": "write"}],
+        }
+    )
+
+    _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": True})
+
+    save_call = next(call for call in captured if call["path"] == VrfLiteEndpoints.config_save("FABRIC1"))
+    deploy_call = next(call for call in captured if call["path"] == VrfLiteEndpoints.vrf_deployments("FABRIC1"))
+
+    # Config save is a body-less fabric trigger and must not carry deploy-scope 'type'.
+    assert save_call["payload"] == {}
+    # Switch-scoped deploy targets only the affected switches.
+    assert deploy_call["payload"] == {"vrfNames": ["GREEN"], "switchIds": ["SN2"]}
+
+
+def test_manage_vrf_lite_00492b_global_scope_deploy_omits_switch_ids(monkeypatch):
+    captured = _capture_config_action_requests(monkeypatch)
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "_changed_vrfs": ["GREEN"],
+            "_ip_to_sn_mapping": {"10.0.0.2": "SN2"},
+            "config_actions": {"save": True, "deploy": True, "type": "global"},
+            "_vrf_lite_nested_config": [{"vrf_name": "GREEN", "attach": [{"ip_address": "10.0.0.2"}]}],
+            "config": [{"vrf_name": "GREEN", "switch_ip": "10.0.0.2"}],
+            "_deploy_targets": [{"vrf_name": "GREEN", "switch_ip": "SN2", "operation": "write"}],
+        }
+    )
+
+    _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": True})
+
+    deploy_call = next(call for call in captured if call["path"] == VrfLiteEndpoints.vrf_deployments("FABRIC1"))
+
+    # Global-scoped deploy omits switchIds so the controller deploys fabric-wide.
+    assert deploy_call["payload"] == {"vrfNames": ["GREEN"]}
+    assert "switchIds" not in deploy_call["payload"]
+
+
+@pytest.mark.parametrize("state", ["replaced", "overridden"])
+@pytest.mark.parametrize("deploy_scope", ["switch", "global"])
+def test_manage_vrf_lite_00492c_partial_removal_deploys_removed_switch(
+    monkeypatch,
+    state,
+    deploy_scope,
+):
+    """Both replacement states preserve a removed switch in the deploy scope."""
+    captured = _capture_config_action_requests(monkeypatch)
+    module = _DummyModule(
+        {
+            "state": state,
+            "fabric_name": "FABRIC1",
+            "_changed_vrfs": ["GREEN"],
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1", "10.0.0.2": "SN2"},
+            "config_actions": {"save": True, "deploy": True, "type": deploy_scope},
+            # SN1 stays attached; SN2 was removed and survives only in the journal.
+            "_vrf_lite_nested_config": [{"vrf_name": "GREEN", "attach": [{"ip_address": "10.0.0.1"}]}],
+            "config": [{"vrf_name": "GREEN", "switch_ip": "10.0.0.1"}],
+            "_deploy_targets": [{"vrf_name": "GREEN", "switch_ip": "SN2", "operation": "delete"}],
+        }
+    )
+
+    _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": True})
+
+    deploy_call = next(call for call in captured if call["path"] == VrfLiteEndpoints.vrf_deployments("FABRIC1"))
+    expected_payload = {"vrfNames": ["GREEN"]}
+    if deploy_scope == "switch":
+        expected_payload["switchIds"] = ["SN2"]
+    assert deploy_call["payload"] == expected_payload
+
+
+@pytest.mark.parametrize("state", ["replaced", "overridden"])
+@pytest.mark.parametrize("deploy_scope", ["switch", "global"])
+def test_manage_vrf_lite_00492d_remove_all_still_deploys_removed_vrf(
+    monkeypatch,
+    state,
+    deploy_scope,
+):
+    """An empty retained config still deploys every removed attachment."""
+    captured = _capture_config_action_requests(monkeypatch)
+    module = _DummyModule(
+        {
+            "state": state,
+            "fabric_name": "FABRIC1",
+            "_changed_vrfs": ["TENANT"],
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1", "10.0.0.2": "SN2"},
+            "config_actions": {"save": True, "deploy": True, "type": deploy_scope},
+            "_vrf_lite_nested_config": [{"vrf_name": "TENANT", "attach": []}],
+            "config": [],
+            "_deploy_targets": [
+                {"vrf_name": "TENANT", "switch_ip": "SN1", "operation": "delete"},
+                {"vrf_name": "TENANT", "switch_ip": "SN2", "operation": "delete"},
+            ],
+        }
+    )
+
+    _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": True})
+
+    deploy_call = next(call for call in captured if call["path"] == VrfLiteEndpoints.vrf_deployments("FABRIC1"))
+    expected_payload = {"vrfNames": ["TENANT"]}
+    if deploy_scope == "switch":
+        expected_payload["switchIds"] = ["SN1", "SN2"]
+    assert deploy_call["payload"] == expected_payload
+
+
+@pytest.mark.parametrize(
+    ("vrf_deploy", "attachment_deploy", "expected_target_vrfs"),
+    [
+        pytest.param(False, None, [], id="vrf-disabled"),
+        pytest.param(True, False, ["GREEN"], id="vrf-enabled-overrides-attachment"),
+        pytest.param(None, False, [], id="attachment-disabled"),
+    ],
+)
+def test_manage_vrf_lite_00492e_operation_journal_honors_nested_deploy_intent(
+    vrf_deploy,
+    attachment_deploy,
+    expected_target_vrfs,
+):
+    """Journal-scoped writes preserve VRF and attachment deploy precedence."""
+    vrf_config = {"vrf_name": "GREEN", "attach": [{"ip_address": "10.0.0.1"}]}
+    if vrf_deploy is not None:
+        vrf_config["deploy"] = vrf_deploy
+    if attachment_deploy is not None:
+        vrf_config["attach"][0]["deploy"] = attachment_deploy
+
+    module = _DummyModule(
+        {
+            "check_mode": True,
+            "fabric_name": "FABRIC1",
+            "_changed_vrfs": ["GREEN"],
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "config_actions": {"save": True, "deploy": True, "type": "switch"},
+            "_vrf_lite_nested_config": [vrf_config],
+            "config": [{"vrf_name": "GREEN", "switch_ip": "10.0.0.1"}],
+            "_deploy_targets": [{"vrf_name": "GREEN", "switch_ip": "10.0.0.1", "operation": "write"}],
+        }
+    )
+
+    result = _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": True})
+
+    assert result["target_vrfs"] == expected_target_vrfs
+    assert len(result["planned_actions"]) == (2 if expected_target_vrfs else 1)
+
+
+def test_manage_vrf_lite_00492ea_vrf_deploy_false_suppresses_removed_switch_deploy():
+    """VRF-level deploy:false remains authoritative for a replacement detach."""
+    module = _DummyModule(
+        {
+            "check_mode": True,
+            "fabric_name": "FABRIC1",
+            "_changed_vrfs": ["GREEN"],
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1", "10.0.0.2": "SN2"},
+            "config_actions": {"save": True, "deploy": True, "type": "switch"},
+            "_vrf_lite_nested_config": [
+                {
+                    "vrf_name": "GREEN",
+                    "deploy": False,
+                    "attach": [{"ip_address": "10.0.0.1"}],
+                }
+            ],
+            "config": [{"vrf_name": "GREEN", "switch_ip": "10.0.0.1", "deploy": False}],
+            "_deploy_targets": [{"vrf_name": "GREEN", "switch_ip": "10.0.0.2", "operation": "delete"}],
+        }
+    )
+
+    result = _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": True})
+
+    assert result["target_vrfs"] == []
+    assert result["planned_actions"] == ["POST {0}".format(VrfLiteEndpoints.config_save("FABRIC1"))]
+
+
+def test_manage_vrf_lite_00492eb_global_scope_deploys_vrf_when_any_changed_pair_is_enabled():
+    """Global scope cannot exclude one switch after the VRF is selected."""
+    module = _DummyModule(
+        {
+            "check_mode": True,
+            "fabric_name": "FABRIC1",
+            "_changed_vrfs": ["GREEN"],
+            "config_actions": {"save": True, "deploy": True, "type": "global"},
+            "_vrf_lite_nested_config": [
+                {
+                    "vrf_name": "GREEN",
+                    "attach": [
+                        {"ip_address": "SN1"},
+                        {"ip_address": "SN2", "deploy": False},
+                    ],
+                }
+            ],
+            "config": [
+                {"vrf_name": "GREEN", "switch_ip": "SN1"},
+                {"vrf_name": "GREEN", "switch_ip": "SN2", "deploy": False},
+            ],
+            "_deploy_targets": [
+                {"vrf_name": "GREEN", "switch_ip": "SN1", "operation": "write"},
+                {"vrf_name": "GREEN", "switch_ip": "SN2", "operation": "write"},
+            ],
+        }
+    )
+
+    result = _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": True})
+
+    assert result["target_vrfs"] == ["GREEN"]
+    assert result["planned_actions"][-1] == "POST {0} vrfNames=GREEN".format(VrfLiteEndpoints.vrf_deployments("FABRIC1"))
+
+
+def test_manage_vrf_lite_00492ec_switch_scope_preserves_disjoint_vrf_switch_pairs(monkeypatch):
+    """Switch-scoped batches cannot turn disjoint pairs into a Cartesian product."""
+    captured = _capture_config_action_requests(monkeypatch)
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "_changed_vrfs": ["BLUE", "GREEN"],
+            "config_actions": {"save": True, "deploy": True, "type": "switch"},
+            "_vrf_lite_nested_config": [
+                {"vrf_name": "BLUE", "attach": [{"ip_address": "SN2"}]},
+                {
+                    "vrf_name": "GREEN",
+                    "attach": [
+                        {"ip_address": "SN1"},
+                        {"ip_address": "SN2", "deploy": False},
+                    ],
+                },
+            ],
+            "config": [
+                {"vrf_name": "BLUE", "switch_ip": "SN2"},
+                {"vrf_name": "GREEN", "switch_ip": "SN1"},
+                {"vrf_name": "GREEN", "switch_ip": "SN2", "deploy": False},
+            ],
+            "_deploy_targets": [
+                {"vrf_name": "BLUE", "switch_ip": "SN2", "operation": "write"},
+                {"vrf_name": "GREEN", "switch_ip": "SN1", "operation": "write"},
+                {"vrf_name": "GREEN", "switch_ip": "SN2", "operation": "write"},
+            ],
+        }
+    )
+
+    _vrf_lite_orchestrator(module)._execute_config_actions(result={"changed": True})
+
+    deploy_payloads = [call["payload"] for call in captured if call["path"] == VrfLiteEndpoints.vrf_deployments("FABRIC1")]
+    assert deploy_payloads == [
+        {"vrfNames": ["GREEN"], "switchIds": ["SN1"]},
+        {"vrfNames": ["BLUE"], "switchIds": ["SN2"]},
+    ]
+
+
+def test_manage_vrf_lite_00492f_check_mode_change_set_recovered_from_preview():
+    """In check mode `sent` is empty, so the deploy scope must be recovered from the
+    before/after preview: created and updated (vrf, switch) rows come from the
+    'after' state so the plan is not a false green. Unchanged rows are excluded."""
+    before = NDConfigCollection(
+        model_class=VrfLiteAttachmentEntry,
+        items=[
+            VrfLiteAttachmentEntry.from_response({"vrf_name": "RED", "switch_ip": "10.1.1.1", "vlan_id": 10}),
+            VrfLiteAttachmentEntry.from_response({"vrf_name": "BLUE", "switch_ip": "10.1.1.2", "vlan_id": 20}),
+        ],
+    )
+    after = NDConfigCollection(
+        model_class=VrfLiteAttachmentEntry,
+        items=[
+            VrfLiteAttachmentEntry.from_response({"vrf_name": "RED", "switch_ip": "10.1.1.1", "vlan_id": 10}),
+            VrfLiteAttachmentEntry.from_response({"vrf_name": "BLUE", "switch_ip": "10.1.1.2", "vlan_id": 99}),
+            VrfLiteAttachmentEntry.from_response({"vrf_name": "GREEN", "switch_ip": "10.1.1.3", "vlan_id": 30}),
+        ],
+    )
+
+    changed = _changed_entries_from_preview(before, after)
+
+    assert sorted((entry.vrf_name, entry.switch_ip) for entry in changed) == [
+        ("BLUE", "10.1.1.2"),
+        ("GREEN", "10.1.1.3"),
+    ]
+    assert sorted({entry.vrf_name for entry in changed}) == ["BLUE", "GREEN"]
+
+
+def test_manage_vrf_lite_00492g_check_mode_change_set_includes_removed_rows():
+    """Removed (vrf, switch) rows are absent from 'after', so they must be recovered
+    from 'before' -- otherwise a remove-all plan would report no deploy scope."""
+    before = NDConfigCollection(
+        model_class=VrfLiteAttachmentEntry,
+        items=[
+            VrfLiteAttachmentEntry.from_response({"vrf_name": "TENANT", "switch_ip": "10.0.0.1", "vlan_id": 10}),
+            VrfLiteAttachmentEntry.from_response({"vrf_name": "TENANT", "switch_ip": "10.0.0.2", "vlan_id": 10}),
+        ],
+    )
+    after = NDConfigCollection(model_class=VrfLiteAttachmentEntry, items=[])
+
+    changed = _changed_entries_from_preview(before, after)
+
+    assert sorted((entry.vrf_name, entry.switch_ip) for entry in changed) == [
+        ("TENANT", "10.0.0.1"),
+        ("TENANT", "10.0.0.2"),
+    ]
+
+
+def test_manage_vrf_lite_00493_attachment_deploy_false_does_not_suppress_attachment_payload():
+    class _FakeNDModule:
+        def request(self, path, verb, payload):
+            del path, verb, payload
+            pytest.fail("dot1q reservation should not be called when dot1q is provided")
+
+    existing_instance_values = json.dumps(
+        {
+            "loopbackIpV6Address": "",
+            "loopbackId": "",
+            "switchRouteTargetImportEvpn": "65000:1",
+            "evpnRouteTargetImport": "65000:2",
+            "loopbackIpAddress": "",
+            "deviceSupportL3VniNoVlan": "false",
+            "switchRouteTargetExportEvpn": "65000:3",
+            "evpnRouteTargetExport": "65000:4",
+        }
+    )
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "_raw_vrf_attachment_map": {
+                "BLUE": {
+                    "SN1": {
+                        "instance_values": existing_instance_values,
+                        "freeform_config": "router ospf 100",
+                    }
+                }
+            },
+            "_vrf_lite_prototype_cache": {
+                _vrf_lite_cache_key("FABRIC1", "BLUE", "SN1"): {
+                    "Ethernet1/10": json.loads(_vrf_lite_prototype()["extensionValues"]),
+                }
+            },
+        }
+    )
+    entry = VrfLiteAttachmentEntry.from_config(
+        {
+            "vrf_name": "BLUE",
+            "switch_ip": "10.0.0.1",
+            "vlan_id": 500,
+            "deploy": False,
+            "extensions": [
+                {
+                    "interface": "ethernet1/10",
+                    "dot1q": 123,
+                    "ipv4_addr": "10.33.0.2/24",
+                    "neighbor_ipv4": "10.33.0.1",
+                }
+            ],
+        }
+    )
+
+    payload = build_attach_payload_for_entry(
+        module=module,
+        rest_send=_FakeNDModule(),
+        entry=entry,
+    )
+
+    assert payload["fabric"] == "FABRIC1"
+    assert payload["serialNumber"] == "SN1"
+    assert payload["vlan"] == 500
+    assert payload["deployment"] is True
+    assert payload["isAttached"] is True
+    rendered_instance_values = json.loads(payload["instanceValues"])
+    assert rendered_instance_values["deviceSupportL3VniNoVlan"] == "false"
+    assert rendered_instance_values["switchRouteTargetImportEvpn"] == ""
+    assert rendered_instance_values["switchRouteTargetExportEvpn"] == ""
+    assert rendered_instance_values["evpnRouteTargetImport"] == ""
+    assert rendered_instance_values["evpnRouteTargetExport"] == ""
+    assert payload["freeformConfig"] == "router ospf 100"
+    assert parse_vrf_lite_extension_values(payload["extensionValues"]) == [
+        {
+            "interface": "Ethernet1/10",
+            "dot1q": 123,
+            "ipv4_addr": "10.33.0.2/24",
+            "neighbor_ipv4": "10.33.0.1",
+        }
+    ]
+    extension_outer = json.loads(payload["extensionValues"])
+    extension_row = json.loads(extension_outer["VRF_LITE_CONN"])["VRF_LITE_CONN"][0]
+    assert extension_row["IF_NAME"] == "Ethernet1/10"
+    assert extension_row["NEIGHBOR_ASN"] == "65001"
+    assert extension_row["AUTO_VRF_LITE_FLAG"] == "false"
+    assert extension_row["IP_MASK"] == "10.33.0.2/24"
+    assert extension_row["NEIGHBOR_IP"] == "10.33.0.1"
+    assert extension_row["DOT1Q_ID"] == "123"
+    assert extension_row["VRF_LITE_JYTHON_TEMPLATE"] == "Ext_VRF_Lite_Jython"
+    assert "MTU" not in extension_row
+    assert "enableBorderExtension" not in extension_row
+    assert "asn" not in extension_row
+
+
+def test_manage_vrf_lite_00493a_payload_preserves_existing_unmanaged_extension_data():
+    existing_outer = {
+        "VRF_LITE_CONN": json.dumps(
+            {
+                "VRF_LITE_CONN": [
+                    {
+                        "IF_NAME": "Ethernet1/10",
+                        "DOT1Q_ID": "2",
+                        "NEIGHBOR_ASN": "65099",
+                        "AUTO_VRF_LITE_FLAG": "true",
+                        "ROUTE_MAP_IN": "PRESERVE-ME",
+                    }
+                ]
+            },
+            separators=(",", ":"),
+        ),
+        "MULTISITE_CONN": json.dumps({"MULTISITE_CONN": [{"site": "preserve-me"}]}, separators=(",", ":")),
+        "UNMANAGED_EXTENSION": "preserve-me",
+    }
+    prototype = json.loads(_vrf_lite_prototype()["extensionValues"])
+
+    rendered = build_vrf_lite_extension_values(
+        [{"interface": "Ethernet1/10", "dot1q": 2, "neighbor_ipv4": "203.0.113.1"}],
+        existing_extension_values=json.dumps(existing_outer),
+        prototype_values_by_interface={"Ethernet1/10": prototype},
+    )
+
+    outer = json.loads(rendered)
+    row = json.loads(outer["VRF_LITE_CONN"])["VRF_LITE_CONN"][0]
+    assert outer["MULTISITE_CONN"] == existing_outer["MULTISITE_CONN"]
+    assert outer["UNMANAGED_EXTENSION"] == "preserve-me"
+    assert row["ROUTE_MAP_IN"] == "PRESERVE-ME"
+    assert row["NEIGHBOR_ASN"] == "65099"
+    assert row["AUTO_VRF_LITE_FLAG"] == "true"
+    assert row["NEIGHBOR_IP"] == "203.0.113.1"
+
+
+def test_manage_vrf_lite_00494_delete_builds_single_attachment_clear_payload():
+    extension_values = build_vrf_lite_extension_values(
+        [{"interface": "Ethernet1/11", "dot1q": 222, "ipv4_addr": "10.33.0.2/24"}],
+    )
+    instance_values = json.dumps(
+        {
+            "loopbackIpV6Address": "2001:db8::1",
+            "loopbackId": "7",
+            "switchRouteTargetImportEvpn": "65000:1",
+            "evpnRouteTargetImport": "65000:2",
+            "loopbackIpAddress": "192.0.2.10",
+            "deviceSupportL3VniNoVlan": "false",
+            "switchRouteTargetExportEvpn": "65000:3",
+            "evpnRouteTargetExport": "65000:4",
+        }
+    )
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "state": "deleted",
+            "config": [{"vrf_name": "BLUE", "attach": [{"ip_address": "10.0.0.2"}]}],
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1", "10.0.0.2": "SN2"},
+            "_raw_vrf_attachment_map": {
+                "BLUE": {
+                    "SN1": {"vlan": 111},
+                    "SN2": {
+                        "vlan": 222,
+                        "extension_values": extension_values,
+                        "instance_values": instance_values,
+                        "freeform_config": "router bgp 65000",
+                    },
+                }
+            },
+        }
+    )
+    entry = VrfLiteAttachmentEntry.from_config(
+        {
+            "vrf_name": "BLUE",
+            "switch_ip": "10.0.0.2",
+            "vlan_id": 500,
+        }
+    )
+
+    payload = build_detach_payload_for_entry(module, entry)
+
+    assert payload["fabric"] == "FABRIC1"
+    assert payload["serialNumber"] == "SN2"
+    assert payload["vlan"] == 500
+    assert payload["deployment"] is True
+    assert payload["isAttached"] is True
+    rendered_instance_values = json.loads(payload["instanceValues"])
+    assert rendered_instance_values["deviceSupportL3VniNoVlan"] == "false"
+    assert rendered_instance_values["loopbackId"] == "7"
+    assert rendered_instance_values["loopbackIpAddress"] == "192.0.2.10"
+    assert rendered_instance_values["loopbackIpV6Address"] == "2001:db8::1"
+    assert rendered_instance_values["switchRouteTargetImportEvpn"] == ""
+    assert rendered_instance_values["switchRouteTargetExportEvpn"] == ""
+    assert rendered_instance_values["evpnRouteTargetImport"] == ""
+    assert rendered_instance_values["evpnRouteTargetExport"] == ""
+    assert payload["freeformConfig"] == "router bgp 65000"
+    assert parse_vrf_lite_extension_values(payload["extensionValues"]) == []
+
+
+def test_manage_vrf_lite_00495_delete_query_filters_vrfs_without_managed_attachments(
+    monkeypatch,
+):
+    module = _DummyModule({"state": "deleted", "fabric_name": "FABRIC1", "config": []})
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.query_vrf_lite_state",
+        lambda module, rest_send, fabric_name, filter_vrfs=None, flat=True: [
+            {"vrf_name": "BLUE", "switch_ip": "SN1", "vlan_id": 500},
+        ],
+    )
+
+    have = _vrf_lite_orchestrator(module)._query_current_state()
+
+    assert have == [{"vrf_name": "BLUE", "switch_ip": "SN1", "vlan_id": 500}]
+    assert module.params["_have"] == have
+
+
+def test_manage_vrf_lite_00495a_deleted_vrf_without_attach_expands_to_current_entries():
+    module = _DummyModule(
+        {
+            "state": "deleted",
+            "fabric_name": "FABRIC1",
+            "_warnings": [],
+        }
+    )
+    current = [
+        {"vrf_name": "BLUE", "switch_ip": "SN1", "vlan_id": 500},
+        {"vrf_name": "GREEN", "switch_ip": "SN2", "vlan_id": 501},
+    ]
+
+    result = explode_playbook_to_entries([{"vrf_name": "BLUE"}], module=module, state="deleted", current_entries=current)
+
+    assert result == [{"vrf_name": "BLUE", "switch_ip": "SN1", "vlan_id": 500}]
+
+
+def test_manage_vrf_lite_00495aa_public_grouping_preserves_scoped_empty_vrf():
+    module = _DummyModule({"_vrf_lite_vrf_vlan_map": {"BLUE": 500}})
+
+    result = group_attachment_entries_to_vrfs([], module=module, include_vrfs=["BLUE"])
+
+    assert result == [{"vrf_name": "BLUE", "attach": [], "vlan_id": 500}]
+
+
+def test_manage_vrf_lite_00495aaa_public_grouping_drops_unknown_scoped_vrf():
+    module = _DummyModule({"_known_vrfs": ["BLUE"], "_vrf_lite_vrf_vlan_map": {"BLUE": 500}})
+
+    result = group_attachment_entries_to_vrfs([], module=module, include_vrfs=["MISSING"])
+
+    assert result == []
+
+
+def test_manage_vrf_lite_00495ab_deleted_public_output_preserves_empty_after_scope():
+    module = _DummyModule(
+        {
+            "state": "deleted",
+            "_vrf_lite_nested_config": [{"vrf_name": "BLUE"}],
+            "_vrf_lite_vrf_vlan_map": {"BLUE": 500},
+        }
+    )
+    orchestrator = _vrf_lite_orchestrator(module)
+
+    result = orchestrator.format_public_output({"before": [], "after": [], "current": [], "diff": []})
+
+    assert result["after"] == [{"vrf_name": "BLUE", "attach": [], "vlan_id": 500}]
+    assert result["current"] == [{"vrf_name": "BLUE", "attach": [], "vlan_id": 500}]
+
+
+def test_manage_vrf_lite_00495b_refresh_is_skipped_when_verify_disabled(monkeypatch):
+    refreshed = [{"vrf_name": "BLUE", "attach": [{"ip_address": "10.0.0.1"}]}]
+    module = _DummyModule(
+        {
+            "state": "deleted",
+            "fabric_name": "FABRIC1",
+            "verify": {"enabled": False},
+        }
+    )
+    orchestrator = _vrf_lite_orchestrator(module)
+
+    monkeypatch.setattr(orchestrator, "_query_current_state", lambda: refreshed)
+
+    result = orchestrator.refresh_verified_state({"changed": True, "after": [], "current": []})
+
+    assert result["after"] == []
+    assert result["current"] == []
+
+
+def test_manage_vrf_lite_00495ba_refresh_invalidates_prewrite_switch_detail_cache(monkeypatch):
+    module = _DummyModule(
+        {
+            "state": "merged",
+            "fabric_name": "FABRIC1",
+            "verify": {"enabled": True},
+            "_vrf_lite_switch_detail_cache": {"stale": {"extensionValues": "before-write"}},
+            "_vrf_lite_nested_config": [{"vrf_name": "BLUE"}],
+        }
+    )
+    orchestrator = _vrf_lite_orchestrator(module)
+    queried = []
+
+    def _query_current_state(flat=True):
+        assert flat is True
+        queried.append(True)
+        assert module.params["_vrf_lite_switch_detail_cache"] == {}
+        return []
+
+    monkeypatch.setattr(orchestrator, "_query_current_state", _query_current_state)
+
+    result = orchestrator.refresh_verified_state({"changed": True, "after": ["stale"], "current": ["stale"]})
+
+    assert queried == [True]
+    assert result["after"] == [{"vrf_name": "BLUE", "attach": []}]
+    assert result["current"] == [{"vrf_name": "BLUE", "attach": []}]
+
+
+def test_manage_vrf_lite_00495c_delete_unknown_attachment_warns_during_explode():
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "state": "deleted",
+            "config": [{"vrf_name": "BLUE", "attach": [{"ip_address": "10.0.0.99"}]}],
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1", "10.0.0.99": "SN99"},
+            "_warnings": [],
+        }
+    )
+    current = [{"vrf_name": "BLUE", "switch_ip": "SN1", "vlan_id": 500}]
+
+    result = explode_playbook_to_entries(module.params["config"], module=module, state="deleted", current_entries=current)
+
+    assert result == [{"vrf_name": "BLUE", "switch_ip": "SN99"}]
+    assert any("No matching VRF Lite attachment" in warning for warning in module.params["_warnings"])
+
+
+def test_manage_vrf_lite_00495d_query_all_prepares_state_machine_config(monkeypatch):
+    module = _DummyModule(
+        {
+            "fabric_name": "FABRIC1",
+            "state": "deleted",
+            "_vrf_lite_requested_state": "deleted",
+            "_vrf_lite_nested_config": [{"vrf_name": "BLUE"}],
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "_warnings": [],
+        }
+    )
+    current = [{"vrf_name": "BLUE", "switch_ip": "SN1", "vlan_id": 500}]
+    orchestrator = _vrf_lite_orchestrator(module)
+
+    monkeypatch.setattr(orchestrator, "_query_current_state", lambda flat=True: current)
+
+    assert orchestrator.query_all() == current
+    assert module.params["config"] == current
+
+
+def test_manage_vrf_lite_00496_verify_retry_policy_is_applied_to_reads():
+    class _FakeRestSend:
+        def __init__(self):
+            self.timeout = 30
+            self.check_mode = True
+            self.path = None
+            self.verb = None
+            self.response_current = {}
+            self.result_current = {}
+            self.response_handler = None
+            self.calls = 0
+            self.saved = 0
+            self.restored = 0
+            self.timeouts = []
+
+        def save_settings(self):
+            self.saved += 1
+
+        def restore_settings(self):
+            self.restored += 1
+            self.timeouts.append(self.timeout)
+
+        def commit(self):
+            assert self.path == "/read"
+            assert self.verb == HttpVerbEnum.GET
+            self.calls += 1
+            if self.calls < 3:
+                raise RuntimeError("controller not ready")
+            self.response_current = {"DATA": {"ok": True}}
+            self.result_current = {"success": True}
+
+    module = _DummyModule({"verify": {"retries": 3, "timeout": 7}})
+    rest_send = _FakeRestSend()
+
+    result = request_with_verify_settings(module, rest_send, "/read", HttpVerbEnum.GET)
+
+    assert result == {"ok": True}
+    assert rest_send.calls == 3
+    assert rest_send.saved == 3
+    assert rest_send.restored == 3
+    assert rest_send.timeouts == [7, 7, 7]
+
+
+def test_manage_vrf_lite_00500_guardrails_reject_missing_prototype_metadata(monkeypatch):
+    module = _DummyWarnModule(
+        {
+            "fabric_name": "F1",
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "_fabric_switch_inventory": {},
+        }
+    )
+    model = _vrf_lite_guardrail_model()
+    _mock_guardrail_inventory(monkeypatch)
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation._query_vrf_lite_support",
+        lambda _module, _rest_send, _fabric_name, _vrf_name, _serial_number: None,
+    )
+
+    with pytest.raises(VrfLiteResourceError, match="did not return VRF Lite interface prototype metadata"):
+        validate_vrf_lite_write_guardrails(module=module, model_instance=model, rest_send=object())
+
+
+def test_manage_vrf_lite_00525_guardrails_trust_authoritative_empty_switch_inventory(monkeypatch):
+    def _unexpected_context(*args, **kwargs):
+        pytest.fail("loaded empty switch inventory must not be queried again: {0} {1}".format(args, kwargs))
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation.FabricContext",
+        _unexpected_context,
+    )
+    module = _DummyModule(
+        {
+            "fabric_name": "F1",
+            "_fabric_switch_inventory": {},
+            "_fabric_switch_inventory_loaded": True,
+            "_fabric_switch_inventory_normalized": False,
+        }
+    )
+
+    for serial_number in ("SN1", "SN2"):
+        entry = VrfLiteAttachmentEntry(vrf_name="BLUE", switch_ip=serial_number)
+        with pytest.raises(VrfLiteResourceError, match="is not present in fabric"):
+            validate_vrf_lite_write_guardrails(module=module, model_instance=entry, rest_send=object())
+
+    assert module.params["_fabric_switch_inventory"] == {}
+    assert module.params["_fabric_switch_inventory_loaded"] is True
+    assert module.params["_fabric_switch_inventory_normalized"] is True
+
+
+def test_manage_vrf_lite_00527_switch_inventory_is_normalized_only_once(monkeypatch):
+    def _unexpected_context(*args, **kwargs):
+        pytest.fail("loaded switch inventory must not be queried again: {0} {1}".format(args, kwargs))
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation.FabricContext",
+        _unexpected_context,
+    )
+    module = _DummyModule(
+        {
+            "_fabric_switch_inventory": {
+                "SN1": {"switchId": "SN1", "switchRole": "border", "fabricManagementIp": "10.0.0.1"},
+            },
+            "_fabric_switch_inventory_loaded": True,
+            "_fabric_switch_inventory_normalized": False,
+        }
+    )
+
+    first = _load_switch_inventory(module, "F1", rest_send=object())
+    second = _load_switch_inventory(module, "F1", rest_send=object())
+
+    assert second is first
+    assert first["SN1"]["role"] == "border"
+    assert module.params["_fabric_switch_inventory_normalized"] is True
+
+
+def test_manage_vrf_lite_00550_guardrails_accept_usable_prototype_case_insensitively(monkeypatch):
+    module = _DummyWarnModule(
+        {
+            "fabric_name": "F1",
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "_fabric_switch_inventory": {},
+        }
+    )
+    model = _vrf_lite_guardrail_model(interface="ethernet1/10")
+    _mock_guardrail_inventory(monkeypatch, role="leaf", fabric_type="externalConnectivity")
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation._query_vrf_lite_support",
+        lambda _module, _rest_send, _fabric_name, _vrf_name, _serial_number: True,
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation.get_cached_vrf_lite_prototypes",
+        lambda *_args: {
+            "Ethernet1/10": json.loads(_vrf_lite_prototype()["extensionValues"]),
+        },
+    )
+
+    validate_vrf_lite_write_guardrails(module=module, model_instance=model, rest_send=object())
+
+
+def test_manage_vrf_lite_00575_guardrails_cache_real_switch_prototype_response():
+    class _FakeRestSend:
+        def __init__(self):
+            self.timeout = 30
+            self.check_mode = False
+            self.path = None
+            self.verb = None
+            self.response_handler = None
+            self.response_current = {}
+            self.result_current = {}
+            self.calls = 0
+
+        def save_settings(self):
+            pass
+
+        def restore_settings(self):
+            pass
+
+        def commit(self):
+            assert self.path == VrfLiteEndpoints.vrf_switch("F1", "BLUE", "SN1")
+            assert self.verb == HttpVerbEnum.GET
+            self.calls += 1
+            self.response_current = {
+                "DATA": [
+                    {
+                        "vrfName": "BLUE",
+                        "switchDetailsList": [
+                            _vrf_lite_switch_detail(),
+                        ],
+                    }
+                ]
+            }
+            self.result_current = {"success": True}
+
+    module = _DummyWarnModule(
+        {
+            "fabric_name": "F1",
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "_fabric_switch_inventory": {
+                "SN1": {
+                    "switchId": "SN1",
+                    "fabricManagementIp": "10.0.0.1",
+                    "switchRole": "border",
+                }
+            },
+            "_vrf_lite_support_cache": {},
+            "_vrf_lite_prototype_cache": {},
+            "_vrf_lite_switch_detail_cache": {},
+        }
+    )
+    model = _vrf_lite_guardrail_model()
+    rest_send = _FakeRestSend()
+
+    validate_vrf_lite_write_guardrails(module=module, model_instance=model, rest_send=rest_send)
+    validate_vrf_lite_write_guardrails(module=module, model_instance=model, rest_send=rest_send)
+
+    assert rest_send.calls == 1
+    prototypes = module.params["_vrf_lite_prototype_cache"][_vrf_lite_cache_key("F1", "BLUE", "SN1")]
+    assert prototypes["Ethernet1/10"]["NEIGHBOR_ASN"] == "65001"
+    assert prototypes["Ethernet1/10"]["AUTO_VRF_LITE_FLAG"] == "false"
+
+
+def test_manage_vrf_lite_00577_switch_detail_cache_isolated_by_vrf():
+    class _FakeRestSend:
+        timeout = 30
+        check_mode = False
+        response_handler = None
+
+        def __init__(self):
+            self.path = None
+            self.verb = None
+            self.response_current = {}
+            self.result_current = {}
+            self.calls = []
+
+        def save_settings(self):
+            pass
+
+        def restore_settings(self):
+            pass
+
+        def commit(self):
+            self.calls.append(self.path)
+            vrf_name = "BLUE" if "vrf-names=BLUE" in self.path else "GREEN"
+            self.response_current = {
+                "DATA": [
+                    {
+                        "vrfName": vrf_name,
+                        "switchDetailsList": [
+                            _vrf_lite_switch_detail(extra_vrf=vrf_name),
+                        ],
+                    }
+                ]
+            }
+            self.result_current = {"success": True}
+
+    module = _DummyModule({"_vrf_lite_switch_detail_cache": {}})
+    rest_send = _FakeRestSend()
+
+    blue = _query_vrf_switch_details(module, rest_send, "F1", "BLUE", ["SN1"])
+    green = _query_vrf_switch_details(module, rest_send, "F1", "GREEN", ["SN1"])
+    blue_cached = _query_vrf_switch_details(module, rest_send, "F1", "BLUE", ["SN1"])
+
+    assert blue["SN1"]["extra_vrf"] == "BLUE"
+    assert green["SN1"]["extra_vrf"] == "GREEN"
+    assert blue_cached == blue
+    assert len(rest_send.calls) == 2
+
+
+def test_manage_vrf_lite_00578_switch_details_batch_serials_per_vrf_and_cache():
+    class _FakeRestSend:
+        timeout = 30
+        check_mode = False
+        response_handler = None
+
+        def __init__(self):
+            self.path = None
+            self.verb = None
+            self.response_current = {}
+            self.result_current = {}
+            self.calls = []
+
+        def save_settings(self):
+            pass
+
+        def restore_settings(self):
+            pass
+
+        def commit(self):
+            self.calls.append(self.path)
+            if self.path == VrfLiteEndpoints.vrf_switch("F1", "BLUE", "SN1,SN2,SN3"):
+                vrf_name = "BLUE"
+            elif self.path == VrfLiteEndpoints.vrf_switch("F1", "GREEN", "SN1,SN2,SN3"):
+                vrf_name = "GREEN"
+            else:
+                pytest.fail("unexpected switch-detail path: {0}".format(self.path))
+
+            self.response_current = {
+                "DATA": [
+                    {
+                        "vrfName": vrf_name,
+                        "switchDetailsList": [
+                            _vrf_lite_switch_detail(serial_number=serial_number, extra_vrf=vrf_name) for serial_number in ("SN1", "SN2", "SN3")
+                        ],
+                    }
+                ]
+            }
+            self.result_current = {"success": True}
+
+    module = _DummyModule({"_vrf_lite_switch_detail_cache": {}})
+    rest_send = _FakeRestSend()
+
+    blue = _query_vrf_switch_details(module, rest_send, "F1", "BLUE", ["SN3", "SN1", "SN2"])
+    green = _query_vrf_switch_details(module, rest_send, "F1", "GREEN", ["SN2", "SN3", "SN1"])
+    blue_cached = _query_vrf_switch_details(module, rest_send, "F1", "BLUE", ["SN1", "SN2", "SN3"])
+
+    assert sorted(blue) == ["SN1", "SN2", "SN3"]
+    assert sorted(green) == ["SN1", "SN2", "SN3"]
+    assert blue_cached == blue
+    assert rest_send.calls == [
+        VrfLiteEndpoints.vrf_switch("F1", "BLUE", "SN1,SN2,SN3"),
+        VrfLiteEndpoints.vrf_switch("F1", "GREEN", "SN1,SN2,SN3"),
+    ]
+
+
+def test_manage_vrf_lite_00580_guardrails_report_requested_and_available_interfaces(monkeypatch):
+    module = _DummyWarnModule(
+        {
+            "fabric_name": "F1",
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "_fabric_switch_inventory": {},
+        }
+    )
+    _mock_guardrail_inventory(monkeypatch)
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation._query_vrf_lite_support",
+        lambda *_args: True,
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation.get_cached_vrf_lite_prototypes",
+        lambda *_args: {
+            "Ethernet1/1": json.loads(_vrf_lite_prototype("Ethernet1/1")["extensionValues"]),
+        },
+    )
+
+    with pytest.raises(VrfLiteResourceError, match=r"Requested interface\(s\): Ethernet1/10.*Available interface\(s\): Ethernet1/1"):
+        validate_vrf_lite_write_guardrails(module=module, model_instance=_vrf_lite_guardrail_model(), rest_send=object())
+
+
+def test_manage_vrf_lite_00582_prototype_parser_distinguishes_absent_empty_and_malformed():
+    assert _extract_vrf_lite_prototypes({"serialNumber": "SN1"}, "SN1") is None
+    assert (
+        _extract_vrf_lite_prototypes(
+            {
+                "serialNumber": "SN1",
+                "extensionPrototypeValues": [],
+            },
+            "SN1",
+        )
+        == {}
+    )
+    assert _extract_vrf_lite_prototypes(
+        {
+            "serialNumber": "SN1",
+            "extensionPrototypeValues": [
+                _vrf_lite_prototype(extension_values="{not-json"),
+            ],
+        },
+        "SN1",
+    ) == {"Ethernet1/10": {"IF_NAME": "Ethernet1/10"}}
+
+
+def test_manage_vrf_lite_00585_guardrails_reject_empty_and_malformed_prototypes(monkeypatch):
+    module = _DummyWarnModule(
+        {
+            "fabric_name": "F1",
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "_fabric_switch_inventory": {},
+        }
+    )
+    _mock_guardrail_inventory(monkeypatch)
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation._query_vrf_lite_support",
+        lambda *_args: True,
+    )
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation.get_cached_vrf_lite_prototypes",
+        lambda *_args: {},
+    )
+    with pytest.raises(VrfLiteResourceError, match="No VRF Lite-capable interfaces"):
+        validate_vrf_lite_write_guardrails(module=module, model_instance=_vrf_lite_guardrail_model(), rest_send=object())
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation.get_cached_vrf_lite_prototypes",
+        lambda *_args: {"Ethernet1/10": {"IF_NAME": "Ethernet1/10"}},
+    )
+    with pytest.raises(VrfLiteResourceError, match="unusable VRF Lite prototype metadata"):
+        validate_vrf_lite_write_guardrails(module=module, model_instance=_vrf_lite_guardrail_model(), rest_send=object())
+
+
+def test_manage_vrf_lite_00600_guardrails_reject_unsupported_switch(monkeypatch):
+    module = _DummyWarnModule(
+        {
+            "fabric_name": "F1",
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "_fabric_switch_inventory": {},
+        }
+    )
+    model = _vrf_lite_guardrail_model()
+    _mock_guardrail_inventory(monkeypatch)
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation._query_vrf_lite_support",
+        lambda _module, _rest_send, _fabric_name, _vrf_name, _serial_number: False,
+    )
+
+    with pytest.raises(VrfLiteResourceError, match="does not report VRF Lite support"):
+        validate_vrf_lite_write_guardrails(module=module, model_instance=model, rest_send=object())
+
+
+def test_manage_vrf_lite_00700_guardrails_fail_closed_when_prototype_query_fails(monkeypatch):
+    module = _DummyWarnModule(
+        {
+            "fabric_name": "F1",
+            "_ip_to_sn_mapping": {"10.0.0.1": "SN1"},
+            "_fabric_switch_inventory": {},
+            "_warnings": [],
+        }
+    )
+    model = _vrf_lite_guardrail_model()
+    _mock_guardrail_inventory(monkeypatch, role="")
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.validation._query_vrf_lite_support",
+        lambda _module, _rest_send, _fabric_name, _vrf_name, _serial_number: (_x for _x in ()).throw(Exception("boom")),
+    )
+
+    with pytest.raises(Exception, match="boom"):
+        validate_vrf_lite_write_guardrails(module=module, model_instance=model, rest_send=object())
+
+
+def test_manage_vrf_lite_00800_attachment_post_uses_legacy_vrf_lite_payload(
+    monkeypatch,
+):
+    calls = []
+
+    def _request(module, rest_send, path, verb, payload):
+        calls.append((module, rest_send, path, verb, payload))
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions._request_vrf_lite_payload",
+        _request,
+    )
+    module = _DummyModule({})
+    rest_send = object()
+    lan_attach_list = [{"serialNumber": "SN1", "isAttached": True}]
+
+    result = _post_attachment_payload(
+        module=module,
+        rest_send=rest_send,
+        fabric_name="FABRIC1",
+        vrf_name="BLUE",
+        lan_attach_list=lan_attach_list,
+    )
+
+    assert result == {"ok": True}
+    assert calls == [
+        (
+            module,
+            rest_send,
+            "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/FABRIC1/vrfs/attachments",
+            HttpVerbEnum.POST,
+            [{"vrfName": "BLUE", "lanAttachList": lan_attach_list}],
+        )
+    ]
+
+
+def test_manage_vrf_lite_00810_create_bulk_reads_and_posts_once_per_vrf(monkeypatch):
+    request_paths = []
+    post_calls = []
+
+    def _request(module, rest_send, path, verb, data=None):
+        del module, rest_send, data
+        assert verb == HttpVerbEnum.GET
+        request_paths.append(path)
+        vrf_name = "BLUE" if "vrf-names=BLUE" in path else "GREEN"
+        return [
+            {
+                "vrfName": vrf_name,
+                "switchDetailsList": [_vrf_lite_switch_detail(serial_number=serial_number) for serial_number in ("SN1", "SN2", "SN3")],
+            }
+        ]
+
+    def _post(module, rest_send, fabric_name, vrf_name, rows):
+        del module, rest_send
+        post_calls.append((fabric_name, vrf_name, rows))
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query.request_with_verify_settings",
+        _request,
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite._post_attachment_payload",
+        _post,
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.build_attach_payload_for_entry",
+        lambda module, rest_send, entry: {"serialNumber": entry.switch_ip},
+    )
+    entries = [
+        VrfLiteAttachmentEntry(
+            vrf_name=vrf_name,
+            switch_ip=serial_number,
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        )
+        for vrf_name in ("GREEN", "BLUE")
+        for serial_number in ("SN3", "SN1", "SN2")
+    ]
+    module = _DummyModule(
+        {
+            "check_mode": False,
+            "fabric_name": "F1",
+            "state": "merged",
+            "_known_vrfs": ["BLUE", "GREEN"],
+            "_known_vrfs_loaded": True,
+            "_fabric_switch_inventory": {serial_number: {"switchId": serial_number, "switchRole": "border"} for serial_number in ("SN1", "SN2", "SN3")},
+            "_fabric_switch_inventory_loaded": True,
+            "_fabric_switch_inventory_normalized": False,
+            "_vrf_lite_switch_detail_cache": {},
+            "_vrf_lite_support_cache": {},
+            "_vrf_lite_prototype_cache": {},
+        }
+    )
+    result = _vrf_lite_orchestrator(module).create_bulk(entries)
+
+    assert request_paths == [
+        VrfLiteEndpoints.vrf_switch("F1", "GREEN", "SN1,SN2,SN3"),
+        VrfLiteEndpoints.vrf_switch("F1", "BLUE", "SN1,SN2,SN3"),
+    ]
+    assert [(vrf_name, len(rows)) for _fabric_name, vrf_name, rows in post_calls] == [("BLUE", 3), ("GREEN", 3)]
+    assert result == {
+        "response": [
+            {"vrf_name": "BLUE", "response": {"ok": True}},
+            {"vrf_name": "GREEN", "response": {"ok": True}},
+        ]
+    }
+
+
+def test_manage_vrf_lite_00850_attachment_post_reports_structured_controller_failure(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions._request_vrf_lite_payload",
+        lambda *args, **kwargs: {
+            "results": [
+                {
+                    "message": "Provided interface doesn't have extensions[Ethernet1/2]",
+                    "status": "failed",
+                    "switchId": "SN1",
+                    "switchName": "leaf1",
+                    "vrfName": "BLUE",
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(VrfLiteResourceError, match="attachment API reported failure") as error:
+        _post_attachment_payload(
+            module=_DummyModule({}),
+            rest_send=object(),
+            fabric_name="FABRIC1",
+            vrf_name="BLUE",
+            lan_attach_list=[{"serialNumber": "SN1"}],
+        )
+
+    assert "BLUE/SN1: Provided interface doesn't have extensions[Ethernet1/2]" in str(error.value)
+
+
+def test_manage_vrf_lite_00860_attachment_post_reports_legacy_controller_failure(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions._request_vrf_lite_payload",
+        lambda *args, **kwargs: {
+            "BLUE-[SN1/leaf1]": "Attach Response : Failed : VPC details not found for Peer Serial no: SN2",
+        },
+    )
+
+    with pytest.raises(VrfLiteResourceError, match="attachment API reported failure") as error:
+        _post_attachment_payload(
+            module=_DummyModule({}),
+            rest_send=object(),
+            fabric_name="FABRIC1",
+            vrf_name="BLUE",
+            lan_attach_list=[{"serialNumber": "SN1"}],
+        )
+
+    assert "VPC details not found for Peer Serial no: SN2" in str(error.value)
+
+
+def test_manage_vrf_lite_00870_list_payload_uses_list_capable_rest_transport(monkeypatch):
+    seen = {}
+
+    def _commit(active_rest_send):
+        seen["path"] = active_rest_send.path
+        seen["verb"] = active_rest_send.verb
+        seen["payload"] = active_rest_send.payload
+        active_rest_send.response_current = {"RETURN_CODE": 200, "DATA": {"ok": True}}
+        active_rest_send.result_current = {"success": True}
+
+    monkeypatch.setattr(_VrfLiteListPayloadRestSend, "commit", _commit)
+    module = _DummyModule({"state": "merged"})
+    sender = Sender()
+    sender.ansible_module = module
+    base_rest_send = RestSend({"check_mode": False, "state": "merged"})
+    base_rest_send.sender = sender
+    base_rest_send.response_handler = ResponseHandler()
+    payload = [{"vrfName": "BLUE", "lanAttachList": [{"serialNumber": "SN1"}]}]
+
+    response = request_with_rest_send(
+        module,
+        base_rest_send,
+        "/legacy/vrfs/attachments",
+        HttpVerbEnum.POST,
+        payload,
+    )
+
+    assert response == {"ok": True}
+    assert seen == {
+        "path": "/legacy/vrfs/attachments",
+        "verb": HttpVerbEnum.POST,
+        "payload": payload,
+    }
+
+
+def test_manage_vrf_lite_00880_request_error_preserves_status_and_controller_body(monkeypatch):
+    def _raise_nd_error(**_kwargs):
+        raise NDModuleError(
+            msg="Internal Server Error",
+            status=500,
+            response_payload={"error": "controller detail"},
+        )
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions.request_with_rest_send",
+        _raise_nd_error,
+    )
+
+    with pytest.raises(VrfLiteResourceError) as error:
+        _request_vrf_lite_payload(
+            module=_DummyModule({}),
+            rest_send=object(),
+            path="/legacy/vrfs/attachments",
+            verb=HttpVerbEnum.POST,
+            payload=[{"vrfName": "BLUE"}],
+        )
+
+    assert "status=500" in error.value.msg
+    assert "controller detail" in error.value.msg
+    assert error.value.details["status"] == 500
+    assert error.value.details["response_payload"] == {"error": "controller detail"}
+
+
+def test_manage_vrf_lite_00890_attachment_post_does_not_double_wrap_resource_error(monkeypatch):
+    original = VrfLiteResourceError(
+        "controller rejected attachment",
+        status=500,
+        response_payload={"error": "specific detail"},
+    )
+
+    def _raise_resource_error(*_args, **_kwargs):
+        raise original
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.actions._request_vrf_lite_payload",
+        _raise_resource_error,
+    )
+
+    with pytest.raises(VrfLiteResourceError) as error:
+        _post_attachment_payload(
+            module=_DummyModule({}),
+            rest_send=object(),
+            fabric_name="FABRIC1",
+            vrf_name="BLUE",
+            lan_attach_list=[{"serialNumber": "SN1"}],
+        )
+
+    assert error.value is original
+    assert error.value.details["response_payload"] == {"error": "specific detail"}
+
+
+def test_manage_vrf_lite_00900_check_mode_preflight_validates_vrf_existence(
+    monkeypatch,
+):
+    """Check mode must reject a nonexistent VRF the same way the real run would.
+
+    The generic state machine skips every write in check mode, so the attach
+    guardrails are reached only through preflight_validate_check_mode.
+    """
+    seen = []
+
+    def _boom(module, rest_send, vrf_name):
+        del module, rest_send
+        seen.append(vrf_name)
+        raise VrfLiteResourceError("VRF {0} does not exist".format(vrf_name))
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite._ensure_vrf_exists",
+        _boom,
+    )
+    module = _DummyModule({"check_mode": True, "state": "merged", "fabric_name": "F1"})
+    orchestrator = _vrf_lite_orchestrator(module)
+
+    with pytest.raises(VrfLiteResourceError, match="does not exist"):
+        orchestrator.preflight_validate_check_mode([_StubEntry("MISSING", "10.0.0.1")])
+    assert seen == ["MISSING"]
+
+
+def test_manage_vrf_lite_00910_preflight_is_noop_outside_check_mode(monkeypatch):
+    """Outside check mode the write path performs validation, so the preflight must
+    not run (and must not double-validate)."""
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("preflight must not validate outside check mode")
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite._ensure_vrf_exists",
+        _fail,
+    )
+    module = _DummyModule({"check_mode": False, "state": "merged", "fabric_name": "F1"})
+    orchestrator = _vrf_lite_orchestrator(module)
+
+    orchestrator.preflight_validate_check_mode([_StubEntry("BLUE", "10.0.0.1")])
+
+
+def test_manage_vrf_lite_00920_preflight_skips_non_write_states(monkeypatch):
+    """deleted/gathered runs perform no attaches, so the attach preflight is skipped."""
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("preflight must not validate for non-write states")
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite._ensure_vrf_exists",
+        _fail,
+    )
+    module = _DummyModule({"check_mode": True, "state": "deleted", "fabric_name": "F1"})
+    orchestrator = _vrf_lite_orchestrator(module)
+
+    orchestrator.preflight_validate_check_mode([_StubEntry("BLUE", "10.0.0.1")])
+
+
+def test_manage_vrf_lite_00930_bulk_validation_prefetches_once_per_vrf(monkeypatch):
+    request_paths = []
+
+    def _request(module, rest_send, path, verb, data=None):
+        del module, rest_send, data
+        assert verb == HttpVerbEnum.GET
+        request_paths.append(path)
+        vrf_name = "BLUE" if "vrf-names=BLUE" in path else "GREEN"
+        return [
+            {
+                "vrfName": vrf_name,
+                "switchDetailsList": [_vrf_lite_switch_detail(serial_number=serial_number) for serial_number in ("SN1", "SN2", "SN3")],
+            }
+        ]
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query.request_with_verify_settings",
+        _request,
+    )
+
+    entries = [
+        VrfLiteAttachmentEntry(
+            vrf_name=vrf_name,
+            switch_ip=serial_number,
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        )
+        for vrf_name in ("BLUE", "GREEN")
+        for serial_number in ("SN3", "SN1", "SN2")
+    ]
+    module = _DummyModule(
+        {
+            "check_mode": False,
+            "state": "merged",
+            "fabric_name": "F1",
+            "_known_vrfs": ["BLUE", "GREEN"],
+            "_known_vrfs_loaded": True,
+            "_fabric_switch_inventory": {serial_number: {"switchId": serial_number, "switchRole": "border"} for serial_number in ("SN1", "SN2", "SN3")},
+            "_fabric_switch_inventory_loaded": True,
+            "_fabric_switch_inventory_normalized": False,
+            "_vrf_lite_switch_detail_cache": {},
+            "_vrf_lite_support_cache": {},
+            "_vrf_lite_prototype_cache": {},
+        }
+    )
+    orchestrator = _vrf_lite_orchestrator(module)
+
+    orchestrator._validate_attach_entries(entries)
+    orchestrator._validate_attach_entries(entries)
+
+    assert request_paths == [
+        VrfLiteEndpoints.vrf_switch("F1", "BLUE", "SN1,SN2,SN3"),
+        VrfLiteEndpoints.vrf_switch("F1", "GREEN", "SN1,SN2,SN3"),
+    ]
+
+
+def test_manage_vrf_lite_00935_unknown_switch_fails_before_unrelated_vrf_prefetch(monkeypatch):
+    request_paths = []
+
+    def _request(module, rest_send, path, verb, data=None):
+        del module, rest_send, verb, data
+        request_paths.append(path)
+        return []
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query.request_with_verify_settings",
+        _request,
+    )
+    entries = [
+        VrfLiteAttachmentEntry(
+            vrf_name="BLUE",
+            switch_ip="UNKNOWN",
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        ),
+        VrfLiteAttachmentEntry(
+            vrf_name="GREEN",
+            switch_ip="SN1",
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        ),
+    ]
+    module = _DummyModule(
+        {
+            "check_mode": False,
+            "state": "merged",
+            "fabric_name": "F1",
+            "_known_vrfs": ["BLUE", "GREEN"],
+            "_known_vrfs_loaded": True,
+            "_fabric_switch_inventory": {"SN1": {"switchId": "SN1", "switchRole": "border"}},
+            "_fabric_switch_inventory_loaded": True,
+            "_fabric_switch_inventory_normalized": False,
+        }
+    )
+    orchestrator = _vrf_lite_orchestrator(module)
+
+    with pytest.raises(VrfLiteResourceError, match="Switch 'UNKNOWN' is not present"):
+        orchestrator._validate_attach_entries(entries)
+
+    assert request_paths == []
+
+
+def test_manage_vrf_lite_00936_earlier_support_error_precedes_later_unknown_switch(monkeypatch):
+    request_paths = []
+
+    def _request(module, rest_send, path, verb, data=None):
+        del module, rest_send, data
+        assert verb == HttpVerbEnum.GET
+        request_paths.append(path)
+        return [
+            {
+                "vrfName": "BLUE",
+                "switchDetailsList": [_vrf_lite_switch_detail(serial_number="SN1", isVrfLiteSupported=False)],
+            }
+        ]
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query.request_with_verify_settings",
+        _request,
+    )
+    entries = [
+        VrfLiteAttachmentEntry(
+            vrf_name="BLUE",
+            switch_ip="SN1",
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        ),
+        VrfLiteAttachmentEntry(
+            vrf_name="BLUE",
+            switch_ip="UNKNOWN",
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        ),
+        VrfLiteAttachmentEntry(
+            vrf_name="GREEN",
+            switch_ip="SN2",
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        ),
+    ]
+    module = _DummyModule(
+        {
+            "check_mode": False,
+            "state": "merged",
+            "fabric_name": "F1",
+            "_known_vrfs": ["BLUE", "GREEN"],
+            "_known_vrfs_loaded": True,
+            "_fabric_switch_inventory": {
+                "SN1": {"switchId": "SN1", "switchRole": "border"},
+                "SN2": {"switchId": "SN2", "switchRole": "border"},
+            },
+            "_fabric_switch_inventory_loaded": True,
+            "_fabric_switch_inventory_normalized": False,
+            "_vrf_lite_switch_detail_cache": {},
+            "_vrf_lite_support_cache": {},
+            "_vrf_lite_prototype_cache": {},
+        }
+    )
+
+    with pytest.raises(VrfLiteResourceError, match="does not report VRF Lite support"):
+        _vrf_lite_orchestrator(module)._validate_attach_entries(entries)
+
+    assert request_paths == [VrfLiteEndpoints.vrf_switch("F1", "BLUE", "SN1")]
+
+
+def test_manage_vrf_lite_00937_interleaved_vrfs_preserve_input_error_order(monkeypatch):
+    request_paths = []
+
+    def _request(module, rest_send, path, verb, data=None):
+        del module, rest_send, data
+        assert verb == HttpVerbEnum.GET
+        request_paths.append(path)
+        return [
+            {
+                "vrfName": "BLUE",
+                "switchDetailsList": [_vrf_lite_switch_detail(serial_number="SN1")],
+            }
+        ]
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query.request_with_verify_settings",
+        _request,
+    )
+    entries = [
+        VrfLiteAttachmentEntry(
+            vrf_name="BLUE",
+            switch_ip="SN1",
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        ),
+        VrfLiteAttachmentEntry(
+            vrf_name="GREEN",
+            switch_ip="UNKNOWN",
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        ),
+        VrfLiteAttachmentEntry(
+            vrf_name="BLUE",
+            switch_ip="SN2",
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        ),
+    ]
+    module = _DummyModule(
+        {
+            "check_mode": False,
+            "state": "merged",
+            "fabric_name": "F1",
+            "_known_vrfs": ["BLUE", "GREEN"],
+            "_known_vrfs_loaded": True,
+            "_fabric_switch_inventory": {
+                "SN1": {"switchId": "SN1", "switchRole": "border"},
+                "SN2": {"switchId": "SN2", "switchRole": "border"},
+            },
+            "_fabric_switch_inventory_loaded": True,
+            "_fabric_switch_inventory_normalized": False,
+            "_vrf_lite_switch_detail_cache": {},
+            "_vrf_lite_support_cache": {},
+            "_vrf_lite_prototype_cache": {},
+        }
+    )
+
+    with pytest.raises(VrfLiteResourceError, match="Switch 'UNKNOWN' is not present"):
+        _vrf_lite_orchestrator(module)._validate_attach_entries(entries)
+
+    assert request_paths == [VrfLiteEndpoints.vrf_switch("F1", "BLUE", "SN1")]
+
+
+def test_manage_vrf_lite_00940_check_mode_preflight_reads_once_per_vrf_without_posts(monkeypatch):
+    request_paths = []
+
+    def _request(module, rest_send, path, verb, data=None):
+        del module, rest_send, data
+        assert verb == HttpVerbEnum.GET
+        request_paths.append(path)
+        vrf_name = "BLUE" if "vrf-names=BLUE" in path else "GREEN"
+        return [
+            {
+                "vrfName": vrf_name,
+                "switchDetailsList": [_vrf_lite_switch_detail(serial_number=serial_number) for serial_number in ("SN1", "SN2", "SN3")],
+            }
+        ]
+
+    def _unexpected_post(*args, **kwargs):
+        pytest.fail("check mode must not submit attachment POSTs: {0} {1}".format(args, kwargs))
+
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query.request_with_verify_settings",
+        _request,
+    )
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite._post_attachment_payload",
+        _unexpected_post,
+    )
+    entries = [
+        VrfLiteAttachmentEntry(
+            vrf_name=vrf_name,
+            switch_ip=serial_number,
+            extensions=[{"interface": "Ethernet1/10", "neighbor_ipv4": "192.0.2.9"}],
+        )
+        for vrf_name in ("BLUE", "GREEN")
+        for serial_number in ("SN3", "SN1", "SN2")
+    ]
+    module = _DummyModule(
+        {
+            "check_mode": True,
+            "state": "merged",
+            "fabric_name": "F1",
+            "_known_vrfs": ["BLUE", "GREEN"],
+            "_known_vrfs_loaded": True,
+            "_fabric_switch_inventory": {serial_number: {"switchId": serial_number, "switchRole": "border"} for serial_number in ("SN1", "SN2", "SN3")},
+            "_fabric_switch_inventory_loaded": True,
+            "_fabric_switch_inventory_normalized": False,
+            "_vrf_lite_switch_detail_cache": {},
+            "_vrf_lite_support_cache": {},
+            "_vrf_lite_prototype_cache": {},
+        }
+    )
+    orchestrator = _vrf_lite_orchestrator(module)
+
+    orchestrator.preflight_validate_check_mode(entries)
+
+    assert request_paths == [
+        VrfLiteEndpoints.vrf_switch("F1", "BLUE", "SN1,SN2,SN3"),
+        VrfLiteEndpoints.vrf_switch("F1", "GREEN", "SN1,SN2,SN3"),
+    ]

--- a/tests/unit/module_utils/test_manage_vrf_lite_attachment_entry.py
+++ b/tests/unit/module_utils/test_manage_vrf_lite_attachment_entry.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Sivakami Sivaraman <sivakasi@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for VrfLiteAttachmentEntry and the flat-mode query output.
+
+These cover PR 1 (Foundations) of the attachment-granularity refactor:
+the new flat per-(vrf_name, switch_ip) attachment model and the
+``flat=True`` output mode of ``query_vrf_lite_state``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_vrf_lite.vrf_lite_attachment_entry import (
+    VrfLiteAttachmentEntry,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+    NDConfigCollection,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    ValidationError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.query import (
+    _flatten_to_entries,
+)
+
+# --- Identifier & basic serialization ------------------------------------
+
+
+def test_identifier_is_composite_tuple():
+    entry = VrfLiteAttachmentEntry(vrf_name="TENANT_A", switch_ip="10.10.10.11")
+    assert entry.identifier_strategy == "composite"
+    assert entry.get_identifier_value() == ("TENANT_A", "10.10.10.11")
+
+
+def test_missing_identifier_field_raises():
+    with pytest.raises(ValidationError):
+        VrfLiteAttachmentEntry(vrf_name="TENANT_A")  # type: ignore[call-arg]
+
+
+def test_round_trip_from_config_preserves_fields():
+    data = {
+        "vrf_name": "TENANT_B",
+        "switch_ip": "10.10.10.12",
+        "vlan_id": 500,
+        "import_evpn_rt": "65000:100",
+        "export_evpn_rt": "65000:100",
+        "extensions": [{"interface": "Ethernet1/20", "dot1q": 500, "ipv4_addr": "10.33.0.2/24"}],
+    }
+    entry = VrfLiteAttachmentEntry.from_config(data)
+    cfg = entry.to_config()
+    assert cfg["vrf_name"] == "TENANT_B"
+    assert cfg["switch_ip"] == "10.10.10.12"
+    assert cfg["vlan_id"] == 500
+    assert cfg["extensions"][0]["interface"] == "Ethernet1/20"
+
+
+def test_deploy_excluded_from_diff_dict():
+    base = VrfLiteAttachmentEntry(vrf_name="A", switch_ip="1.1.1.1")
+    with_deploy = VrfLiteAttachmentEntry(vrf_name="A", switch_ip="1.1.1.1", deploy=True)
+    assert base.to_diff_dict() == with_deploy.to_diff_dict()
+
+
+def test_deploy_only_diff_is_no_diff():
+    """Existing entry with deploy=True vs proposed without deploy must be no_diff.
+
+    Regression test for TC9: query returns deploy=True on an already-deployed
+    entry; if the user did not set deploy in their playbook the state machine
+    must not classify it as 'changed' for either merge or replace/override.
+    """
+    existing = VrfLiteAttachmentEntry(vrf_name="A", switch_ip="1.1.1.1", vlan_id=10, deploy=True)
+    proposed = VrfLiteAttachmentEntry(vrf_name="A", switch_ip="1.1.1.1", vlan_id=10)
+    coll = NDConfigCollection(model_class=VrfLiteAttachmentEntry, items=[existing])
+    # merge state (exclude_unset=True)
+    assert coll.get_diff_config(proposed, exclude_unset=True) == "no_diff"
+    # replace/override state (exclude_unset=False)
+    assert coll.get_diff_config(proposed, exclude_unset=False) == "no_diff"
+
+
+def test_empty_string_evpn_rt_coerced_to_none():
+    """Empty-string EVPN RT is normalised to None by the model validator.
+
+    The query layer may produce '' for absent EVPN RT fields. The model
+    must coerce that to None so it is excluded by exclude_none=True in
+    to_diff_dict, preventing false 'changed' classifications.
+    """
+    entry = VrfLiteAttachmentEntry(vrf_name="A", switch_ip="1.1.1.1", import_evpn_rt="", export_evpn_rt="")
+    assert entry.import_evpn_rt is None
+    assert entry.export_evpn_rt is None
+    assert "import_evpn_rt" not in entry.to_diff_dict()
+    assert "export_evpn_rt" not in entry.to_diff_dict()
+
+
+# --- Merge behaviour ------------------------------------------------------
+
+
+def test_merge_preserves_unmentioned_interfaces():
+    base = VrfLiteAttachmentEntry.from_config(
+        {
+            "vrf_name": "X",
+            "switch_ip": "1.1.1.1",
+            "extensions": [
+                {"interface": "Eth1", "dot1q": 100},
+                {"interface": "Eth2", "dot1q": 200},
+            ],
+        }
+    )
+    incoming = VrfLiteAttachmentEntry.from_config(
+        {
+            "vrf_name": "X",
+            "switch_ip": "1.1.1.1",
+            "extensions": [{"interface": "Eth1", "dot1q": 150}],
+        }
+    )
+    merged = base.merge(incoming)
+    by_iface = {e.interface: e.dot1q for e in merged.extensions}
+    assert by_iface == {"Eth1": 150, "Eth2": 200}
+
+
+def test_merge_preserves_same_interface_with_different_dot1q_values():
+    base = VrfLiteAttachmentEntry.from_config(
+        {
+            "vrf_name": "X",
+            "switch_ip": "1.1.1.1",
+            "extensions": [
+                {"interface": "Eth1", "dot1q": 100, "ipv4_addr": "10.0.0.2/30"},
+                {"interface": "Eth1", "dot1q": 101, "ipv4_addr": "10.0.0.6/30"},
+            ],
+        }
+    )
+    incoming = VrfLiteAttachmentEntry.from_config(
+        {
+            "vrf_name": "X",
+            "switch_ip": "1.1.1.1",
+            "extensions": [
+                {"interface": "Eth1", "dot1q": 100, "ipv4_addr": "10.0.0.2/30"},
+                {"interface": "Eth1", "dot1q": 101, "ipv4_addr": "10.0.0.6/30"},
+            ],
+        }
+    )
+
+    merged = base.merge(incoming)
+
+    assert merged.extensions is not None
+    assert [(item.interface, item.dot1q) for item in merged.extensions] == [
+        ("Eth1", 100),
+        ("Eth1", 101),
+    ]
+
+    coll = NDConfigCollection(model_class=VrfLiteAttachmentEntry, items=[base])
+    assert coll.get_diff_config(merged, exclude_unset=True) == "no_diff"
+
+
+def test_merge_scalar_fields_only_when_set():
+    base = VrfLiteAttachmentEntry(vrf_name="X", switch_ip="1.1.1.1", vlan_id=100)
+    incoming = VrfLiteAttachmentEntry(vrf_name="X", switch_ip="1.1.1.1")  # vlan_id unset
+    merged = base.merge(incoming)
+    assert merged.vlan_id == 100
+
+
+def test_merge_empty_extensions_list_preserves_existing():
+    """An incoming entry with extensions=[] must not wipe existing extensions.
+
+    An empty list is treated the same as an absent list: the existing
+    extensions are preserved so that a playbook mentioning a VRF attachment
+    without specifying extensions does not accidentally remove them.
+    """
+    base = VrfLiteAttachmentEntry.from_config(
+        {
+            "vrf_name": "X",
+            "switch_ip": "1.1.1.1",
+            "extensions": [{"interface": "Eth1", "dot1q": 100}],
+        }
+    )
+    incoming = VrfLiteAttachmentEntry.from_config(
+        {
+            "vrf_name": "X",
+            "switch_ip": "1.1.1.1",
+            "extensions": [],
+        }
+    )
+    merged = base.merge(incoming)
+    assert merged.extensions is not None and len(merged.extensions) == 1
+    assert merged.extensions[0].interface == "Eth1"
+
+
+# --- NDConfigCollection integration --------------------------------------
+
+
+def test_collection_classifies_new_no_diff_changed():
+    e1 = VrfLiteAttachmentEntry(vrf_name="A", switch_ip="1.1.1.1", vlan_id=10)
+    e2 = VrfLiteAttachmentEntry(vrf_name="B", switch_ip="2.2.2.2", vlan_id=20)
+    coll = NDConfigCollection(model_class=VrfLiteAttachmentEntry, items=[e1, e2])
+
+    assert coll.get_diff_config(VrfLiteAttachmentEntry(vrf_name="C", switch_ip="3.3.3.3")) == "new"
+    assert coll.get_diff_config(VrfLiteAttachmentEntry(vrf_name="A", switch_ip="1.1.1.1", vlan_id=10)) == "no_diff"
+    assert coll.get_diff_config(VrfLiteAttachmentEntry(vrf_name="A", switch_ip="1.1.1.1", vlan_id=99)) == "changed"
+
+
+def test_collection_keys_use_tuples():
+    coll = NDConfigCollection(
+        model_class=VrfLiteAttachmentEntry,
+        items=[VrfLiteAttachmentEntry(vrf_name="A", switch_ip="1.1.1.1")],
+    )
+    assert ("A", "1.1.1.1") in coll.keys()
+
+
+# --- Flat query flattener -------------------------------------------------
+
+
+def test_flatten_emits_one_entry_per_switch():
+    nested = [
+        {
+            "vrf_name": "TENANT_A",
+            "vlan_id": 500,
+            "attach": [
+                {"ip_address": "10.10.10.11", "deploy": True, "vrf_lite": [{"interface": "Eth1"}]},
+                {"ip_address": "10.10.10.12", "deploy": True},
+            ],
+        }
+    ]
+    flat = _flatten_to_entries(nested)
+    assert [e["switch_ip"] for e in flat] == ["10.10.10.11", "10.10.10.12"]
+    assert all(e["vrf_name"] == "TENANT_A" for e in flat)
+    assert flat[0]["vlan_id"] == 500
+    assert flat[0]["extensions"] == [{"interface": "Eth1"}]
+
+
+def test_flatten_skips_vrfs_with_no_attach():
+    nested = [{"vrf_name": "EMPTY", "vlan_id": 10, "attach": []}]
+    assert _flatten_to_entries(nested) == []
+
+
+def test_flatten_sorts_by_vrf_then_switch():
+    nested = [
+        {"vrf_name": "B", "attach": [{"ip_address": "2.2.2.2"}, {"ip_address": "1.1.1.1"}]},
+        {"vrf_name": "A", "attach": [{"ip_address": "3.3.3.3"}]},
+    ]
+    flat = _flatten_to_entries(nested)
+    assert [(e["vrf_name"], e["switch_ip"]) for e in flat] == [
+        ("A", "3.3.3.3"),
+        ("B", "1.1.1.1"),
+        ("B", "2.2.2.2"),
+    ]
+
+
+def test_flatten_drops_none_fields():
+    nested = [{"vrf_name": "A", "attach": [{"ip_address": "1.1.1.1", "deploy": None, "import_evpn_rt": None}]}]
+    entry = _flatten_to_entries(nested)[0]
+    assert "deploy" not in entry
+    assert "import_evpn_rt" not in entry

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -1,0 +1,349 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for utils.py
+
+Tests the ``issubset`` helper (both the default bidirectional list matching and
+the one-directional ``allow_superset=True`` matching) and ``NDBaseModel.get_diff``
+with list-valued fields under ``exclude_unset=True``.
+"""
+
+# pylint: disable=protected-access
+
+from __future__ import absolute_import, annotations, division, print_function
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+from typing import Any, ClassVar, Dict, List, Literal, Optional
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.utils import issubset
+
+# =============================================================================
+# issubset - scalars
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "subset, superset, expected",
+    [
+        (1, 1, True),
+        (1, 2, False),
+        ("a", "a", True),
+        ("a", "b", False),
+        (True, True, True),
+        (1, "1", False),  # different types
+        (1.0, 1, False),  # different types (float vs int)
+    ],
+)
+def test_issubset_scalars(subset, superset, expected):
+    """Scalar comparison is strict equality and type-sensitive."""
+    assert issubset(subset, superset) is expected
+
+
+# =============================================================================
+# issubset - dicts
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "subset, superset, expected",
+    [
+        # Subset of keys present with matching values -> True
+        ({"a": 1}, {"a": 1, "b": 2}, True),
+        # Exact match -> True
+        ({"a": 1, "b": 2}, {"a": 1, "b": 2}, True),
+        # Missing key in superset -> False
+        ({"a": 1, "c": 3}, {"a": 1, "b": 2}, False),
+        # Value mismatch -> False
+        ({"a": 1}, {"a": 2}, False),
+        # None values in subset are ignored
+        ({"a": 1, "b": None}, {"a": 1}, True),
+        # Nested dict subset
+        ({"a": {"x": 1}}, {"a": {"x": 1, "y": 2}}, True),
+        # Nested dict mismatch
+        ({"a": {"x": 1}}, {"a": {"x": 2}}, False),
+    ],
+)
+def test_issubset_dicts(subset, superset, expected):
+    """Dict comparison checks each non-None key/value of subset."""
+    assert issubset(subset, superset) is expected
+
+
+def test_issubset_dicts_none_keys_not_strict_equality():
+    """
+    Bidirectional dict matching is NOT strict ``==`` equality: ``None``-valued
+    keys are skipped, so unequal dicts can still match in both directions.
+    This documents the behavior described in the ``issubset`` docstring.
+    """
+    a = {"a": 1, "b": None}
+    b = {"a": 1}
+
+    # Not equal as plain dicts ...
+    assert a != b
+    # ... yet issubset matches in both directions (b: None is ignored).
+    assert issubset(a, b) is True
+    assert issubset(b, a) is True
+
+
+# =============================================================================
+# issubset - lists with allow_superset=False (default, bidirectional)
+#
+# This is the behavior deliberately added in PR #209: for lists of dicts the
+# match is bidirectional, which is equivalent to equality. An element whose
+# candidate carries extra keys does NOT match.
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "subset, superset, expected",
+    [
+        # Equal lists -> True
+        ([1, 2, 3], [1, 2, 3], True),
+        # Order-independent matching -> True
+        ([3, 1, 2], [1, 2, 3], True),
+        # Different length -> False
+        ([1, 2], [1, 2, 3], False),
+        # Element missing -> False
+        ([1, 2, 4], [1, 2, 3], False),
+        # Lists of dicts, exact element match -> True
+        ([{"a": 1}], [{"a": 1}], True),
+        # Lists of dicts, candidate has EXTRA key -> False (bidirectional)
+        ([{"a": 1}], [{"a": 1, "b": 2}], False),
+        # Lists of dicts, subset element has extra key -> False
+        ([{"a": 1, "b": 2}], [{"a": 1}], False),
+    ],
+)
+def test_issubset_lists_bidirectional(subset, superset, expected):
+    """Default list matching is bidirectional (equivalent to equality)."""
+    assert issubset(subset, superset) is expected
+
+
+# =============================================================================
+# issubset - lists with allow_superset=True (one-directional)
+#
+# New behavior introduced in this PR: an element in ``subset`` matches a
+# candidate in ``superset`` when it is a subset of that candidate, even if the
+# candidate has additional keys. The ``subset`` list may also be shorter than
+# ``superset`` (extra existing elements are tolerated) as long as every
+# proposed element matches a distinct candidate.
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "subset, superset, expected",
+    [
+        # Candidate has EXTRA key -> now matches (one-directional)
+        ([{"a": 1}], [{"a": 1, "b": 2}], True),
+        # Multiple elements, each a subset of a distinct candidate -> True
+        (
+            [{"a": 1}, {"c": 3}],
+            [{"a": 1, "b": 2}, {"c": 3, "d": 4}],
+            True,
+        ),
+        # Subset element with extra key not in candidate -> still False
+        ([{"a": 1, "z": 9}], [{"a": 1, "b": 2}], False),
+        # Proposed list shorter than existing: the proposed item matches a
+        # candidate and the extra existing element is tolerated -> True
+        ([{"a": 1}], [{"a": 1, "b": 2}, {"c": 3}], True),
+        # More proposed items than candidates -> no one-to-one match -> False
+        ([{"a": 1}, {"c": 3}], [{"a": 1, "b": 2}], False),
+        # Value mismatch -> False
+        ([{"a": 2}], [{"a": 1, "b": 2}], False),
+    ],
+)
+def test_issubset_lists_one_directional(subset, superset, expected):
+    """``allow_superset=True`` relaxes list matching to one-directional."""
+    assert issubset(subset, superset, allow_superset=True) is expected
+
+
+def test_issubset_one_directional_does_not_reuse_candidate():
+    """Each candidate is consumed at most once during list matching."""
+    # Two identical subset elements require two matching candidates.
+    subset = [{"a": 1}, {"a": 1}]
+    superset = [{"a": 1, "b": 2}, {"a": 1, "c": 3}]
+    assert issubset(subset, superset, allow_superset=True) is True
+
+    # Only one candidate matches -> the second subset element fails.
+    subset = [{"a": 1}, {"a": 1}]
+    superset = [{"a": 1, "b": 2}, {"x": 9}]
+    assert issubset(subset, superset, allow_superset=True) is False
+
+
+def test_issubset_one_directional_allows_shorter_subset():
+    """Under allow_superset the proposed list may be shorter than the existing.
+
+    This is the merged-state contract: a user who names only some children must
+    not flag the parent as changed when the controller already holds additional
+    children. Every proposed child must still match a distinct existing child.
+    """
+    # One proposed child, two existing children -> matches the first; the extra
+    # existing child is tolerated.
+    subset = [{"vrf_name": "TENANT_A"}]
+    superset = [
+        {"vrf_name": "TENANT_A", "vlan_id": 500},
+        {"vrf_name": "TENANT_B", "vlan_id": 600},
+    ]
+    assert issubset(subset, superset, allow_superset=True) is True
+
+    # Two proposed children, each matching a distinct existing child that
+    # carries extra keys, with a third existing child left untouched -> True.
+    subset = [{"vrf_name": "TENANT_A"}, {"vrf_name": "TENANT_B"}]
+    superset = [
+        {"vrf_name": "TENANT_A", "vlan_id": 500},
+        {"vrf_name": "TENANT_B", "vlan_id": 600},
+        {"vrf_name": "TENANT_C", "vlan_id": 700},
+    ]
+    assert issubset(subset, superset, allow_superset=True) is True
+
+    # A proposed child that matches none of the existing children -> False.
+    subset = [{"vrf_name": "TENANT_Z"}]
+    superset = [
+        {"vrf_name": "TENANT_A", "vlan_id": 500},
+        {"vrf_name": "TENANT_B", "vlan_id": 600},
+    ]
+    assert issubset(subset, superset, allow_superset=True) is False
+
+    # More proposed children than existing -> one-to-one match impossible.
+    subset = [{"vrf_name": "TENANT_A"}, {"vrf_name": "TENANT_B"}]
+    superset = [{"vrf_name": "TENANT_A", "vlan_id": 500}]
+    assert issubset(subset, superset, allow_superset=True) is False
+
+
+def test_issubset_type_mismatch_returns_false():
+    """Mismatched top-level types short-circuit to False."""
+    assert issubset({"a": 1}, [1, 2]) is False
+    assert issubset([1], {"a": 1}) is False
+
+
+# =============================================================================
+# issubset - greedy-matching regression (bipartite matching)
+#
+# A less-specific subset item must not greedily consume a candidate that a
+# more-specific item needs. These cases fail with first-match/greedy logic but
+# pass with a proper maximum-matching solution.
+# =============================================================================
+
+
+def test_issubset_one_directional_no_greedy_false_diff():
+    """
+    The less-specific ``{"a": 1}`` must yield the ``{"a": 1, "b": 2}`` candidate
+    to the more-specific ``{"a": 1, "b": 2}`` proposed item, matching instead
+    against ``{"a": 1, "b": 3}``. A valid pairing exists, so no diff.
+    """
+    subset = [{"a": 1}, {"a": 1, "b": 2}]
+    superset = [{"a": 1, "b": 2}, {"a": 1, "b": 3}]
+    assert issubset(subset, superset, allow_superset=True) is True
+
+
+def test_issubset_one_directional_no_greedy_reordered():
+    """Order-independence: same data, subset elements swapped."""
+    subset = [{"a": 1, "b": 2}, {"a": 1}]
+    superset = [{"a": 1, "b": 3}, {"a": 1, "b": 2}]
+    assert issubset(subset, superset, allow_superset=True) is True
+
+
+def test_issubset_one_directional_no_valid_pairing_is_false():
+    """When no perfect pairing exists, a diff is still correctly reported."""
+    # Both proposed items demand b==2, but only one candidate has b==2.
+    subset = [{"a": 1, "b": 2}, {"a": 1, "b": 2}]
+    superset = [{"a": 1, "b": 2}, {"a": 1, "b": 3}]
+    assert issubset(subset, superset, allow_superset=True) is False
+
+
+def test_issubset_bidirectional_no_greedy_false_diff():
+    """
+    Greedy matching can also misfire in the default bidirectional mode when
+    duplicate values are present. A perfect matching still exists here.
+    """
+    subset = [{"a": 1}, {"a": 1}]
+    superset = [{"a": 1}, {"a": 1}]
+    assert issubset(subset, superset) is True
+
+
+# =============================================================================
+# NDBaseModel.get_diff with list-valued fields under exclude_unset=True
+# =============================================================================
+
+
+class _ListFieldModel(NDBaseModel):
+    """Minimal model with a list-valued field for diff testing."""
+
+    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"]] = "single"
+
+    name: str = Field(alias="name")
+    members: Optional[List[Dict[str, Any]]] = Field(default=None, alias="members")
+
+
+def test_get_diff_list_field_subset_with_extra_keys_no_diff():
+    """
+    With allow_superset=True, an existing element carrying extra keys (e.g. a
+    controller-populated ``deploy`` flag) does not trigger a spurious diff when
+    the proposed element omits those keys.
+    """
+    existing = _ListFieldModel(name="vrf1", members=[{"id": 1, "deploy": True}])
+    proposed = _ListFieldModel(name="vrf1", members=[{"id": 1}])
+
+    # allow_superset=True -> one-directional list match -> proposed is a subset.
+    assert existing.get_diff(proposed, exclude_unset=True, allow_superset=True) is True
+
+
+def test_get_diff_exclude_unset_without_allow_superset_flags_extra_keys():
+    """
+    exclude_unset and allow_superset are independent: comparing only the
+    proposed model's set fields (exclude_unset=True) while keeping strict
+    bidirectional list matching (allow_superset=False) still flags an existing
+    element that carries extra keys.
+    """
+    existing = _ListFieldModel(name="vrf1", members=[{"id": 1, "deploy": True}])
+    proposed = _ListFieldModel(name="vrf1", members=[{"id": 1}])
+
+    assert existing.get_diff(proposed, exclude_unset=True, allow_superset=False) is False
+
+
+def test_get_diff_allow_superset_without_exclude_unset():
+    """
+    allow_superset can be requested on its own: with exclude_unset=False the
+    proposed model's defaults are compared, but list elements are still matched
+    one-directionally so the extra ``deploy`` key is tolerated.
+    """
+    existing = _ListFieldModel(name="vrf1", members=[{"id": 1, "deploy": True}])
+    proposed = _ListFieldModel(name="vrf1", members=[{"id": 1}])
+
+    assert existing.get_diff(proposed, allow_superset=True) is True
+
+
+def test_get_diff_list_field_extra_keys_triggers_diff_without_exclude_unset():
+    """
+    Without exclude_unset (default), list matching is bidirectional, so the
+    extra ``deploy`` key on the existing element produces a diff.
+    """
+    existing = _ListFieldModel(name="vrf1", members=[{"id": 1, "deploy": True}])
+    proposed = _ListFieldModel(name="vrf1", members=[{"id": 1}])
+
+    assert existing.get_diff(proposed) is False
+
+
+def test_get_diff_list_field_value_change_triggers_diff():
+    """A genuine value change in a list element is always a diff."""
+    existing = _ListFieldModel(name="vrf1", members=[{"id": 1}])
+    proposed = _ListFieldModel(name="vrf1", members=[{"id": 2}])
+
+    assert existing.get_diff(proposed, exclude_unset=True) is False
+
+
+def test_get_diff_unset_list_field_ignored():
+    """A list field not set on the proposed model is ignored under exclude_unset."""
+    existing = _ListFieldModel(name="vrf1", members=[{"id": 1, "deploy": True}])
+    proposed = _ListFieldModel(name="vrf1")  # members not set
+
+    assert existing.get_diff(proposed, exclude_unset=True) is True

--- a/tests/unit/modules/test_nd_manage_vrf_lite.py
+++ b/tests/unit/modules/test_nd_manage_vrf_lite.py
@@ -99,6 +99,10 @@ def _run_vrf_lite_module(module_args, current_state=None, runtime_metadata=None)
             ip_to_sn_mapping = dict(runtime_metadata["ip_to_sn_mapping"])
             module.params["_ip_to_sn_mapping"] = ip_to_sn_mapping
             module.params["_sn_to_ip_mapping"] = {serial: ip_address for ip_address, serial in ip_to_sn_mapping.items()}
+        if "pending_deploy_targets" in runtime_metadata:
+            module.params["_pending_deploy_targets"] = [
+                dict(target) for target in runtime_metadata["pending_deploy_targets"]
+            ]
         return [dict(item) for item in current_state]
 
     def exit_json(module, **kwargs):
@@ -277,6 +281,81 @@ def test_vrf_lite_wrapper_documents_projected_deployment_fields_in_check_mode():
     ]
     assert result["deployment"]["response"] == []
     _assert_result_matches_return_docs(result, _WRITE_BASE_FIELDS | {"deployment", "deployment_needed"})
+
+
+@pytest.mark.parametrize(
+    ("state", "config", "current_state", "operation"),
+    [
+        pytest.param(
+            "merged", _DESIRED_CONFIG, [_EXISTING_ENTRY], "write", id="merged-write"
+        ),
+        pytest.param(
+            "replaced",
+            [{"vrf_name": "VRF1", "attach": []}],
+            [],
+            "delete",
+            id="replaced-removal",
+        ),
+        pytest.param(
+            "overridden",
+            [{"vrf_name": "VRF1", "attach": []}],
+            [],
+            "delete",
+            id="overridden-removal",
+        ),
+        pytest.param(
+            "deleted",
+            [{"vrf_name": "VRF1", "attach": [{"ip_address": "SERIAL1"}]}],
+            [],
+            "delete",
+            id="deleted-removal",
+        ),
+    ],
+)
+def test_vrf_lite_wrapper_later_identical_run_deploys_controller_pending_target(
+    state,
+    config,
+    current_state,
+    operation,
+):
+    module_args = _module_args(
+        state,
+        config,
+        False,
+        config_actions={"save": True, "deploy": True, "type": "switch"},
+    )
+    module_args["verify"] = {"enabled": False}
+
+    with patch(
+        "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.request_with_rest_send",
+        return_value={},
+    ):
+        run = _run_vrf_lite_module(
+            module_args,
+            current_state=current_state,
+            runtime_metadata={
+                "pending_deploy_targets": [
+                    {"vrf_name": "VRF1", "switch_ip": "SERIAL1", "operation": operation}
+                ]
+            },
+        )
+
+    assert run["module"].params["_changed_vrfs"] == []
+    assert run["module"].params["_deploy_targets"] == []
+    assert run["result"]["changed"] is True
+    deployment = run["result"]["deployment"]
+    assert deployment["deployment_needed"] is True
+    assert deployment["changed"] is True
+    assert [item["operation"] for item in deployment["response"]] == [
+        "config_save",
+        "vrf_deploy",
+    ]
+    assert deployment["response"][-1]["payload"] == {
+        "vrfNames": ["VRF1"],
+        "switchIds": ["SERIAL1"],
+    }
+    if state == "deleted":
+        assert "warnings" not in run["result"]
 
 
 @pytest.mark.parametrize("state", ["replaced", "overridden"])

--- a/tests/unit/modules/test_nd_manage_vrf_lite.py
+++ b/tests/unit/modules/test_nd_manage_vrf_lite.py
@@ -1,0 +1,553 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco Systems, Inc.
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Production-wrapper tests for ``nd_manage_vrf_lite``."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+import json
+from unittest.mock import patch
+
+import pytest
+import yaml
+from ansible.module_utils import basic as ansible_basic
+
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite import ManageVrfLiteOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vrf_lite.runtime_endpoints import VrfLiteEndpoints
+from ansible_collections.cisco.nd.plugins.modules import nd_manage_vrf_lite
+
+_MISSING_CONFIG = object()
+_EXISTING_ENTRY = {"vrf_name": "VRF1", "switch_ip": "SERIAL1", "vlan_id": 500}
+_SECOND_EXISTING_ENTRY = {"vrf_name": "VRF1", "switch_ip": "SERIAL2", "vlan_id": 500}
+_DESIRED_CONFIG = [
+    {
+        "vrf_name": "VRF1",
+        "vlan_id": 500,
+        "attach": [{"ip_address": "SERIAL1"}],
+    }
+]
+_WRITE_BASE_FIELDS = {"output_level", "changed", "before", "after", "current", "diff"}
+_ALL_RETURN_FIELDS = {
+    "changed",
+    "output_level",
+    "before",
+    "after",
+    "current",
+    "diff",
+    "proposed",
+    "logs",
+    "gathered",
+    "warnings",
+    "deployment",
+    "deployment_needed",
+    "ip_to_sn_mapping",
+    "response",
+    "result",
+}
+
+
+class _ModuleFailure(Exception):
+    """Capture ``AnsibleModule.fail_json`` without terminating pytest."""
+
+    def __init__(self, module, result):
+        super().__init__(result.get("msg", "module failed"))
+        self.module = module
+        self.result = result
+
+
+class _ModuleExit(BaseException):
+    """Stop the production wrapper after ``exit_json`` is captured."""
+
+
+def _module_args(state, config, check_mode, output_level="normal", config_actions=None):
+    args = {
+        "fabric_name": "fab1",
+        "state": state,
+        "config_actions": (
+            config_actions
+            if config_actions is not None
+            else {
+                "save": False,
+                "deploy": False,
+                "type": "switch",
+            }
+        ),
+        "output_level": output_level,
+        "_ansible_check_mode": check_mode,
+        "_ansible_verbosity": 0,
+    }
+    if config is not _MISSING_CONFIG:
+        args["config"] = config
+    return args
+
+
+def _run_vrf_lite_module(module_args, current_state=None, runtime_metadata=None):
+    """Run the production wrapper, state machine, and orchestrator without controller I/O."""
+    raw_args = json.dumps({"ANSIBLE_MODULE_ARGS": module_args}).encode()
+    captured = {}
+    current_state = list(current_state or [])
+    runtime_metadata = dict(runtime_metadata or {})
+
+    def query_current_state(orchestrator, flat=True):
+        assert flat is True
+        module = orchestrator._module()
+        if "warnings" in runtime_metadata:
+            module.params["_warnings"] = list(runtime_metadata["warnings"])
+        if "ip_to_sn_mapping" in runtime_metadata:
+            ip_to_sn_mapping = dict(runtime_metadata["ip_to_sn_mapping"])
+            module.params["_ip_to_sn_mapping"] = ip_to_sn_mapping
+            module.params["_sn_to_ip_mapping"] = {serial: ip_address for ip_address, serial in ip_to_sn_mapping.items()}
+        return [dict(item) for item in current_state]
+
+    def exit_json(module, **kwargs):
+        captured["module"] = module
+        captured["result"] = kwargs
+        raise _ModuleExit()
+
+    def fail_json(module, **kwargs):
+        raise _ModuleFailure(module, kwargs)
+
+    with (
+        patch.object(ansible_basic, "_ANSIBLE_ARGS", raw_args),
+        patch.object(ansible_basic, "_ANSIBLE_PROFILE", "legacy", create=True),
+        patch.object(nd_manage_vrf_lite.AnsibleModule, "exit_json", exit_json),
+        patch.object(nd_manage_vrf_lite.AnsibleModule, "fail_json", fail_json),
+        patch.object(nd_manage_vrf_lite, "setup_logging"),
+        patch.object(ManageVrfLiteOrchestrator, "_query_current_state", query_current_state),
+    ):
+        try:
+            nd_manage_vrf_lite.main()
+        except _ModuleExit:
+            pass
+
+    return captured
+
+
+def _assert_result_matches_return_docs(result, expected_fields):
+    """Require the exact wrapper shape and matching documented Python types."""
+    return_docs = yaml.safe_load(nd_manage_vrf_lite.RETURN)
+    python_types = {
+        "bool": bool,
+        "dict": dict,
+        "list": list,
+        "str": str,
+    }
+
+    def assert_documented_value(value, field_docs):
+        documented_type = field_docs["type"]
+        assert documented_type in python_types
+        assert isinstance(value, python_types[documented_type])
+        if documented_type == "list" and value and field_docs.get("elements"):
+            assert all(isinstance(item, python_types[field_docs["elements"]]) for item in value)
+        if documented_type == "dict" and field_docs.get("contains"):
+            assert set(value).issubset(field_docs["contains"])
+            for nested_field, nested_value in value.items():
+                assert_documented_value(nested_value, field_docs["contains"][nested_field])
+
+    assert set(result) == expected_fields
+    assert set(result).issubset(return_docs)
+    for field, value in result.items():
+        assert_documented_value(value, return_docs[field])
+
+    if "deployment" in result:
+        deployment_docs = return_docs["deployment"]["contains"]
+        expected_deployment_fields = {"msg", "changed", "deployment_needed", "config_actions", "response"}
+        if result["deployment"]["deployment_needed"]:
+            expected_deployment_fields.update({"target_vrfs", "planned_actions"})
+        assert set(result["deployment"]) == expected_deployment_fields
+        assert set(result["deployment"]["config_actions"]) == set(deployment_docs["config_actions"]["contains"])
+
+
+@pytest.mark.parametrize("state", ["merged", "replaced", "overridden"])
+@pytest.mark.parametrize("check_mode", [False, True])
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(_MISSING_CONFIG, id="omitted"),
+        pytest.param(None, id="null"),
+    ],
+)
+def test_vrf_lite_wrapper_rejects_missing_write_config_before_normalization(state, check_mode, config):
+    """Omitted/null config must fail before the wrapper turns it into ``[]``."""
+    with patch.object(ManageVrfLiteOrchestrator, "prepare_module_params") as prepare:
+        with pytest.raises(_ModuleFailure) as exc_info:
+            _run_vrf_lite_module(_module_args(state, config, check_mode))
+
+    assert exc_info.value.module.params["config"] is None
+    assert "config must be provided and cannot be null" in exc_info.value.result["msg"]
+    prepare.assert_not_called()
+
+
+@pytest.mark.parametrize("state", ["merged", "replaced", "overridden"])
+@pytest.mark.parametrize("check_mode", [False, True])
+def test_vrf_lite_wrapper_preserves_explicit_empty_write_config(state, check_mode):
+    """Explicit ``config: []`` remains a valid intentional empty desired set."""
+    run = _run_vrf_lite_module(_module_args(state, [], check_mode))
+
+    assert run["module"].params["_vrf_lite_nested_config"] == []
+    assert run["module"].params["config"] == []
+    assert run["result"]["changed"] is False
+
+
+@pytest.mark.parametrize(
+    ("output_level", "has_proposed", "has_logs"),
+    [
+        ("normal", False, False),
+        ("info", True, False),
+        ("debug", True, True),
+    ],
+)
+def test_vrf_lite_wrapper_output_level_fields_match_return_contract(output_level, has_proposed, has_logs):
+    """The wrapper must emit verbosity-controlled fields exactly as documented."""
+    run = _run_vrf_lite_module(
+        _module_args("merged", _DESIRED_CONFIG, False, output_level=output_level),
+        current_state=[_EXISTING_ENTRY],
+    )
+
+    result = run["result"]
+    assert result["output_level"] == output_level
+    assert result["before"] and result["after"] and result["current"]
+    assert result["diff"] == []
+    assert ("proposed" in result) is has_proposed
+    assert ("logs" in result) is has_logs
+    if has_proposed:
+        assert result["proposed"]
+    if has_logs:
+        assert result["logs"] == []
+    expected_fields = set(_WRITE_BASE_FIELDS)
+    if has_proposed:
+        expected_fields.add("proposed")
+    if has_logs:
+        expected_fields.add("logs")
+    _assert_result_matches_return_docs(result, expected_fields)
+
+
+@pytest.mark.parametrize(
+    "config_actions",
+    [
+        pytest.param({"save": True, "deploy": False, "type": "switch"}, id="save-only"),
+        pytest.param({"save": True, "deploy": True, "type": "switch"}, id="save-and-deploy"),
+    ],
+)
+def test_vrf_lite_wrapper_documents_idempotent_deployment_fields(config_actions):
+    """Enabled config actions expose a documented no-deployment-needed result."""
+    run = _run_vrf_lite_module(
+        _module_args(
+            "merged",
+            _DESIRED_CONFIG,
+            False,
+            config_actions=config_actions,
+        ),
+        current_state=[_EXISTING_ENTRY],
+    )
+
+    result = run["result"]
+    assert result["changed"] is False
+    assert result["deployment_needed"] is False
+    assert result["deployment"]["deployment_needed"] is False
+    _assert_result_matches_return_docs(result, _WRITE_BASE_FIELDS | {"deployment", "deployment_needed"})
+
+
+def test_vrf_lite_wrapper_documents_projected_deployment_fields_in_check_mode():
+    """A changed check-mode plan exposes deployment-needed without controller writes."""
+    run = _run_vrf_lite_module(
+        _module_args(
+            "overridden",
+            [],
+            True,
+            config_actions={"save": True, "deploy": True, "type": "switch"},
+        ),
+        current_state=[_EXISTING_ENTRY],
+    )
+
+    result = run["result"]
+    assert result["changed"] is True
+    assert result["deployment_needed"] is True
+    assert result["deployment"]["deployment_needed"] is True
+    assert result["deployment"]["changed"] is True
+    # Check mode reconstructs the operation journal from the before/after preview,
+    # preserving the removed switch in the projected deploy scope.
+    assert run["module"].params["_deploy_targets"] == [{"vrf_name": "VRF1", "switch_ip": "SERIAL1", "operation": "delete"}]
+    assert result["deployment"]["target_vrfs"] == ["VRF1"]
+    assert result["deployment"]["planned_actions"] == [
+        "POST {0}".format(VrfLiteEndpoints.config_save("fab1")),
+        "POST {0} vrfNames=VRF1 switchIds=SERIAL1".format(VrfLiteEndpoints.vrf_deployments("fab1")),
+    ]
+    assert result["deployment"]["response"] == []
+    _assert_result_matches_return_docs(result, _WRITE_BASE_FIELDS | {"deployment", "deployment_needed"})
+
+
+@pytest.mark.parametrize("state", ["replaced", "overridden"])
+@pytest.mark.parametrize(
+    ("config", "expected_switch_ids"),
+    [
+        pytest.param(_DESIRED_CONFIG, ["SERIAL2"], id="partial-removal"),
+        pytest.param([{"vrf_name": "VRF1", "vlan_id": 500, "attach": []}], ["SERIAL1", "SERIAL2"], id="remove-all"),
+    ],
+)
+@pytest.mark.parametrize("deploy_scope", ["switch", "global"])
+@pytest.mark.parametrize("check_mode", [False, True], ids=["normal", "check-mode"])
+def test_vrf_lite_wrapper_deploys_replacement_removals_from_operation_journal(
+    state,
+    config,
+    expected_switch_ids,
+    deploy_scope,
+    check_mode,
+):
+    """Production reconciliation plans/deploys partial and remove-all detaches."""
+    module_args = _module_args(
+        state,
+        config,
+        check_mode,
+        config_actions={"save": True, "deploy": True, "type": deploy_scope},
+    )
+    module_args["verify"] = {"enabled": False}
+
+    with (
+        patch.object(ManageVrfLiteOrchestrator, "_post_grouped_rows", return_value={"response": []}) as post_grouped_rows,
+        patch.object(ManageVrfLiteOrchestrator, "_validate_attach_entries"),
+        patch(
+            "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.request_with_rest_send",
+            return_value={},
+        ),
+    ):
+        run = _run_vrf_lite_module(
+            module_args,
+            current_state=[_EXISTING_ENTRY, _SECOND_EXISTING_ENTRY],
+        )
+
+    if check_mode:
+        post_grouped_rows.assert_not_called()
+    else:
+        post_grouped_rows.assert_called_once()
+    assert run["module"].params["_changed_vrfs"] == ["VRF1"]
+    assert {(target["vrf_name"], target["switch_ip"], target["operation"]) for target in run["module"].params["_deploy_targets"]} == {
+        ("VRF1", switch_id, "delete") for switch_id in expected_switch_ids
+    }
+
+    deployment = run["result"]["deployment"]
+    assert deployment["target_vrfs"] == ["VRF1"]
+    expected_payload = {"vrfNames": ["VRF1"]}
+    if deploy_scope == "switch":
+        expected_payload["switchIds"] = expected_switch_ids
+    if check_mode:
+        expected_deploy_action = "POST {0} vrfNames=VRF1".format(VrfLiteEndpoints.vrf_deployments("fab1"))
+        if deploy_scope == "switch":
+            expected_deploy_action += " switchIds={0}".format(",".join(expected_switch_ids))
+        assert deployment["planned_actions"] == [
+            "POST {0}".format(VrfLiteEndpoints.config_save("fab1")),
+            expected_deploy_action,
+        ]
+        assert deployment["response"] == []
+    else:
+        deploy_response = next(item for item in deployment["response"] if item["operation"] == "vrf_deploy")
+        assert deploy_response["payload"] == expected_payload
+
+
+@pytest.mark.parametrize(
+    ("state", "config", "current_state", "expected_operation"),
+    [
+        pytest.param("merged", _DESIRED_CONFIG, [], "write", id="merged-write"),
+        pytest.param("deleted", [{"vrf_name": "VRF1"}], [_EXISTING_ENTRY], "delete", id="deleted-removal"),
+    ],
+)
+def test_vrf_lite_wrapper_journals_other_write_states_for_deployment(
+    state,
+    config,
+    current_state,
+    expected_operation,
+):
+    """The shared journal continues to deploy merged writes and explicit deletes."""
+    module_args = _module_args(
+        state,
+        config,
+        False,
+        config_actions={"save": True, "deploy": True, "type": "switch"},
+    )
+    module_args["verify"] = {"enabled": False}
+
+    with (
+        patch.object(ManageVrfLiteOrchestrator, "_post_attach_entries", return_value={"response": []}),
+        patch.object(ManageVrfLiteOrchestrator, "_post_grouped_rows", return_value={"response": []}),
+        patch(
+            "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.request_with_rest_send",
+            return_value={},
+        ),
+    ):
+        run = _run_vrf_lite_module(module_args, current_state=current_state)
+
+    assert run["module"].params["_deploy_targets"] == [{"vrf_name": "VRF1", "switch_ip": "SERIAL1", "operation": expected_operation}]
+    deploy_response = next(item for item in run["result"]["deployment"]["response"] if item["operation"] == "vrf_deploy")
+    assert deploy_response["payload"] == {"vrfNames": ["VRF1"], "switchIds": ["SERIAL1"]}
+
+
+def test_vrf_lite_wrapper_deploys_mixed_write_and_removal_targets():
+    """A replacement deploy includes both an updated and a removed switch."""
+    config = [
+        {
+            "vrf_name": "VRF1",
+            "vlan_id": 501,
+            "attach": [{"ip_address": "SERIAL1"}],
+        }
+    ]
+    module_args = _module_args(
+        "replaced",
+        config,
+        False,
+        config_actions={"save": True, "deploy": True, "type": "switch"},
+    )
+    module_args["verify"] = {"enabled": False}
+
+    with (
+        patch.object(ManageVrfLiteOrchestrator, "_post_attach_entries", return_value={"response": []}),
+        patch.object(ManageVrfLiteOrchestrator, "_post_grouped_rows", return_value={"response": []}),
+        patch(
+            "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.request_with_rest_send",
+            return_value={},
+        ),
+    ):
+        run = _run_vrf_lite_module(
+            module_args,
+            current_state=[_EXISTING_ENTRY, _SECOND_EXISTING_ENTRY],
+        )
+
+    assert {(target["switch_ip"], target["operation"]) for target in run["module"].params["_deploy_targets"]} == {("SERIAL1", "write"), ("SERIAL2", "delete")}
+    deploy_response = next(item for item in run["result"]["deployment"]["response"] if item["operation"] == "vrf_deploy")
+    assert deploy_response["payload"] == {"vrfNames": ["VRF1"], "switchIds": ["SERIAL1", "SERIAL2"]}
+
+
+def test_vrf_lite_wrapper_vrf_deploy_false_suppresses_replacement_removal_deploy():
+    """Top-level deploy:false saves a detach without deploying that VRF."""
+    config = [
+        {
+            "vrf_name": "VRF1",
+            "vlan_id": 500,
+            "deploy": False,
+            "attach": [{"ip_address": "SERIAL1"}],
+        }
+    ]
+    module_args = _module_args(
+        "replaced",
+        config,
+        False,
+        config_actions={"save": True, "deploy": True, "type": "switch"},
+    )
+    module_args["verify"] = {"enabled": False}
+
+    with (
+        patch.object(ManageVrfLiteOrchestrator, "_post_grouped_rows", return_value={"response": []}),
+        patch(
+            "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.request_with_rest_send",
+            return_value={},
+        ),
+    ):
+        run = _run_vrf_lite_module(
+            module_args,
+            current_state=[_EXISTING_ENTRY, _SECOND_EXISTING_ENTRY],
+        )
+
+    assert run["module"].params["_deploy_targets"] == [{"vrf_name": "VRF1", "switch_ip": "SERIAL2", "operation": "delete"}]
+    assert run["result"]["deployment"]["target_vrfs"] == []
+    assert [item["operation"] for item in run["result"]["deployment"]["response"]] == ["config_save"]
+
+
+@pytest.mark.parametrize("check_mode", [False, True], ids=["normal", "check-mode"])
+def test_vrf_lite_wrapper_canonicalizes_removed_switch_ip_for_deployment(check_mode):
+    """Normal and check mode both resolve a removed management IP to its serial."""
+    module_args = _module_args(
+        "replaced",
+        [{"vrf_name": "VRF1", "attach": []}],
+        check_mode,
+        config_actions={"save": True, "deploy": True, "type": "switch"},
+    )
+    module_args["verify"] = {"enabled": False}
+
+    with (
+        patch.object(ManageVrfLiteOrchestrator, "_post_grouped_rows", return_value={"response": []}),
+        patch(
+            "ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_vrf_lite.request_with_rest_send",
+            return_value={},
+        ),
+    ):
+        run = _run_vrf_lite_module(
+            module_args,
+            current_state=[{"vrf_name": "VRF1", "switch_ip": "10.0.0.1", "vlan_id": 500}],
+            runtime_metadata={"ip_to_sn_mapping": {"10.0.0.1": "SERIAL1"}},
+        )
+
+    assert run["module"].params["_deploy_targets"] == [{"vrf_name": "VRF1", "switch_ip": "10.0.0.1", "operation": "delete"}]
+    deployment = run["result"]["deployment"]
+    if check_mode:
+        assert deployment["planned_actions"][-1].endswith("vrfNames=VRF1 switchIds=SERIAL1")
+    else:
+        deploy_response = next(item for item in deployment["response"] if item["operation"] == "vrf_deploy")
+        assert deploy_response["payload"] == {"vrfNames": ["VRF1"], "switchIds": ["SERIAL1"]}
+
+
+@pytest.mark.parametrize("check_mode", [False, True], ids=["normal", "check-mode"])
+def test_vrf_lite_wrapper_rejects_unresolved_removed_switch_ip_in_both_modes(check_mode):
+    """Check mode cannot produce a false-green plan for an unknown switch IP."""
+    module_args = _module_args(
+        "replaced",
+        [{"vrf_name": "VRF1", "attach": []}],
+        check_mode,
+        config_actions={"save": True, "deploy": True, "type": "switch"},
+    )
+    module_args["verify"] = {"enabled": False}
+
+    with pytest.raises(_ModuleFailure) as exc_info:
+        _run_vrf_lite_module(
+            module_args,
+            current_state=[{"vrf_name": "VRF1", "switch_ip": "10.0.0.99", "vlan_id": 500}],
+        )
+
+    assert "could not be resolved to a fabric switch serial number" in exc_info.value.result["msg"]
+
+
+def test_vrf_lite_wrapper_documents_conditional_runtime_metadata_fields():
+    """Warnings and switch-resolution mappings are documented when emitted."""
+    run = _run_vrf_lite_module(
+        _module_args("merged", _DESIRED_CONFIG, False),
+        current_state=[_EXISTING_ENTRY],
+        runtime_metadata={
+            "warnings": ["wrapper contract warning"],
+            "ip_to_sn_mapping": {"10.0.0.1": "SERIAL1"},
+        },
+    )
+
+    result = run["result"]
+    assert result["ip_to_sn_mapping"] == {"10.0.0.1": "SERIAL1"}
+    assert result["warnings"] == ["wrapper contract warning"]
+    _assert_result_matches_return_docs(result, _WRITE_BASE_FIELDS | {"warnings", "ip_to_sn_mapping"})
+
+
+@pytest.mark.parametrize("output_level", ["normal", "info", "debug"])
+def test_vrf_lite_wrapper_documents_gathered_response_and_result_fields(output_level):
+    """The gathered wrapper contract includes its controller result collections."""
+    run = _run_vrf_lite_module(
+        _module_args("gathered", _MISSING_CONFIG, False, output_level=output_level),
+        current_state=[_EXISTING_ENTRY],
+    )
+
+    result = run["result"]
+    assert result["output_level"] == output_level
+    assert result["gathered"] == result["before"] == result["after"] == result["current"]
+    assert result["gathered"][0]["vrf_name"] == "VRF1"
+    assert result["response"] == []
+    assert result["result"] == []
+    assert "proposed" not in result
+    assert "logs" not in result
+    assert "deployment" not in result
+    assert "deployment_needed" not in result
+    _assert_result_matches_return_docs(
+        result,
+        _WRITE_BASE_FIELDS | {"response", "result", "gathered"},
+    )
+
+
+def test_vrf_lite_return_docs_list_every_public_wrapper_field():
+    """Keep ansible-doc synchronized with every top-level public result field."""
+    return_docs = yaml.safe_load(nd_manage_vrf_lite.RETURN)
+    assert set(return_docs) == _ALL_RETURN_FIELDS

--- a/tests/unit/modules/test_nd_manage_vrf_lite.py
+++ b/tests/unit/modules/test_nd_manage_vrf_lite.py
@@ -100,9 +100,7 @@ def _run_vrf_lite_module(module_args, current_state=None, runtime_metadata=None)
             module.params["_ip_to_sn_mapping"] = ip_to_sn_mapping
             module.params["_sn_to_ip_mapping"] = {serial: ip_address for ip_address, serial in ip_to_sn_mapping.items()}
         if "pending_deploy_targets" in runtime_metadata:
-            module.params["_pending_deploy_targets"] = [
-                dict(target) for target in runtime_metadata["pending_deploy_targets"]
-            ]
+            module.params["_pending_deploy_targets"] = [dict(target) for target in runtime_metadata["pending_deploy_targets"]]
         return [dict(item) for item in current_state]
 
     def exit_json(module, **kwargs):
@@ -286,9 +284,7 @@ def test_vrf_lite_wrapper_documents_projected_deployment_fields_in_check_mode():
 @pytest.mark.parametrize(
     ("state", "config", "current_state", "operation"),
     [
-        pytest.param(
-            "merged", _DESIRED_CONFIG, [_EXISTING_ENTRY], "write", id="merged-write"
-        ),
+        pytest.param("merged", _DESIRED_CONFIG, [_EXISTING_ENTRY], "write", id="merged-write"),
         pytest.param(
             "replaced",
             [{"vrf_name": "VRF1", "attach": []}],
@@ -333,11 +329,7 @@ def test_vrf_lite_wrapper_later_identical_run_deploys_controller_pending_target(
         run = _run_vrf_lite_module(
             module_args,
             current_state=current_state,
-            runtime_metadata={
-                "pending_deploy_targets": [
-                    {"vrf_name": "VRF1", "switch_ip": "SERIAL1", "operation": operation}
-                ]
-            },
+            runtime_metadata={"pending_deploy_targets": [{"vrf_name": "VRF1", "switch_ip": "SERIAL1", "operation": operation}]},
         )
 
     assert run["module"].params["_changed_vrfs"] == []


### PR DESCRIPTION

VRF Lite attachments staged with deploy=false were skipped as "no change"
on a subsequent run that requested deploy=true with the same configuration,
leaving controller-pending intent undeployed. Discover that pending intent
during query and redeploy it instead of treating it as idempotent.

- query: derive attach_state and flag PENDING/OUT-OF-SYNC/FAILED attachments
  as pending; publish _pending_deploy_targets (write/delete op per attachment)
  and _not_in_sync_vrfs for downstream consumers.
- deploy: scope pending targets to the requested state (merged -> configured
  pairs, replaced -> configured VRFs, overridden -> all, deleted -> delete ops),
  honor disabled_vrfs/disabled_pairs, and gate deployment on scoped pending
  targets in _needs_deployment; swallow the non-fatal HTTP 500 vPC config-save
  sanity error.
- config_transform: suppress the false "No matching VRF Lite attachment found
  to delete" warning for staged pending-deletes.
- orchestrators/manage_vrf_lite: seed pending-target params, fold pending
  targets into changed_vrfs, and gate on _needs_deployment.
- tests: add unit coverage for pending discovery, state scoping, and gating;
  update merge integration tasks to re-deploy staged intent until idempotent.

Fixes https://github.com/CiscoDevNet/ansible-nd/issues/468