### PR TITLE
Remove legacy /version.json dependency from nd httpapi

### DIFF
--- a/changelogs/fragments/cleanup-httpapi-nd-version.yml
+++ b/changelogs/fragments/cleanup-httpapi-nd-version.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - nd httpapi plugin - remove the ``get_version(platform="nd")`` branch that queried the legacy
+    ``/version.json`` endpoint, which the unified Nexus Dashboard (4.2+) no longer exposes. The NDFC
+    version path used by cisco.dcnm modules is unchanged.
+minor_changes:
+  - NDModule - remove the unused ``version`` property, which relied on the legacy ``/version.json``
+    endpoint that is not available on the unified Nexus Dashboard (4.2+).

--- a/plugins/httpapi/nd.py
+++ b/plugins/httpapi/nd.py
@@ -99,21 +99,14 @@ class HttpApi(HttpApiBase):
         except Exception:
             return []
 
-    # Required for cisco.dcnm modules
-    # The cisco.nd HTTPAPI provider only supports NDFC 12+
-    # TODO Add support for more platforms.
+    # Required for cisco.dcnm modules, which query the NDFC platform version.
+    # The cisco.nd HTTPAPI provider only supports NDFC 12+.
     def get_version(self, platform="ndfc"):
         if platform == "ndfc":
             if self.version is None:
                 self.version = 12
             return self.version
-        elif platform == "nd":
-            if self.version is None:
-                response_json = self._send_nd_request("GET", "/version.json", self.headers)
-                self.version = ".".join(str(response_json.get("body")[key]) for key in ["major", "minor", "maintenance"])
-            return self.version
-        else:
-            raise ValueError("Unknown platform type: {0}".format(platform))
+        raise ValueError("Unknown platform type: {0}".format(platform))
 
     # Required for cisco.dcnm modules
     def get_token(self):

--- a/plugins/module_utils/nd.py
+++ b/plugins/module_utils/nd.py
@@ -154,7 +154,6 @@ class NDModule(object):
         self.url = None
         self.httpapi_logs = list()
         self.connection = None
-        self._version = None
 
         # Set Connection plugin
         self.set_connection()
@@ -162,12 +161,6 @@ class NDModule(object):
         if self.module._debug:
             self.module.warn("Enable debug output because ANSIBLE_DEBUG was set.")
             self.params["output_level"] = "debug"
-
-    @property
-    def version(self):
-        if self._version is None and self.connection:
-            self._version = self.connection.get_version("nd")
-        return self._version
 
     def set_connection(self):
         if self.connection is None:


### PR DESCRIPTION
## Summary

The unified Nexus Dashboard (4.2+) no longer exposes the legacy `/version.json` endpoint. This PR removes the dead code path that depended on it, so nothing in the collection can accidentally query a non-existent endpoint on the new controller.

## What changed

- **`plugins/httpapi/nd.py`** — removed the `get_version(platform="nd")` branch that fetched `/version.json`. The NDFC path (`get_version("ndfc")`, hardcoded `12`) that `cisco.dcnm` modules rely on is **unchanged**.
- **`plugins/module_utils/nd.py`** — removed the now-unused `NDModule.version` property (and its `self._version` init), which was the only caller of `get_version("nd")`.
- Added a changelog fragment.

## Why it's safe

- `get_version("nd")` / `NDModule.version` was only consumed by the `nd_version` module (removed for 2.0.0 in the companion PR). Grep confirmed **no surviving module reads `.version`** — the manage/interface/fabric modules go through the state machine + orchestrators + REST sender, not this property.
- `cisco.dcnm` calls `get_version()` with the default `"ndfc"`, so it is unaffected.

## Verification done locally

- `python -m py_compile` passes for both edited files.
- Changelog fragment YAML validated.
- Grep confirms no remaining `/version.json` or `get_version("nd")` references; only the legitimate NDFC `self.version` shim remains.

## Scope note

This is the httpapi cleanup split out from the legacy-module-removal PR to keep each diff focused. It does **not** add a runtime generation guard (`get_platform_generation()`); that can follow separately if/when modules need to gate on ND generation.