### PR TITLE
Fix lint and formatting breakage on develop blocking all PR CI

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_fabrics.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_fabrics.py
@@ -36,12 +36,12 @@ __metaclass__ = type
 from typing import ClassVar, Literal
 from urllib.parse import quote
 
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import FabricNameMixin
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
 
@@ -523,7 +523,9 @@ class EpManageFabricsSummaryGet(_EpManageFabricsBase):
     ```
     """
 
-    class_name: Literal["EpManageFabricsSummaryGet"] = Field(default="EpManageFabricsSummaryGet", frozen=True, description="Class name for backward compatibility")
+    class_name: Literal["EpManageFabricsSummaryGet"] = Field(
+        default="EpManageFabricsSummaryGet", frozen=True, description="Class name for backward compatibility"
+    )
 
     _path_suffix: ClassVar[str | None] = "summary"
 

--- a/plugins/module_utils/models/manage_fabric/manage_fabric_base.py
+++ b/plugins/module_utils/models/manage_fabric/manage_fabric_base.py
@@ -83,7 +83,7 @@ def _unwrap_optional(annotation):
     origin = get_origin(annotation)
     # Handle typing.Union (Python 3.9 Optional[X]) and types.UnionType (Python 3.10+ X | None)
     if origin is typing.Union or isinstance(annotation, types.UnionType):
-        args = [a for a in get_args(annotation) if a is not type(None)]
+        args = [a for a in get_args(annotation) if a is not types.NoneType]
         if len(args) == 1:
             return args[0], True
     return annotation, False

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -4,7 +4,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-from typing import Dict, Any, Optional, List, Union
+from typing import Any, Dict, List, Optional, Union
+
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
@@ -100,7 +101,7 @@ class NDOutput:
         diff: Optional[NDConfigCollection] = None,
         proposed: Optional[NDConfigCollection] = None,
         logs: Optional[List] = None,
-        **kwargs
+        **kwargs,
     ) -> None:
         if isinstance(after, NDConfigCollection):
             self._after = after

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_actions_config_save_deploy.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_fabrics_actions_config_save_deploy.py
@@ -65,7 +65,7 @@ def test_endpoints_api_v1_manage_fabrics_actions_config_save_00110():
     """
     instance = EpFabricConfigSavePost()
     with pytest.raises(ValueError, match="fabric_name is required"):
-        _ = instance.path
+        result = instance.path  # pylint: disable=unused-variable
 
 
 def test_endpoints_api_v1_manage_fabrics_actions_config_save_00120():
@@ -126,7 +126,7 @@ def test_endpoints_api_v1_manage_fabrics_actions_deploy_00110():
     """
     instance = EpFabricDeployPost()
     with pytest.raises(ValueError, match="fabric_name is required"):
-        _ = instance.path
+        result = instance.path  # pylint: disable=unused-variable
 
 
 def test_endpoints_api_v1_manage_fabrics_actions_deploy_00120():

--- a/tests/unit/module_utils/orchestrators/test_config_actions_mixin.py
+++ b/tests/unit/module_utils/orchestrators/test_config_actions_mixin.py
@@ -772,7 +772,6 @@ class TestExecuteConfigActions:
         # 3 API calls: GET switches + save + POST switchActions/deploy
         assert len(results._tasks) == 3
 
-
     def test_execute_skips_switchless_fabric(self):
         """
         # Summary

--- a/tests/unit/modules/test_manage_resource_manager.py
+++ b/tests/unit/modules/test_manage_resource_manager.py
@@ -14,8 +14,10 @@ from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-
-from ansible_collections.cisco.nd.plugins.modules import nd_manage_resource_manager as manage_resource_manager_module
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDModuleError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import HAS_PYDANTIC
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_resources import (
     EpManageFabricResourcesGet,
 )
@@ -33,12 +35,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_resource_ma
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_resource_manager.resource_manager_response_model import (
     ResourceManagerResponse,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
-    NDModuleError,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import HAS_PYDANTIC
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
+from ansible_collections.cisco.nd.plugins.modules import nd_manage_resource_manager as manage_resource_manager_module
 
 LOG = logging.getLogger("nd.tests.resource_manager")
 
@@ -158,24 +157,30 @@ def test_main_requires_pydantic_before_continuing():
     call_order = []
     mocked_rm_module = MagicMock()
 
-    with patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}), patch.object(
-        manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}
-    ), patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module), patch.object(
-        manage_resource_manager_module,
-        "require_pydantic",
-        side_effect=lambda module: call_order.append(("require_pydantic", module)),
-    ), patch.object(
-        manage_resource_manager_module,
-        "setup_logging",
-        side_effect=lambda *args, **kwargs: call_order.append(("setup_logging", args[0])),
-    ), patch.object(
-        manage_resource_manager_module,
-        "NDModule",
-        side_effect=lambda module: call_order.append(("NDModule", module)) or MagicMock(),
-    ), patch.object(
-        manage_resource_manager_module,
-        "NDResourceManagerModule",
-        return_value=mocked_rm_module,
+    with (
+        patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module),
+        patch.object(
+            manage_resource_manager_module,
+            "require_pydantic",
+            side_effect=lambda module: call_order.append(("require_pydantic", module)),
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "setup_logging",
+            side_effect=lambda *args, **kwargs: call_order.append(("setup_logging", args[0])),
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "NDModule",
+            side_effect=lambda module: call_order.append(("NDModule", module)) or MagicMock(),
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "NDResourceManagerModule",
+            return_value=mocked_rm_module,
+        ),
     ):
         mocked_rm_module.manage_state.side_effect = lambda: call_order.append(("manage_state", None))
         mocked_rm_module.exit_module.side_effect = lambda: call_order.append(("exit_module", None))
@@ -206,18 +211,23 @@ def test_main_fails_with_structured_payload_when_fabric_name_missing():
         "username": "admin",
     }
 
-    with patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}), patch.object(
-        manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}
-    ), patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module), patch.object(
-        manage_resource_manager_module,
-        "require_pydantic",
-    ), patch.object(
-        manage_resource_manager_module,
-        "setup_logging",
-    ), patch.object(
-        manage_resource_manager_module,
-        "NDModule",
-    ) as ndmodule_mock:
+    with (
+        patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module),
+        patch.object(
+            manage_resource_manager_module,
+            "require_pydantic",
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "setup_logging",
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "NDModule",
+        ) as ndmodule_mock,
+    ):
         with pytest.raises(RuntimeError, match="fail_json_called"):
             manage_resource_manager_module.main()
 
@@ -282,18 +292,23 @@ def test_main_ndmoduleerror_path_fails_with_standard_output():
         "username": "admin",
     }
 
-    with patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}), patch.object(
-        manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}
-    ), patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module), patch.object(
-        manage_resource_manager_module,
-        "require_pydantic",
-    ), patch.object(
-        manage_resource_manager_module,
-        "setup_logging",
-    ), patch.object(
-        manage_resource_manager_module,
-        "NDModule",
-        side_effect=NDModuleError(msg="auth failed", status=401),
+    with (
+        patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module),
+        patch.object(
+            manage_resource_manager_module,
+            "require_pydantic",
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "setup_logging",
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "NDModule",
+            side_effect=NDModuleError(msg="auth failed", status=401),
+        ),
     ):
         with pytest.raises(RuntimeError, match="fail_json_called"):
             manage_resource_manager_module.main()
@@ -324,22 +339,28 @@ def test_main_valueerror_path_fails_with_validation_message():
     mocked_rm_module = MagicMock()
     mocked_rm_module.manage_state.side_effect = ValueError("invalid config")
 
-    with patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}), patch.object(
-        manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}
-    ), patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module), patch.object(
-        manage_resource_manager_module,
-        "require_pydantic",
-    ), patch.object(
-        manage_resource_manager_module,
-        "setup_logging",
-    ), patch.object(
-        manage_resource_manager_module,
-        "NDModule",
-        return_value=MagicMock(),
-    ), patch.object(
-        manage_resource_manager_module,
-        "NDResourceManagerModule",
-        return_value=mocked_rm_module,
+    with (
+        patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module),
+        patch.object(
+            manage_resource_manager_module,
+            "require_pydantic",
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "setup_logging",
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "NDModule",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "NDResourceManagerModule",
+            return_value=mocked_rm_module,
+        ),
     ):
         with pytest.raises(RuntimeError, match="fail_json_called"):
             manage_resource_manager_module.main()
@@ -369,22 +390,28 @@ def test_main_generic_exception_debug_includes_traceback():
     mocked_rm_module = MagicMock()
     mocked_rm_module.manage_state.side_effect = RuntimeError("boom")
 
-    with patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}), patch.object(
-        manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}
-    ), patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module), patch.object(
-        manage_resource_manager_module,
-        "require_pydantic",
-    ), patch.object(
-        manage_resource_manager_module,
-        "setup_logging",
-    ), patch.object(
-        manage_resource_manager_module,
-        "NDModule",
-        return_value=MagicMock(),
-    ), patch.object(
-        manage_resource_manager_module,
-        "NDResourceManagerModule",
-        return_value=mocked_rm_module,
+    with (
+        patch.object(manage_resource_manager_module, "nd_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module.ResourceManagerConfigModel, "get_argument_spec", return_value={}),
+        patch.object(manage_resource_manager_module, "AnsibleModule", return_value=dummy_module),
+        patch.object(
+            manage_resource_manager_module,
+            "require_pydantic",
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "setup_logging",
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "NDModule",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            manage_resource_manager_module,
+            "NDResourceManagerModule",
+            return_value=mocked_rm_module,
+        ),
     ):
         with pytest.raises(RuntimeError, match="fail_json_called"):
             manage_resource_manager_module.main()
@@ -2346,13 +2373,16 @@ def test_manage_state_deleted_matches_link_returned_under_opposite_endpoint_swit
     remove_item.model_dump.return_value = {"resourceId": 501}
     remove_response = MagicMock(resources=[remove_item])
 
-    with patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager.nd_manage_resource_manager_resources.FabricSwitchInventory.from_fabric",
-        return_value=_mock_fabric_inventory(),
-    ), patch(
-        "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager.nd_manage_resource_manager_resources"
-        ".RemoveResourcesByIdsResponse.from_response",
-        return_value=remove_response,
+    with (
+        patch(
+            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager.nd_manage_resource_manager_resources.FabricSwitchInventory.from_fabric",
+            return_value=_mock_fabric_inventory(),
+        ),
+        patch(
+            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager.nd_manage_resource_manager_resources"
+            ".RemoveResourcesByIdsResponse.from_response",
+            return_value=remove_response,
+        ),
     ):
         module = NDResourceManagerModule(nd, Results(), log=LOG)
         module.manage_state()
@@ -3895,10 +3925,13 @@ def test_manage_merged_update_removes_existing_id_before_create():
         {"resources": [{"entityName": "loopback0", "status": "created"}]},
     ]
 
-    with patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes), patch(
-        (
-            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
-            "nd_manage_resource_manager_resources.ResourceManagerDiffEngine.validate_resource_api_fields"
+    with (
+        patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes),
+        patch(
+            (
+                "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
+                "nd_manage_resource_manager_resources.ResourceManagerDiffEngine.validate_resource_api_fields"
+            ),
         ),
     ):
         module.manage_merged()
@@ -4015,18 +4048,21 @@ def test_manage_merged_validates_response_fields_for_matching_entity():
     resp_item = _response(entity_name="loopback99", resource_value="99")
     fake_batch_response = MagicMock(resources=[resp_item])
 
-    with patch(
-        (
-            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
-            "nd_manage_resource_manager_resources.ResourcesManagerBatchResponse.from_response"
+    with (
+        patch(
+            (
+                "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
+                "nd_manage_resource_manager_resources.ResourcesManagerBatchResponse.from_response"
+            ),
+            return_value=fake_batch_response,
         ),
-        return_value=fake_batch_response,
-    ), patch(
-        (
-            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
-            "nd_manage_resource_manager_resources.ResourceManagerDiffEngine.validate_resource_api_fields"
-        ),
-    ) as validate_fields:
+        patch(
+            (
+                "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
+                "nd_manage_resource_manager_resources.ResourceManagerDiffEngine.validate_resource_api_fields"
+            ),
+        ) as validate_fields,
+    ):
         module.manage_merged()
 
     assert validate_fields.called
@@ -4104,12 +4140,15 @@ def test_manage_merged_raises_on_partial_create_response():
     create_item.model_dump.return_value = {"entityName": "loopback99", "status": "created"}
     fake_batch_response = MagicMock(resources=[create_item])
 
-    with patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes), patch(
-        (
-            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
-            "nd_manage_resource_manager_resources.ResourcesManagerBatchResponse.from_response"
+    with (
+        patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes),
+        patch(
+            (
+                "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
+                "nd_manage_resource_manager_resources.ResourcesManagerBatchResponse.from_response"
+            ),
+            return_value=fake_batch_response,
         ),
-        return_value=fake_batch_response,
     ):
         with pytest.raises(ValueError, match="Partial success in batch create"):
             module.manage_merged()
@@ -4142,12 +4181,15 @@ def test_manage_merged_raises_on_failed_create_status():
     }
     fake_batch_response = MagicMock(resources=[failed_item])
 
-    with patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes), patch(
-        (
-            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
-            "nd_manage_resource_manager_resources.ResourcesManagerBatchResponse.from_response"
+    with (
+        patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes),
+        patch(
+            (
+                "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
+                "nd_manage_resource_manager_resources.ResourcesManagerBatchResponse.from_response"
+            ),
+            return_value=fake_batch_response,
         ),
-        return_value=fake_batch_response,
     ):
         with pytest.raises(ValueError, match="Partial success in batch create") as exc_info:
             module.manage_merged()
@@ -4199,12 +4241,15 @@ def test_manage_merged_raises_on_mixed_create_success_and_failure():
 
     fake_batch_response = MagicMock(resources=[success_item, failed_item])
 
-    with patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes), patch(
-        (
-            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
-            "nd_manage_resource_manager_resources.ResourcesManagerBatchResponse.from_response"
+    with (
+        patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes),
+        patch(
+            (
+                "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
+                "nd_manage_resource_manager_resources.ResourcesManagerBatchResponse.from_response"
+            ),
+            return_value=fake_batch_response,
         ),
-        return_value=fake_batch_response,
     ):
         with pytest.raises(ValueError, match="Partial success in batch create") as exc_info:
             module.manage_merged()
@@ -4293,12 +4338,15 @@ def test_manage_deleted_success_parses_remove_response_items():
     remove_item.model_dump.return_value = {"resourceId": 101}
     fake_remove_response = MagicMock(resources=[remove_item])
 
-    with patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes), patch(
-        (
-            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
-            "nd_manage_resource_manager_resources.RemoveResourcesByIdsResponse.from_response"
+    with (
+        patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes),
+        patch(
+            (
+                "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
+                "nd_manage_resource_manager_resources.RemoveResourcesByIdsResponse.from_response"
+            ),
+            return_value=fake_remove_response,
         ),
-        return_value=fake_remove_response,
     ):
         module.manage_deleted()
 
@@ -4331,12 +4379,15 @@ def test_manage_deleted_raises_on_partial_delete_response():
     remove_item.model_dump.return_value = {"resourceValue": "101", "status": "deleted"}
     fake_remove_response = MagicMock(resources=[remove_item])
 
-    with patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes), patch(
-        (
-            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
-            "nd_manage_resource_manager_resources.RemoveResourcesByIdsResponse.from_response"
+    with (
+        patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes),
+        patch(
+            (
+                "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
+                "nd_manage_resource_manager_resources.RemoveResourcesByIdsResponse.from_response"
+            ),
+            return_value=fake_remove_response,
         ),
-        return_value=fake_remove_response,
     ):
         with pytest.raises(ValueError, match="Partial success in batch delete"):
             module.manage_deleted()
@@ -4369,12 +4420,15 @@ def test_manage_deleted_raises_on_failed_delete_status():
     }
     fake_remove_response = MagicMock(resources=[failed_item])
 
-    with patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes), patch(
-        (
-            "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
-            "nd_manage_resource_manager_resources.RemoveResourcesByIdsResponse.from_response"
+    with (
+        patch.object(ResourceManagerDiffEngine, "compute_changes", return_value=fake_changes),
+        patch(
+            (
+                "ansible_collections.cisco.nd.plugins.module_utils.manage_resource_manager."
+                "nd_manage_resource_manager_resources.RemoveResourcesByIdsResponse.from_response"
+            ),
+            return_value=fake_remove_response,
         ),
-        return_value=fake_remove_response,
     ):
         with pytest.raises(ValueError, match="Partial success in batch delete"):
             module.manage_deleted()

--- a/tests/unit/modules/test_nd_manage_networks.py
+++ b/tests/unit/modules/test_nd_manage_networks.py
@@ -50,9 +50,11 @@ def test_nd_manage_networks_requires_pydantic_immediately_after_module_creation(
     def fake_require_pydantic(module):
         events.append(("require_pydantic", module))
 
-    with patch.object(nd_manage_networks, "AnsibleModule", FakeAnsibleModule), patch.object(
-        nd_manage_networks, "require_pydantic", fake_require_pydantic
-    ), patch.object(nd_manage_networks, "NetworkWorkflowCoordinator", FakeCoordinator):
+    with (
+        patch.object(nd_manage_networks, "AnsibleModule", FakeAnsibleModule),
+        patch.object(nd_manage_networks, "require_pydantic", fake_require_pydantic),
+        patch.object(nd_manage_networks, "NetworkWorkflowCoordinator", FakeCoordinator),
+    ):
         nd_manage_networks.main()
 
     assert [event[0] for event in events] == [

--- a/tests/unit/modules/test_nd_manage_vrfs.py
+++ b/tests/unit/modules/test_nd_manage_vrfs.py
@@ -50,9 +50,11 @@ def test_nd_manage_vrfs_requires_pydantic_immediately_after_module_creation():
     def fake_require_pydantic(module):
         events.append(("require_pydantic", module))
 
-    with patch.object(nd_manage_vrfs, "AnsibleModule", FakeAnsibleModule), patch.object(
-        nd_manage_vrfs, "require_pydantic", fake_require_pydantic
-    ), patch.object(nd_manage_vrfs, "VrfWorkflowCoordinator", FakeCoordinator):
+    with (
+        patch.object(nd_manage_vrfs, "AnsibleModule", FakeAnsibleModule),
+        patch.object(nd_manage_vrfs, "require_pydantic", fake_require_pydantic),
+        patch.object(nd_manage_vrfs, "VrfWorkflowCoordinator", FakeCoordinator),
+    ):
         nd_manage_vrfs.main()
 
     assert [event[0] for event in events] == [


### PR DESCRIPTION
## Related Issue(s)

None — unblocks CI for all open PRs (first observed on #454; violations introduced by #491 plus black-version drift).

## Proposed Changes

- Fix the two pep8 violations introduced by #491: wrap the 163-char `class_name` Field line in `manage_fabrics.py` (E501) and drop the double blank line in `test_config_actions_mixin.py` (E303).
- Fix the two pylint `disallowed-name` violations from #491: replace `_ = instance.path` with `result = instance.path  # pylint: disable=unused-variable` in the configSave/deploy endpoint tests, matching the existing convention in sibling endpoint tests.
- Reformat four files with current `psf/black@stable` (parenthesized multi-item `with` statements, magic trailing commas): `nd_output.py`, `test_nd_manage_networks.py`, `test_nd_manage_vrfs.py`, `test_manage_resource_manager.py`. These fail the "Pep8 Compliance - Black" check on every PR because the stable black version moved forward since they were last formatted.
- Replace `a is not type(None)` with `a is not types.NoneType` in `manage_fabric_base.py` — the pylint bundled with newer ansible-core flags it as `unidiomatic-typecheck` (Python floor is 3.10, so `types.NoneType` is always available).
- isort the three files whose imports were touched.

All changes are mechanical lint/format fixes; no behavior changes.

## Test Notes

- `ansible-test sanity --test pep8` and `--test pylint` pass (nd-dev container machine)
- `black --check` clean across `plugins/` and `tests/` (line length 159)
- `isort --check-only` clean on changed files
- Unit tests in all touched areas pass: 298 tests (endpoints/orchestrators/modules test files) + 1543 model tests

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly (N/A — lint-only)
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sbmW5b5UXHqMEwV7ysq2G