### PR TITLE
Classify 4xx (except 429) as terminal in RestSend retry policy

### DIFF
--- a/plugins/module_utils/rest/protocols/response_validation.py
+++ b/plugins/module_utils/rest/protocols/response_validation.py
@@ -14,6 +14,9 @@ including status code validation and error message extraction.
 
 When ND API v2 is released with different status codes or response formats,
 implementing a new strategy class allows clean separation of v1 and v2 logic.
+
+`TerminalClientErrorPolicy` is an optional, separately-checked capability: a strategy that also implements it opts in to
+classifying 4xx client errors as terminal (not retryable). Strategies that omit it remain valid and keep every 4xx retryable.
 """
 
 # isort: off
@@ -145,34 +148,6 @@ class ResponseValidationStrategy(Protocol):
         """
         ...
 
-    def is_terminal_client_error(self, return_code: int, verb: HttpVerbEnum) -> bool:
-        """
-        # Summary
-
-        Check whether `return_code` is a 4xx client error that is terminal (not retryable) for `verb`.
-
-        ## Description
-
-        A 4xx response proves the request reached the application and was rejected, so an identical replay is deterministic and retrying wastes the
-        retry budget. Implementations decide which 4xx codes are nevertheless transient (and how that depends on the verb) for their API version —
-        e.g. rate limiting, or conflict codes the API documents on safe reads. Non-4xx codes must return False: this method classifies only client
-        errors, leaving success and 5xx policy to the caller.
-
-        ## Parameters
-
-        - return_code: HTTP status code to check
-        - verb: The HTTP verb of the request the response answers
-
-        ## Returns
-
-        - True if the code is a 4xx client error that is terminal for `verb`, False otherwise
-
-        ## Raises
-
-        None
-        """
-        ...
-
     def is_changed(self, response: dict) -> bool:
         """
         # Summary
@@ -249,5 +224,54 @@ class ResponseValidationStrategy(Protocol):
         ## Raises
 
         None - should return None gracefully if error message cannot be extracted
+        """
+        ...
+
+
+@runtime_checkable
+class TerminalClientErrorPolicy(Protocol):  # pylint: disable=too-few-public-methods
+    """
+    # Summary
+
+    Optional capability protocol: classify 4xx client errors as terminal (not retryable) or transient for a given verb.
+
+    ## Description
+
+    This is deliberately separate from `ResponseValidationStrategy`, which is the contract `ResponseHandler.validation_strategy` enforces at
+    assignment. A strategy written against the original protocol (every member of `ResponseValidationStrategy`, nothing more) remains valid and
+    keeps the historical behavior — every non-success 4xx stays retryable. A strategy that additionally satisfies this protocol opts in to
+    terminal-4xx classification: `ResponseHandler` feature-detects `is_terminal_client_error` and consults it before deciding `retryable`
+    (issue #457). `NdV1Strategy` implements both protocols.
+
+    ## Raises
+
+    None - implementations may raise exceptions per their logic
+    """
+
+    def is_terminal_client_error(self, return_code: int, verb: HttpVerbEnum) -> bool:
+        """
+        # Summary
+
+        Check whether `return_code` is a 4xx client error that is terminal (not retryable) for `verb`.
+
+        ## Description
+
+        A 4xx response proves the request reached the application and was rejected, so an identical replay is deterministic and retrying wastes the
+        retry budget. Implementations decide which 4xx codes are nevertheless transient (and how that depends on the verb) for their API version —
+        e.g. rate limiting, or conflict codes the API documents on safe reads. Non-4xx codes must return False: this method classifies only client
+        errors, leaving success and 5xx policy to the caller.
+
+        ## Parameters
+
+        - return_code: HTTP status code to check
+        - verb: The HTTP verb of the request the response answers
+
+        ## Returns
+
+        - True if the code is a 4xx client error that is terminal for `verb`, False otherwise
+
+        ## Raises
+
+        None
         """
         ...

--- a/plugins/module_utils/rest/protocols/response_validation.py
+++ b/plugins/module_utils/rest/protocols/response_validation.py
@@ -43,6 +43,8 @@ except ImportError:
 
 from typing import Optional
 
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
 # pylint: disable=unnecessary-ellipsis
 
 
@@ -136,6 +138,34 @@ class ResponseValidationStrategy(Protocol):
         ## Returns
 
         - True if code matches not_found_code, False otherwise
+
+        ## Raises
+
+        None
+        """
+        ...
+
+    def is_terminal_client_error(self, return_code: int, verb: HttpVerbEnum) -> bool:
+        """
+        # Summary
+
+        Check whether `return_code` is a 4xx client error that is terminal (not retryable) for `verb`.
+
+        ## Description
+
+        A 4xx response proves the request reached the application and was rejected, so an identical replay is deterministic and retrying wastes the
+        retry budget. Implementations decide which 4xx codes are nevertheless transient (and how that depends on the verb) for their API version —
+        e.g. rate limiting, or conflict codes the API documents on safe reads. Non-4xx codes must return False: this method classifies only client
+        errors, leaving success and 5xx policy to the caller.
+
+        ## Parameters
+
+        - return_code: HTTP status code to check
+        - verb: The HTTP verb of the request the response answers
+
+        ## Returns
+
+        - True if the code is a 4xx client error that is terminal for `verb`, False otherwise
 
         ## Raises
 

--- a/plugins/module_utils/rest/response_handler_nd.py
+++ b/plugins/module_utils/rest/response_handler_nd.py
@@ -170,6 +170,25 @@ class ResponseHandler:
         else:
             self._handle_post_put_delete_response()
 
+    def _is_terminal_client_error(self, return_code) -> bool:
+        """
+        # Summary
+
+        Return True when `return_code` is a 4xx client error other than 429 (Too Many Requests).
+
+        ## Description
+
+        A 4xx response proves the request reached the application and was rejected: replaying the identical request
+        cannot succeed, so the failure is terminal for every verb. 429 is the one transient 4xx (rate limiting) and
+        stays retryable. No retryable 4xx is documented for any ND 4.2.1 endpoint (the dcnm-era retry-on-400 cases
+        do not carry over). See issue #457.
+
+        ## Raises
+
+        None
+        """
+        return isinstance(return_code, int) and 400 <= return_code <= 499 and return_code != 429
+
     def _handle_get_response(self) -> None:
         """
         # Summary
@@ -183,6 +202,11 @@ class ResponseHandler:
             -   success:
                     -   True if RETURN_CODE in (200, 201, 202, 204, 207, 404)
                     -   False otherwise (error status codes)
+            -   retryable:
+                    -   False when the request succeeded, or when it failed with a 4xx code other than 429 (the
+                        request reached the application and was rejected; an identical replay cannot succeed)
+                    -   True when it failed with any other code (e.g. 5xx — potentially transient, and GET retries
+                        also serve eventual-consistency polling)
         """
         result = {}
         return_code = self.response.get("RETURN_CODE")
@@ -191,14 +215,17 @@ class ResponseHandler:
         if self._strategy.is_not_found(return_code):
             result["found"] = False
             result["success"] = True
+            result["retryable"] = False
         # Success codes with no embedded error - resource found
         elif self._strategy.is_success(self.response):
             result["found"] = True
             result["success"] = True
+            result["retryable"] = False
         # Error codes - request failed
         else:
             result["found"] = False
             result["success"] = False
+            result["retryable"] = not self._is_terminal_client_error(return_code)
 
         self.result = copy.copy(result)
 
@@ -219,8 +246,10 @@ class ResponseHandler:
             -   `retryable`:
                 -   False when the request succeeded, or when it failed with a success-class RETURN_CODE (the application
                     definitively rejected the request, e.g. a Multi-Status per-item failure — replaying the identical
-                    payload cannot succeed, so `RestSend` must not retry)
-                -   True when the request failed with a non-success RETURN_CODE (e.g. 5xx — potentially transient)
+                    payload cannot succeed, so `RestSend` must not retry), or when it failed with a 4xx code other than
+                    429 (the request reached the application and was rejected; same reasoning — see issue #457)
+                -   True when the request failed with any other non-success RETURN_CODE (e.g. 5xx — potentially
+                    transient) or with 429 (rate limiting)
 
         ## Raises
 
@@ -237,12 +266,13 @@ class ResponseHandler:
             result["retryable"] = False
         else:
             # A failure on a success-class RETURN_CODE is an application-level rejection
-            # (embedded error or per-item failure): deterministic, so not retryable.
-            # A failure on a non-success RETURN_CODE keeps the historical retry behavior.
+            # (embedded error or per-item failure): deterministic, so not retryable. A 4xx
+            # other than 429 is equally deterministic — the application rejected the request
+            # (issue #457). Any other non-success RETURN_CODE keeps the historical retry behavior.
             return_code = self.response.get("RETURN_CODE", -1)
             result["success"] = False
             result["changed"] = self._strategy.is_changed_on_failure(self.response)
-            result["retryable"] = return_code not in self._strategy.success_codes
+            result["retryable"] = return_code not in self._strategy.success_codes and not self._is_terminal_client_error(return_code)
 
         self.result = copy.copy(result)
 

--- a/plugins/module_utils/rest/response_handler_nd.py
+++ b/plugins/module_utils/rest/response_handler_nd.py
@@ -23,6 +23,10 @@ to `NdV1Strategy` (ND 4.2+):
 If ND API v2 uses different codes, inject a new strategy via the
 `validation_strategy` property rather than modifying this class.
 
+Terminal-4xx classification is an optional strategy capability (`TerminalClientErrorPolicy`): a strategy that
+implements only the `ResponseValidationStrategy` members is still accepted, and every non-success 4xx it
+reports stays retryable (the pre-#502 behavior).
+
 ### Response Format
 
 Expects ND HttpApi plugin to provide responses with these keys:
@@ -171,6 +175,35 @@ class ResponseHandler:
         else:
             self._handle_post_put_delete_response()
 
+    def _is_terminal_client_error(self, return_code: int) -> bool:
+        """
+        # Summary
+
+        Ask the injected strategy whether `return_code` is a terminal (not retryable) 4xx for the current verb, feature-detecting the capability.
+
+        ## Description
+
+        Terminal-4xx classification is an optional strategy capability (`TerminalClientErrorPolicy`), not part of the `ResponseValidationStrategy`
+        contract enforced at assignment. A strategy written against the original protocol has no `is_terminal_client_error`; for such a strategy
+        this returns False so the caller keeps the historical behavior (every non-success 4xx retryable) rather than terminalizing on its behalf.
+
+        ## Parameters
+
+        - return_code: HTTP status code of the current response
+
+        ## Returns
+
+        - True if the strategy classifies `return_code` as terminal for `self.verb`, False if it is transient or the strategy cannot classify it
+
+        ## Raises
+
+        None
+        """
+        classify = getattr(self._strategy, "is_terminal_client_error", None)
+        if classify is None:
+            return False
+        return bool(classify(return_code, self.verb))
+
     def _handle_get_response(self) -> None:
         """
         # Summary
@@ -191,7 +224,8 @@ class ResponseHandler:
                     -   True when it failed with any other code: 5xx (potentially transient, and GET retries also
                         serve eventual-consistency polling) or a transient 4xx per the strategy (`NdV1Strategy`:
                         408/421/425/429 for every verb, plus 409 for GET — documented on safe GETs where the
-                        conflict can clear on its own)
+                        conflict can clear on its own), or any 4xx when the strategy does not implement
+                        `TerminalClientErrorPolicy`
         """
         result = {}
         # The response setter guarantees RETURN_CODE is present; the default only narrows the type for mypy.
@@ -211,7 +245,7 @@ class ResponseHandler:
         else:
             result["found"] = False
             result["success"] = False
-            result["retryable"] = not self._strategy.is_terminal_client_error(return_code, self.verb)
+            result["retryable"] = not self._is_terminal_client_error(return_code)
 
         self.result = copy.copy(result)
 
@@ -235,8 +269,9 @@ class ResponseHandler:
                     payload cannot succeed, so `RestSend` must not retry), or when it failed with a 4xx code the injected
                     strategy classifies as terminal for the verb (the request reached the application and was rejected;
                     same reasoning — see issue #457)
-                -   True when the request failed with any other non-success RETURN_CODE: 5xx (potentially transient) or
-                    a transient 4xx per the strategy (`NdV1Strategy`: 408/421/425/429)
+                -   True when the request failed with any other non-success RETURN_CODE: 5xx (potentially transient),
+                    a transient 4xx per the strategy (`NdV1Strategy`: 408/421/425/429), or any 4xx when the strategy
+                    does not implement `TerminalClientErrorPolicy`
 
         ## Raises
 
@@ -260,7 +295,7 @@ class ResponseHandler:
             return_code = self.response.get("RETURN_CODE", -1)
             result["success"] = False
             result["changed"] = self._strategy.is_changed_on_failure(self.response)
-            result["retryable"] = return_code not in self._strategy.success_codes and not self._strategy.is_terminal_client_error(return_code, self.verb)
+            result["retryable"] = return_code not in self._strategy.success_codes and not self._is_terminal_client_error(return_code)
 
         self.result = copy.copy(result)
 

--- a/plugins/module_utils/rest/response_handler_nd.py
+++ b/plugins/module_utils/rest/response_handler_nd.py
@@ -18,6 +18,7 @@ to `NdV1Strategy` (ND 4.2+):
 - Success: 200, 201, 202, 204, 207
 - Not Found: 404 (treated as success for GET)
 - Error: 405, 409
+- Terminal 4xx (not retryable): every 4xx except the transient codes 408/421/425/429 (all verbs) and 409 (GET only)
 
 If ND API v2 uses different codes, inject a new strategy via the
 `validation_strategy` property rather than modifying this class.
@@ -170,25 +171,6 @@ class ResponseHandler:
         else:
             self._handle_post_put_delete_response()
 
-    def _is_terminal_client_error(self, return_code) -> bool:
-        """
-        # Summary
-
-        Return True when `return_code` is a 4xx client error other than 429 (Too Many Requests).
-
-        ## Description
-
-        A 4xx response proves the request reached the application and was rejected: replaying the identical request
-        cannot succeed, so the failure is terminal for every verb. 429 is the one transient 4xx (rate limiting) and
-        stays retryable. No retryable 4xx is documented for any ND 4.2.1 endpoint (the dcnm-era retry-on-400 cases
-        do not carry over). See issue #457.
-
-        ## Raises
-
-        None
-        """
-        return isinstance(return_code, int) and 400 <= return_code <= 499 and return_code != 429
-
     def _handle_get_response(self) -> None:
         """
         # Summary
@@ -203,13 +185,17 @@ class ResponseHandler:
                     -   True if RETURN_CODE in (200, 201, 202, 204, 207, 404)
                     -   False otherwise (error status codes)
             -   retryable:
-                    -   False when the request succeeded, or when it failed with a 4xx code other than 429 (the
-                        request reached the application and was rejected; an identical replay cannot succeed)
-                    -   True when it failed with any other code (e.g. 5xx — potentially transient, and GET retries
-                        also serve eventual-consistency polling)
+                    -   False when the request succeeded, or when it failed with a 4xx code the injected strategy
+                        classifies as terminal for GET (the request reached the application and was rejected; an
+                        identical replay cannot succeed)
+                    -   True when it failed with any other code: 5xx (potentially transient, and GET retries also
+                        serve eventual-consistency polling) or a transient 4xx per the strategy (`NdV1Strategy`:
+                        408/421/425/429 for every verb, plus 409 for GET — documented on safe GETs where the
+                        conflict can clear on its own)
         """
         result = {}
-        return_code = self.response.get("RETURN_CODE")
+        # The response setter guarantees RETURN_CODE is present; the default only narrows the type for mypy.
+        return_code = self.response.get("RETURN_CODE", -1)
 
         # 404 Not Found - resource doesn't exist, but request was successful
         if self._strategy.is_not_found(return_code):
@@ -225,7 +211,7 @@ class ResponseHandler:
         else:
             result["found"] = False
             result["success"] = False
-            result["retryable"] = not self._is_terminal_client_error(return_code)
+            result["retryable"] = not self._strategy.is_terminal_client_error(return_code, self.verb)
 
         self.result = copy.copy(result)
 
@@ -246,10 +232,11 @@ class ResponseHandler:
             -   `retryable`:
                 -   False when the request succeeded, or when it failed with a success-class RETURN_CODE (the application
                     definitively rejected the request, e.g. a Multi-Status per-item failure — replaying the identical
-                    payload cannot succeed, so `RestSend` must not retry), or when it failed with a 4xx code other than
-                    429 (the request reached the application and was rejected; same reasoning — see issue #457)
-                -   True when the request failed with any other non-success RETURN_CODE (e.g. 5xx — potentially
-                    transient) or with 429 (rate limiting)
+                    payload cannot succeed, so `RestSend` must not retry), or when it failed with a 4xx code the injected
+                    strategy classifies as terminal for the verb (the request reached the application and was rejected;
+                    same reasoning — see issue #457)
+                -   True when the request failed with any other non-success RETURN_CODE: 5xx (potentially transient) or
+                    a transient 4xx per the strategy (`NdV1Strategy`: 408/421/425/429)
 
         ## Raises
 
@@ -266,13 +253,14 @@ class ResponseHandler:
             result["retryable"] = False
         else:
             # A failure on a success-class RETURN_CODE is an application-level rejection
-            # (embedded error or per-item failure): deterministic, so not retryable. A 4xx
-            # other than 429 is equally deterministic — the application rejected the request
-            # (issue #457). Any other non-success RETURN_CODE keeps the historical retry behavior.
+            # (embedded error or per-item failure): deterministic, so not retryable. A 4xx the
+            # strategy classifies as terminal for the verb is equally deterministic — the
+            # application rejected the request (issue #457). Any other non-success RETURN_CODE
+            # keeps the historical retry behavior.
             return_code = self.response.get("RETURN_CODE", -1)
             result["success"] = False
             result["changed"] = self._strategy.is_changed_on_failure(self.response)
-            result["retryable"] = return_code not in self._strategy.success_codes and not self._is_terminal_client_error(return_code)
+            result["retryable"] = return_code not in self._strategy.success_codes and not self._strategy.is_terminal_client_error(return_code, self.verb)
 
         self.result = copy.copy(result)
 

--- a/plugins/module_utils/rest/response_strategies/nd_v1_strategy.py
+++ b/plugins/module_utils/rest/response_strategies/nd_v1_strategy.py
@@ -246,7 +246,7 @@ class NdV1Strategy:
     ## Description
 
     Implements status code validation and error message extraction
-    for ND API v1 (ND 4.2+).
+    for ND API v1 (ND 4.2+). Satisfies `ResponseValidationStrategy` and the optional `TerminalClientErrorPolicy` capability.
 
     ## Status Codes
 

--- a/plugins/module_utils/rest/response_strategies/nd_v1_strategy.py
+++ b/plugins/module_utils/rest/response_strategies/nd_v1_strategy.py
@@ -29,7 +29,25 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any, Optional, TypeVar
 
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+
 T = TypeVar("T")
+
+# 4xx codes that are transient for every verb and therefore stay retryable: 408 Request Timeout and 421 Misdirected Request
+# (RFC 9110 sections 15.5.9 / 15.5.20), 425 Too Early (RFC 8470 section 5.2), and 429 Too Many Requests (rate limiting).
+# ND 4.2.1 documents none of 408/421/425 for any endpoint, so retaining them simply preserves the pre-#502 retry behavior for
+# codes ND is not expected to send. RFC 9110 calls for retrying 421 on a *different* connection; connection lifecycle belongs
+# to Ansible's persistent httpapi transport (which re-establishes a dropped connection transparently), so the retry rides
+# whatever connection that layer provides.
+_TRANSIENT_CLIENT_ERROR_CODES = frozenset({408, 421, 425, 429})
+
+# 4xx codes that are additionally transient for GET. The ND 4.2.1 OpenAPI documents 409 Conflict on safe GETs (manage v1.1.411:
+# /links, /links/{linkId}, /logicalLinks, /remoteFabrics, /anomalyRules/postProcessingRules; onemanage documents three more)
+# where the conflict is with the resource's *current* state and can clear on its own (e.g. topology reconciliation after a
+# switch add), so GET keeps retrying/polling through it. For mutations 409 remains terminal: the documented mutation 409s are
+# create/update conflicts (resource already exists), which an identical replay cannot resolve — retrying them would reintroduce
+# the full-retry-budget stall that issue #457 removes.
+_TRANSIENT_GET_CLIENT_ERROR_CODES = frozenset({409})
 
 # Per-item status literals that mark a failure inside a Multi-Status body. ND sends these
 # on HTTP 207 and, for some endpoints, on HTTP 200 as well, so the body is scanned on any
@@ -397,6 +415,45 @@ class NdV1Strategy:
         None
         """
         return return_code == self.not_found_code
+
+    def is_terminal_client_error(self, return_code: int, verb: HttpVerbEnum) -> bool:
+        """
+        # Summary
+
+        Check whether `return_code` is a 4xx client error that is terminal (not retryable) for `verb` (v1).
+
+        ## Description
+
+        A 4xx response proves the request reached the application and was rejected, so replaying the identical request is deterministic and the
+        failure is terminal — except for the transient codes below, which stay retryable (see issue #457):
+
+        - For every verb: 408 Request Timeout and 421 Misdirected Request (RFC 9110), 425 Too Early (RFC 8470), and 429 Too Many Requests.
+        - For GET only: 409 Conflict, which the ND 4.2.1 OpenAPI documents on safe GETs where the conflict is with the resource's current state and
+          can clear on its own (GET retries also serve eventual-consistency polling). For mutations 409 is a deterministic create/update conflict
+          and stays terminal.
+
+        Non-4xx codes always return False; this method classifies only client errors, leaving success and 5xx policy to the caller.
+
+        ## Parameters
+
+        - return_code: HTTP status code to check
+        - verb: The HTTP verb of the request the response answers
+
+        ## Returns
+
+        - True if the code is a 4xx client error that is terminal for `verb`, False otherwise
+
+        ## Raises
+
+        None
+        """
+        if not isinstance(return_code, int) or not 400 <= return_code <= 499:
+            return False
+        if return_code in _TRANSIENT_CLIENT_ERROR_CODES:
+            return False
+        if verb == HttpVerbEnum.GET and return_code in _TRANSIENT_GET_CLIENT_ERROR_CODES:
+            return False
+        return True
 
     def is_changed(self, response: dict) -> bool:
         """

--- a/tests/unit/module_utils/fixtures/fixture_data/test_rest_send.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_rest_send.json
@@ -282,5 +282,21 @@
         "REQUEST_PATH": "/api/v1/manage/links",
         "MESSAGE": "OK",
         "DATA": {"links": [{"linkId": "link-1"}]}
+    },
+    "test_rest_send_01130a": {
+        "TEST_NOTES": ["POST 400 under a legacy injected strategy with no is_terminal_client_error(). The handler cannot classify it, so it keeps the historical retryable=True and the loop must consume the follow-up 200 in 01130b."],
+        "RETURN_CODE": 400,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/test/legacy",
+        "MESSAGE": "Bad Request",
+        "DATA": {"code": 400, "message": "Transient validation failure"}
+    },
+    "test_rest_send_01130b": {
+        "TEST_NOTES": ["Recovery response consumed by the retry of 01130a."],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/test/legacy",
+        "MESSAGE": "OK",
+        "DATA": {"results": [{"name": "item", "status": "success"}]}
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_rest_send.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_rest_send.json
@@ -266,5 +266,21 @@
         "REQUEST_PATH": "/api/v1/test/transient",
         "MESSAGE": "OK",
         "DATA": {"results": [{"name": "acl_new", "status": "success"}]}
+    },
+    "test_rest_send_01120a": {
+        "TEST_NOTES": ["Transient GET 409 (ND OpenAPI documents 409 on safe GETs, e.g. /links, while the resource state is reconciling). Retryable - the loop must consume the follow-up 200 in 01120b."],
+        "RETURN_CODE": 409,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/links",
+        "MESSAGE": "Conflict",
+        "DATA": {"code": 409, "message": "The request could not be completed due to a conflict with the current state of the resource."}
+    },
+    "test_rest_send_01120b": {
+        "TEST_NOTES": ["Recovery response consumed by the retry of 01120a - reconciliation finished."],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/links",
+        "MESSAGE": "OK",
+        "DATA": {"links": [{"linkId": "link-1"}]}
     }
 }

--- a/tests/unit/module_utils/legacy_response_strategy.py
+++ b/tests/unit/module_utils/legacy_response_strategy.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Allen Robel (@arobel) <arobel@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+# Summary
+
+A structural response validation strategy implementing only the original (pre-#502) `ResponseValidationStrategy` members.
+
+## Description
+
+`LegacyStrategy` implements every member of `ResponseValidationStrategy` and nothing else — in particular no `is_terminal_client_error()`
+(the optional `TerminalClientErrorPolicy` capability). It stands in for an out-of-tree strategy written against the older protocol, so unit
+tests can prove that such a strategy is still accepted by `ResponseHandler.validation_strategy` and keeps the historical retry behavior
+(every non-success 4xx retryable). Shared by `test_response_handler_nd.py` and `test_rest_send.py`.
+"""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type  # pylint: disable=invalid-name
+
+
+class LegacyStrategy:
+    """
+    # Summary
+
+    Pre-#502 structural strategy: satisfies `ResponseValidationStrategy` but not `TerminalClientErrorPolicy`.
+
+    ## Raises
+
+    None
+    """
+
+    @property
+    def success_codes(self) -> set[int]:
+        """
+        # Summary
+
+        HTTP status codes treated as success.
+
+        ## Raises
+
+        None
+        """
+        return {200, 201, 202, 204, 207}
+
+    @property
+    def not_found_code(self) -> int:
+        """
+        # Summary
+
+        HTTP status code treated as not-found.
+
+        ## Raises
+
+        None
+        """
+        return 404
+
+    def is_success(self, response: dict) -> bool:
+        """
+        # Summary
+
+        True when `RETURN_CODE` is a success code.
+
+        ## Raises
+
+        None
+        """
+        return response["RETURN_CODE"] in self.success_codes
+
+    def is_not_found(self, return_code: int) -> bool:
+        """
+        # Summary
+
+        True when `return_code` is the not-found code.
+
+        ## Raises
+
+        None
+        """
+        return return_code == self.not_found_code
+
+    def is_changed(self, response: dict) -> bool:
+        """
+        # Summary
+
+        True unless the `modified` header is explicitly `"false"`.
+
+        ## Raises
+
+        None
+        """
+        return response.get("modified") != "false"
+
+    def is_changed_on_failure(self, response: dict) -> bool:  # pylint: disable=unused-argument
+        """
+        # Summary
+
+        A failed mutation never changed state under this strategy.
+
+        ## Raises
+
+        None
+        """
+        return False
+
+    def extract_error_message(self, response: dict) -> str | None:
+        """
+        # Summary
+
+        Return the HTTP reason phrase as the error message.
+
+        ## Raises
+
+        None
+        """
+        return response.get("MESSAGE")

--- a/tests/unit/module_utils/test_response_handler_nd.py
+++ b/tests/unit/module_utils/test_response_handler_nd.py
@@ -2756,7 +2756,7 @@ def test_response_handler_nd_01600():
 
     ## Classes and Methods
 
-    - ResponseHandler._is_terminal_client_error()
+    - NdV1Strategy.is_terminal_client_error()
     - ResponseHandler._handle_post_put_delete_response()
     - ResponseHandler.commit()
     """
@@ -2778,8 +2778,8 @@ def test_response_handler_nd_01610():
     """
     # Summary
 
-    Verify a POST failing with 429 (Too Many Requests) remains retryable: rate limiting is the one transient 4xx, so
-    it is excluded from the 4xx-terminal rule (issue #457).
+    Verify a POST failing with 429 (Too Many Requests) remains retryable: rate limiting is transient, so 429 is
+    excluded from the 4xx-terminal rule (issue #457).
 
     ## Test
 
@@ -2788,7 +2788,7 @@ def test_response_handler_nd_01610():
 
     ## Classes and Methods
 
-    - ResponseHandler._is_terminal_client_error()
+    - NdV1Strategy.is_terminal_client_error()
     - ResponseHandler._handle_post_put_delete_response()
     - ResponseHandler.commit()
     """
@@ -2820,7 +2820,7 @@ def test_response_handler_nd_01620():
 
     ## Classes and Methods
 
-    - ResponseHandler._is_terminal_client_error()
+    - NdV1Strategy.is_terminal_client_error()
     - ResponseHandler._handle_get_response()
     - ResponseHandler.commit()
     """
@@ -2884,7 +2884,7 @@ def test_response_handler_nd_01640():
 
     ## Classes and Methods
 
-    - ResponseHandler._is_terminal_client_error()
+    - NdV1Strategy.is_terminal_client_error()
     - ResponseHandler._handle_post_put_delete_response()
     - ResponseHandler.commit()
     """
@@ -2899,3 +2899,164 @@ def test_response_handler_nd_01640():
         instance.commit()
     assert instance.result["success"] is False
     assert instance.result["retryable"] is False
+
+
+def test_response_handler_nd_01650():
+    """
+    # Summary
+
+    Verify a GET failing with 409 (Conflict) remains retryable: the ND 4.2.1 OpenAPI documents 409 on safe GETs
+    (e.g. manage /links, /remoteFabrics) where the conflict is with the resource's current state and can clear on
+    its own (e.g. topology reconciliation), so GET retries/polls through it.
+
+    ## Test
+
+    - GET returns 409
+    - success is False, found is False, retryable is True
+
+    ## Classes and Methods
+
+    - NdV1Strategy.is_terminal_client_error()
+    - ResponseHandler._handle_get_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 409,
+        "MESSAGE": "Conflict",
+        "DATA": {"code": 409, "message": "The request could not be completed due to a conflict with the current state of the resource."},
+    }
+    instance.verb = HttpVerbEnum.GET
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["found"] is False
+    assert instance.result["retryable"] is True
+
+
+def test_response_handler_nd_01660():
+    """
+    # Summary
+
+    Verify a POST failing with 409 (Conflict) is terminal (retryable=False): for mutations 409 is a deterministic
+    create/update conflict (e.g. resource already exists), so an identical replay cannot succeed — only GET treats
+    409 as transient.
+
+    ## Test
+
+    - POST returns 409
+    - success is False and retryable is False
+
+    ## Classes and Methods
+
+    - NdV1Strategy.is_terminal_client_error()
+    - ResponseHandler._handle_post_put_delete_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 409,
+        "MESSAGE": "Conflict",
+        "DATA": {"code": 409, "message": "Fabric already exists"},
+    }
+    instance.verb = HttpVerbEnum.POST
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["retryable"] is False
+
+
+def test_response_handler_nd_01670():
+    """
+    # Summary
+
+    Verify a POST failing with 408 (Request Timeout) remains retryable: RFC 9110 section 15.5.9 defines 408 as
+    retryable (the server timed out waiting for the request), so it is in the transient set for every verb.
+
+    ## Test
+
+    - POST returns 408
+    - success is False and retryable is True
+
+    ## Classes and Methods
+
+    - NdV1Strategy.is_terminal_client_error()
+    - ResponseHandler._handle_post_put_delete_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 408,
+        "MESSAGE": "Request Timeout",
+        "DATA": {},
+    }
+    instance.verb = HttpVerbEnum.POST
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["retryable"] is True
+
+
+def test_response_handler_nd_01680():
+    """
+    # Summary
+
+    Verify a GET failing with 425 (Too Early) remains retryable: RFC 8470 section 5.2 expects an automatic retry
+    outside early data, so 425 is in the transient set for every verb.
+
+    ## Test
+
+    - GET returns 425
+    - success is False, found is False, retryable is True
+
+    ## Classes and Methods
+
+    - NdV1Strategy.is_terminal_client_error()
+    - ResponseHandler._handle_get_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 425,
+        "MESSAGE": "Too Early",
+        "DATA": {},
+    }
+    instance.verb = HttpVerbEnum.GET
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["found"] is False
+    assert instance.result["retryable"] is True
+
+
+def test_response_handler_nd_01690():
+    """
+    # Summary
+
+    Verify a GET failing with 421 (Misdirected Request) remains retryable: RFC 9110 section 15.5.20 permits retrying
+    421 (on a different connection — connection lifecycle belongs to Ansible's persistent httpapi transport, so the
+    retry rides whatever connection that layer provides).
+
+    ## Test
+
+    - GET returns 421
+    - success is False, found is False, retryable is True
+
+    ## Classes and Methods
+
+    - NdV1Strategy.is_terminal_client_error()
+    - ResponseHandler._handle_get_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 421,
+        "MESSAGE": "Misdirected Request",
+        "DATA": {},
+    }
+    instance.verb = HttpVerbEnum.GET
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["found"] is False
+    assert instance.result["retryable"] is True

--- a/tests/unit/module_utils/test_response_handler_nd.py
+++ b/tests/unit/module_utils/test_response_handler_nd.py
@@ -2312,12 +2312,13 @@ def test_response_handler_nd_01440():
     """
     # Summary
 
-    Verify GET results carry no retryable key (GET retry semantics are unchanged).
+    Verify a GET failing with a 5xx code remains retryable (GET retries serve eventual-consistency polling and 5xx is
+    potentially transient; only 4xx-except-429 is terminal — see issue #457).
 
     ## Test
 
     - GET returns 500
-    - result has no "retryable" key, so RestSend's .get("retryable", True) default preserves today's GET retry behavior
+    - success is False and retryable is True
 
     ## Classes and Methods
 
@@ -2334,7 +2335,7 @@ def test_response_handler_nd_01440():
     with does_not_raise():
         instance.commit()
     assert instance.result["success"] is False
-    assert "retryable" not in instance.result
+    assert instance.result["retryable"] is True
 
 
 def test_response_handler_nd_01450():
@@ -2733,3 +2734,168 @@ def test_response_handler_nd_01570():
         "DATA": {"results": [{"name": "loopback10", "message": "invalid policyType"}]},
     }
     assert strategy.extract_error_message(response) == "ND Error: loopback10: invalid policyType"
+
+
+# =============================================================================
+# Test: 4xx terminal classification in the retry policy (issue #457, PR #502)
+# =============================================================================
+
+
+def test_response_handler_nd_01600():
+    """
+    # Summary
+
+    Verify a POST failing with a 4xx code is terminal (retryable=False): the request reached the application and was
+    rejected, so an identical replay cannot succeed (issue #457 — deterministic 400s previously burned the full retry
+    budget).
+
+    ## Test
+
+    - POST returns 400
+    - success is False, retryable is False, changed is False
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_post_put_delete_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 400,
+        "MESSAGE": "Bad Request",
+        "DATA": {"error": "Invalid fabric settings"},
+    }
+    instance.verb = HttpVerbEnum.POST
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["retryable"] is False
+    assert instance.result["changed"] is False
+
+
+def test_response_handler_nd_01610():
+    """
+    # Summary
+
+    Verify a POST failing with 429 (Too Many Requests) remains retryable: rate limiting is the one transient 4xx, so
+    it is excluded from the 4xx-terminal rule (issue #457).
+
+    ## Test
+
+    - POST returns 429
+    - success is False and retryable is True
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_post_put_delete_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 429,
+        "MESSAGE": "Too Many Requests",
+        "DATA": {},
+    }
+    instance.verb = HttpVerbEnum.POST
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["retryable"] is True
+
+
+def test_response_handler_nd_01620():
+    """
+    # Summary
+
+    Verify a GET failing with a 4xx code is terminal (retryable=False): a deterministic client error on a GET (bad
+    query parameter, malformed path segment) previously burned the full retry budget just like a mutation (issue
+    #457 scope note — the 4xx-terminal rule applies to all verbs).
+
+    ## Test
+
+    - GET returns 400
+    - success is False, found is False, retryable is False
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_get_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 400,
+        "MESSAGE": "Bad Request",
+        "DATA": {"error": "invalid query parameter"},
+    }
+    instance.verb = HttpVerbEnum.GET
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["found"] is False
+    assert instance.result["retryable"] is False
+
+
+def test_response_handler_nd_01630():
+    """
+    # Summary
+
+    Verify a GET returning 404 keeps its not-found-is-success contract with retryable=False (the key is now present
+    on every GET result for a consistent shape; a successful result never re-enters the retry loop).
+
+    ## Test
+
+    - GET returns 404
+    - success is True, found is False, retryable is False
+
+    ## Classes and Methods
+
+    - ResponseHandler._handle_get_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 404,
+        "MESSAGE": "Not Found",
+        "DATA": {},
+    }
+    instance.verb = HttpVerbEnum.GET
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is True
+    assert instance.result["found"] is False
+    assert instance.result["retryable"] is False
+
+
+def test_response_handler_nd_01640():
+    """
+    # Summary
+
+    Verify a DELETE failing with 404 is terminal (retryable=False): only GET treats 404 as not-found-success; for a
+    mutation it is a client error, and replaying an identical DELETE against a missing resource cannot succeed
+    (issue #457 — orchestrators with bounded domain-level retries, e.g. L3Out attach, own that pacing themselves).
+
+    ## Test
+
+    - DELETE returns 404
+    - success is False and retryable is False
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_post_put_delete_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 404,
+        "MESSAGE": "Not Found",
+        "DATA": {"error": "resource does not exist"},
+    }
+    instance.verb = HttpVerbEnum.DELETE
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["retryable"] is False

--- a/tests/unit/module_utils/test_response_handler_nd.py
+++ b/tests/unit/module_utils/test_response_handler_nd.py
@@ -25,9 +25,11 @@ __metaclass__ = type  # pylint: disable=invalid-name
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.rest.protocols.response_validation import ResponseValidationStrategy, TerminalClientErrorPolicy
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_strategies.nd_v1_strategy import NdV1Strategy
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.legacy_response_strategy import LegacyStrategy
 
 # =============================================================================
 # Test: ResponseHandler initialization
@@ -3060,3 +3062,128 @@ def test_response_handler_nd_01690():
     assert instance.result["success"] is False
     assert instance.result["found"] is False
     assert instance.result["retryable"] is True
+
+
+# =============================================================================
+# Test: Legacy (pre-#502) injected strategies remain accepted
+# =============================================================================
+
+
+def test_response_handler_nd_01700():
+    """
+    # Summary
+
+    Verify a strategy implementing only the pre-#502 protocol members is still accepted by the validation_strategy
+    setter: terminal-4xx classification is an optional capability, so widening the retry policy must not turn the
+    documented strategy-injection extension point into a breaking change.
+
+    ## Test
+
+    - A structural strategy without is_terminal_client_error() is assigned
+    - No TypeError is raised and the getter returns the injected instance
+
+    ## Classes and Methods
+
+    - ResponseHandler.validation_strategy (setter)
+    - ResponseHandler.validation_strategy (getter)
+    """
+    instance = ResponseHandler()
+    strategy = LegacyStrategy()
+    with does_not_raise():
+        instance.validation_strategy = strategy
+    assert instance.validation_strategy is strategy
+
+
+def test_response_handler_nd_01710():
+    """
+    # Summary
+
+    Verify a POST failing with 400 under a legacy strategy (no is_terminal_client_error()) keeps the historical
+    retryable=True behavior: when the injected strategy cannot classify client errors, the handler must not
+    terminalize on its behalf.
+
+    ## Test
+
+    - Legacy strategy is injected
+    - POST returns 400
+    - success is False, changed is False, retryable is True
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_post_put_delete_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.validation_strategy = LegacyStrategy()
+    instance.response = {
+        "RETURN_CODE": 400,
+        "MESSAGE": "Bad Request",
+        "DATA": {"error": "Invalid fabric settings"},
+    }
+    instance.verb = HttpVerbEnum.POST
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["changed"] is False
+    assert instance.result["retryable"] is True
+
+
+def test_response_handler_nd_01720():
+    """
+    # Summary
+
+    Verify a GET failing with 400 under a legacy strategy (no is_terminal_client_error()) keeps the historical
+    retryable=True behavior on the GET path as well.
+
+    ## Test
+
+    - Legacy strategy is injected
+    - GET returns 400
+    - success is False, found is False, retryable is True
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_get_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.validation_strategy = LegacyStrategy()
+    instance.response = {
+        "RETURN_CODE": 400,
+        "MESSAGE": "Bad Request",
+        "DATA": {"error": "Invalid query"},
+    }
+    instance.verb = HttpVerbEnum.GET
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["found"] is False
+    assert instance.result["retryable"] is True
+
+
+def test_response_handler_nd_01730():
+    """
+    # Summary
+
+    Verify the protocol split: NdV1Strategy satisfies both the base ResponseValidationStrategy protocol and the
+    optional TerminalClientErrorPolicy capability, while the legacy strategy satisfies only the base protocol.
+
+    ## Test
+
+    - isinstance(NdV1Strategy(), ResponseValidationStrategy) is True
+    - isinstance(NdV1Strategy(), TerminalClientErrorPolicy) is True
+    - isinstance(LegacyStrategy(), ResponseValidationStrategy) is True
+    - isinstance(LegacyStrategy(), TerminalClientErrorPolicy) is False
+
+    ## Classes and Methods
+
+    - ResponseValidationStrategy
+    - TerminalClientErrorPolicy
+    - NdV1Strategy
+    """
+    assert isinstance(NdV1Strategy(), ResponseValidationStrategy)
+    assert isinstance(NdV1Strategy(), TerminalClientErrorPolicy)
+    assert isinstance(LegacyStrategy(), ResponseValidationStrategy)
+    assert not isinstance(LegacyStrategy(), TerminalClientErrorPolicy)

--- a/tests/unit/module_utils/test_rest_send.py
+++ b/tests/unit/module_utils/test_rest_send.py
@@ -24,6 +24,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd 
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
 from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.legacy_response_strategy import LegacyStrategy
 from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
 from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
@@ -1600,6 +1601,63 @@ def test_rest_send_01120():
     assert instance.response_current["RETURN_CODE"] == 200
     assert instance.result_current["success"] is True
     assert instance.result_current["found"] is True
+
+
+def test_rest_send_01130():
+    """
+    # Summary
+
+    Verify the end-to-end compatibility path for a legacy injected strategy (pre-#502 protocol, no
+    is_terminal_client_error()): RestSend accepts the handler carrying it, and a POST failing with 400 keeps the
+    historical retry behavior — the loop retries and consumes the recovery response instead of terminalizing.
+
+    ## Test
+
+    - A legacy structural strategy is injected into the ResponseHandler without TypeError
+    - POST returns 400 (retryable=True under the legacy strategy), then 200 on the retry
+    - timeout (10) and send_interval (5) allow exactly two submissions
+    - The loop consumes both responses and the final result is the successful 200
+
+    ## Classes and Methods
+
+    - ResponseHandler.validation_strategy (setter)
+    - ResponseHandler._is_terminal_client_error()
+    - RestSend.commit()
+    - RestSend._commit_normal_mode()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_rest_send(f"{method_name}a")
+        yield responses_rest_send(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    params = {"check_mode": False}
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    with does_not_raise():
+        instance = RestSend(params)
+        instance.sender = sender
+        response_handler = ResponseHandler()
+        response_handler.validation_strategy = LegacyStrategy()
+        response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+        response_handler.verb = HttpVerbEnum.GET
+        response_handler.commit()
+        instance.response_handler = response_handler
+        instance.unit_test = True
+        instance.timeout = 10
+        instance.send_interval = 5
+        instance.path = "/api/v1/test/legacy"
+        instance.verb = HttpVerbEnum.POST
+        instance.payload = {"name": "item"}
+        instance.commit()
+
+    assert instance.response_current["RETURN_CODE"] == 200
+    assert instance.result_current["success"] is True
+    assert instance.result_current["retryable"] is False
 
 
 # =============================================================================

--- a/tests/unit/module_utils/test_rest_send.py
+++ b/tests/unit/module_utils/test_rest_send.py
@@ -1550,6 +1550,58 @@ def test_rest_send_01110():
     assert instance.result_current["success"] is True
 
 
+def test_rest_send_01120():
+    """
+    # Summary
+
+    Verify a GET failing with 409 (Conflict) retries and consumes the recovery response: the ND OpenAPI documents
+    409 on safe GETs (e.g. /links) where the conflict is with the resource's current state (e.g. topology
+    reconciliation) and can clear on its own.
+
+    ## Test
+
+    - GET returns 409 (retryable=True), then 200 on the retry
+    - timeout (10) and send_interval (5) allow exactly two submissions
+    - The loop consumes both responses and the final result is the successful 200
+
+    ## Classes and Methods
+
+    - RestSend.commit()
+    - RestSend._commit_normal_mode()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_rest_send(f"{method_name}a")
+        yield responses_rest_send(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+
+    params = {"check_mode": False}
+    sender = Sender()
+    sender.ansible_module = MockAnsibleModule()
+    sender.gen = gen_responses
+
+    with does_not_raise():
+        instance = RestSend(params)
+        instance.sender = sender
+        response_handler = ResponseHandler()
+        response_handler.response = {"RETURN_CODE": 200, "MESSAGE": "OK"}
+        response_handler.verb = HttpVerbEnum.GET
+        response_handler.commit()
+        instance.response_handler = response_handler
+        instance.unit_test = True
+        instance.timeout = 10
+        instance.send_interval = 5
+        instance.path = "/api/v1/manage/links"
+        instance.verb = HttpVerbEnum.GET
+        instance.commit()
+
+    assert instance.response_current["RETURN_CODE"] == 200
+    assert instance.result_current["success"] is True
+    assert instance.result_current["found"] is True
+
+
 # =============================================================================
 # Test: RestSend.add_response()
 # =============================================================================


### PR DESCRIPTION
## Related Issue(s)

Addresses the 4xx half of #457 (deliberately does NOT close it — the 5xx retry question remains open for discussion there).

## Proposed Changes

Implements the independently-shippable piece proposed in [#457's field-report comment](https://github.com/CiscoDevNet/ansible-nd/issues/457#issuecomment-5220049760): a 4xx response proves the request reached the application and was rejected, so replaying the identical request cannot succeed. Previously a deterministic 400 (e.g. an immediately-rejected fabric mutation) was resubmitted every 5 seconds for the full 300-second `RestSend` budget, delaying module failure by 5 minutes with no user-facing knob to shorten it.

- `NdV1Strategy.is_terminal_client_error(return_code, verb)` — the review round moved the classification from the handler onto the injected `ResponseValidationStrategy`, the handler's documented extension point for version-specific status-code policy. A 4xx is terminal unless transient: 408/421/425/429 for every verb (RFC 9110 §15.5.9/§15.5.20, RFC 8470 §5.2, rate limiting; ND 4.2.1 documents none of 408/421/425, so retaining them preserves historical behavior), plus 409 for GET only — the ND 4.2.1 OpenAPI documents 409 on safe GETs (manage v1.1.411: `/links`, `/links/{linkId}`, `/logicalLinks`, `/remoteFabrics`, `/anomalyRules/postProcessingRules`; onemanage: three more) where the conflict is with the resource's current state and can clear on its own. Mutation 409 stays terminal (deterministic create/update conflict). The dcnm-era retry-on-400 cases do not carry over.
- **Mutations (POST/PUT/DELETE):** the `retryable` classification introduced by #398 now also excludes terminal client errors. 5xx keeps the historical retry behavior — that half of #457 is untouched.
- **GET:** results now carry `retryable`, applying the same 4xx rule (with the GET-only 409 carve-out above) per the issue's scope note — a deterministic 400 on a GET burned the same budget. 5xx GETs remain retryable for eventual-consistency polling, and the 404 not-found-is-success contract is unchanged.
- `RestSend` needs no changes — the terminal break from #398 already consumes `retryable` verb-agnostically.
- **Strategy-injection compatibility (review round 2):** `is_terminal_client_error()` lives on a separate `@runtime_checkable` `TerminalClientErrorPolicy` capability protocol rather than on `ResponseValidationStrategy`, so the assignment-time `isinstance` check in `ResponseHandler.validation_strategy` is back to the original contract and a strategy written against the pre-PR protocol is still accepted. The handler feature-detects the capability (`_is_terminal_client_error()` via `getattr`) and falls back to the historical retryable=True for every non-success 4xx when the injected strategy lacks it. `NdV1Strategy` satisfies both protocols and is unchanged.

Test changes: five new ResponseHandler tests (01500–01540: POST 400 terminal, POST 429 retryable, GET 400 terminal, GET 404 contract, DELETE 404 terminal) and a deliberate rewrite of 01440, which previously pinned the "GET results carry no retryable key" behavior this PR removes. The review round added handler tests 01550–01590 (GET 409 retryable, POST 409 terminal, POST 408 / GET 425 / GET 421 retryable) and RestSend test 01120 (GET 409 retries and consumes the recovery 200). Round 2 added a shared `LegacyStrategy` test helper (pre-PR protocol members only), handler tests 01700–01730 (legacy strategy accepted at assignment, POST 400 / GET 400 keep retryable=True, protocol split) and RestSend test 01130 (legacy strategy injected end-to-end: POST 400 retries and consumes the recovery 200).

## Test Notes

- Full unit suite passes in the nd-dev container machine: 4295 passed (`ndpytest tests/unit/`)
- `pylint` 10.00/10 on the changed modules; `black`/`isort` clean; `mypy` reports only one error pre-existing on develop (the review round incidentally fixed the other pre-existing one)

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [ ] manage
* [ ] onemanage
* [x] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XZiWNrVHYXbeNXRM8kUrz

