### PR TITLE
Default policy and policy group deployment to false

### DIFF
--- a/changelogs/fragments/policy_deploy_default_false.yml
+++ b/changelogs/fragments/policy_deploy_default_false.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - nd_manage_policy - default ``deploy`` to ``false`` so controller-side changes are staged unless deployment is explicitly requested.
-  - nd_manage_policy_group - default ``deploy`` to ``false`` so controller-side changes are staged unless deployment is explicitly requested.

--- a/changelogs/fragments/policy_deploy_default_false.yml
+++ b/changelogs/fragments/policy_deploy_default_false.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - nd_manage_policy - default ``deploy`` to ``false`` so controller-side changes are staged unless deployment is explicitly requested.
+  - nd_manage_policy_group - default ``deploy`` to ``false`` so controller-side changes are staged unless deployment is explicitly requested.

--- a/plugins/module_utils/models/manage_policies/config_models.py
+++ b/plugins/module_utils/models/manage_policies/config_models.py
@@ -277,7 +277,7 @@ class PlaybookPolicyConfig(NDNestedModel):
             fabric_name=dict(type="str", required=True, aliases=["fabric"]),
             config=dict(type="list", elements="dict"),
             use_description_as_key=dict(type="bool", default=False),
-            deploy=dict(type="bool", default=True),
+            deploy=dict(type="bool", default=False),
             ticket_id=dict(type="str"),
             cluster_name=dict(type="str"),
             state=dict(type="str", default="merged", choices=["merged", "deleted", "gathered"]),

--- a/plugins/module_utils/models/manage_policy_groups/policy_group_base.py
+++ b/plugins/module_utils/models/manage_policy_groups/policy_group_base.py
@@ -269,7 +269,7 @@ class PolicyGroupCreate(NDBaseModel):
         """
         return dict(
             fabric_name=dict(type="str", required=True, aliases=["fabric"]),
-            deploy=dict(type="bool", default=True),
+            deploy=dict(type="bool", default=False),
             config=dict(
                 type="list",
                 elements="dict",

--- a/plugins/module_utils/orchestrators/manage_policy_group.py
+++ b/plugins/module_utils/orchestrators/manage_policy_group.py
@@ -106,7 +106,7 @@ class PolicyGroupOrchestrator(NDBaseOrchestrator[PolicyGroupCreate]):
 
     # Configuration
     fabric_name: str | None = None
-    deploy: bool = True
+    deploy: bool = False
 
     # Change Control / multi-cluster query parameters.  When set, these are
     # forwarded as ``ticketId`` and ``clusterName`` on every policy-group

--- a/plugins/modules/nd_manage_policy.py
+++ b/plugins/modules/nd_manage_policy.py
@@ -193,6 +193,7 @@ options:
     - When set to V(true), policies are deployed to devices after create/update/delete operations.
     - When set to V(false), controller-side changes are staged without deploying
       the corresponding config changes to devices.
+    - Deployment is opt-in. Set O(deploy=true) explicitly to push changes to devices.
     - For C(merged), create/update deploy uses the resource-level policy deploy
       operation scoped to the affected policy IDs. Entries that already match the
       controller are also deployed when O(deploy=true), but this no-diff deploy does
@@ -222,7 +223,7 @@ options:
       to resolve to a switch ID and may also deploy a mistyped or already-clean
       target.
     type: bool
-    default: true
+    default: false
   ticket_id:
     description:
     - Change Control Ticket ID to associate with create/update operations,
@@ -366,6 +367,7 @@ EXAMPLES = r"""
 - name: Create policy including required template inputs
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ fabric_name }}"
+    deploy: true
     config:
       - name: switch_freeform
         create_additional_policy: false
@@ -405,6 +407,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ fabric_name }}"
     use_description_as_key: true
+    deploy: true
     config:
       - name: feature_enable
         description: "Enable LACP"
@@ -422,6 +425,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ fabric_name }}"
     use_description_as_key: true
+    deploy: true
     config:
       - name: switch_freeform
         create_additional_policy: false
@@ -455,6 +459,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ fabric_name }}"
     state: deleted
+    deploy: true
     config:
       - name: template_101
       - name: template_102
@@ -467,6 +472,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ fabric_name }}"
     state: deleted
+    deploy: true
     config:
       - name: POLICY-101101
       - name: POLICY-102102
@@ -477,6 +483,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ fabric_name }}"
     state: deleted
+    deploy: true
     config:
       - switch:
           - serial_number: "{{ switch1 }}"
@@ -502,6 +509,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ fabric_name }}"
     state: deleted
+    deploy: true
     config:
       - name: switch_freeform
       - switch:
@@ -512,6 +520,7 @@ EXAMPLES = r"""
     fabric_name: "{{ fabric_name }}"
     use_description_as_key: true
     state: deleted
+    deploy: true
     config:
       - name: switch_freeform
         description: "Enable LACP"
@@ -538,18 +547,21 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ target_fabric }}"
     state: merged
+    deploy: true
     config: "{{ all_policies.gathered }}"
 
 - name: Round-trip on the same fabric — gathered output updates existing policies in place by policy_id
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ fabric_name }}"
     state: merged
+    deploy: true
     config: "{{ all_policies.gathered }}"
 
 - name: Use gathered output to delete those exact policies by policy ID
   cisco.nd.nd_manage_policy:
     fabric_name: "{{ fabric_name }}"
     state: deleted
+    deploy: true
     config: "{{ all_policies.gathered }}"
 """
 

--- a/plugins/modules/nd_manage_policy_group.py
+++ b/plugins/modules/nd_manage_policy_group.py
@@ -25,6 +25,7 @@ options:
     - Whether to deploy changes after create/update/delete operations.
     - When V(false), changes are staged on the controller but running config is
       not deployed to the switches until a later deploy.
+    - Deployment is opt-in. Set O(deploy=true) explicitly to push changes to switches.
     - Policy groups have no per-policy deploy path. The ND
       C(policyActions/pushConfig) operation is B(not) honoured for policy groups,
       so every O(deploy=true) path uses switch-level deploy.
@@ -67,7 +68,7 @@ options:
       a per-task or staged-only variant of switch-level deploy. Use O(deploy=false)
       to stage policy-group changes without triggering switch-level deploy.
     type: bool
-    default: true
+    default: false
   config:
     description:
     - List of policy group configurations.
@@ -264,6 +265,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy_group:
     fabric_name: my_fabric
     state: merged
+    deploy: true
     config:
       - name: feature_enable
         description: "Enable LACP on leaf switches"
@@ -277,6 +279,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy_group:
     fabric_name: my_fabric
     state: merged
+    deploy: true
     config:
       - name: feature_enable
         description: "Enable LACP"
@@ -293,6 +296,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy_group:
     fabric_name: my_fabric
     state: merged
+    deploy: true
     config:
       - name: switch_freeform
         create_additional_policy: true
@@ -304,6 +308,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy_group:
     fabric_name: my_fabric
     state: deleted
+    deploy: true
     config:
       - name: feature_enable
         description: "Enable LACP"
@@ -312,6 +317,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy_group:
     fabric_name: my_fabric
     state: deleted
+    deploy: true
     config:
       - name: feature_enable
 
@@ -319,6 +325,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy_group:
     fabric_name: my_fabric
     state: deleted
+    deploy: true
     config:
       - name: POLICY-GROUP-123456
       - name: POLICY-GROUP-789012
@@ -327,6 +334,7 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy_group:
     fabric_name: my_fabric
     state: merged
+    deploy: true
     config:
       - name: POLICY-GROUP-123456
         switch_ids:
@@ -377,12 +385,14 @@ EXAMPLES = r"""
   cisco.nd.nd_manage_policy_group:
     fabric_name: "{{ target_fabric }}"
     state: merged
+    deploy: true
     config: "{{ all_policy_groups.gathered }}"
 
 - name: Use gathered output to delete those exact policy groups
   cisco.nd.nd_manage_policy_group:
     fabric_name: my_fabric
     state: deleted
+    deploy: true
     config: "{{ all_policy_groups.gathered }}"
 """
 

--- a/tests/integration/targets/nd_manage_policy_group/tests/merged.yaml
+++ b/tests/integration/targets/nd_manage_policy_group/tests/merged.yaml
@@ -248,6 +248,7 @@
       cisco.nd.nd_manage_policy_group:
         fabric_name: "{{ fabric_name }}"
         state: merged
+        deploy: false
         config:
           - name: switch_freeform
             switch_ids:

--- a/tests/unit/module_utils/models/test_manage_policies_config_models.py
+++ b/tests/unit/module_utils/models/test_manage_policies_config_models.py
@@ -694,7 +694,7 @@ def test_manage_policies_config_models_00600() -> None:
     - All expected keys are present.
     - ``fabric_name`` is required and aliased to ``fabric``.
     - ``state`` defaults to ``merged`` with the documented choices.
-    - ``deploy`` defaults to ``True`` and ``use_description_as_key`` defaults to
+    - ``deploy`` defaults to ``False`` and ``use_description_as_key`` defaults to
       ``False``.
 
     ## Classes and Methods
@@ -716,7 +716,7 @@ def test_manage_policies_config_models_00600() -> None:
     assert spec["fabric_name"]["aliases"] == ["fabric"]
     assert spec["state"]["default"] == "merged"
     assert spec["state"]["choices"] == ["merged", "deleted", "gathered"]
-    assert spec["deploy"]["default"] is True
+    assert spec["deploy"]["default"] is False
     assert spec["use_description_as_key"]["default"] is False
     assert spec["config"]["type"] == "list"
     assert spec["config"]["elements"] == "dict"

--- a/tests/unit/module_utils/models/test_manage_policy_groups_policy_group_base.py
+++ b/tests/unit/module_utils/models/test_manage_policy_groups_policy_group_base.py
@@ -667,7 +667,7 @@ def test_manage_policy_groups_policy_group_base_00500() -> None:
     - Top-level keys ``fabric_name``, ``deploy``, ``config``,
       ``ticket_id``, ``cluster_name``, ``state`` are present.
     - ``fabric_name`` is required and aliased to ``fabric``.
-    - ``deploy`` defaults to ``True``.
+    - ``deploy`` defaults to ``False``.
     - ``ticket_id`` and ``cluster_name`` are plain optional strings
       (no default, no required flag) so they are omitted from the
       emitted request path when callers do not set them.
@@ -689,7 +689,7 @@ def test_manage_policy_groups_policy_group_base_00500() -> None:
     }
     assert spec["fabric_name"]["required"] is True
     assert spec["fabric_name"]["aliases"] == ["fabric"]
-    assert spec["deploy"]["default"] is True
+    assert spec["deploy"]["default"] is False
     assert spec["ticket_id"] == {"type": "str"}
     assert spec["cluster_name"] == {"type": "str"}
     assert spec["state"]["default"] == "merged"

--- a/tests/unit/modules/test_nd_policy_group_module.py
+++ b/tests/unit/modules/test_nd_policy_group_module.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+import yaml
 from ansible_collections.cisco.nd.plugins.modules import nd_manage_policy_group
 from ansible_collections.cisco.nd.plugins.modules.nd_manage_policy_group import (
     _FabricInventoryRestClient,
@@ -52,6 +53,15 @@ from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
 
 class FailJsonError(Exception):
     """Raised by ``FakeModule.fail_json`` so tests can ``pytest.raises`` cleanly."""
+
+
+def test_nd_policy_group_module_00005_deploy_default_matches_documentation() -> None:
+    """Verify the safe deploy default is identical in docs and argument spec."""
+    documentation = yaml.safe_load(nd_manage_policy_group.DOCUMENTATION)
+    argument_spec = nd_manage_policy_group.PolicyGroupCreate.get_argument_spec()
+
+    assert documentation["options"]["deploy"]["default"] is False
+    assert argument_spec["deploy"]["default"] is False
 
 
 class FakeModule:

--- a/tests/unit/modules/test_nd_policy_module.py
+++ b/tests/unit/modules/test_nd_policy_module.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+import yaml
 from ansible_collections.cisco.nd.plugins.modules import nd_manage_policy
 
 # =============================================================================
@@ -122,3 +123,12 @@ def test_nd_policy_module_00010(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert module.fail_json_called is not None
     assert "pydantic" in module.fail_json_called["msg"].lower()
+
+
+def test_nd_policy_module_00020_deploy_default_matches_documentation() -> None:
+    """Verify the safe deploy default is identical in docs and argument spec."""
+    documentation = yaml.safe_load(nd_manage_policy.DOCUMENTATION)
+    argument_spec = nd_manage_policy.PlaybookPolicyConfig.get_argument_spec()
+
+    assert documentation["options"]["deploy"]["default"] is False
+    assert argument_spec["deploy"]["default"] is False


### PR DESCRIPTION
## Related Issue(s)

Resolves #425 , Resolves #464 

This PR changes the default deployment behavior for the Policy and Policy Group modules. It does not implement the complete `config_actions` scope from #425 or complete the live staged-configuration audit required by #464 as neither are required.

## Proposed Changes

- Default `deploy` to `false` for:
  - `nd_manage_policy`
  - `nd_manage_policy_group`
- Stage controller-side create, update, and delete changes when `deploy` is omitted.
- Preserve the existing deployment behavior when `deploy: true` is explicitly supplied.
- Document deployment as opt-in in both modules.
- Add `deploy: true` to write-oriented module examples whose previous effective behavior included deployment.
- Keep read-only `state: gathered` examples and tests free of an irrelevant deploy setting.
- Add regression tests verifying that each module's documentation and argument specification agree that the default is `false`.
- Make the policy-group validation-failure integration case explicitly use `deploy: false`.
- Add changelog entries for both modules.

## Behavior Impact

Previously, omitting `deploy` caused Policy and Policy Group changes to be deployed immediately.

After this change, omitting `deploy` stages controller-side changes without pushing them to devices. Playbooks requiring immediate deployment must specify:

```yaml
deploy: true
```

Explicit `deploy: true` and `deploy: false` execution paths are otherwise unchanged.

## Regression Audit

The audit covered:

- module argument specifications
- module documentation and examples
- implementation comments and docstrings
- Policy and Policy Group unit tests
- Policy and Policy Group integration tasks
- changelog consistency

All 172 write-oriented module examples and integration invocations now specify their deployment intent explicitly. The 69 invocations that omit `deploy` are read-only `state: gathered` operations.

No unrelated module deploy defaults were changed.

## Test Notes

- 413 Policy and Policy Group focused unit tests passed.
- Full changed-file `ansible-test sanity --python 3.11` passed, including:
  - `ansible-doc`
  - `validate-modules`
  - changelog validation
  - compile and import
  - pep8 and pylint
  - yamllint
- Repository invocation audit passed:
  - 172 write calls have explicit deploy intent
  - 69 read-only gathered calls safely omit `deploy`
- `git diff --check` passed.

Live controller validation was not run as part of this default/documentation change. The broader staged-addition, staged-removal, later-deployment, and API evidence requirements remain tracked by #464.

## Cisco Nexus Dashboard Version

Not applicable to the local unit and sanity validation performed for this PR. Live ND-version-specific staging validation remains part of #464.

## Related ND API Resource Category

- [ ] analyze
- [ ] infra
- [x] manage
- [ ] onemanage
- [ ] other

## Checklist

- [x] Latest commit is based on the current `develop` branch with no merge conflicts.
- [x] Documentation has been updated accordingly.
- [ ] Proper reviewers have been assigned.
