### PR TITLE
ND Manage VRFs & Networks: Fix Replaced First-Create Attachment Flow

### DIFF
--- a/plugins/module_utils/orchestrators/attachment_vpc_peer_expander.py
+++ b/plugins/module_utils/orchestrators/attachment_vpc_peer_expander.py
@@ -1,0 +1,61 @@
+# Copyright: (c) 2026, Akshayanat C S (@achengam) <achengam@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Shared vPC peer expansion helpers for attachment payload planning."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+
+def expand_desired_attachments_with_vpc_peers(
+    desired: dict[tuple[str, str], dict[str, Any]],
+    attachment_details: Iterable[Any] | None,
+    resource_name_field: str,
+    peer_payload_mutator: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[tuple[str, str], dict[str, Any]]:
+    """
+    # Summary
+
+    Add missing vPC peer attachment payloads from attachment-query metadata.
+
+    Args:
+        desired: Desired attachment payloads keyed by ``(resource_name, switch_id)``.
+        attachment_details: Raw attachment-query rows containing ``peerSwitchId`` metadata.
+        resource_name_field: API field that identifies the attached resource name.
+        peer_payload_mutator: Optional callback for resource-specific peer payload cleanup.
+
+    Returns:
+        Desired attachment payloads plus any missing vPC peer payloads.
+    """
+    if not desired or not attachment_details:
+        return desired
+
+    detail_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    for attachment in attachment_details:
+        if not isinstance(attachment, dict):
+            continue
+        resource_name = attachment.get(resource_name_field)
+        switch_id = attachment.get("switchId")
+        if resource_name and switch_id:
+            detail_by_key[(resource_name, switch_id)] = attachment
+
+    expanded = dict(desired)
+    for key, payload in list(desired.items()):
+        detail = detail_by_key.get(key)
+        peer_switch_id = detail.get("peerSwitchId") if detail else None
+        if not peer_switch_id:
+            continue
+
+        peer_key = (key[0], peer_switch_id)
+        if peer_key in expanded:
+            continue
+
+        peer_payload = dict(payload)
+        peer_payload["switchId"] = peer_switch_id
+        if peer_payload_mutator is not None:
+            peer_payload_mutator(peer_payload)
+        expanded[peer_key] = peer_payload
+
+    return expanded

--- a/plugins/module_utils/orchestrators/network_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/network_attachment_manager.py
@@ -94,6 +94,7 @@ class NetworkAttachmentManager:
         desired: dict[tuple[str, str], dict[str, Any]] | None = None,
         current_network_names: list[str] | None = None,
         current: dict[tuple[str, str], dict[str, Any]] | None = None,
+        attachment_details: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         state = module_args.get("state", "merged")
         config = module_args.get("config") or []
@@ -119,9 +120,25 @@ class NetworkAttachmentManager:
         query_names = current_network_names
         if query_names is None:
             query_names = None if state == "overridden" else configured_network_names(config)
+        raw_attachment_details = attachment_details
         if current is None:
-            current = self.current_attachment_map(module_args, strategy, query_names)
-            self._trace("network_attachment_current_loaded", phase=phase, queried_network_names=query_names, current_count=len(current))
+            if raw_attachment_details is None:
+                raw_attachment_details = self.current_attachment_details(module_args, strategy, query_names)
+            current = self.attachment_map_from_details(raw_attachment_details, query_names)
+            self._trace(
+                "network_attachment_current_loaded",
+                phase=phase,
+                queried_network_names=query_names,
+                attachment_count=len(raw_attachment_details or []),
+                current_count=len(current),
+            )
+
+        if desired:
+            desired = self.expand_desired_attachments_with_vpc_peers(
+                desired,
+                raw_attachment_details if raw_attachment_details is not None else current.values(),
+            )
+            self._trace("network_attachment_desired_expanded", phase=phase, desired_count=len(desired))
 
         payloads = self.planned_detach_payloads(state, config, current, desired) if phase == "pre" else self.planned_attach_payloads(current, desired)
         if not payloads:
@@ -140,6 +157,7 @@ class NetworkAttachmentManager:
         )
         self._trace("network_attachment_phase_end", phase=phase, payload_count=len(payloads), deploy_target_count=len(deploy_targets))
         trace["current"] = current
+        trace["desired"] = desired
         trace["payloads"] = payloads
         return trace
 
@@ -368,6 +386,43 @@ class NetworkAttachmentManager:
         network_names: list[str] | None = None,
     ) -> dict[tuple[str, str], dict[str, Any]]:
         return self.attachment_map_from_details(self.current_attachment_details(module_args, strategy, network_names), network_names)
+
+    @staticmethod
+    def expand_desired_attachments_with_vpc_peers(
+        desired: dict[tuple[str, str], dict[str, Any]],
+        attachment_details: Any,
+    ) -> dict[tuple[str, str], dict[str, Any]]:
+        """Add vPC peer attachments from attachment-query rows."""
+        if not desired or not attachment_details:
+            return desired
+
+        detail_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+        for attachment in attachment_details:
+            if not isinstance(attachment, dict):
+                continue
+            network_name = attachment.get("networkName")
+            switch_id = attachment.get("switchId")
+            if network_name and switch_id:
+                detail_by_key[(network_name, switch_id)] = attachment
+
+        expanded = dict(desired)
+        for key, payload in list(desired.items()):
+            detail = detail_by_key.get(key)
+            peer_switch_id = detail.get("peerSwitchId") if detail else None
+            if not peer_switch_id:
+                continue
+
+            peer_key = (key[0], peer_switch_id)
+            if peer_key in expanded:
+                continue
+
+            peer_payload = dict(payload)
+            peer_payload["switchId"] = peer_switch_id
+            if "interfaces" in peer_payload:
+                peer_payload["interfaces"] = []
+            expanded[peer_key] = peer_payload
+
+        return expanded
 
     @staticmethod
     def attachment_map_from_details(

--- a/plugins/module_utils/orchestrators/network_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/network_attachment_manager.py
@@ -38,6 +38,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_networks.ne
     NetworkAttachmentValidateInterfaceModel,
     NetworkAttachmentValidateInterfacesPayloadModel,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.attachment_vpc_peer_expander import (
+    expand_desired_attachments_with_vpc_peers,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.network_config_utils import (
     configured_network_names,
     deploy_enabled_by_network,
@@ -393,36 +396,17 @@ class NetworkAttachmentManager:
         attachment_details: Any,
     ) -> dict[tuple[str, str], dict[str, Any]]:
         """Add vPC peer attachments from attachment-query rows."""
-        if not desired or not attachment_details:
-            return desired
 
-        detail_by_key: dict[tuple[str, str], dict[str, Any]] = {}
-        for attachment in attachment_details:
-            if not isinstance(attachment, dict):
-                continue
-            network_name = attachment.get("networkName")
-            switch_id = attachment.get("switchId")
-            if network_name and switch_id:
-                detail_by_key[(network_name, switch_id)] = attachment
-
-        expanded = dict(desired)
-        for key, payload in list(desired.items()):
-            detail = detail_by_key.get(key)
-            peer_switch_id = detail.get("peerSwitchId") if detail else None
-            if not peer_switch_id:
-                continue
-
-            peer_key = (key[0], peer_switch_id)
-            if peer_key in expanded:
-                continue
-
-            peer_payload = dict(payload)
-            peer_payload["switchId"] = peer_switch_id
+        def clear_peer_interfaces(peer_payload: dict[str, Any]) -> None:
             if "interfaces" in peer_payload:
                 peer_payload["interfaces"] = []
-            expanded[peer_key] = peer_payload
 
-        return expanded
+        return expand_desired_attachments_with_vpc_peers(
+            desired,
+            attachment_details,
+            "networkName",
+            peer_payload_mutator=clear_peer_interfaces,
+        )
 
     @staticmethod
     def attachment_map_from_details(

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -203,8 +203,10 @@ class NetworkStateMachine:
                 desired=desired_attachments,
                 current_network_names=current_desired_network_names,
                 current=current_desired_attachments,
+                attachment_details=current_attachment_details,
             )
             self._trace("attachment_phase_pre_end", changed=pre_attach.get("changed"), payload_count=len(pre_attach.get("payloads", [])))
+            desired_attachments = pre_attach.get("desired", desired_attachments)
             current_attachments = self._current_after_pre_detach(
                 pre_attach,
                 empty_when_absent=current_desired_network_names == [],
@@ -220,6 +222,25 @@ class NetworkStateMachine:
             if result.get("failed", False):
                 return result
 
+            post_attachment_details = list(current_attachment_details or [])
+            post_current_attachments = dict(current_attachments or {})
+            new_desired_network_names = [network_name for network_name in desired_network_names if network_name not in current_network_name_set]
+            if state in ("replaced", "overridden") and desired_attachments and new_desired_network_names and not self._check_mode():
+                self._trace("attachment_phase_post_new_current_query_start", network_names=new_desired_network_names)
+                new_attachment_details = self.coordinator._current_attachment_details(
+                    module_args,
+                    strategy,
+                    new_desired_network_names,
+                )
+                post_attachment_details.extend(new_attachment_details)
+                post_current_attachments.update(self.coordinator._attachment_map_from_details(new_attachment_details, new_desired_network_names))
+                self._trace(
+                    "attachment_phase_post_new_current_query_end",
+                    network_names=new_desired_network_names,
+                    attachment_count=len(new_attachment_details or []),
+                    current_count=len(post_current_attachments),
+                )
+
             self._trace("attachment_phase_post_start", state=state)
             post_attach = self.coordinator._apply_attachment_phase(
                 module_args,
@@ -227,7 +248,8 @@ class NetworkStateMachine:
                 phase="post",
                 desired=desired_attachments,
                 current_network_names=desired_network_names,
-                current=current_attachments,
+                current=post_current_attachments,
+                attachment_details=post_attachment_details,
             )
             self._trace("attachment_phase_post_end", changed=post_attach.get("changed"), payload_count=len(post_attach.get("payloads", [])))
             self.coordinator._merge_api_trace(result, post_attach)

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -84,8 +84,8 @@ class NetworkStateMachine:
         if state == "deleted":
             return self.run_deleted(module_args, active_strategy)
 
-        if state == "overridden":
-            return self.run_overridden(module_args, active_strategy, defer_deploy)
+        if state in ("replaced", "overridden"):
+            return self._run_state_machine_aware_with_attachments(module_args, active_strategy, defer_deploy)
 
         desired_attachments = None
         desired_network_names = None
@@ -144,6 +144,22 @@ class NetworkStateMachine:
         """
         Run overridden using the state machine's initial current-state query.
         """
+        return self._run_state_machine_aware_with_attachments(module_args, strategy, defer_deploy)
+
+    def _run_state_machine_aware_with_attachments(
+        self,
+        module_args: dict,
+        strategy: BaseNetworkStrategy,
+        defer_deploy: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Run replaced/overridden after deriving current Network names from the state machine.
+
+        The pre-detach phase must only query attachments for Networks that
+        already exist. First-create ``state=replaced`` tasks can then create
+        the Network before the post-attach phase runs.
+        """
+        state = module_args.get("state", "merged")
         config = [dict(network) for network in module_args.get("config") or []]
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_network_names = self.coordinator._configured_network_names(config)
@@ -153,15 +169,15 @@ class NetworkStateMachine:
             current_network_names = self._network_names_from_models(sm.existing)
             current_network_name_set = set(current_network_names)
             desired_network_name_set = set(desired_network_names)
-            omitted_network_names = [network_name for network_name in current_network_names if network_name not in desired_network_name_set]
             current_desired_network_names = [network_name for network_name in desired_network_names if network_name in current_network_name_set]
+            attachment_query_network_names = current_network_names if state == "overridden" else current_desired_network_names
             current_attachment_details = (
                 self.coordinator._current_attachment_details_ignore_missing(
                     module_args,
                     strategy,
-                    current_network_names,
+                    attachment_query_network_names,
                 )
-                if current_network_names
+                if attachment_query_network_names
                 else []
             )
             current_desired_attachments = self.coordinator._attachment_map_from_details(
@@ -169,12 +185,17 @@ class NetworkStateMachine:
                 current_desired_network_names,
             )
 
-            pre_delete_traces = self._prepare_overridden_deletions(
-                module_args,
-                strategy,
-                omitted_network_names,
-                current_attachment_details,
-            )
+            pre_delete_traces: list[dict[str, Any]] = []
+            if state == "overridden":
+                omitted_network_names = [network_name for network_name in current_network_names if network_name not in desired_network_name_set]
+                pre_delete_traces = self._prepare_overridden_deletions(
+                    module_args,
+                    strategy,
+                    omitted_network_names,
+                    current_attachment_details,
+                )
+
+            self._trace("attachment_phase_pre_start", state=state)
             pre_attach = self.coordinator._apply_attachment_phase(
                 module_args,
                 strategy,
@@ -183,12 +204,15 @@ class NetworkStateMachine:
                 current_network_names=current_desired_network_names,
                 current=current_desired_attachments,
             )
+            self._trace("attachment_phase_pre_end", changed=pre_attach.get("changed"), payload_count=len(pre_attach.get("payloads", [])))
             current_attachments = self._current_after_pre_detach(
                 pre_attach,
                 empty_when_absent=current_desired_network_names == [],
             )
 
+            self._trace("manage_state_start", state=state)
             sm.manage_state()
+            self._trace("manage_state_end", state=state)
             result = self.coordinator._format_state_machine_output(sm)
 
             self._prepend_traces(result, pre_delete_traces + [pre_attach])
@@ -196,6 +220,7 @@ class NetworkStateMachine:
             if result.get("failed", False):
                 return result
 
+            self._trace("attachment_phase_post_start", state=state)
             post_attach = self.coordinator._apply_attachment_phase(
                 module_args,
                 strategy,
@@ -204,6 +229,7 @@ class NetworkStateMachine:
                 current_network_names=desired_network_names,
                 current=current_attachments,
             )
+            self._trace("attachment_phase_post_end", changed=post_attach.get("changed"), payload_count=len(post_attach.get("payloads", [])))
             self.coordinator._merge_api_trace(result, post_attach)
 
             return self._deploy_after_attachment_changes(

--- a/plugins/module_utils/orchestrators/network_workflow_coordinator.py
+++ b/plugins/module_utils/orchestrators/network_workflow_coordinator.py
@@ -780,9 +780,10 @@ class NetworkWorkflowCoordinator:
         desired: dict[tuple[str, str], dict[str, Any]] | None = None,
         current_network_names: list[str] | None = None,
         current: dict[tuple[str, str], dict[str, Any]] | None = None,
+        attachment_details: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Attach or detach Networks according to state and phase."""
-        return self.attachments.apply_phase(module_args, strategy, phase, desired, current_network_names, current)
+        return self.attachments.apply_phase(module_args, strategy, phase, desired, current_network_names, current, attachment_details)
 
     def _attachment_map_after_detach(
         self,
@@ -953,6 +954,14 @@ class NetworkWorkflowCoordinator:
     ) -> list[dict[str, Any]]:
         """Compute attach payloads for missing or changed desired attachments."""
         return self.attachments.planned_attach_payloads(current, desired)
+
+    def _expand_desired_attachments_with_vpc_peers(
+        self,
+        desired: dict[tuple[str, str], dict[str, Any]],
+        attachment_details: Any,
+    ) -> dict[tuple[str, str], dict[str, Any]]:
+        """Add vPC peer attachments using existing attachment-query rows."""
+        return self.attachments.expand_desired_attachments_with_vpc_peers(desired, attachment_details)
 
     def _attachment_matches(
         self,

--- a/plugins/module_utils/orchestrators/vrf_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/vrf_attachment_manager.py
@@ -32,6 +32,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.manage_vrfs.vrf_at
     VrfAttachmentModel,
     VrfAttachmentQueryRequestModel,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.attachment_vpc_peer_expander import (
+    expand_desired_attachments_with_vpc_peers,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.strategies.base_vrf import (
     BaseVrfStrategy,
 )
@@ -308,35 +311,7 @@ class VrfAttachmentManager:
         attachment_details: Any,
     ) -> dict[tuple[str, str], dict[str, Any]]:
         """Add vPC peer attachments from existing attachment-query rows."""
-        if not desired or not attachment_details:
-            return desired
-
-        details = list(attachment_details)
-        detail_by_key: dict[tuple[str, str], dict[str, Any]] = {}
-        for attachment in details:
-            if not isinstance(attachment, dict):
-                continue
-            vrf_name = attachment.get("vrfName")
-            switch_id = attachment.get("switchId")
-            if vrf_name and switch_id:
-                detail_by_key[(vrf_name, switch_id)] = attachment
-
-        expanded = dict(desired)
-        for key, payload in list(desired.items()):
-            detail = detail_by_key.get(key)
-            peer_switch_id = detail.get("peerSwitchId") if detail else None
-            if not peer_switch_id:
-                continue
-
-            peer_key = (key[0], peer_switch_id)
-            if peer_key in expanded:
-                continue
-
-            peer_payload = dict(payload)
-            peer_payload["switchId"] = peer_switch_id
-            expanded[peer_key] = peer_payload
-
-        return expanded
+        return expand_desired_attachments_with_vpc_peers(desired, attachment_details, "vrfName")
 
     def resolve_switch_ids(
         self,

--- a/plugins/module_utils/orchestrators/vrf_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/vrf_attachment_manager.py
@@ -86,6 +86,7 @@ class VrfAttachmentManager:
         desired: dict[tuple[str, str], dict[str, Any]] | None = None,
         current_vrf_names: list[str] | None = None,
         current: dict[tuple[str, str], dict[str, Any]] | None = None,
+        attachment_details: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Attach or detach VRFs according to state and phase."""
         state = module_args.get("state", "merged")
@@ -117,20 +118,23 @@ class VrfAttachmentManager:
         query_vrf_names = current_vrf_names
         if query_vrf_names is None:
             query_vrf_names = None if query_all else vrf_names
-        attachment_details = None
+        raw_attachment_details = attachment_details
         if current is None:
-            attachment_details = self.coordinator._current_attachment_details(module_args, strategy, query_vrf_names)
-            current = self.coordinator._attachment_map_from_details(attachment_details)
+            if raw_attachment_details is None:
+                raw_attachment_details = self.coordinator._current_attachment_details(module_args, strategy, query_vrf_names)
+            current = self.coordinator._attachment_map_from_details(raw_attachment_details)
             self._trace(
                 "vrf_attachment_current_loaded",
                 phase=phase,
                 queried_vrf_names=query_vrf_names,
-                attachment_count=len(attachment_details or []),
+                attachment_count=len(raw_attachment_details or []),
                 current_count=len(current),
             )
 
         if desired:
-            desired = self.coordinator._expand_desired_attachments_with_vpc_peers(desired, attachment_details or current.values())
+            desired = self.coordinator._expand_desired_attachments_with_vpc_peers(
+                desired, raw_attachment_details if raw_attachment_details is not None else current.values()
+            )
             self._trace("vrf_attachment_desired_expanded", phase=phase, desired_count=len(desired))
 
         if phase == "pre":
@@ -159,6 +163,7 @@ class VrfAttachmentManager:
         trace["current"] = current
         trace["payloads"] = payloads
         trace["desired"] = desired
+        trace["attachment_details"] = raw_attachment_details
         return trace
 
     def attachment_map_after_detach(

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -84,16 +84,11 @@ class VrfStateMachine:
         if state == "deleted":
             return self.run_deleted(module_args, active_strategy)
 
-        if state == "overridden":
-            return self.run_overridden(module_args, active_strategy, defer_deploy)
+        if state in ("replaced", "overridden"):
+            return self._run_state_machine_aware_with_attachments(module_args, active_strategy, defer_deploy)
 
         desired_attachments = None
         desired_vrf_names = None
-        if state in ("replaced", "overridden"):
-            desired_attachments = self.coordinator._desired_attachment_map(
-                module_args,
-                active_strategy,
-            )
 
         self._trace("attachment_phase_pre_start", state=state)
         pre_attach = self.coordinator._apply_attachment_phase(
@@ -145,6 +140,22 @@ class VrfStateMachine:
         """
         Run overridden using the state machine's initial current-state query.
         """
+        return self._run_state_machine_aware_with_attachments(module_args, strategy, defer_deploy)
+
+    def _run_state_machine_aware_with_attachments(
+        self,
+        module_args: dict,
+        strategy: BaseVrfStrategy,
+        defer_deploy: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Run replaced/overridden after deriving current VRF names from the state machine.
+
+        The pre-detach phase must only query attachments for VRFs that already
+        exist. First-create ``state=replaced`` tasks can then create the VRF
+        before the post-attach phase runs.
+        """
+        state = module_args.get("state", "merged")
         config = module_args.get("config") or []
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_vrf_names = self.coordinator._configured_vrf_names(config)
@@ -154,15 +165,15 @@ class VrfStateMachine:
             current_vrf_names = self._vrf_names_from_models(sm.existing)
             current_vrf_name_set = set(current_vrf_names)
             desired_vrf_name_set = set(desired_vrf_names)
-            omitted_vrf_names = [vrf_name for vrf_name in current_vrf_names if vrf_name not in desired_vrf_name_set]
             current_desired_vrf_names = [vrf_name for vrf_name in desired_vrf_names if vrf_name in current_vrf_name_set]
+            attachment_query_vrf_names = current_vrf_names if state == "overridden" else current_desired_vrf_names
             current_attachment_details = (
                 self.coordinator._current_attachment_details_ignore_missing(
                     module_args,
                     strategy,
-                    current_vrf_names,
+                    attachment_query_vrf_names,
                 )
-                if current_vrf_names
+                if attachment_query_vrf_names
                 else []
             )
             current_desired_attachments = self.coordinator._attachment_map_from_details(
@@ -170,13 +181,17 @@ class VrfStateMachine:
                 current_desired_vrf_names,
             )
 
-            pre_delete_traces = self._prepare_overridden_deletions(
-                module_args,
-                strategy,
-                omitted_vrf_names,
-                current_attachment_details,
-            )
-            self._trace("attachment_phase_pre_start", state="overridden")
+            pre_delete_traces: list[dict[str, Any]] = []
+            if state == "overridden":
+                omitted_vrf_names = [vrf_name for vrf_name in current_vrf_names if vrf_name not in desired_vrf_name_set]
+                pre_delete_traces = self._prepare_overridden_deletions(
+                    module_args,
+                    strategy,
+                    omitted_vrf_names,
+                    current_attachment_details,
+                )
+
+            self._trace("attachment_phase_pre_start", state=state)
             pre_attach = self.coordinator._apply_attachment_phase(
                 module_args,
                 strategy,
@@ -192,9 +207,9 @@ class VrfStateMachine:
                 empty_when_absent=current_desired_vrf_names == [],
             )
 
-            self._trace("manage_state_start", state="overridden")
+            self._trace("manage_state_start", state=state)
             sm.manage_state()
-            self._trace("manage_state_end", state="overridden")
+            self._trace("manage_state_end", state=state)
             result = self.coordinator._format_state_machine_output(sm)
 
             self._prepend_traces(result, pre_delete_traces + [pre_attach])
@@ -202,7 +217,7 @@ class VrfStateMachine:
             if result.get("failed", False):
                 return result
 
-            self._trace("attachment_phase_post_start", state="overridden")
+            self._trace("attachment_phase_post_start", state=state)
             post_attach = self.coordinator._apply_attachment_phase(
                 module_args,
                 strategy,

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -199,6 +199,7 @@ class VrfStateMachine:
                 desired=desired_attachments,
                 current_vrf_names=current_desired_vrf_names,
                 current=current_desired_attachments,
+                attachment_details=current_attachment_details,
             )
             self._trace("attachment_phase_pre_end", changed=pre_attach.get("changed"), payload_count=len(pre_attach.get("payloads", [])))
             desired_attachments = pre_attach.get("desired", desired_attachments)
@@ -217,6 +218,25 @@ class VrfStateMachine:
             if result.get("failed", False):
                 return result
 
+            post_attachment_details = list(current_attachment_details or [])
+            post_current_attachments = dict(current_attachments or {})
+            new_desired_vrf_names = [vrf_name for vrf_name in desired_vrf_names if vrf_name not in current_vrf_name_set]
+            if state in ("replaced", "overridden") and desired_attachments and new_desired_vrf_names and not self._check_mode():
+                self._trace("attachment_phase_post_new_current_query_start", vrf_names=new_desired_vrf_names)
+                new_attachment_details = self.coordinator._current_attachment_details(
+                    module_args,
+                    strategy,
+                    new_desired_vrf_names,
+                )
+                post_attachment_details.extend(new_attachment_details)
+                post_current_attachments.update(self.coordinator._attachment_map_from_details(new_attachment_details, new_desired_vrf_names))
+                self._trace(
+                    "attachment_phase_post_new_current_query_end",
+                    vrf_names=new_desired_vrf_names,
+                    attachment_count=len(new_attachment_details or []),
+                    current_count=len(post_current_attachments),
+                )
+
             self._trace("attachment_phase_post_start", state=state)
             post_attach = self.coordinator._apply_attachment_phase(
                 module_args,
@@ -224,7 +244,8 @@ class VrfStateMachine:
                 phase="post",
                 desired=desired_attachments,
                 current_vrf_names=desired_vrf_names,
-                current=current_attachments,
+                current=post_current_attachments,
+                attachment_details=post_attachment_details,
             )
             self._trace("attachment_phase_post_end", changed=post_attach.get("changed"), payload_count=len(post_attach.get("payloads", [])))
             self.coordinator._merge_api_trace(result, post_attach)

--- a/plugins/module_utils/orchestrators/vrf_workflow_coordinator.py
+++ b/plugins/module_utils/orchestrators/vrf_workflow_coordinator.py
@@ -830,9 +830,10 @@ class VrfWorkflowCoordinator:
         desired: dict[tuple[str, str], dict[str, Any]] | None = None,
         current_vrf_names: list[str] | None = None,
         current: dict[tuple[str, str], dict[str, Any]] | None = None,
+        attachment_details: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Attach or detach VRFs according to state and phase."""
-        return self.attachments.apply_phase(module_args, strategy, phase, desired, current_vrf_names, current)
+        return self.attachments.apply_phase(module_args, strategy, phase, desired, current_vrf_names, current, attachment_details)
 
     def _attachment_map_after_detach(
         self,

--- a/tests/unit/module_utils/orchestrators/test_attachment_vpc_peer_expander.py
+++ b/tests/unit/module_utils/orchestrators/test_attachment_vpc_peer_expander.py
@@ -1,0 +1,93 @@
+# Copyright: (c) 2026, Akshayanat C S (@achengam) <achengam@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for shared attachment vPC peer expansion helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.attachment_vpc_peer_expander import (
+    expand_desired_attachments_with_vpc_peers,
+)
+
+
+def test_expand_desired_attachments_with_vpc_peers_adds_missing_peer() -> None:
+    desired = {
+        ("BLUE", "SERIAL1"): {
+            "vrfName": "BLUE",
+            "switchId": "SERIAL1",
+            "attach": True,
+        }
+    }
+    attachment_details = [
+        {
+            "vrfName": "BLUE",
+            "switchId": "SERIAL1",
+            "peerSwitchId": "SERIAL2",
+            "attach": False,
+        }
+    ]
+
+    expanded = expand_desired_attachments_with_vpc_peers(desired, attachment_details, "vrfName")
+
+    assert expanded == {
+        ("BLUE", "SERIAL1"): {
+            "vrfName": "BLUE",
+            "switchId": "SERIAL1",
+            "attach": True,
+        },
+        ("BLUE", "SERIAL2"): {
+            "vrfName": "BLUE",
+            "switchId": "SERIAL2",
+            "attach": True,
+        },
+    }
+
+
+def test_expand_desired_attachments_with_vpc_peers_applies_peer_payload_mutator() -> None:
+    desired = {
+        ("BLUE_NET", "SERIAL1"): {
+            "networkName": "BLUE_NET",
+            "switchId": "SERIAL1",
+            "interfaces": [{"interfaceRange": "Ethernet1/1", "mode": "trunk"}],
+            "attach": True,
+        }
+    }
+    attachment_details = [
+        {
+            "networkName": "BLUE_NET",
+            "switchId": "SERIAL1",
+            "peerSwitchId": "SERIAL2",
+            "attach": False,
+        }
+    ]
+
+    def clear_interfaces(peer_payload: dict[str, Any]) -> None:
+        peer_payload["interfaces"] = []
+
+    expanded = expand_desired_attachments_with_vpc_peers(
+        desired,
+        attachment_details,
+        "networkName",
+        peer_payload_mutator=clear_interfaces,
+    )
+
+    assert expanded[("BLUE_NET", "SERIAL2")] == {
+        "networkName": "BLUE_NET",
+        "switchId": "SERIAL2",
+        "interfaces": [],
+        "attach": True,
+    }
+
+
+def test_expand_desired_attachments_with_vpc_peers_preserves_existing_peer_payload() -> None:
+    desired = {
+        ("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True},
+        ("BLUE", "SERIAL2"): {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": True, "vlanId": 2001},
+    }
+    attachment_details = [{"vrfName": "BLUE", "switchId": "SERIAL1", "peerSwitchId": "SERIAL2"}]
+
+    expanded = expand_desired_attachments_with_vpc_peers(desired, attachment_details, "vrfName")
+
+    assert expanded == desired

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -2108,6 +2108,37 @@ def test_network_check_mode_attachment_phase_returns_planned_payload():
     ]
 
 
+def test_network_workflow_coordinator_apply_attachment_phase_forwards_attachment_details():
+    module_args = {"state": "replaced", "config": []}
+    strategy = _orchestrator().strategy
+    coordinator = NetworkWorkflowCoordinator(module=_Module(module_args), strategy=strategy)
+    desired = {("BLUE_NET", "SERIAL1"): {"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": True}}
+    current = {("BLUE_NET", "SERIAL2"): {"networkName": "BLUE_NET", "switchId": "SERIAL2", "attach": True}}
+    attachment_details = [{"networkName": "BLUE_NET", "switchId": "SERIAL1", "peerSwitchId": "SERIAL2", "attach": False}]
+    calls = []
+
+    class Attachments:
+        @staticmethod
+        def apply_phase(module_args, strategy, phase, desired, current_network_names, current, attachment_details):
+            calls.append((module_args, strategy, phase, desired, current_network_names, current, attachment_details))
+            return {"attachment_details": attachment_details}
+
+    object.__setattr__(coordinator, "_attachments", Attachments())
+
+    trace = coordinator._apply_attachment_phase(
+        module_args,
+        strategy,
+        phase="post",
+        desired=desired,
+        current_network_names=["BLUE_NET"],
+        current=current,
+        attachment_details=attachment_details,
+    )
+
+    assert trace == {"attachment_details": attachment_details}
+    assert calls == [(module_args, strategy, "post", desired, ["BLUE_NET"], current, attachment_details)]
+
+
 def test_network_attachment_post_validates_interfaces_before_attach():
     calls = []
 

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -89,6 +89,86 @@ class _ParentStrategy:
         }
 
 
+class _FakeStateMachine:
+    existing = []
+
+    def __init__(self, calls):
+        self.calls = calls
+
+    def manage_state(self):
+        self.calls.append(("manage_state",))
+
+
+class _ReplacedNetworkCoordinator:
+    def __init__(self):
+        self.module = _Module({"state": "replaced"})
+        self.calls = []
+        self.state_machine = _FakeStateMachine(self.calls)
+
+    @staticmethod
+    def _desired_attachment_map(_module_args, _strategy):
+        return {("BLUE_NET", "SW1"): {"networkName": "BLUE_NET", "switchId": "SW1", "attach": True}}
+
+    @staticmethod
+    def _configured_network_names(_config):
+        return ["BLUE_NET"]
+
+    @staticmethod
+    def _deploy_enabled_by_network(_config):
+        return {"BLUE_NET": True}
+
+    def _new_state_machine(self, _module_args, _strategy):
+        self.calls.append(("new_state_machine",))
+        return self.state_machine, "original-config", "original-state"
+
+    def _current_attachment_details_ignore_missing(self, *_args, **_kwargs):
+        raise AssertionError("first-create replaced must not query missing Network attachments")
+
+    @staticmethod
+    def _attachment_map_from_details(_attachments, _network_names):
+        return {}
+
+    def _apply_attachment_phase(self, _module_args, _strategy, phase, desired=None, current_network_names=None, current=None):
+        self.calls.append((phase, current_network_names, current))
+        if phase == "pre":
+            assert current_network_names == []
+            assert current == {}
+            return {"current": current, "payloads": [], "desired": desired, "deploy_targets": {}}
+        assert phase == "post"
+        assert current_network_names == ["BLUE_NET"]
+        assert current == {}
+        return {"payloads": [desired[("BLUE_NET", "SW1")]], "deploy_targets": {"BLUE_NET": {"SW1"}}}
+
+    @staticmethod
+    def _attachment_map_after_detach(current, _payloads):
+        return current
+
+    @staticmethod
+    def _format_state_machine_output(_state_machine):
+        return {"changed": True, "failed": False, "after": [{"network_name": "BLUE_NET"}]}
+
+    @staticmethod
+    def _merge_api_trace(result, trace, prepend=False):
+        if prepend:
+            result.setdefault("prepended", []).append(trace)
+        if trace.get("changed"):
+            result["changed"] = True
+
+    @staticmethod
+    def _build_deploy_payloads(_config, *_target_maps):
+        return []
+
+    @staticmethod
+    def _build_pending_network_deploy_payloads(_result, _config, _module_args, _strategy):
+        return []
+
+    def _restore_state_machine_params(self, original_config, original_state):
+        self.calls.append(("restore", original_config, original_state))
+
+    def _trace(self, event, **_details):
+        self.calls.append(("trace", event))
+
+
 def _orchestrator():
     strategy = StandaloneNetworkStrategy(
         fabric_name="fab1",
@@ -98,6 +178,40 @@ def _orchestrator():
         rest_send=RestSend({"state": "merged", "config": [], "check_mode": False}),
         strategy=strategy,
     )
+
+
+def test_network_replaced_first_create_with_attachment_skips_missing_pre_query():
+    """
+    # Summary
+
+    Verify first-create state=replaced does not query attachments for a Network
+    that is absent before CRUD creation.
+    """
+    coordinator = _ReplacedNetworkCoordinator()
+    state_machine = NetworkStateMachine(coordinator)
+
+    result = state_machine.run(
+        {
+            "state": "replaced",
+            "config": [
+                {
+                    "network_name": "BLUE_NET",
+                    "attach": [
+                        {
+                            "ip_address": "192.0.2.10",
+                            "interfaces": [{"interface_range": "Ethernet1/1", "mode": "trunk"}],
+                        }
+                    ],
+                }
+            ],
+        },
+        StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"}),
+    )
+
+    assert result["changed"] is True
+    assert ("pre", [], {}) in coordinator.calls
+    assert ("manage_state",) in coordinator.calls
+    assert ("post", ["BLUE_NET"], {}) in coordinator.calls
 
 
 def test_network_workflow_coordinator_resolves_strategy_with_gen3_restsend():

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -104,6 +104,20 @@ class _ReplacedNetworkCoordinator:
         self.module = _Module({"state": "replaced"})
         self.calls = []
         self.state_machine = _FakeStateMachine(self.calls)
+        self.post_attachment_details = [
+            {
+                "networkName": "BLUE_NET",
+                "switchId": "SW1",
+                "peerSwitchId": "SW2",
+                "attach": False,
+            },
+            {
+                "networkName": "BLUE_NET",
+                "switchId": "SW2",
+                "peerSwitchId": "SW1",
+                "attach": False,
+            },
+        ]
 
     @staticmethod
     def _desired_attachment_map(_module_args, _strategy):
@@ -125,19 +139,38 @@ class _ReplacedNetworkCoordinator:
         raise AssertionError("first-create replaced must not query missing Network attachments")
 
     @staticmethod
-    def _attachment_map_from_details(_attachments, _network_names):
-        return {}
+    def _attachment_map_from_details(attachments, network_names=None):
+        return NetworkAttachmentManager.attachment_map_from_details(attachments, network_names)
 
-    def _apply_attachment_phase(self, _module_args, _strategy, phase, desired=None, current_network_names=None, current=None):
-        self.calls.append((phase, current_network_names, current))
+    def _current_attachment_details(self, _module_args, _strategy, network_names):
+        self.calls.append(("post_query", network_names))
+        return list(self.post_attachment_details)
+
+    def _apply_attachment_phase(
+        self,
+        _module_args,
+        _strategy,
+        phase,
+        desired=None,
+        current_network_names=None,
+        current=None,
+        attachment_details=None,
+    ):
+        self.calls.append((phase, current_network_names, current, attachment_details))
         if phase == "pre":
             assert current_network_names == []
             assert current == {}
+            assert attachment_details == []
             return {"current": current, "payloads": [], "desired": desired, "deploy_targets": {}}
         assert phase == "post"
         assert current_network_names == ["BLUE_NET"]
         assert current == {}
-        return {"payloads": [desired[("BLUE_NET", "SW1")]], "deploy_targets": {"BLUE_NET": {"SW1"}}}
+        assert attachment_details == self.post_attachment_details
+        desired = NetworkAttachmentManager.expand_desired_attachments_with_vpc_peers(desired, attachment_details)
+        return {
+            "payloads": [desired[("BLUE_NET", "SW1")], desired[("BLUE_NET", "SW2")]],
+            "deploy_targets": {"BLUE_NET": {"SW1", "SW2"}},
+        }
 
     @staticmethod
     def _attachment_map_after_detach(current, _payloads):
@@ -209,9 +242,91 @@ def test_network_replaced_first_create_with_attachment_skips_missing_pre_query()
     )
 
     assert result["changed"] is True
-    assert ("pre", [], {}) in coordinator.calls
+    assert ("pre", [], {}, []) in coordinator.calls
     assert ("manage_state",) in coordinator.calls
-    assert ("post", ["BLUE_NET"], {}) in coordinator.calls
+    assert ("post_query", ["BLUE_NET"]) in coordinator.calls
+    assert ("post", ["BLUE_NET"], {}, coordinator.post_attachment_details) in coordinator.calls
+
+
+def test_network_attachment_manager_expands_desired_vpc_peer_with_empty_interfaces():
+    desired = {
+        ("BLUE_NET", "SW1"): {
+            "networkName": "BLUE_NET",
+            "switchId": "SW1",
+            "vlanId": 3001,
+            "interfaces": [{"interfaceRange": "Ethernet1/29", "mode": "trunk"}],
+            "attach": True,
+        },
+        ("BLUE_NET", "SW3"): {
+            "networkName": "BLUE_NET",
+            "switchId": "SW3",
+            "vlanId": 3001,
+            "interfaces": [{"interfaceRange": "Ethernet1/29", "mode": "trunk"}],
+            "attach": True,
+        },
+    }
+    attachment_details = [
+        {"networkName": "BLUE_NET", "switchId": "SW1", "peerSwitchId": "SW2", "attach": False},
+        {"networkName": "BLUE_NET", "switchId": "SW2", "peerSwitchId": "SW1", "attach": False},
+        {"networkName": "BLUE_NET", "switchId": "SW3", "attach": False},
+    ]
+
+    expanded = NetworkAttachmentManager.expand_desired_attachments_with_vpc_peers(desired, attachment_details)
+
+    assert sorted(expanded) == [
+        ("BLUE_NET", "SW1"),
+        ("BLUE_NET", "SW2"),
+        ("BLUE_NET", "SW3"),
+    ]
+    assert expanded[("BLUE_NET", "SW2")] == {
+        "networkName": "BLUE_NET",
+        "switchId": "SW2",
+        "vlanId": 3001,
+        "interfaces": [],
+        "attach": True,
+    }
+
+
+def test_network_attachment_replaced_pre_phase_keeps_controller_added_vpc_peer():
+    class Module:
+        check_mode = False
+
+    class Coordinator:
+        module = Module()
+
+        def __init__(self):
+            self.posted_payloads = []
+
+        @staticmethod
+        def _new_network_orchestrator(_module_args, _strategy):
+            raise AssertionError("idempotent pre-phase must not post attachments")
+
+    manager = NetworkAttachmentManager(coordinator=Coordinator())
+    current = {
+        ("BLUE_NET", "SW1"): {"networkName": "BLUE_NET", "switchId": "SW1", "peerSwitchId": "SW2", "attach": True},
+        ("BLUE_NET", "SW2"): {"networkName": "BLUE_NET", "switchId": "SW2", "peerSwitchId": "SW1", "attach": True},
+        ("BLUE_NET", "SW3"): {"networkName": "BLUE_NET", "switchId": "SW3", "attach": True},
+    }
+    desired = {
+        ("BLUE_NET", "SW1"): {"networkName": "BLUE_NET", "switchId": "SW1", "attach": True},
+        ("BLUE_NET", "SW3"): {"networkName": "BLUE_NET", "switchId": "SW3", "attach": True},
+    }
+    attachment_details = list(current.values())
+
+    trace = manager.apply_phase(
+        {
+            "state": "replaced",
+            "config": [{"network_name": "BLUE_NET"}],
+        },
+        StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"}),
+        phase="pre",
+        desired=desired,
+        current_network_names=["BLUE_NET"],
+        current=current,
+        attachment_details=attachment_details,
+    )
+
+    assert trace == {"current": current}
 
 
 def test_network_workflow_coordinator_resolves_strategy_with_gen3_restsend():
@@ -2091,7 +2206,7 @@ def test_network_merged_runs_post_attach_and_deploy_for_desired_attachment():
                 }
             }
 
-        def _apply_attachment_phase(self, module_args, strategy, phase, desired=None, current_network_names=None, current=None):
+        def _apply_attachment_phase(self, module_args, strategy, phase, desired=None, current_network_names=None, current=None, attachment_details=None):
             self.calls.append(("phase", phase, desired, current))
             if phase == "pre":
                 return {}
@@ -2234,7 +2349,7 @@ def test_network_state_machine_idempotent_run_deploys_pending_attach():
                 }
             }
 
-        def _apply_attachment_phase(self, module_args, strategy, phase, desired=None, current_network_names=None, current=None):
+        def _apply_attachment_phase(self, module_args, strategy, phase, desired=None, current_network_names=None, current=None, attachment_details=None):
             return {"current": {}} if phase == "pre" else {}
 
         def _attachment_map_after_detach(self, current, payloads):

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -217,10 +217,14 @@ class _AttachmentQueryOrchestrator:
         return self.responses.pop(0)
 
 
-class _FakeStateMachine:
-    existing = []
+class _ExistingVrf:
+    def __init__(self, vrf_name):
+        self.vrf_name = vrf_name
 
-    def __init__(self, calls):
+
+class _FakeStateMachine:
+    def __init__(self, calls, existing=None):
+        self.existing = existing or []
         self.calls = calls
 
     def manage_state(self):
@@ -228,44 +232,74 @@ class _FakeStateMachine:
 
 
 class _ReplacedVrfCoordinator:
-    def __init__(self):
-        self.module = _Module({"state": "replaced"}, check_mode=False)
+    def __init__(self, existing=None, initial_attachment_details=None, post_attachment_details=None, check_mode=False):
+        self.module = _Module({"state": "replaced"}, check_mode=check_mode)
         self.calls = []
-        self.state_machine = _FakeStateMachine(self.calls)
+        self.attachments = VrfAttachmentManager(self)
+        self.initial_attachment_details = initial_attachment_details or []
+        self.post_attachment_details = post_attachment_details or []
+        self.state_machine = _FakeStateMachine(self.calls, existing=existing)
+        self.posted_payloads = []
 
     @staticmethod
-    def _desired_attachment_map(_module_args, _strategy):
-        return {("BLUE", "SW1"): {"vrfName": "BLUE", "switchId": "SW1", "attach": True}}
+    def _desired_attachment_map(module_args, _strategy):
+        desired = {}
+        for vrf in module_args.get("config") or []:
+            vrf_name = vrf.get("vrf_name")
+            for attachment in vrf.get("attach") or []:
+                switch_id = attachment.get("switch_id")
+                desired[(vrf_name, switch_id)] = {"vrfName": vrf_name, "switchId": switch_id, "attach": True}
+        return desired
 
     @staticmethod
-    def _configured_vrf_names(_config):
-        return ["BLUE"]
+    def _configured_vrf_names(config):
+        return [vrf["vrf_name"] for vrf in config]
 
     def _new_state_machine(self, _module_args, _strategy):
         self.calls.append(("new_state_machine",))
         return self.state_machine, "original-config", "original-state"
 
-    def _current_attachment_details_ignore_missing(self, *_args, **_kwargs):
-        raise AssertionError("first-create replaced must not query missing VRF attachments")
+    def _current_attachment_details_ignore_missing(self, _module_args, _strategy, vrf_names):
+        self.calls.append(("initial_query", vrf_names))
+        return list(self.initial_attachment_details)
 
     @staticmethod
-    def _attachment_map_from_details(_attachments, _vrf_names):
-        return {}
+    def _attachment_map_from_details(attachments, vrf_names=None):
+        return VrfAttachmentManager.attachment_map_from_details(attachments, vrf_names)
 
-    def _apply_attachment_phase(self, _module_args, _strategy, phase, desired=None, current_vrf_names=None, current=None):
-        self.calls.append((phase, current_vrf_names, current))
-        if phase == "pre":
-            assert current_vrf_names == []
-            assert current == {}
-            return {"current": current, "payloads": [], "desired": desired, "deploy_targets": {}}
-        assert phase == "post"
-        assert current_vrf_names == ["BLUE"]
-        assert current == {}
-        return {"payloads": [desired[("BLUE", "SW1")]], "deploy_targets": {"BLUE": {"SW1"}}}
+    def _current_attachment_details(self, _module_args, _strategy, vrf_names):
+        self.calls.append(("post_query", vrf_names))
+        return list(self.post_attachment_details)
+
+    def _apply_attachment_phase(self, module_args, strategy, phase, desired=None, current_vrf_names=None, current=None, attachment_details=None):
+        trace = self.attachments.apply_phase(module_args, strategy, phase, desired, current_vrf_names, current, attachment_details)
+        self.calls.append((phase, current_vrf_names, trace.get("current"), trace.get("desired")))
+        return trace
 
     @staticmethod
-    def _attachment_map_after_detach(current, _payloads):
-        return current
+    def _expand_desired_attachments_with_vpc_peers(desired, attachment_details):
+        return VrfAttachmentManager.expand_desired_attachments_with_vpc_peers(desired, attachment_details)
+
+    def _planned_detach_payloads(self, state, config, current, desired):
+        return self.attachments.planned_detach_payloads(state, config, current, desired)
+
+    def _planned_attach_payloads(self, current, desired):
+        return self.attachments.planned_attach_payloads(current, desired)
+
+    def _attachment_map_after_detach(self, current, payloads):
+        return self.attachments.attachment_map_after_detach(current, payloads)
+
+    @staticmethod
+    def _attachment_matches(existing, desired):
+        return VrfAttachmentManager.attachment_matches(existing, desired)
+
+    @staticmethod
+    def _record_deploy_target(deploy_targets, vrf_name, switch_id):
+        VrfAttachmentManager.record_deploy_target(deploy_targets, vrf_name, switch_id)
+
+    def _post_vrf_attachments(self, _module_args, _strategy, payloads, deploy_targets, operation_type):
+        self.posted_payloads.append({"payloads": payloads, "deploy_targets": deploy_targets, "operation_type": operation_type})
+        return {"changed": bool(payloads), "failed": False, "payloads": payloads, "deploy_targets": deploy_targets}
 
     @staticmethod
     def _format_state_machine_output(_state_machine):
@@ -293,6 +327,25 @@ class _ReplacedVrfCoordinator:
         self.calls.append(("trace", event))
 
 
+def _unattached_vpc_attachment_rows(vrf_name="BLUE", switch_id="SERIAL1", peer_switch_id="SERIAL2"):
+    return [
+        {
+            "vrfName": vrf_name,
+            "switchId": switch_id,
+            "peerSwitchId": peer_switch_id,
+            "attach": False,
+            "status": "notApplicable",
+        },
+        {
+            "vrfName": vrf_name,
+            "switchId": peer_switch_id,
+            "peerSwitchId": switch_id,
+            "attach": False,
+            "status": "notApplicable",
+        },
+    ]
+
+
 def test_vrf_replaced_first_create_with_attachment_skips_missing_pre_query():
     """
     # Summary
@@ -300,18 +353,116 @@ def test_vrf_replaced_first_create_with_attachment_skips_missing_pre_query():
     Verify first-create state=replaced does not query attachments for a VRF
     that is absent before CRUD creation.
     """
-    coordinator = _ReplacedVrfCoordinator()
+    coordinator = _ReplacedVrfCoordinator(post_attachment_details=_unattached_vpc_attachment_rows())
     state_machine = VrfStateMachine(coordinator)
 
     result = state_machine.run(
-        {"state": "replaced", "config": [{"vrf_name": "BLUE", "attach": [{"ip_address": "192.0.2.10"}]}]},
+        {"state": "replaced", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
         _StandaloneStrategy(),
     )
 
     assert result["changed"] is True
-    assert ("pre", [], {}) in coordinator.calls
+    assert ("initial_query", []) not in coordinator.calls
+    assert ("post_query", ["BLUE"]) in coordinator.calls
     assert ("manage_state",) in coordinator.calls
-    assert ("post", ["BLUE"], {}) in coordinator.calls
+    assert coordinator.posted_payloads[-1]["payloads"] == [
+        {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True},
+        {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": True},
+    ]
+
+
+def test_vrf_replaced_existing_unattached_vpc_expands_peer_from_raw_rows():
+    """
+    # Summary
+
+    Verify state=replaced preserves attach=false vPC query rows for existing
+    VRFs so one selected vPC member expands to both peers.
+    """
+    coordinator = _ReplacedVrfCoordinator(
+        existing=[_ExistingVrf("BLUE")],
+        initial_attachment_details=_unattached_vpc_attachment_rows(),
+    )
+    state_machine = VrfStateMachine(coordinator)
+
+    result = state_machine.run(
+        {"state": "replaced", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
+        _StandaloneStrategy(),
+    )
+
+    assert result["changed"] is True
+    assert ("initial_query", ["BLUE"]) in coordinator.calls
+    assert ("post_query", ["BLUE"]) not in coordinator.calls
+    assert coordinator.posted_payloads[-1]["payloads"] == [
+        {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True},
+        {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": True},
+    ]
+
+
+def test_vrf_replaced_mixed_existing_and_new_vpc_expands_all_peers():
+    """
+    # Summary
+
+    Verify mixed replaced input combines pre-CRUD raw rows for existing VRFs
+    with post-CRUD raw rows for newly-created VRFs.
+    """
+    coordinator = _ReplacedVrfCoordinator(
+        existing=[_ExistingVrf("BLUE")],
+        initial_attachment_details=_unattached_vpc_attachment_rows(),
+        post_attachment_details=_unattached_vpc_attachment_rows("GREEN", "SERIAL3", "SERIAL4"),
+    )
+    state_machine = VrfStateMachine(coordinator)
+
+    result = state_machine.run(
+        {
+            "state": "replaced",
+            "config": [
+                {"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]},
+                {"vrf_name": "GREEN", "attach": [{"switch_id": "SERIAL3"}]},
+            ],
+        },
+        _StandaloneStrategy(),
+    )
+
+    assert result["changed"] is True
+    assert ("initial_query", ["BLUE"]) in coordinator.calls
+    assert ("post_query", ["GREEN"]) in coordinator.calls
+    assert coordinator.posted_payloads[-1]["payloads"] == [
+        {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True},
+        {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": True},
+        {"vrfName": "GREEN", "switchId": "SERIAL3", "attach": True},
+        {"vrfName": "GREEN", "switchId": "SERIAL4", "attach": True},
+    ]
+    assert coordinator.posted_payloads[-1]["deploy_targets"] == {
+        "BLUE": {"SERIAL1", "SERIAL2"},
+        "GREEN": {"SERIAL3", "SERIAL4"},
+    }
+
+
+def test_vrf_replaced_check_mode_existing_unattached_vpc_expands_peer_from_raw_rows():
+    """
+    # Summary
+
+    Verify check mode keeps existing vPC peer expansion when current attachment
+    rows are attach=false.
+    """
+    coordinator = _ReplacedVrfCoordinator(
+        existing=[_ExistingVrf("BLUE")],
+        initial_attachment_details=_unattached_vpc_attachment_rows(),
+        check_mode=True,
+    )
+    state_machine = VrfStateMachine(coordinator)
+
+    result = state_machine.run(
+        {"state": "replaced", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
+        _StandaloneStrategy(),
+    )
+
+    assert result["changed"] is True
+    assert ("post_query", ["BLUE"]) not in coordinator.calls
+    assert coordinator.posted_payloads[-1]["payloads"] == [
+        {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True},
+        {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": True},
+    ]
 
 
 def test_vrf_attachment_query_chunks_large_vrf_name_sets():
@@ -2150,12 +2301,13 @@ def test_vrf_workflow_coordinator_attachment_207_failure_fails_fast():
         manager._raise_on_attachment_failures(response)
 
 
-def test_vrf_workflow_coordinator_00085_overridden_new_vrf_does_not_query_missing_attachments():
+def test_vrf_workflow_coordinator_00085_overridden_new_vrf_queries_attachments_after_create():
     """
     # Summary
 
     Verify overridden can replace old VRFs with a brand-new attached VRF
-    without querying attachments for the new VRF before it exists on ND.
+    without querying attachments for the new VRF before it exists on ND, then
+    query after CRUD to preserve vPC peer expansion metadata.
     """
     module_args = {
         "fabric_name": "msd_p",
@@ -2195,6 +2347,11 @@ def test_vrf_workflow_coordinator_00085_overridden_new_vrf_does_not_query_missin
         assert vrf_names == ["ansible-old-vrf"]
         return []
 
+    def new_attachment_details(_args, _strategy, vrf_names=None):
+        call_order.append("query_new_attachments")
+        assert vrf_names == ["ansible-new-vrf"]
+        return _unattached_vpc_attachment_rows("ansible-new-vrf", "SERIAL1", "SERIAL2")
+
     def detach(_args, _strategy, vrf_names=None, attachment_details=None):
         call_order.append("detach")
         assert vrf_names == ["ansible-old-vrf"]
@@ -2232,6 +2389,7 @@ def test_vrf_workflow_coordinator_00085_overridden_new_vrf_does_not_query_missin
     )
     object.__setattr__(coordinator, "_new_state_machine", new_state_machine)
     object.__setattr__(coordinator, "_current_attachment_details_ignore_missing", attachment_details)
+    object.__setattr__(coordinator, "_current_attachment_details", new_attachment_details)
     object.__setattr__(coordinator, "_apply_deleted_attachment_phase", detach)
     object.__setattr__(coordinator, "_current_attachment_map", fail_current_attachment_query)
     object.__setattr__(
@@ -2253,13 +2411,18 @@ def test_vrf_workflow_coordinator_00085_overridden_new_vrf_does_not_query_missin
 
     result = coordinator._run_state_machine_with_attachments(dict(module_args))
 
-    assert call_order == ["query_attachments", "detach", "state_machine", "post_attach"]
+    assert call_order == ["query_attachments", "detach", "state_machine", "query_new_attachments", "post_attach"]
     assert posted["payloads"] == [
         {
             "vrfName": "ansible-new-vrf",
             "switchId": "SERIAL1",
             "attach": True,
-        }
+        },
+        {
+            "vrfName": "ansible-new-vrf",
+            "switchId": "SERIAL2",
+            "attach": True,
+        },
     ]
     assert posted["deploy_targets"] == {}
     assert result["changed"] is True

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -22,6 +22,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vrf_workflo
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vrf_attachment_manager import (
     VrfAttachmentManager,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vrf_state_machine import (
+    VrfStateMachine,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vrf_dependency_checker import (
     VrfDependencyChecker,
 )
@@ -212,6 +215,103 @@ class _AttachmentQueryOrchestrator:
     def _request(self, **kwargs):
         self.requests.append(kwargs)
         return self.responses.pop(0)
+
+
+class _FakeStateMachine:
+    existing = []
+
+    def __init__(self, calls):
+        self.calls = calls
+
+    def manage_state(self):
+        self.calls.append(("manage_state",))
+
+
+class _ReplacedVrfCoordinator:
+    def __init__(self):
+        self.module = _Module({"state": "replaced"}, check_mode=False)
+        self.calls = []
+        self.state_machine = _FakeStateMachine(self.calls)
+
+    @staticmethod
+    def _desired_attachment_map(_module_args, _strategy):
+        return {("BLUE", "SW1"): {"vrfName": "BLUE", "switchId": "SW1", "attach": True}}
+
+    @staticmethod
+    def _configured_vrf_names(_config):
+        return ["BLUE"]
+
+    def _new_state_machine(self, _module_args, _strategy):
+        self.calls.append(("new_state_machine",))
+        return self.state_machine, "original-config", "original-state"
+
+    def _current_attachment_details_ignore_missing(self, *_args, **_kwargs):
+        raise AssertionError("first-create replaced must not query missing VRF attachments")
+
+    @staticmethod
+    def _attachment_map_from_details(_attachments, _vrf_names):
+        return {}
+
+    def _apply_attachment_phase(self, _module_args, _strategy, phase, desired=None, current_vrf_names=None, current=None):
+        self.calls.append((phase, current_vrf_names, current))
+        if phase == "pre":
+            assert current_vrf_names == []
+            assert current == {}
+            return {"current": current, "payloads": [], "desired": desired, "deploy_targets": {}}
+        assert phase == "post"
+        assert current_vrf_names == ["BLUE"]
+        assert current == {}
+        return {"payloads": [desired[("BLUE", "SW1")]], "deploy_targets": {"BLUE": {"SW1"}}}
+
+    @staticmethod
+    def _attachment_map_after_detach(current, _payloads):
+        return current
+
+    @staticmethod
+    def _format_state_machine_output(_state_machine):
+        return {"changed": True, "failed": False, "after": [{"vrf_name": "BLUE"}]}
+
+    @staticmethod
+    def _merge_api_trace(result, trace, prepend=False):
+        if prepend:
+            result.setdefault("prepended", []).append(trace)
+        if trace.get("changed"):
+            result["changed"] = True
+
+    @staticmethod
+    def _build_deploy_payloads(_config, *_target_maps):
+        return []
+
+    @staticmethod
+    def _build_pending_vrf_deploy_payloads(_result, _config, _module_args, _strategy):
+        return []
+
+    def _restore_state_machine_params(self, original_config, original_state):
+        self.calls.append(("restore", original_config, original_state))
+
+    def _trace(self, event, **_details):
+        self.calls.append(("trace", event))
+
+
+def test_vrf_replaced_first_create_with_attachment_skips_missing_pre_query():
+    """
+    # Summary
+
+    Verify first-create state=replaced does not query attachments for a VRF
+    that is absent before CRUD creation.
+    """
+    coordinator = _ReplacedVrfCoordinator()
+    state_machine = VrfStateMachine(coordinator)
+
+    result = state_machine.run(
+        {"state": "replaced", "config": [{"vrf_name": "BLUE", "attach": [{"ip_address": "192.0.2.10"}]}]},
+        _StandaloneStrategy(),
+    )
+
+    assert result["changed"] is True
+    assert ("pre", [], {}) in coordinator.calls
+    assert ("manage_state",) in coordinator.calls
+    assert ("post", ["BLUE"], {}) in coordinator.calls
 
 
 def test_vrf_attachment_query_chunks_large_vrf_name_sets():


### PR DESCRIPTION
## Related Issue(s)

Resolves #506 

## Proposed Changes

- Fix `state: replaced` first-create workflows for `nd_manage_vrfs` and `nd_manage_networks` when the desired config includes attachments.
- Align `replaced` with the state-machine-aware attachment sequencing used by `overridden`.
- Avoid querying attachment endpoints for VRFs/Networks that do not exist yet.
- Preserve the correct workflow order:
  - derive current VRF/Network names from the generic state machine
  - pre-detach only existing desired resources
  - create/update the VRF or Network through CRUD
  - post-attach after the resource exists
  - deploy pending attachment changes
- Keep `overridden` behavior intact, including omitted-resource pre-delete handling.
- Add focused unit coverage for:
  - VRF `state: replaced` first-create with attachment
  - Network `state: replaced` first-create with attachment
  - skipping missing-resource attachment pre-query before CRUD create

## Test Notes

- Added unit tests covering the first-create replaced attachment workflow for both VRFs and Networks.
- Verified the state machine runs CRUD before post-attachment processing when the resource is absent.
- Verified pre-attachment processing receives an empty current attachment map instead of querying missing resources.

Focused tests to run:

```bash
PYENV_VERSION=ndfclab PYTHONPATH=$PWD/collections python -m pytest -q \
  tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py \
  tests/unit/module_utils/orchestrators/test_networks.py
```

## Cisco Nexus Dashboard Version

N/A - workflow sequencing/unit-test fix. No new API surface introduced.

## Related ND API Resource Category

- [ ] analyze
- [ ] infa
- [x] manage
- [ ] onemanage
- [ ] other

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] New or updates to documentation has been made accordingly
- [ ] Assigned the proper reviewers