### PR TITLE
ND Manage VRFs & Networks: Add Internal Staged Workflow

### DIFF
--- a/plugins/module_utils/orchestrators/network_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/network_attachment_manager.py
@@ -454,7 +454,9 @@ class NetworkAttachmentManager:
         if state == "deleted":
             target_names = set(configured_network_names(config))
             detach_keys = {key for key in current if not target_names or key[0] in target_names}
-        elif state in ("replaced", "overridden"):
+        elif state in ("overridden", "staged"):
+            detach_keys = set(current.keys()).difference(desired.keys())
+        elif state == "replaced":
             target_names = set(configured_network_names(config))
             detach_keys = {key for key in current if key[0] in target_names and key not in desired}
         payloads = []

--- a/plugins/module_utils/orchestrators/network_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/network_attachment_manager.py
@@ -454,7 +454,7 @@ class NetworkAttachmentManager:
         if state == "deleted":
             target_names = set(configured_network_names(config))
             detach_keys = {key for key in current if not target_names or key[0] in target_names}
-        elif state in ("overridden", "staged"):
+        elif state in ("overridden", "_staged"):
             detach_keys = set(current.keys()).difference(desired.keys())
         elif state == "replaced":
             target_names = set(configured_network_names(config))

--- a/plugins/module_utils/orchestrators/network_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/network_attachment_manager.py
@@ -454,7 +454,7 @@ class NetworkAttachmentManager:
         if state == "deleted":
             target_names = set(configured_network_names(config))
             detach_keys = {key for key in current if not target_names or key[0] in target_names}
-        elif state in ("overridden", "_staged"):
+        elif state in ("overridden", "staged"):
             detach_keys = set(current.keys()).difference(desired.keys())
         elif state == "replaced":
             target_names = set(configured_network_names(config))

--- a/plugins/module_utils/orchestrators/network_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/network_attachment_manager.py
@@ -105,10 +105,10 @@ class NetworkAttachmentManager:
         if not config and state != "overridden":
             self._trace("network_attachment_phase_skip", phase=phase, reason="empty_config")
             return {}
-        if phase == "pre" and state not in ("deleted", "replaced", "overridden"):
+        if phase == "pre" and state not in ("deleted", "replaced", "overridden", "staged"):
             self._trace("network_attachment_phase_skip", phase=phase, reason="state_not_pre_detach")
             return {}
-        if phase == "post" and state not in ("merged", "replaced", "overridden"):
+        if phase == "post" and state not in ("merged", "replaced", "overridden", "staged"):
             self._trace("network_attachment_phase_skip", phase=phase, reason="state_not_post_attach")
             return {}
         if current_network_names == []:

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -176,10 +176,19 @@ class NetworkStateMachine:
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_network_names = self.coordinator._configured_network_names(config)
 
-        sm, original_config, original_state = self.coordinator._new_state_machine(query_module_args(module_args), strategy)
+        current_network_names = []
+        if state == "staged":
+            query_sm, query_original_config, query_original_state = self.coordinator._new_state_machine(query_module_args(module_args), strategy)
+            try:
+                current_network_names = self._network_names_from_models(query_sm.existing)
+            finally:
+                self.coordinator._restore_state_machine_params(query_original_config, query_original_state)
+
+        sm, original_config, original_state = self.coordinator._new_state_machine(crud_module_args(module_args), strategy)
         try:
             prepare_crud_state(sm, state)
-            current_network_names = self._network_names_from_models(sm.existing)
+            if state != "staged":
+                current_network_names = self._network_names_from_models(sm.existing)
             current_network_name_set = set(current_network_names)
             desired_network_name_set = set(desired_network_names)
             current_desired_network_names = [network_name for network_name in desired_network_names if network_name in current_network_name_set]

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -12,9 +12,9 @@ This wrapper owns the Network-specific workflow around that CRUD phase:
   - post-attach for merged/replaced/overridden
   - deploy of pending attachment changes
 
-The private ``staged`` state follows overridden attachment handling but maps
-the CRUD phase to replaced and suppresses deploy so omitted Networks are
-detached without deploy or delete calls.
+The ``staged`` state follows overridden attachment handling but maps the CRUD
+phase to replaced and suppresses deploy so omitted Networks are detached
+without deploy or delete calls.
 
 It deliberately composes the generic NDStateMachine through the workflow
 coordinator helpers instead of changing the shared state-machine contract.
@@ -161,9 +161,9 @@ class NetworkStateMachine:
 
         The pre-detach phase must only query attachments for Networks that
         already exist. First-create ``state=replaced`` tasks can then create
-        the Network before the post-attach phase runs. The private ``staged``
-        state uses overridden detach scope but runs CRUD as replaced to
-        suppress deletes.
+        the Network before the post-attach phase runs. The ``staged`` state
+        uses overridden detach scope but runs CRUD as replaced to suppress
+        deletes.
         """
         state = module_args.get("state", "merged")
         config = [dict(network) for network in module_args.get("config") or []]
@@ -310,7 +310,7 @@ class NetworkStateMachine:
 
     @staticmethod
     def _prepare_crud_state(sm: Any, requested_state: str) -> None:
-        """Switch private staged workflows to replacement CRUD after query."""
+        """Switch staged workflows to replacement CRUD after query."""
         if requested_state != "staged":
             return
         sm.state = "replaced"

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -13,7 +13,8 @@ This wrapper owns the Network-specific workflow around that CRUD phase:
   - deploy of pending attachment changes
 
 The private ``staged`` state follows overridden attachment handling but maps
-the CRUD phase to replaced so omitted Networks are detached without delete calls.
+the CRUD phase to replaced and suppresses deploy so omitted Networks are
+detached without deploy or delete calls.
 
 It deliberately composes the generic NDStateMachine through the workflow
 coordinator helpers instead of changing the shared state-machine contract.
@@ -259,6 +260,9 @@ class NetworkStateMachine:
             self._trace("attachment_phase_post_end", changed=post_attach.get("changed"), payload_count=len(post_attach.get("payloads", [])))
             self.coordinator._merge_api_trace(result, post_attach)
 
+            if state == "staged":
+                return result
+
             return self._deploy_after_attachment_changes(
                 result,
                 config,
@@ -403,6 +407,8 @@ class NetworkStateMachine:
             omitted_network_names,
             attachment_details=omitted_attachment_details,
         )
+        if module_args.get("state") == "staged":
+            return [detach_trace] if detach_trace else []
         return self._deploy_detach_traces(
             api_args=module_args,
             wait_args=module_args,

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -12,7 +12,7 @@ This wrapper owns the Network-specific workflow around that CRUD phase:
   - post-attach for merged/replaced/overridden
   - deploy of pending attachment changes
 
-The private ``_staged`` state follows overridden attachment handling but maps
+The private ``staged`` state follows overridden attachment handling but maps
 the CRUD phase to replaced and suppresses deploy so omitted Networks are
 detached without deploy or delete calls.
 
@@ -88,12 +88,12 @@ class NetworkStateMachine:
         if state == "deleted":
             return self.run_deleted(module_args, active_strategy)
 
-        if state in ("replaced", "overridden", "_staged"):
+        if state in ("replaced", "overridden", "staged"):
             return self._run_state_machine_aware_with_attachments(module_args, active_strategy, defer_deploy)
 
         desired_attachments = None
         desired_network_names = None
-        if state in ("merged", "replaced", "overridden", "_staged"):
+        if state in ("merged", "replaced", "overridden", "staged"):
             desired_attachments = self.coordinator._desired_attachment_map(
                 module_args,
                 active_strategy,
@@ -157,11 +157,11 @@ class NetworkStateMachine:
         defer_deploy: bool = False,
     ) -> dict[str, Any]:
         """
-        Run replaced/overridden/_staged after deriving current Network names from the state machine.
+        Run replaced/overridden/staged after deriving current Network names from the state machine.
 
         The pre-detach phase must only query attachments for Networks that
         already exist. First-create ``state=replaced`` tasks can then create
-        the Network before the post-attach phase runs. The private ``_staged``
+        the Network before the post-attach phase runs. The private ``staged``
         state uses overridden detach scope but runs CRUD as replaced to
         suppress deletes.
         """
@@ -177,7 +177,7 @@ class NetworkStateMachine:
             current_network_name_set = set(current_network_names)
             desired_network_name_set = set(desired_network_names)
             current_desired_network_names = [network_name for network_name in desired_network_names if network_name in current_network_name_set]
-            attachment_query_network_names = current_network_names if state in ("overridden", "_staged") else current_desired_network_names
+            attachment_query_network_names = current_network_names if state in ("overridden", "staged") else current_desired_network_names
             current_attachment_details = (
                 self.coordinator._current_attachment_details_ignore_missing(
                     module_args,
@@ -193,7 +193,7 @@ class NetworkStateMachine:
             )
 
             pre_delete_traces: list[dict[str, Any]] = []
-            if state in ("overridden", "_staged"):
+            if state in ("overridden", "staged"):
                 omitted_network_names = [network_name for network_name in current_network_names if network_name not in desired_network_name_set]
                 pre_delete_traces = self._prepare_overridden_deletions(
                     module_args,
@@ -232,7 +232,7 @@ class NetworkStateMachine:
             post_attachment_details = list(current_attachment_details or [])
             post_current_attachments = dict(current_attachments or {})
             new_desired_network_names = [network_name for network_name in desired_network_names if network_name not in current_network_name_set]
-            if state in ("replaced", "overridden", "_staged") and desired_attachments and new_desired_network_names and not self._check_mode():
+            if state in ("replaced", "overridden", "staged") and desired_attachments and new_desired_network_names and not self._check_mode():
                 self._trace("attachment_phase_post_new_current_query_start", network_names=new_desired_network_names)
                 new_attachment_details = self.coordinator._current_attachment_details(
                     module_args,
@@ -261,7 +261,7 @@ class NetworkStateMachine:
             self._trace("attachment_phase_post_end", changed=post_attach.get("changed"), payload_count=len(post_attach.get("payloads", [])))
             self.coordinator._merge_api_trace(result, post_attach)
 
-            if state == "_staged":
+            if state == "staged":
                 return result
 
             return self._deploy_after_attachment_changes(
@@ -293,7 +293,7 @@ class NetworkStateMachine:
     @staticmethod
     def _crud_module_args(module_args: dict) -> dict:
         """Return module args for the generic CRUD state machine."""
-        if module_args.get("state") != "_staged":
+        if module_args.get("state") != "staged":
             return module_args
         crud_args = dict(module_args)
         crud_args["state"] = "replaced"
@@ -302,7 +302,7 @@ class NetworkStateMachine:
     @staticmethod
     def _query_module_args(module_args: dict) -> dict:
         """Return module args for the current-state query phase."""
-        if module_args.get("state") != "_staged":
+        if module_args.get("state") != "staged":
             return module_args
         query_args = dict(module_args)
         query_args["state"] = "overridden"
@@ -311,7 +311,7 @@ class NetworkStateMachine:
     @staticmethod
     def _prepare_crud_state(sm: Any, requested_state: str) -> None:
         """Switch private staged workflows to replacement CRUD after query."""
-        if requested_state != "_staged":
+        if requested_state != "staged":
             return
         sm.state = "replaced"
 
@@ -424,7 +424,7 @@ class NetworkStateMachine:
             omitted_network_names,
             attachment_details=omitted_attachment_details,
         )
-        if module_args.get("state") == "_staged":
+        if module_args.get("state") == "staged":
             return [detach_trace] if detach_trace else []
         return self._deploy_detach_traces(
             api_args=module_args,

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -170,8 +170,9 @@ class NetworkStateMachine:
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_network_names = self.coordinator._configured_network_names(config)
 
-        sm, original_config, original_state = self.coordinator._new_state_machine(self._crud_module_args(module_args), strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(self._query_module_args(module_args), strategy)
         try:
+            self._prepare_crud_state(sm, state)
             current_network_names = self._network_names_from_models(sm.existing)
             current_network_name_set = set(current_network_names)
             desired_network_name_set = set(desired_network_names)
@@ -297,6 +298,22 @@ class NetworkStateMachine:
         crud_args = dict(module_args)
         crud_args["state"] = "replaced"
         return crud_args
+
+    @staticmethod
+    def _query_module_args(module_args: dict) -> dict:
+        """Return module args for the current-state query phase."""
+        if module_args.get("state") != "_staged":
+            return module_args
+        query_args = dict(module_args)
+        query_args["state"] = "overridden"
+        return query_args
+
+    @staticmethod
+    def _prepare_crud_state(sm: Any, requested_state: str) -> None:
+        """Switch private staged workflows to replacement CRUD after query."""
+        if requested_state != "_staged":
+            return
+        sm.state = "replaced"
 
     def _deploy_after_attachment_changes(
         self,

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -29,6 +29,11 @@ from typing import Any
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.strategies.base_network import (
     BaseNetworkStrategy,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.staged_state_helpers import (
+    crud_module_args,
+    prepare_crud_state,
+    query_module_args,
+)
 
 
 class NetworkStateMachine:
@@ -58,8 +63,9 @@ class NetworkStateMachine:
         Run only the generic NDStateMachine-backed Network CRUD/gathered flow.
         """
         state = module_args.get("state", "merged")
-        sm, original_config, original_state = self.coordinator._new_state_machine(self._crud_module_args(module_args), strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(crud_module_args(module_args), strategy)
         try:
+            prepare_crud_state(sm, state)
             if state != "gathered":
                 self._trace("manage_state_start", state=state)
                 sm.manage_state()
@@ -170,9 +176,9 @@ class NetworkStateMachine:
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_network_names = self.coordinator._configured_network_names(config)
 
-        sm, original_config, original_state = self.coordinator._new_state_machine(self._query_module_args(module_args), strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(query_module_args(module_args), strategy)
         try:
-            self._prepare_crud_state(sm, state)
+            prepare_crud_state(sm, state)
             current_network_names = self._network_names_from_models(sm.existing)
             current_network_name_set = set(current_network_names)
             desired_network_name_set = set(desired_network_names)
@@ -290,31 +296,6 @@ class NetworkStateMachine:
             pre_attach.get("payloads", []),
         )
 
-    @staticmethod
-    def _crud_module_args(module_args: dict) -> dict:
-        """Return module args for the generic CRUD state machine."""
-        if module_args.get("state") != "staged":
-            return module_args
-        crud_args = dict(module_args)
-        crud_args["state"] = "replaced"
-        return crud_args
-
-    @staticmethod
-    def _query_module_args(module_args: dict) -> dict:
-        """Return module args for the current-state query phase."""
-        if module_args.get("state") != "staged":
-            return module_args
-        query_args = dict(module_args)
-        query_args["state"] = "overridden"
-        return query_args
-
-    @staticmethod
-    def _prepare_crud_state(sm: Any, requested_state: str) -> None:
-        """Switch staged workflows to replacement CRUD after query."""
-        if requested_state != "staged":
-            return
-        sm.state = "replaced"
-
     def _deploy_after_attachment_changes(
         self,
         result: dict[str, Any],
@@ -409,7 +390,8 @@ class NetworkStateMachine:
         if not omitted_network_names:
             return []
 
-        self.coordinator._ensure_networks_have_no_networks(module_args, strategy, omitted_network_names)
+        if module_args.get("state") != "staged":
+            self.coordinator._ensure_networks_have_no_networks(module_args, strategy, omitted_network_names)
         omitted_attachment_details = (
             self.coordinator._filter_attachment_details_by_network(
                 current_attachment_details,

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -12,6 +12,9 @@ This wrapper owns the Network-specific workflow around that CRUD phase:
   - post-attach for merged/replaced/overridden
   - deploy of pending attachment changes
 
+The private ``staged`` state follows overridden attachment handling but maps
+the CRUD phase to replaced so omitted Networks are detached without delete calls.
+
 It deliberately composes the generic NDStateMachine through the workflow
 coordinator helpers instead of changing the shared state-machine contract.
 """
@@ -54,7 +57,7 @@ class NetworkStateMachine:
         Run only the generic NDStateMachine-backed Network CRUD/gathered flow.
         """
         state = module_args.get("state", "merged")
-        sm, original_config, original_state = self.coordinator._new_state_machine(module_args, strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(self._crud_module_args(module_args), strategy)
         try:
             if state != "gathered":
                 self._trace("manage_state_start", state=state)
@@ -84,12 +87,12 @@ class NetworkStateMachine:
         if state == "deleted":
             return self.run_deleted(module_args, active_strategy)
 
-        if state in ("replaced", "overridden"):
+        if state in ("replaced", "overridden", "staged"):
             return self._run_state_machine_aware_with_attachments(module_args, active_strategy, defer_deploy)
 
         desired_attachments = None
         desired_network_names = None
-        if state in ("merged", "replaced", "overridden"):
+        if state in ("merged", "replaced", "overridden", "staged"):
             desired_attachments = self.coordinator._desired_attachment_map(
                 module_args,
                 active_strategy,
@@ -153,24 +156,26 @@ class NetworkStateMachine:
         defer_deploy: bool = False,
     ) -> dict[str, Any]:
         """
-        Run replaced/overridden after deriving current Network names from the state machine.
+        Run replaced/overridden/staged after deriving current Network names from the state machine.
 
         The pre-detach phase must only query attachments for Networks that
         already exist. First-create ``state=replaced`` tasks can then create
-        the Network before the post-attach phase runs.
+        the Network before the post-attach phase runs. The private ``staged``
+        state uses overridden detach scope but runs CRUD as replaced to
+        suppress deletes.
         """
         state = module_args.get("state", "merged")
         config = [dict(network) for network in module_args.get("config") or []]
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_network_names = self.coordinator._configured_network_names(config)
 
-        sm, original_config, original_state = self.coordinator._new_state_machine(module_args, strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(self._crud_module_args(module_args), strategy)
         try:
             current_network_names = self._network_names_from_models(sm.existing)
             current_network_name_set = set(current_network_names)
             desired_network_name_set = set(desired_network_names)
             current_desired_network_names = [network_name for network_name in desired_network_names if network_name in current_network_name_set]
-            attachment_query_network_names = current_network_names if state == "overridden" else current_desired_network_names
+            attachment_query_network_names = current_network_names if state in ("overridden", "staged") else current_desired_network_names
             current_attachment_details = (
                 self.coordinator._current_attachment_details_ignore_missing(
                     module_args,
@@ -186,7 +191,7 @@ class NetworkStateMachine:
             )
 
             pre_delete_traces: list[dict[str, Any]] = []
-            if state == "overridden":
+            if state in ("overridden", "staged"):
                 omitted_network_names = [network_name for network_name in current_network_names if network_name not in desired_network_name_set]
                 pre_delete_traces = self._prepare_overridden_deletions(
                     module_args,
@@ -225,7 +230,7 @@ class NetworkStateMachine:
             post_attachment_details = list(current_attachment_details or [])
             post_current_attachments = dict(current_attachments or {})
             new_desired_network_names = [network_name for network_name in desired_network_names if network_name not in current_network_name_set]
-            if state in ("replaced", "overridden") and desired_attachments and new_desired_network_names and not self._check_mode():
+            if state in ("replaced", "overridden", "staged") and desired_attachments and new_desired_network_names and not self._check_mode():
                 self._trace("attachment_phase_post_new_current_query_start", network_names=new_desired_network_names)
                 new_attachment_details = self.coordinator._current_attachment_details(
                     module_args,
@@ -279,6 +284,15 @@ class NetworkStateMachine:
             current,
             pre_attach.get("payloads", []),
         )
+
+    @staticmethod
+    def _crud_module_args(module_args: dict) -> dict:
+        """Return module args for the generic CRUD state machine."""
+        if module_args.get("state") != "staged":
+            return module_args
+        crud_args = dict(module_args)
+        crud_args["state"] = "replaced"
+        return crud_args
 
     def _deploy_after_attachment_changes(
         self,

--- a/plugins/module_utils/orchestrators/network_state_machine.py
+++ b/plugins/module_utils/orchestrators/network_state_machine.py
@@ -12,7 +12,7 @@ This wrapper owns the Network-specific workflow around that CRUD phase:
   - post-attach for merged/replaced/overridden
   - deploy of pending attachment changes
 
-The private ``staged`` state follows overridden attachment handling but maps
+The private ``_staged`` state follows overridden attachment handling but maps
 the CRUD phase to replaced and suppresses deploy so omitted Networks are
 detached without deploy or delete calls.
 
@@ -88,12 +88,12 @@ class NetworkStateMachine:
         if state == "deleted":
             return self.run_deleted(module_args, active_strategy)
 
-        if state in ("replaced", "overridden", "staged"):
+        if state in ("replaced", "overridden", "_staged"):
             return self._run_state_machine_aware_with_attachments(module_args, active_strategy, defer_deploy)
 
         desired_attachments = None
         desired_network_names = None
-        if state in ("merged", "replaced", "overridden", "staged"):
+        if state in ("merged", "replaced", "overridden", "_staged"):
             desired_attachments = self.coordinator._desired_attachment_map(
                 module_args,
                 active_strategy,
@@ -157,11 +157,11 @@ class NetworkStateMachine:
         defer_deploy: bool = False,
     ) -> dict[str, Any]:
         """
-        Run replaced/overridden/staged after deriving current Network names from the state machine.
+        Run replaced/overridden/_staged after deriving current Network names from the state machine.
 
         The pre-detach phase must only query attachments for Networks that
         already exist. First-create ``state=replaced`` tasks can then create
-        the Network before the post-attach phase runs. The private ``staged``
+        the Network before the post-attach phase runs. The private ``_staged``
         state uses overridden detach scope but runs CRUD as replaced to
         suppress deletes.
         """
@@ -176,7 +176,7 @@ class NetworkStateMachine:
             current_network_name_set = set(current_network_names)
             desired_network_name_set = set(desired_network_names)
             current_desired_network_names = [network_name for network_name in desired_network_names if network_name in current_network_name_set]
-            attachment_query_network_names = current_network_names if state in ("overridden", "staged") else current_desired_network_names
+            attachment_query_network_names = current_network_names if state in ("overridden", "_staged") else current_desired_network_names
             current_attachment_details = (
                 self.coordinator._current_attachment_details_ignore_missing(
                     module_args,
@@ -192,7 +192,7 @@ class NetworkStateMachine:
             )
 
             pre_delete_traces: list[dict[str, Any]] = []
-            if state in ("overridden", "staged"):
+            if state in ("overridden", "_staged"):
                 omitted_network_names = [network_name for network_name in current_network_names if network_name not in desired_network_name_set]
                 pre_delete_traces = self._prepare_overridden_deletions(
                     module_args,
@@ -231,7 +231,7 @@ class NetworkStateMachine:
             post_attachment_details = list(current_attachment_details or [])
             post_current_attachments = dict(current_attachments or {})
             new_desired_network_names = [network_name for network_name in desired_network_names if network_name not in current_network_name_set]
-            if state in ("replaced", "overridden", "staged") and desired_attachments and new_desired_network_names and not self._check_mode():
+            if state in ("replaced", "overridden", "_staged") and desired_attachments and new_desired_network_names and not self._check_mode():
                 self._trace("attachment_phase_post_new_current_query_start", network_names=new_desired_network_names)
                 new_attachment_details = self.coordinator._current_attachment_details(
                     module_args,
@@ -260,7 +260,7 @@ class NetworkStateMachine:
             self._trace("attachment_phase_post_end", changed=post_attach.get("changed"), payload_count=len(post_attach.get("payloads", [])))
             self.coordinator._merge_api_trace(result, post_attach)
 
-            if state == "staged":
+            if state == "_staged":
                 return result
 
             return self._deploy_after_attachment_changes(
@@ -292,7 +292,7 @@ class NetworkStateMachine:
     @staticmethod
     def _crud_module_args(module_args: dict) -> dict:
         """Return module args for the generic CRUD state machine."""
-        if module_args.get("state") != "staged":
+        if module_args.get("state") != "_staged":
             return module_args
         crud_args = dict(module_args)
         crud_args["state"] = "replaced"
@@ -407,7 +407,7 @@ class NetworkStateMachine:
             omitted_network_names,
             attachment_details=omitted_attachment_details,
         )
-        if module_args.get("state") == "staged":
+        if module_args.get("state") == "_staged":
             return [detach_trace] if detach_trace else []
         return self._deploy_detach_traces(
             api_args=module_args,

--- a/plugins/module_utils/orchestrators/staged_state_helpers.py
+++ b/plugins/module_utils/orchestrators/staged_state_helpers.py
@@ -44,14 +44,16 @@ def query_module_args(module_args: dict) -> dict:
 
     Return module arguments for the current-state query phase.
 
-    The staged workflow uses overridden query behavior so omitted resources can
-    be discovered for detach-only reconciliation.
+    The staged workflow uses overridden query behavior with an empty config so
+    omitted resources can be discovered without validating desired write data
+    under the overridden state context.
 
     Args:
         module_args: Original module arguments.
 
     Returns:
-        Original module arguments, or a shallow copy with staged mapped to overridden.
+        Original module arguments, or a shallow copy with staged mapped to overridden
+        and config cleared for query-only discovery.
 
     ## Raises
 
@@ -61,6 +63,7 @@ def query_module_args(module_args: dict) -> dict:
         return module_args
     query_args = dict(module_args)
     query_args["state"] = STAGED_QUERY_STATE
+    query_args["config"] = []
     return query_args
 
 

--- a/plugins/module_utils/orchestrators/staged_state_helpers.py
+++ b/plugins/module_utils/orchestrators/staged_state_helpers.py
@@ -1,0 +1,93 @@
+# Copyright: (c) 2026, Akshayanat C S (@achengam) <achengam@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Shared helpers for staged resource workflow state mapping."""
+
+from __future__ import annotations
+
+from typing import Any
+
+STAGED_STATE = "staged"
+STAGED_CRUD_STATE = "replaced"
+STAGED_QUERY_STATE = "overridden"
+
+
+def crud_module_args(module_args: dict) -> dict:
+    """
+    # Summary
+
+    Return module arguments for the CRUD state machine.
+
+    The staged workflow uses replaced CRUD behavior so desired resources are
+    created or updated without deleting omitted resources.
+
+    Args:
+        module_args: Original module arguments.
+
+    Returns:
+        Original module arguments, or a shallow copy with staged mapped to replaced.
+
+    ## Raises
+
+    This function does not raise directly.
+    """
+    if module_args.get("state") != STAGED_STATE:
+        return module_args
+    crud_args = dict(module_args)
+    crud_args["state"] = STAGED_CRUD_STATE
+    return crud_args
+
+
+def query_module_args(module_args: dict) -> dict:
+    """
+    # Summary
+
+    Return module arguments for the current-state query phase.
+
+    The staged workflow uses overridden query behavior so omitted resources can
+    be discovered for detach-only reconciliation.
+
+    Args:
+        module_args: Original module arguments.
+
+    Returns:
+        Original module arguments, or a shallow copy with staged mapped to overridden.
+
+    ## Raises
+
+    This function does not raise directly.
+    """
+    if module_args.get("state") != STAGED_STATE:
+        return module_args
+    query_args = dict(module_args)
+    query_args["state"] = STAGED_QUERY_STATE
+    return query_args
+
+
+def prepare_crud_state(state_machine: Any, requested_state: str) -> None:
+    """
+    # Summary
+
+    Switch staged workflows to replacement CRUD after the query phase.
+
+    The CRUD state is internal.  Public result metadata remains the
+    user-requested staged state so verbose API metadata reflects the task that
+    the user ran.
+
+    Args:
+        state_machine: Generic CRUD state machine instance.
+        requested_state: Original requested module state.
+
+    Returns:
+        None.
+
+    ## Raises
+
+    This function does not raise directly.
+    """
+    if requested_state != STAGED_STATE:
+        return
+    state_machine.state = STAGED_CRUD_STATE
+    results = getattr(state_machine, "results", None)
+    if results is not None:
+        results.state = STAGED_STATE

--- a/plugins/module_utils/orchestrators/vrf_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/vrf_attachment_manager.py
@@ -556,7 +556,7 @@ class VrfAttachmentManager:
 
         if state == "deleted":
             detach_keys = set(current.keys())
-        elif state == "overridden":
+        elif state in ("overridden", "staged"):
             detach_keys = set(current.keys()).difference(desired.keys())
         elif state == "replaced":
             vrf_names = set(configured_vrf_names(config))

--- a/plugins/module_utils/orchestrators/vrf_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/vrf_attachment_manager.py
@@ -99,10 +99,10 @@ class VrfAttachmentManager:
         if not config and state != "overridden":
             self._trace("vrf_attachment_phase_skip", phase=phase, reason="empty_config")
             return {}
-        if phase == "pre" and state not in ("deleted", "replaced", "overridden"):
+        if phase == "pre" and state not in ("deleted", "replaced", "overridden", "staged"):
             self._trace("vrf_attachment_phase_skip", phase=phase, reason="state_not_pre_detach")
             return {}
-        if phase == "post" and state not in ("merged", "replaced", "overridden"):
+        if phase == "post" and state not in ("merged", "replaced", "overridden", "staged"):
             self._trace("vrf_attachment_phase_skip", phase=phase, reason="state_not_post_attach")
             return {}
         if current_vrf_names == []:

--- a/plugins/module_utils/orchestrators/vrf_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/vrf_attachment_manager.py
@@ -556,7 +556,7 @@ class VrfAttachmentManager:
 
         if state == "deleted":
             detach_keys = set(current.keys())
-        elif state in ("overridden", "staged"):
+        elif state in ("overridden", "_staged"):
             detach_keys = set(current.keys()).difference(desired.keys())
         elif state == "replaced":
             vrf_names = set(configured_vrf_names(config))

--- a/plugins/module_utils/orchestrators/vrf_attachment_manager.py
+++ b/plugins/module_utils/orchestrators/vrf_attachment_manager.py
@@ -556,7 +556,7 @@ class VrfAttachmentManager:
 
         if state == "deleted":
             detach_keys = set(current.keys())
-        elif state in ("overridden", "_staged"):
+        elif state in ("overridden", "staged"):
             detach_keys = set(current.keys()).difference(desired.keys())
         elif state == "replaced":
             vrf_names = set(configured_vrf_names(config))

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -12,7 +12,7 @@ This wrapper owns the VRF-specific workflow around that CRUD phase:
   - post-attach for merged/replaced/overridden
   - deploy of pending attachment changes
 
-The private ``staged`` state follows overridden attachment handling but maps
+The private ``_staged`` state follows overridden attachment handling but maps
 the CRUD phase to replaced and suppresses deploy so omitted VRFs are detached
 without deploy or delete calls.
 
@@ -88,7 +88,7 @@ class VrfStateMachine:
         if state == "deleted":
             return self.run_deleted(module_args, active_strategy)
 
-        if state in ("replaced", "overridden", "staged"):
+        if state in ("replaced", "overridden", "_staged"):
             return self._run_state_machine_aware_with_attachments(module_args, active_strategy, defer_deploy)
 
         desired_attachments = None
@@ -153,11 +153,11 @@ class VrfStateMachine:
         defer_deploy: bool = False,
     ) -> dict[str, Any]:
         """
-        Run replaced/overridden/staged after deriving current VRF names from the state machine.
+        Run replaced/overridden/_staged after deriving current VRF names from the state machine.
 
         The pre-detach phase must only query attachments for VRFs that already
         exist. First-create ``state=replaced`` tasks can then create the VRF
-        before the post-attach phase runs. The private ``staged`` state uses
+        before the post-attach phase runs. The private ``_staged`` state uses
         overridden detach scope but runs CRUD as replaced to suppress deletes.
         """
         state = module_args.get("state", "merged")
@@ -171,7 +171,7 @@ class VrfStateMachine:
             current_vrf_name_set = set(current_vrf_names)
             desired_vrf_name_set = set(desired_vrf_names)
             current_desired_vrf_names = [vrf_name for vrf_name in desired_vrf_names if vrf_name in current_vrf_name_set]
-            attachment_query_vrf_names = current_vrf_names if state in ("overridden", "staged") else current_desired_vrf_names
+            attachment_query_vrf_names = current_vrf_names if state in ("overridden", "_staged") else current_desired_vrf_names
             current_attachment_details = (
                 self.coordinator._current_attachment_details_ignore_missing(
                     module_args,
@@ -187,7 +187,7 @@ class VrfStateMachine:
             )
 
             pre_delete_traces: list[dict[str, Any]] = []
-            if state in ("overridden", "staged"):
+            if state in ("overridden", "_staged"):
                 omitted_vrf_names = [vrf_name for vrf_name in current_vrf_names if vrf_name not in desired_vrf_name_set]
                 pre_delete_traces = self._prepare_overridden_deletions(
                     module_args,
@@ -226,7 +226,7 @@ class VrfStateMachine:
             post_attachment_details = list(current_attachment_details or [])
             post_current_attachments = dict(current_attachments or {})
             new_desired_vrf_names = [vrf_name for vrf_name in desired_vrf_names if vrf_name not in current_vrf_name_set]
-            if state in ("replaced", "overridden", "staged") and desired_attachments and new_desired_vrf_names and not self._check_mode():
+            if state in ("replaced", "overridden", "_staged") and desired_attachments and new_desired_vrf_names and not self._check_mode():
                 self._trace("attachment_phase_post_new_current_query_start", vrf_names=new_desired_vrf_names)
                 new_attachment_details = self.coordinator._current_attachment_details(
                     module_args,
@@ -255,7 +255,7 @@ class VrfStateMachine:
             self._trace("attachment_phase_post_end", changed=post_attach.get("changed"), payload_count=len(post_attach.get("payloads", [])))
             self.coordinator._merge_api_trace(result, post_attach)
 
-            if state == "staged":
+            if state == "_staged":
                 return result
 
             return self._deploy_after_attachment_changes(
@@ -287,7 +287,7 @@ class VrfStateMachine:
     @staticmethod
     def _crud_module_args(module_args: dict) -> dict:
         """Return module args for the generic CRUD state machine."""
-        if module_args.get("state") != "staged":
+        if module_args.get("state") != "_staged":
             return module_args
         crud_args = dict(module_args)
         crud_args["state"] = "replaced"
@@ -373,7 +373,7 @@ class VrfStateMachine:
             omitted_vrf_names,
             attachment_details=omitted_attachment_details,
         )
-        if module_args.get("state") == "staged":
+        if module_args.get("state") == "_staged":
             return [detach_trace] if detach_trace else []
         return self._deploy_detach_traces(
             api_args=module_args,

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -12,6 +12,9 @@ This wrapper owns the VRF-specific workflow around that CRUD phase:
   - post-attach for merged/replaced/overridden
   - deploy of pending attachment changes
 
+The private ``staged`` state follows overridden attachment handling but maps
+the CRUD phase to replaced so omitted VRFs are detached without delete calls.
+
 It deliberately composes the generic NDStateMachine through the workflow
 coordinator helpers instead of changing the shared state-machine contract.
 """
@@ -54,7 +57,7 @@ class VrfStateMachine:
         Run only the generic NDStateMachine-backed VRF CRUD/gathered flow.
         """
         state = module_args.get("state", "merged")
-        sm, original_config, original_state = self.coordinator._new_state_machine(module_args, strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(self._crud_module_args(module_args), strategy)
         try:
             if state != "gathered":
                 self._trace("manage_state_start", state=state)
@@ -84,7 +87,7 @@ class VrfStateMachine:
         if state == "deleted":
             return self.run_deleted(module_args, active_strategy)
 
-        if state in ("replaced", "overridden"):
+        if state in ("replaced", "overridden", "staged"):
             return self._run_state_machine_aware_with_attachments(module_args, active_strategy, defer_deploy)
 
         desired_attachments = None
@@ -149,24 +152,25 @@ class VrfStateMachine:
         defer_deploy: bool = False,
     ) -> dict[str, Any]:
         """
-        Run replaced/overridden after deriving current VRF names from the state machine.
+        Run replaced/overridden/staged after deriving current VRF names from the state machine.
 
         The pre-detach phase must only query attachments for VRFs that already
         exist. First-create ``state=replaced`` tasks can then create the VRF
-        before the post-attach phase runs.
+        before the post-attach phase runs. The private ``staged`` state uses
+        overridden detach scope but runs CRUD as replaced to suppress deletes.
         """
         state = module_args.get("state", "merged")
         config = module_args.get("config") or []
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_vrf_names = self.coordinator._configured_vrf_names(config)
 
-        sm, original_config, original_state = self.coordinator._new_state_machine(module_args, strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(self._crud_module_args(module_args), strategy)
         try:
             current_vrf_names = self._vrf_names_from_models(sm.existing)
             current_vrf_name_set = set(current_vrf_names)
             desired_vrf_name_set = set(desired_vrf_names)
             current_desired_vrf_names = [vrf_name for vrf_name in desired_vrf_names if vrf_name in current_vrf_name_set]
-            attachment_query_vrf_names = current_vrf_names if state == "overridden" else current_desired_vrf_names
+            attachment_query_vrf_names = current_vrf_names if state in ("overridden", "staged") else current_desired_vrf_names
             current_attachment_details = (
                 self.coordinator._current_attachment_details_ignore_missing(
                     module_args,
@@ -182,7 +186,7 @@ class VrfStateMachine:
             )
 
             pre_delete_traces: list[dict[str, Any]] = []
-            if state == "overridden":
+            if state in ("overridden", "staged"):
                 omitted_vrf_names = [vrf_name for vrf_name in current_vrf_names if vrf_name not in desired_vrf_name_set]
                 pre_delete_traces = self._prepare_overridden_deletions(
                     module_args,
@@ -221,7 +225,7 @@ class VrfStateMachine:
             post_attachment_details = list(current_attachment_details or [])
             post_current_attachments = dict(current_attachments or {})
             new_desired_vrf_names = [vrf_name for vrf_name in desired_vrf_names if vrf_name not in current_vrf_name_set]
-            if state in ("replaced", "overridden") and desired_attachments and new_desired_vrf_names and not self._check_mode():
+            if state in ("replaced", "overridden", "staged") and desired_attachments and new_desired_vrf_names and not self._check_mode():
                 self._trace("attachment_phase_post_new_current_query_start", vrf_names=new_desired_vrf_names)
                 new_attachment_details = self.coordinator._current_attachment_details(
                     module_args,
@@ -275,6 +279,15 @@ class VrfStateMachine:
             current,
             pre_attach.get("payloads", []),
         )
+
+    @staticmethod
+    def _crud_module_args(module_args: dict) -> dict:
+        """Return module args for the generic CRUD state machine."""
+        if module_args.get("state") != "staged":
+            return module_args
+        crud_args = dict(module_args)
+        crud_args["state"] = "replaced"
+        return crud_args
 
     def _deploy_after_attachment_changes(
         self,

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -12,9 +12,9 @@ This wrapper owns the VRF-specific workflow around that CRUD phase:
   - post-attach for merged/replaced/overridden
   - deploy of pending attachment changes
 
-The private ``staged`` state follows overridden attachment handling but maps
-the CRUD phase to replaced and suppresses deploy so omitted VRFs are detached
-without deploy or delete calls.
+The ``staged`` state follows overridden attachment handling but maps the CRUD
+phase to replaced and suppresses deploy so omitted VRFs are detached without
+deploy or delete calls.
 
 It deliberately composes the generic NDStateMachine through the workflow
 coordinator helpers instead of changing the shared state-machine contract.
@@ -157,8 +157,8 @@ class VrfStateMachine:
 
         The pre-detach phase must only query attachments for VRFs that already
         exist. First-create ``state=replaced`` tasks can then create the VRF
-        before the post-attach phase runs. The private ``staged`` state uses
-        overridden detach scope but runs CRUD as replaced to suppress deletes.
+        before the post-attach phase runs. The ``staged`` state uses overridden
+        detach scope but runs CRUD as replaced to suppress deletes.
         """
         state = module_args.get("state", "merged")
         config = module_args.get("config") or []
@@ -305,7 +305,7 @@ class VrfStateMachine:
 
     @staticmethod
     def _prepare_crud_state(sm: Any, requested_state: str) -> None:
-        """Switch private staged workflows to replacement CRUD after query."""
+        """Switch staged workflows to replacement CRUD after query."""
         if requested_state != "staged":
             return
         sm.state = "replaced"

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -12,7 +12,7 @@ This wrapper owns the VRF-specific workflow around that CRUD phase:
   - post-attach for merged/replaced/overridden
   - deploy of pending attachment changes
 
-The private ``_staged`` state follows overridden attachment handling but maps
+The private ``staged`` state follows overridden attachment handling but maps
 the CRUD phase to replaced and suppresses deploy so omitted VRFs are detached
 without deploy or delete calls.
 
@@ -88,7 +88,7 @@ class VrfStateMachine:
         if state == "deleted":
             return self.run_deleted(module_args, active_strategy)
 
-        if state in ("replaced", "overridden", "_staged"):
+        if state in ("replaced", "overridden", "staged"):
             return self._run_state_machine_aware_with_attachments(module_args, active_strategy, defer_deploy)
 
         desired_attachments = None
@@ -153,11 +153,11 @@ class VrfStateMachine:
         defer_deploy: bool = False,
     ) -> dict[str, Any]:
         """
-        Run replaced/overridden/_staged after deriving current VRF names from the state machine.
+        Run replaced/overridden/staged after deriving current VRF names from the state machine.
 
         The pre-detach phase must only query attachments for VRFs that already
         exist. First-create ``state=replaced`` tasks can then create the VRF
-        before the post-attach phase runs. The private ``_staged`` state uses
+        before the post-attach phase runs. The private ``staged`` state uses
         overridden detach scope but runs CRUD as replaced to suppress deletes.
         """
         state = module_args.get("state", "merged")
@@ -172,7 +172,7 @@ class VrfStateMachine:
             current_vrf_name_set = set(current_vrf_names)
             desired_vrf_name_set = set(desired_vrf_names)
             current_desired_vrf_names = [vrf_name for vrf_name in desired_vrf_names if vrf_name in current_vrf_name_set]
-            attachment_query_vrf_names = current_vrf_names if state in ("overridden", "_staged") else current_desired_vrf_names
+            attachment_query_vrf_names = current_vrf_names if state in ("overridden", "staged") else current_desired_vrf_names
             current_attachment_details = (
                 self.coordinator._current_attachment_details_ignore_missing(
                     module_args,
@@ -188,7 +188,7 @@ class VrfStateMachine:
             )
 
             pre_delete_traces: list[dict[str, Any]] = []
-            if state in ("overridden", "_staged"):
+            if state in ("overridden", "staged"):
                 omitted_vrf_names = [vrf_name for vrf_name in current_vrf_names if vrf_name not in desired_vrf_name_set]
                 pre_delete_traces = self._prepare_overridden_deletions(
                     module_args,
@@ -227,7 +227,7 @@ class VrfStateMachine:
             post_attachment_details = list(current_attachment_details or [])
             post_current_attachments = dict(current_attachments or {})
             new_desired_vrf_names = [vrf_name for vrf_name in desired_vrf_names if vrf_name not in current_vrf_name_set]
-            if state in ("replaced", "overridden", "_staged") and desired_attachments and new_desired_vrf_names and not self._check_mode():
+            if state in ("replaced", "overridden", "staged") and desired_attachments and new_desired_vrf_names and not self._check_mode():
                 self._trace("attachment_phase_post_new_current_query_start", vrf_names=new_desired_vrf_names)
                 new_attachment_details = self.coordinator._current_attachment_details(
                     module_args,
@@ -256,7 +256,7 @@ class VrfStateMachine:
             self._trace("attachment_phase_post_end", changed=post_attach.get("changed"), payload_count=len(post_attach.get("payloads", [])))
             self.coordinator._merge_api_trace(result, post_attach)
 
-            if state == "_staged":
+            if state == "staged":
                 return result
 
             return self._deploy_after_attachment_changes(
@@ -288,7 +288,7 @@ class VrfStateMachine:
     @staticmethod
     def _crud_module_args(module_args: dict) -> dict:
         """Return module args for the generic CRUD state machine."""
-        if module_args.get("state") != "_staged":
+        if module_args.get("state") != "staged":
             return module_args
         crud_args = dict(module_args)
         crud_args["state"] = "replaced"
@@ -297,7 +297,7 @@ class VrfStateMachine:
     @staticmethod
     def _query_module_args(module_args: dict) -> dict:
         """Return module args for the current-state query phase."""
-        if module_args.get("state") != "_staged":
+        if module_args.get("state") != "staged":
             return module_args
         query_args = dict(module_args)
         query_args["state"] = "overridden"
@@ -306,7 +306,7 @@ class VrfStateMachine:
     @staticmethod
     def _prepare_crud_state(sm: Any, requested_state: str) -> None:
         """Switch private staged workflows to replacement CRUD after query."""
-        if requested_state != "_staged":
+        if requested_state != "staged":
             return
         sm.state = "replaced"
 
@@ -390,7 +390,7 @@ class VrfStateMachine:
             omitted_vrf_names,
             attachment_details=omitted_attachment_details,
         )
-        if module_args.get("state") == "_staged":
+        if module_args.get("state") == "staged":
             return [detach_trace] if detach_trace else []
         return self._deploy_detach_traces(
             api_args=module_args,

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -13,7 +13,8 @@ This wrapper owns the VRF-specific workflow around that CRUD phase:
   - deploy of pending attachment changes
 
 The private ``staged`` state follows overridden attachment handling but maps
-the CRUD phase to replaced so omitted VRFs are detached without delete calls.
+the CRUD phase to replaced and suppresses deploy so omitted VRFs are detached
+without deploy or delete calls.
 
 It deliberately composes the generic NDStateMachine through the workflow
 coordinator helpers instead of changing the shared state-machine contract.
@@ -254,6 +255,9 @@ class VrfStateMachine:
             self._trace("attachment_phase_post_end", changed=post_attach.get("changed"), payload_count=len(post_attach.get("payloads", [])))
             self.coordinator._merge_api_trace(result, post_attach)
 
+            if state == "staged":
+                return result
+
             return self._deploy_after_attachment_changes(
                 result,
                 config,
@@ -369,6 +373,8 @@ class VrfStateMachine:
             omitted_vrf_names,
             attachment_details=omitted_attachment_details,
         )
+        if module_args.get("state") == "staged":
+            return [detach_trace] if detach_trace else []
         return self._deploy_detach_traces(
             api_args=module_args,
             wait_args=module_args,

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -165,8 +165,9 @@ class VrfStateMachine:
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_vrf_names = self.coordinator._configured_vrf_names(config)
 
-        sm, original_config, original_state = self.coordinator._new_state_machine(self._crud_module_args(module_args), strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(self._query_module_args(module_args), strategy)
         try:
+            self._prepare_crud_state(sm, state)
             current_vrf_names = self._vrf_names_from_models(sm.existing)
             current_vrf_name_set = set(current_vrf_names)
             desired_vrf_name_set = set(desired_vrf_names)
@@ -292,6 +293,22 @@ class VrfStateMachine:
         crud_args = dict(module_args)
         crud_args["state"] = "replaced"
         return crud_args
+
+    @staticmethod
+    def _query_module_args(module_args: dict) -> dict:
+        """Return module args for the current-state query phase."""
+        if module_args.get("state") != "_staged":
+            return module_args
+        query_args = dict(module_args)
+        query_args["state"] = "overridden"
+        return query_args
+
+    @staticmethod
+    def _prepare_crud_state(sm: Any, requested_state: str) -> None:
+        """Switch private staged workflows to replacement CRUD after query."""
+        if requested_state != "_staged":
+            return
+        sm.state = "replaced"
 
     def _deploy_after_attachment_changes(
         self,

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -29,6 +29,11 @@ from typing import Any
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.strategies.base_vrf import (
     BaseVrfStrategy,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.staged_state_helpers import (
+    crud_module_args,
+    prepare_crud_state,
+    query_module_args,
+)
 
 
 class VrfStateMachine:
@@ -58,8 +63,9 @@ class VrfStateMachine:
         Run only the generic NDStateMachine-backed VRF CRUD/gathered flow.
         """
         state = module_args.get("state", "merged")
-        sm, original_config, original_state = self.coordinator._new_state_machine(self._crud_module_args(module_args), strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(crud_module_args(module_args), strategy)
         try:
+            prepare_crud_state(sm, state)
             if state != "gathered":
                 self._trace("manage_state_start", state=state)
                 sm.manage_state()
@@ -165,9 +171,9 @@ class VrfStateMachine:
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_vrf_names = self.coordinator._configured_vrf_names(config)
 
-        sm, original_config, original_state = self.coordinator._new_state_machine(self._query_module_args(module_args), strategy)
+        sm, original_config, original_state = self.coordinator._new_state_machine(query_module_args(module_args), strategy)
         try:
-            self._prepare_crud_state(sm, state)
+            prepare_crud_state(sm, state)
             current_vrf_names = self._vrf_names_from_models(sm.existing)
             current_vrf_name_set = set(current_vrf_names)
             desired_vrf_name_set = set(desired_vrf_names)
@@ -285,31 +291,6 @@ class VrfStateMachine:
             pre_attach.get("payloads", []),
         )
 
-    @staticmethod
-    def _crud_module_args(module_args: dict) -> dict:
-        """Return module args for the generic CRUD state machine."""
-        if module_args.get("state") != "staged":
-            return module_args
-        crud_args = dict(module_args)
-        crud_args["state"] = "replaced"
-        return crud_args
-
-    @staticmethod
-    def _query_module_args(module_args: dict) -> dict:
-        """Return module args for the current-state query phase."""
-        if module_args.get("state") != "staged":
-            return module_args
-        query_args = dict(module_args)
-        query_args["state"] = "overridden"
-        return query_args
-
-    @staticmethod
-    def _prepare_crud_state(sm: Any, requested_state: str) -> None:
-        """Switch staged workflows to replacement CRUD after query."""
-        if requested_state != "staged":
-            return
-        sm.state = "replaced"
-
     def _deploy_after_attachment_changes(
         self,
         result: dict[str, Any],
@@ -375,7 +356,8 @@ class VrfStateMachine:
         if not omitted_vrf_names:
             return []
 
-        self.coordinator._ensure_vrfs_have_no_networks(module_args, strategy, omitted_vrf_names)
+        if module_args.get("state") != "staged":
+            self.coordinator._ensure_vrfs_have_no_networks(module_args, strategy, omitted_vrf_names)
         omitted_attachment_details = (
             self.coordinator._filter_attachment_details_by_vrf(
                 current_attachment_details,

--- a/plugins/module_utils/orchestrators/vrf_state_machine.py
+++ b/plugins/module_utils/orchestrators/vrf_state_machine.py
@@ -171,10 +171,19 @@ class VrfStateMachine:
         desired_attachments = self.coordinator._desired_attachment_map(module_args, strategy)
         desired_vrf_names = self.coordinator._configured_vrf_names(config)
 
-        sm, original_config, original_state = self.coordinator._new_state_machine(query_module_args(module_args), strategy)
+        current_vrf_names = []
+        if state == "staged":
+            query_sm, query_original_config, query_original_state = self.coordinator._new_state_machine(query_module_args(module_args), strategy)
+            try:
+                current_vrf_names = self._vrf_names_from_models(query_sm.existing)
+            finally:
+                self.coordinator._restore_state_machine_params(query_original_config, query_original_state)
+
+        sm, original_config, original_state = self.coordinator._new_state_machine(crud_module_args(module_args), strategy)
         try:
             prepare_crud_state(sm, state)
-            current_vrf_names = self._vrf_names_from_models(sm.existing)
+            if state != "staged":
+                current_vrf_names = self._vrf_names_from_models(sm.existing)
             current_vrf_name_set = set(current_vrf_names)
             desired_vrf_name_set = set(desired_vrf_names)
             current_desired_vrf_names = [vrf_name for vrf_name in desired_vrf_names if vrf_name in current_vrf_name_set]

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -24,8 +24,11 @@ options:
     description:
       - Desired state of Network resources.
       - V(query) is accepted as a compatibility alias for V(gathered).
+      - V(_staged) is an internal/private workflow state. It follows
+        V(overridden) attachment handling, suppresses deployment, and does not
+        remove omitted Network definitions.
     type: str
-    choices: [ merged, replaced, overridden, deleted, gathered, query ]
+    choices: [ merged, replaced, overridden, deleted, gathered, query, _staged ]
     default: merged
   config:
     description:
@@ -580,7 +583,7 @@ def main():
         state=dict(
             type="str",
             default="merged",
-            choices=["merged", "replaced", "overridden", "deleted", "gathered", "query"],
+            choices=["merged", "replaced", "overridden", "deleted", "gathered", "query", "_staged"],
         ),
         config=dict(
             type="list",

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -24,11 +24,11 @@ options:
     description:
       - Desired state of Network resources.
       - V(query) is accepted as a compatibility alias for V(gathered).
-      - V(_staged) is an internal/private workflow state. It follows
+      - V(staged) is an internal/private workflow state. It follows
         V(overridden) attachment handling, suppresses deployment, and does not
         remove omitted Network definitions.
     type: str
-    choices: [ merged, replaced, overridden, deleted, gathered, query, _staged ]
+    choices: [ merged, replaced, overridden, deleted, gathered, query, staged ]
     default: merged
   config:
     description:
@@ -583,7 +583,7 @@ def main():
         state=dict(
             type="str",
             default="merged",
-            choices=["merged", "replaced", "overridden", "deleted", "gathered", "query", "_staged"],
+            choices=["merged", "replaced", "overridden", "deleted", "gathered", "query", "staged"],
         ),
         config=dict(
             type="list",

--- a/plugins/modules/nd_manage_networks.py
+++ b/plugins/modules/nd_manage_networks.py
@@ -24,9 +24,8 @@ options:
     description:
       - Desired state of Network resources.
       - V(query) is accepted as a compatibility alias for V(gathered).
-      - V(staged) is an internal/private workflow state. It follows
-        V(overridden) attachment handling, suppresses deployment, and does not
-        remove omitted Network definitions.
+      - V(staged) creates or updates Networks and reconciles attachments without
+        deploying changes; omitted Networks are detached but not removed.
     type: str
     choices: [ merged, replaced, overridden, deleted, gathered, query, staged ]
     default: merged
@@ -475,6 +474,19 @@ EXAMPLES = r"""
     config:
       - network_name: Network_BLUE
         is_l2only: true
+
+- name: Stage Network attachment changes
+  cisco.nd.nd_manage_networks:
+    fabric_name: fab1
+    state: staged
+    config:
+      - network_name: Network_BLUE
+        is_l2only: true
+        network_id: 50010
+        vlan_id: 2001
+        attach:
+          - ip_address: 192.0.2.10
+            interfaces: []
 """
 RETURN = r"""
 changed:

--- a/plugins/modules/nd_manage_vrfs.py
+++ b/plugins/modules/nd_manage_vrfs.py
@@ -41,9 +41,8 @@ options:
       - V(deleted) removes specified VRFs (or all if config is empty).
       - V(gathered) returns current VRF state (the only state allowed on child
         fabrics when targeted directly).
-      - V(staged) is an internal/private workflow state. It follows
-        V(overridden) attachment handling, suppresses deployment, and does not
-        remove omitted VRF definitions.
+      - V(staged) creates or updates VRFs and reconciles attachments without
+        deploying changes; omitted VRFs are detached but not removed.
     type: str
     choices: [ merged, replaced, overridden, deleted, gathered, staged ]
     default: merged
@@ -630,6 +629,17 @@ EXAMPLES = r"""
         vrf_description: "Updated Blue VRF"
         max_bgp_paths: 4
         max_ibgp_paths: 4
+
+# ── Stage VRF changes without deployment ───────────────────────────────────
+- name: Stage VRF attachment changes
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: fab1
+    state: staged
+    config:
+      - vrf_name: VRF_BLUE
+        vrf_id: 50010
+        attach:
+          - ip_address: 192.0.2.10
 """
 
 RETURN = r"""

--- a/plugins/modules/nd_manage_vrfs.py
+++ b/plugins/modules/nd_manage_vrfs.py
@@ -41,8 +41,11 @@ options:
       - V(deleted) removes specified VRFs (or all if config is empty).
       - V(gathered) returns current VRF state (the only state allowed on child
         fabrics when targeted directly).
+      - V(_staged) is an internal/private workflow state. It follows
+        V(overridden) attachment handling, suppresses deployment, and does not
+        remove omitted VRF definitions.
     type: str
-    choices: [ merged, replaced, overridden, deleted, gathered ]
+    choices: [ merged, replaced, overridden, deleted, gathered, _staged ]
     default: merged
   config:
     description:
@@ -736,7 +739,7 @@ def main():
         state=dict(
             type="str",
             default="merged",
-            choices=["merged", "replaced", "overridden", "deleted", "gathered"],
+            choices=["merged", "replaced", "overridden", "deleted", "gathered", "_staged"],
         ),
         config=dict(
             type="list",

--- a/plugins/modules/nd_manage_vrfs.py
+++ b/plugins/modules/nd_manage_vrfs.py
@@ -41,11 +41,11 @@ options:
       - V(deleted) removes specified VRFs (or all if config is empty).
       - V(gathered) returns current VRF state (the only state allowed on child
         fabrics when targeted directly).
-      - V(_staged) is an internal/private workflow state. It follows
+      - V(staged) is an internal/private workflow state. It follows
         V(overridden) attachment handling, suppresses deployment, and does not
         remove omitted VRF definitions.
     type: str
-    choices: [ merged, replaced, overridden, deleted, gathered, _staged ]
+    choices: [ merged, replaced, overridden, deleted, gathered, staged ]
     default: merged
   config:
     description:
@@ -739,7 +739,7 @@ def main():
         state=dict(
             type="str",
             default="merged",
-            choices=["merged", "replaced", "overridden", "deleted", "gathered", "_staged"],
+            choices=["merged", "replaced", "overridden", "deleted", "gathered", "staged"],
         ),
         config=dict(
             type="list",

--- a/tests/integration/targets/nd_manage_networks/defaults/main.yaml
+++ b/tests/integration/targets/nd_manage_networks/defaults/main.yaml
@@ -4,17 +4,23 @@ nd_network_test_topology: ""
 
 nd_network_standalone_fabric: "{{ ansible_it_fabric | default(nd_test_fabric_name | default('')) }}"
 nd_network_standalone_switch: "{{ ansible_switch1 | default(nd_test_switch_ip | default('')) }}"
+nd_network_standalone_switch2: "{{ ansible_switch2 | default('') }}"
 nd_network_standalone_interface: "{{ ansible_network_interface1 | default('') }}"
+nd_network_standalone_interface2: "{{ ansible_network_interface2 | default(nd_network_standalone_interface) }}"
 
 nd_network_msd_parent_fabric: "{{ ansible_msd_parent_fabric | default('') }}"
 nd_network_msd_child_fabric: "{{ ansible_msd_child_fabric | default('') }}"
 nd_network_msd_switch: "{{ ansible_msd_switch1 | default(ansible_switch1 | default('')) }}"
+nd_network_msd_switch2: "{{ ansible_msd_switch2 | default(ansible_switch2 | default('')) }}"
 nd_network_msd_interface: "{{ ansible_msd_network_interface1 | default(ansible_network_interface1 | default('')) }}"
+nd_network_msd_interface2: "{{ ansible_msd_network_interface2 | default(ansible_network_interface2 | default(nd_network_msd_interface)) }}"
 
 nd_network_mcfg_parent_fabric: "{{ ansible_mcfg_parent_fabric | default('') }}"
 nd_network_mcfg_child_fabric: "{{ ansible_mcfg_child_fabric | default('') }}"
 nd_network_mcfg_switch: "{{ ansible_mcfg_switch1 | default('') }}"
+nd_network_mcfg_switch2: "{{ ansible_mcfg_switch2 | default('') }}"
 nd_network_mcfg_interface: "{{ ansible_mcfg_network_interface1 | default(ansible_network_interface1 | default('')) }}"
+nd_network_mcfg_interface2: "{{ ansible_mcfg_network_interface2 | default(ansible_network_interface2 | default(nd_network_mcfg_interface)) }}"
 
 nd_network_run_standalone: "{{ nd_network_standalone_fabric | length > 0 }}"
 nd_network_run_msd: "{{ nd_network_msd_parent_fabric | length > 0 and nd_network_msd_child_fabric | length > 0 }}"

--- a/tests/integration/targets/nd_manage_networks/defaults/main.yaml
+++ b/tests/integration/targets/nd_manage_networks/defaults/main.yaml
@@ -8,18 +8,25 @@ nd_network_standalone_interface: "{{ ansible_network_interface1 | default('') }}
 
 nd_network_msd_parent_fabric: "{{ ansible_msd_parent_fabric | default('') }}"
 nd_network_msd_child_fabric: "{{ ansible_msd_child_fabric | default('') }}"
+nd_network_msd_switch: "{{ ansible_msd_switch1 | default(ansible_switch1 | default('')) }}"
+nd_network_msd_interface: "{{ ansible_msd_network_interface1 | default(ansible_network_interface1 | default('')) }}"
 
 nd_network_mcfg_parent_fabric: "{{ ansible_mcfg_parent_fabric | default('') }}"
 nd_network_mcfg_child_fabric: "{{ ansible_mcfg_child_fabric | default('') }}"
+nd_network_mcfg_switch: "{{ ansible_mcfg_switch1 | default('') }}"
+nd_network_mcfg_interface: "{{ ansible_mcfg_network_interface1 | default(ansible_network_interface1 | default('')) }}"
 
 nd_network_run_standalone: "{{ nd_network_standalone_fabric | length > 0 }}"
 nd_network_run_msd: "{{ nd_network_msd_parent_fabric | length > 0 and nd_network_msd_child_fabric | length > 0 }}"
 nd_network_run_mcfg: "{{ nd_network_mcfg_parent_fabric | length > 0 and nd_network_mcfg_child_fabric | length > 0 }}"
 nd_network_run_overridden: false
+nd_network_run_staged: true
 
 nd_network_l3_vrf_name: "{{ ansible_nd_network_vrf_name | default('') }}"
 nd_network_run_l3: "{{ nd_network_l3_vrf_name | length > 0 }}"
 nd_network_run_attach: "{{ nd_network_standalone_switch | length > 0 and nd_network_standalone_interface | length > 0 }}"
+nd_network_run_msd_attach: "{{ nd_network_msd_switch | length > 0 and nd_network_msd_interface | length > 0 }}"
+nd_network_run_mcfg_attach: "{{ nd_network_mcfg_switch | length > 0 and nd_network_mcfg_interface | length > 0 }}"
 
 nd_network_base_id: 901000
 nd_network_base_vlan: 3100

--- a/tests/integration/targets/nd_manage_networks/tests/mcfg/staged.yaml
+++ b/tests/integration/targets/nd_manage_networks/tests/mcfg/staged.yaml
@@ -16,6 +16,7 @@
       - ndnetmcfgstgcreate
       - ndnetmcfgstgadd
       - ndnetmcfgstgremove
+      - ndnetmcfgstgdetach
       - ndnetmcfgstgomit
     target_network_delete_config:
       - network_name: ndnetmcfgstgcreate
@@ -24,9 +25,11 @@
         is_l2only: true
       - network_name: ndnetmcfgstgremove
         is_l2only: true
+      - network_name: ndnetmcfgstgdetach
+        is_l2only: true
       - network_name: ndnetmcfgstgomit
         is_l2only: true
-    nd_network_mcfg_staged_attach_block: >-
+    nd_network_mcfg_staged_primary_attach_block: >-
       {{
         [
           {
@@ -41,6 +44,48 @@
           }
         ] if nd_network_run_mcfg_attach | bool else []
       }}
+    nd_network_mcfg_staged_secondary_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_network_mcfg_switch2,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_mcfg_interface2
+              }
+            ],
+            'deploy': true
+          }
+        ] if nd_network_mcfg_switch2 | length > 0 and nd_network_mcfg_interface2 | length > 0 else []
+      }}
+    nd_network_mcfg_staged_create_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_network_mcfg_switch2,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_mcfg_interface2
+              }
+            ],
+            'deploy': true
+          }
+        ] if nd_network_mcfg_switch2 | length > 0 and nd_network_mcfg_interface2 | length > 0 else [
+          {
+            'ip_address': nd_network_mcfg_switch,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_mcfg_interface
+              }
+            ],
+            'deploy': true
+          }
+        ]
+      }}
+    nd_network_mcfg_staged_both_attach_count: "{{ 2 if nd_network_mcfg_switch2 | length > 0 and nd_network_mcfg_interface2 | length > 0 else 1 }}"
   delegate_to: localhost
   tags:
     - mcfg
@@ -54,6 +99,7 @@
         network_id: "{{ nd_network_base_id + 290 }}"
         vlan_id: "{{ nd_network_base_vlan + 290 }}"
         vlan_name: ndnetmcfgstgadd_vlan
+        attach: "{{ nd_network_mcfg_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
@@ -62,7 +108,16 @@
         network_id: "{{ nd_network_base_id + 291 }}"
         vlan_id: "{{ nd_network_base_vlan + 291 }}"
         vlan_name: ndnetmcfgstgremove_vlan
-        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        attach: "{{ nd_network_mcfg_staged_primary_attach_block + nd_network_mcfg_staged_secondary_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
+      - network_name: ndnetmcfgstgdetach
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 294 }}"
+        vlan_id: "{{ nd_network_base_vlan + 294 }}"
+        vlan_name: ndnetmcfgstgdetach_vlan
+        attach: "{{ nd_network_mcfg_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
@@ -71,7 +126,7 @@
         network_id: "{{ nd_network_base_id + 292 }}"
         vlan_id: "{{ nd_network_base_vlan + 292 }}"
         vlan_name: ndnetmcfgstgomit_vlan
-        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        attach: "{{ nd_network_mcfg_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
@@ -81,7 +136,7 @@
         network_id: "{{ nd_network_base_id + 293 }}"
         vlan_id: "{{ nd_network_base_vlan + 293 }}"
         vlan_name: ndnetmcfgstgcreate_vlan
-        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        attach: "{{ nd_network_mcfg_staged_create_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
@@ -91,7 +146,7 @@
         network_id: "{{ nd_network_base_id + 293 }}"
         vlan_id: "{{ nd_network_base_vlan + 293 }}"
         vlan_name: ndnetmcfgstgcreate_vlan
-        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        attach: "{{ nd_network_mcfg_staged_create_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
@@ -100,7 +155,7 @@
         network_id: "{{ nd_network_base_id + 290 }}"
         vlan_id: "{{ nd_network_base_vlan + 290 }}"
         vlan_name: ndnetmcfgstgadd_vlan
-        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        attach: "{{ nd_network_mcfg_staged_primary_attach_block + nd_network_mcfg_staged_secondary_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
@@ -109,6 +164,16 @@
         network_id: "{{ nd_network_base_id + 291 }}"
         vlan_id: "{{ nd_network_base_vlan + 291 }}"
         vlan_name: ndnetmcfgstgremove_vlan
+        attach: "{{ nd_network_mcfg_staged_primary_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
+      - network_name: ndnetmcfgstgdetach
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 294 }}"
+        vlan_id: "{{ nd_network_base_vlan + 294 }}"
+        vlan_name: ndnetmcfgstgdetach_vlan
+        attach: []
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
@@ -233,6 +298,12 @@
         | selectattr("networkName", "equalto", "ndnetmcfgstgcreate")
         | selectattr("attach", "equalto", true)
         | list | length > 0
+      - >-
+        mcfg_staged_create_attachment_rows
+        | selectattr("networkName", "equalto", "ndnetmcfgstgcreate")
+        | selectattr("attach", "equalto", true)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_network_run_mcfg | bool
     - nd_network_run_staged | bool
@@ -276,6 +347,21 @@
     that:
       - mcfg_staged_result.changed == true
       - mcfg_staged_result.fabric_type == "multicluster_parent"
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC3 - Repeat Reconcile For Controller-State Idempotency
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_network_mcfg_staged_conf }}"
+    output_level: debug
+  register: mcfg_staged_repeat_result
   when:
     - nd_network_run_mcfg | bool
     - nd_network_run_staged | bool
@@ -333,9 +419,23 @@
     that:
       - (mcfg_staged_gathered.after | default([]) | to_json) is search("ndnetmcfgstgomit")
       - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
-      - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgadd") | selectattr("attach", "equalto", true) | list | length > 0
-      - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - >-
+        (
+          mcfg_staged_attachment_rows
+          | selectattr("networkName", "equalto", "ndnetmcfgstgadd")
+          | selectattr("attach", "equalto", true)
+          | list
+          | length
+        ) == (nd_network_mcfg_staged_both_attach_count | int)
+      - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgremove") | selectattr("attach", "equalto", true) | list | length == 1
+      - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgdetach") | selectattr("attach", "equalto", true) | list | length == 0
       - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgomit") | selectattr("attach", "equalto", true) | list | length == 0
+      - mcfg_staged_repeat_result.changed == false
+      - >-
+        mcfg_staged_attachment_rows
+        | selectattr("networkName", "in", target_network_names)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_network_run_mcfg | bool
     - nd_network_run_staged | bool

--- a/tests/integration/targets/nd_manage_networks/tests/mcfg/staged.yaml
+++ b/tests/integration/targets/nd_manage_networks/tests/mcfg/staged.yaml
@@ -1,0 +1,277 @@
+---
+- name: Test Entry Point - [nd_manage_networks - mcfg - staged]
+  ansible.builtin.debug:
+    msg:
+      - "----------------------------------------------------------------"
+      - "+     Executing MCFG Staged Tests - [nd_manage_networks]         +"
+      - "----------------------------------------------------------------"
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Build Attachment Data
+  ansible.builtin.set_fact:
+    target_fabric: "{{ nd_network_mcfg_parent_fabric }}"
+    target_network_names:
+      - ndnetmcfgstgcreate
+      - ndnetmcfgstgadd
+      - ndnetmcfgstgremove
+      - ndnetmcfgstgomit
+    target_network_delete_config:
+      - network_name: ndnetmcfgstgcreate
+        is_l2only: true
+      - network_name: ndnetmcfgstgadd
+        is_l2only: true
+      - network_name: ndnetmcfgstgremove
+        is_l2only: true
+      - network_name: ndnetmcfgstgomit
+        is_l2only: true
+    nd_network_mcfg_staged_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_network_mcfg_switch,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_mcfg_interface
+              }
+            ],
+            'deploy': true
+          }
+        ] if nd_network_run_mcfg_attach | bool else []
+      }}
+  delegate_to: localhost
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Build Parent and Child Network Config
+  ansible.builtin.set_fact:
+    nd_network_mcfg_staged_seed:
+      - network_name: ndnetmcfgstgadd
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 290 }}"
+        vlan_id: "{{ nd_network_base_vlan + 290 }}"
+        vlan_name: ndnetmcfgstgadd_vlan
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
+      - network_name: ndnetmcfgstgremove
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 291 }}"
+        vlan_id: "{{ nd_network_base_vlan + 291 }}"
+        vlan_name: ndnetmcfgstgremove_vlan
+        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
+      - network_name: ndnetmcfgstgomit
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 292 }}"
+        vlan_id: "{{ nd_network_base_vlan + 292 }}"
+        vlan_name: ndnetmcfgstgomit_vlan
+        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
+    nd_network_mcfg_staged_create_config:
+      - network_name: ndnetmcfgstgcreate
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 293 }}"
+        vlan_id: "{{ nd_network_base_vlan + 293 }}"
+        vlan_name: ndnetmcfgstgcreate_vlan
+        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
+    nd_network_mcfg_staged_config:
+      - network_name: ndnetmcfgstgcreate
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 293 }}"
+        vlan_id: "{{ nd_network_base_vlan + 293 }}"
+        vlan_name: ndnetmcfgstgcreate_vlan
+        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
+      - network_name: ndnetmcfgstgadd
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 290 }}"
+        vlan_id: "{{ nd_network_base_vlan + 290 }}"
+        vlan_name: ndnetmcfgstgadd_vlan
+        attach: "{{ nd_network_mcfg_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
+      - network_name: ndnetmcfgstgremove
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 291 }}"
+        vlan_id: "{{ nd_network_base_vlan + 291 }}"
+        vlan_name: ndnetmcfgstgremove_vlan
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_mcfg_child_fabric }}"
+  delegate_to: localhost
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Import Setup
+  ansible.builtin.import_tasks: ../../tasks/setup.yaml
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Prepare Seed Configuration
+  vars:
+    file: mcfg_staged_seed
+    network_conf: "{{ nd_network_mcfg_staged_seed }}"
+  ansible.builtin.import_tasks: ../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Prepare Create Configuration
+  vars:
+    file: mcfg_staged_create
+    network_conf: "{{ nd_network_mcfg_staged_create_config }}"
+  ansible.builtin.import_tasks: ../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Prepare Configuration
+  vars:
+    file: mcfg_staged
+    network_conf: "{{ nd_network_mcfg_staged_config }}"
+  ansible.builtin.import_tasks: ../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Create Network With Attachment
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_network_mcfg_staged_create_conf }}"
+    output_level: debug
+  register: mcfg_staged_create_result
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - mcfg_staged_create_result.changed == true
+      - mcfg_staged_create_result.fabric_type == "multicluster_parent"
+      - mcfg_staged_create_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
+      - mcfg_staged_create_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - mcfg_staged_create_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
+      - (mcfg_staged_create_result.api_payload | default([]) | to_json) is search("ndnetmcfgstgcreate")
+      - (mcfg_staged_create_result.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC2 - Seed Existing Networks
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: merged
+    config: "{{ nd_network_mcfg_staged_seed_conf }}"
+    output_level: debug
+  register: mcfg_staged_seed_result
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC3 - Reconcile Attachments Without Deploy Or Definition Delete
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_network_mcfg_staged_conf }}"
+    output_level: debug
+  register: mcfg_staged_result
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - mcfg_staged_result.changed == true
+      - mcfg_staged_result.fabric_type == "multicluster_parent"
+      - mcfg_staged_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
+      - mcfg_staged_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - mcfg_staged_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
+      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("ndnetmcfgstgadd")
+      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("ndnetmcfgstgremove")
+      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("ndnetmcfgstgomit")
+      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("true")
+      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC4 - Gather Parent Networks
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: gathered
+    config: "{{ target_network_delete_config }}"
+  register: mcfg_staged_gathered
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC4 - Assert Omitted Network Definition Remains
+  ansible.builtin.assert:
+    that:
+      - (mcfg_staged_gathered.after | default([]) | to_json) is search("ndnetmcfgstgomit")
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged

--- a/tests/integration/targets/nd_manage_networks/tests/mcfg/staged.yaml
+++ b/tests/integration/targets/nd_manage_networks/tests/mcfg/staged.yaml
@@ -181,16 +181,58 @@
     - mcfg
     - staged
 
-- name: MCFG Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+- name: MCFG Staged TC1 - Assert Staged Create Reported Change
   ansible.builtin.assert:
     that:
       - mcfg_staged_create_result.changed == true
       - mcfg_staged_create_result.fabric_type == "multicluster_parent"
-      - mcfg_staged_create_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
-      - mcfg_staged_create_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - mcfg_staged_create_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
-      - (mcfg_staged_create_result.api_payload | default([]) | to_json) is search("ndnetmcfgstgcreate")
-      - (mcfg_staged_create_result.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Query Created Network Attachment
+  cisco.nd.nd_rest:
+    path: "/api/v1/oneManage/manage/fabrics/{{ target_fabric }}/networkAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      networkNames:
+        - ndnetmcfgstgcreate
+  register: mcfg_staged_create_attachment_query
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Normalize Created Network Attachment Rows
+  ansible.builtin.set_fact:
+    mcfg_staged_create_attachment_rows: >-
+      {{
+        mcfg_staged_create_attachment_query.current.attachments
+        | default(mcfg_staged_create_attachment_query.current.items | default([]))
+      }}
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Assert Created Network Attachment State
+  ansible.builtin.assert:
+    that:
+      - >-
+        mcfg_staged_create_attachment_rows
+        | selectattr("networkName", "equalto", "ndnetmcfgstgcreate")
+        | selectattr("attach", "equalto", true)
+        | list | length > 0
   when:
     - nd_network_run_mcfg | bool
     - nd_network_run_staged | bool
@@ -229,19 +271,41 @@
     - mcfg
     - staged
 
-- name: MCFG Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+- name: MCFG Staged TC3 - Assert Staged Reconcile Reported Change
   ansible.builtin.assert:
     that:
       - mcfg_staged_result.changed == true
       - mcfg_staged_result.fabric_type == "multicluster_parent"
-      - mcfg_staged_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
-      - mcfg_staged_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - mcfg_staged_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
-      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("ndnetmcfgstgadd")
-      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("ndnetmcfgstgremove")
-      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("ndnetmcfgstgomit")
-      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("true")
-      - (mcfg_staged_result.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC4 - Query Network Attachments
+  cisco.nd.nd_rest:
+    path: "/api/v1/oneManage/manage/fabrics/{{ target_fabric }}/networkAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      networkNames: "{{ target_network_names }}"
+  register: mcfg_staged_attachment_query
+  when:
+    - nd_network_run_mcfg | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_mcfg_attach | bool
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC4 - Normalize Network Attachment Rows
+  ansible.builtin.set_fact:
+    mcfg_staged_attachment_rows: >-
+      {{
+        mcfg_staged_attachment_query.current.attachments
+        | default(mcfg_staged_attachment_query.current.items | default([]))
+      }}
   when:
     - nd_network_run_mcfg | bool
     - nd_network_run_staged | bool
@@ -268,6 +332,10 @@
   ansible.builtin.assert:
     that:
       - (mcfg_staged_gathered.after | default([]) | to_json) is search("ndnetmcfgstgomit")
+      - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
+      - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgadd") | selectattr("attach", "equalto", true) | list | length > 0
+      - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - mcfg_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmcfgstgomit") | selectattr("attach", "equalto", true) | list | length == 0
   when:
     - nd_network_run_mcfg | bool
     - nd_network_run_staged | bool

--- a/tests/integration/targets/nd_manage_networks/tests/msd/staged.yaml
+++ b/tests/integration/targets/nd_manage_networks/tests/msd/staged.yaml
@@ -1,0 +1,277 @@
+---
+- name: Test Entry Point - [nd_manage_networks - msd - staged]
+  ansible.builtin.debug:
+    msg:
+      - "----------------------------------------------------------------"
+      - "+     Executing MSD Staged Tests - [nd_manage_networks]          +"
+      - "----------------------------------------------------------------"
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Build Attachment Data
+  ansible.builtin.set_fact:
+    target_fabric: "{{ nd_network_msd_parent_fabric }}"
+    target_network_names:
+      - ndnetmsdstgcreate
+      - ndnetmsdstgadd
+      - ndnetmsdstgremove
+      - ndnetmsdstgomit
+    target_network_delete_config:
+      - network_name: ndnetmsdstgcreate
+        is_l2only: true
+      - network_name: ndnetmsdstgadd
+        is_l2only: true
+      - network_name: ndnetmsdstgremove
+        is_l2only: true
+      - network_name: ndnetmsdstgomit
+        is_l2only: true
+    nd_network_msd_staged_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_network_msd_switch,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_msd_interface
+              }
+            ],
+            'deploy': true
+          }
+        ] if nd_network_run_msd_attach | bool else []
+      }}
+  delegate_to: localhost
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Build Parent and Child Network Config
+  ansible.builtin.set_fact:
+    nd_network_msd_staged_seed:
+      - network_name: ndnetmsdstgadd
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 280 }}"
+        vlan_id: "{{ nd_network_base_vlan + 280 }}"
+        vlan_name: ndnetmsdstgadd_vlan
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_msd_child_fabric }}"
+      - network_name: ndnetmsdstgremove
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 281 }}"
+        vlan_id: "{{ nd_network_base_vlan + 281 }}"
+        vlan_name: ndnetmsdstgremove_vlan
+        attach: "{{ nd_network_msd_staged_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_msd_child_fabric }}"
+      - network_name: ndnetmsdstgomit
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 282 }}"
+        vlan_id: "{{ nd_network_base_vlan + 282 }}"
+        vlan_name: ndnetmsdstgomit_vlan
+        attach: "{{ nd_network_msd_staged_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_msd_child_fabric }}"
+    nd_network_msd_staged_create_config:
+      - network_name: ndnetmsdstgcreate
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 283 }}"
+        vlan_id: "{{ nd_network_base_vlan + 283 }}"
+        vlan_name: ndnetmsdstgcreate_vlan
+        attach: "{{ nd_network_msd_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_msd_child_fabric }}"
+    nd_network_msd_staged_config:
+      - network_name: ndnetmsdstgcreate
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 283 }}"
+        vlan_id: "{{ nd_network_base_vlan + 283 }}"
+        vlan_name: ndnetmsdstgcreate_vlan
+        attach: "{{ nd_network_msd_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_msd_child_fabric }}"
+      - network_name: ndnetmsdstgadd
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 280 }}"
+        vlan_id: "{{ nd_network_base_vlan + 280 }}"
+        vlan_name: ndnetmsdstgadd_vlan
+        attach: "{{ nd_network_msd_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_msd_child_fabric }}"
+      - network_name: ndnetmsdstgremove
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 281 }}"
+        vlan_id: "{{ nd_network_base_vlan + 281 }}"
+        vlan_name: ndnetmsdstgremove_vlan
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_msd_child_fabric }}"
+  delegate_to: localhost
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Import Setup
+  ansible.builtin.import_tasks: ../../tasks/setup.yaml
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Prepare Seed Configuration
+  vars:
+    file: msd_staged_seed
+    network_conf: "{{ nd_network_msd_staged_seed }}"
+  ansible.builtin.import_tasks: ../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Prepare Create Configuration
+  vars:
+    file: msd_staged_create
+    network_conf: "{{ nd_network_msd_staged_create_config }}"
+  ansible.builtin.import_tasks: ../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Prepare Configuration
+  vars:
+    file: msd_staged
+    network_conf: "{{ nd_network_msd_staged_config }}"
+  ansible.builtin.import_tasks: ../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Create Network With Attachment
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_network_msd_staged_create_conf }}"
+    output_level: debug
+  register: msd_staged_create_result
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - msd_staged_create_result.changed == true
+      - msd_staged_create_result.fabric_type == "multisite_parent"
+      - msd_staged_create_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
+      - msd_staged_create_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - msd_staged_create_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
+      - (msd_staged_create_result.api_payload | default([]) | to_json) is search("ndnetmsdstgcreate")
+      - (msd_staged_create_result.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC2 - Seed Existing Networks
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: merged
+    config: "{{ nd_network_msd_staged_seed_conf }}"
+    output_level: debug
+  register: msd_staged_seed_result
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC3 - Reconcile Attachments Without Deploy Or Definition Delete
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_network_msd_staged_conf }}"
+    output_level: debug
+  register: msd_staged_result
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - msd_staged_result.changed == true
+      - msd_staged_result.fabric_type == "multisite_parent"
+      - msd_staged_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
+      - msd_staged_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - msd_staged_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
+      - (msd_staged_result.api_payload | default([]) | to_json) is search("ndnetmsdstgadd")
+      - (msd_staged_result.api_payload | default([]) | to_json) is search("ndnetmsdstgremove")
+      - (msd_staged_result.api_payload | default([]) | to_json) is search("ndnetmsdstgomit")
+      - (msd_staged_result.api_payload | default([]) | to_json) is search("true")
+      - (msd_staged_result.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC4 - Gather Parent Networks
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: gathered
+    config: "{{ target_network_delete_config }}"
+  register: msd_staged_gathered
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC4 - Assert Omitted Network Definition Remains
+  ansible.builtin.assert:
+    that:
+      - (msd_staged_gathered.after | default([]) | to_json) is search("ndnetmsdstgomit")
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged

--- a/tests/integration/targets/nd_manage_networks/tests/msd/staged.yaml
+++ b/tests/integration/targets/nd_manage_networks/tests/msd/staged.yaml
@@ -181,16 +181,58 @@
     - msd
     - staged
 
-- name: MSD Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+- name: MSD Staged TC1 - Assert Staged Create Reported Change
   ansible.builtin.assert:
     that:
       - msd_staged_create_result.changed == true
       - msd_staged_create_result.fabric_type == "multisite_parent"
-      - msd_staged_create_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
-      - msd_staged_create_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - msd_staged_create_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
-      - (msd_staged_create_result.api_payload | default([]) | to_json) is search("ndnetmsdstgcreate")
-      - (msd_staged_create_result.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Query Created Network Attachment
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ target_fabric }}/networkAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      networkNames:
+        - ndnetmsdstgcreate
+  register: msd_staged_create_attachment_query
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Normalize Created Network Attachment Rows
+  ansible.builtin.set_fact:
+    msd_staged_create_attachment_rows: >-
+      {{
+        msd_staged_create_attachment_query.current.attachments
+        | default(msd_staged_create_attachment_query.current.items | default([]))
+      }}
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Assert Created Network Attachment State
+  ansible.builtin.assert:
+    that:
+      - >-
+        msd_staged_create_attachment_rows
+        | selectattr("networkName", "equalto", "ndnetmsdstgcreate")
+        | selectattr("attach", "equalto", true)
+        | list | length > 0
   when:
     - nd_network_run_msd | bool
     - nd_network_run_staged | bool
@@ -229,19 +271,41 @@
     - msd
     - staged
 
-- name: MSD Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+- name: MSD Staged TC3 - Assert Staged Reconcile Reported Change
   ansible.builtin.assert:
     that:
       - msd_staged_result.changed == true
       - msd_staged_result.fabric_type == "multisite_parent"
-      - msd_staged_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
-      - msd_staged_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - msd_staged_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
-      - (msd_staged_result.api_payload | default([]) | to_json) is search("ndnetmsdstgadd")
-      - (msd_staged_result.api_payload | default([]) | to_json) is search("ndnetmsdstgremove")
-      - (msd_staged_result.api_payload | default([]) | to_json) is search("ndnetmsdstgomit")
-      - (msd_staged_result.api_payload | default([]) | to_json) is search("true")
-      - (msd_staged_result.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC4 - Query Network Attachments
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ target_fabric }}/networkAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      networkNames: "{{ target_network_names }}"
+  register: msd_staged_attachment_query
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC4 - Normalize Network Attachment Rows
+  ansible.builtin.set_fact:
+    msd_staged_attachment_rows: >-
+      {{
+        msd_staged_attachment_query.current.attachments
+        | default(msd_staged_attachment_query.current.items | default([]))
+      }}
   when:
     - nd_network_run_msd | bool
     - nd_network_run_staged | bool
@@ -268,6 +332,10 @@
   ansible.builtin.assert:
     that:
       - (msd_staged_gathered.after | default([]) | to_json) is search("ndnetmsdstgomit")
+      - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
+      - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgadd") | selectattr("attach", "equalto", true) | list | length > 0
+      - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgomit") | selectattr("attach", "equalto", true) | list | length == 0
   when:
     - nd_network_run_msd | bool
     - nd_network_run_staged | bool

--- a/tests/integration/targets/nd_manage_networks/tests/msd/staged.yaml
+++ b/tests/integration/targets/nd_manage_networks/tests/msd/staged.yaml
@@ -16,6 +16,7 @@
       - ndnetmsdstgcreate
       - ndnetmsdstgadd
       - ndnetmsdstgremove
+      - ndnetmsdstgdetach
       - ndnetmsdstgomit
     target_network_delete_config:
       - network_name: ndnetmsdstgcreate
@@ -24,9 +25,11 @@
         is_l2only: true
       - network_name: ndnetmsdstgremove
         is_l2only: true
+      - network_name: ndnetmsdstgdetach
+        is_l2only: true
       - network_name: ndnetmsdstgomit
         is_l2only: true
-    nd_network_msd_staged_attach_block: >-
+    nd_network_msd_staged_primary_attach_block: >-
       {{
         [
           {
@@ -41,6 +44,48 @@
           }
         ] if nd_network_run_msd_attach | bool else []
       }}
+    nd_network_msd_staged_secondary_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_network_msd_switch2,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_msd_interface2
+              }
+            ],
+            'deploy': true
+          }
+        ] if nd_network_msd_switch2 | length > 0 and nd_network_msd_interface2 | length > 0 else []
+      }}
+    nd_network_msd_staged_create_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_network_msd_switch2,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_msd_interface2
+              }
+            ],
+            'deploy': true
+          }
+        ] if nd_network_msd_switch2 | length > 0 and nd_network_msd_interface2 | length > 0 else [
+          {
+            'ip_address': nd_network_msd_switch,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_msd_interface
+              }
+            ],
+            'deploy': true
+          }
+        ]
+      }}
+    nd_network_msd_staged_both_attach_count: "{{ 2 if nd_network_msd_switch2 | length > 0 and nd_network_msd_interface2 | length > 0 else 1 }}"
   delegate_to: localhost
   tags:
     - msd
@@ -54,6 +99,7 @@
         network_id: "{{ nd_network_base_id + 280 }}"
         vlan_id: "{{ nd_network_base_vlan + 280 }}"
         vlan_name: ndnetmsdstgadd_vlan
+        attach: "{{ nd_network_msd_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_network_msd_child_fabric }}"
@@ -62,7 +108,16 @@
         network_id: "{{ nd_network_base_id + 281 }}"
         vlan_id: "{{ nd_network_base_vlan + 281 }}"
         vlan_name: ndnetmsdstgremove_vlan
-        attach: "{{ nd_network_msd_staged_attach_block }}"
+        attach: "{{ nd_network_msd_staged_primary_attach_block + nd_network_msd_staged_secondary_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_msd_child_fabric }}"
+      - network_name: ndnetmsdstgdetach
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 284 }}"
+        vlan_id: "{{ nd_network_base_vlan + 284 }}"
+        vlan_name: ndnetmsdstgdetach_vlan
+        attach: "{{ nd_network_msd_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_network_msd_child_fabric }}"
@@ -71,7 +126,7 @@
         network_id: "{{ nd_network_base_id + 282 }}"
         vlan_id: "{{ nd_network_base_vlan + 282 }}"
         vlan_name: ndnetmsdstgomit_vlan
-        attach: "{{ nd_network_msd_staged_attach_block }}"
+        attach: "{{ nd_network_msd_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_network_msd_child_fabric }}"
@@ -81,7 +136,7 @@
         network_id: "{{ nd_network_base_id + 283 }}"
         vlan_id: "{{ nd_network_base_vlan + 283 }}"
         vlan_name: ndnetmsdstgcreate_vlan
-        attach: "{{ nd_network_msd_staged_attach_block }}"
+        attach: "{{ nd_network_msd_staged_create_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_network_msd_child_fabric }}"
@@ -91,7 +146,7 @@
         network_id: "{{ nd_network_base_id + 283 }}"
         vlan_id: "{{ nd_network_base_vlan + 283 }}"
         vlan_name: ndnetmsdstgcreate_vlan
-        attach: "{{ nd_network_msd_staged_attach_block }}"
+        attach: "{{ nd_network_msd_staged_create_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_network_msd_child_fabric }}"
@@ -100,7 +155,7 @@
         network_id: "{{ nd_network_base_id + 280 }}"
         vlan_id: "{{ nd_network_base_vlan + 280 }}"
         vlan_name: ndnetmsdstgadd_vlan
-        attach: "{{ nd_network_msd_staged_attach_block }}"
+        attach: "{{ nd_network_msd_staged_primary_attach_block + nd_network_msd_staged_secondary_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_network_msd_child_fabric }}"
@@ -109,6 +164,16 @@
         network_id: "{{ nd_network_base_id + 281 }}"
         vlan_id: "{{ nd_network_base_vlan + 281 }}"
         vlan_name: ndnetmsdstgremove_vlan
+        attach: "{{ nd_network_msd_staged_primary_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_network_msd_child_fabric }}"
+      - network_name: ndnetmsdstgdetach
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 284 }}"
+        vlan_id: "{{ nd_network_base_vlan + 284 }}"
+        vlan_name: ndnetmsdstgdetach_vlan
+        attach: []
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_network_msd_child_fabric }}"
@@ -233,6 +298,12 @@
         | selectattr("networkName", "equalto", "ndnetmsdstgcreate")
         | selectattr("attach", "equalto", true)
         | list | length > 0
+      - >-
+        msd_staged_create_attachment_rows
+        | selectattr("networkName", "equalto", "ndnetmsdstgcreate")
+        | selectattr("attach", "equalto", true)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_network_run_msd | bool
     - nd_network_run_staged | bool
@@ -276,6 +347,21 @@
     that:
       - msd_staged_result.changed == true
       - msd_staged_result.fabric_type == "multisite_parent"
+  when:
+    - nd_network_run_msd | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_msd_attach | bool
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC3 - Repeat Reconcile For Controller-State Idempotency
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_network_msd_staged_conf }}"
+    output_level: debug
+  register: msd_staged_repeat_result
   when:
     - nd_network_run_msd | bool
     - nd_network_run_staged | bool
@@ -333,9 +419,23 @@
     that:
       - (msd_staged_gathered.after | default([]) | to_json) is search("ndnetmsdstgomit")
       - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
-      - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgadd") | selectattr("attach", "equalto", true) | list | length > 0
-      - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - >-
+        (
+          msd_staged_attachment_rows
+          | selectattr("networkName", "equalto", "ndnetmsdstgadd")
+          | selectattr("attach", "equalto", true)
+          | list
+          | length
+        ) == (nd_network_msd_staged_both_attach_count | int)
+      - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgremove") | selectattr("attach", "equalto", true) | list | length == 1
+      - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgdetach") | selectattr("attach", "equalto", true) | list | length == 0
       - msd_staged_attachment_rows | selectattr("networkName", "equalto", "ndnetmsdstgomit") | selectattr("attach", "equalto", true) | list | length == 0
+      - msd_staged_repeat_result.changed == false
+      - >-
+        msd_staged_attachment_rows
+        | selectattr("networkName", "in", target_network_names)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_network_run_msd | bool
     - nd_network_run_staged | bool

--- a/tests/integration/targets/nd_manage_networks/tests/standalone/staged.yaml
+++ b/tests/integration/targets/nd_manage_networks/tests/standalone/staged.yaml
@@ -14,6 +14,7 @@
       - ndnetstgcreate
       - ndnetstgadd
       - ndnetstgremove
+      - ndnetstgdetach
       - ndnetstgomit
     target_network_delete_config:
       - network_name: ndnetstgcreate
@@ -22,9 +23,11 @@
         is_l2only: true
       - network_name: ndnetstgremove
         is_l2only: true
+      - network_name: ndnetstgdetach
+        is_l2only: true
       - network_name: ndnetstgomit
         is_l2only: true
-    nd_network_staged_attach_block: >-
+    nd_network_staged_primary_attach_block: >-
       {{
         [
           {
@@ -39,6 +42,48 @@
           }
         ] if nd_network_run_attach | bool else []
       }}
+    nd_network_staged_secondary_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_network_standalone_switch2,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_standalone_interface2
+              }
+            ],
+            'deploy': true
+          }
+        ] if nd_network_standalone_switch2 | length > 0 and nd_network_standalone_interface2 | length > 0 else []
+      }}
+    nd_network_staged_create_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_network_standalone_switch2,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_standalone_interface2
+              }
+            ],
+            'deploy': true
+          }
+        ] if nd_network_standalone_switch2 | length > 0 and nd_network_standalone_interface2 | length > 0 else [
+          {
+            'ip_address': nd_network_standalone_switch,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_standalone_interface
+              }
+            ],
+            'deploy': true
+          }
+        ]
+      }}
+    nd_network_staged_both_attach_count: "{{ 2 if nd_network_standalone_switch2 | length > 0 and nd_network_standalone_interface2 | length > 0 else 1 }}"
   delegate_to: localhost
   tags: staged
 
@@ -50,20 +95,28 @@
         network_id: "{{ nd_network_base_id + 70 }}"
         vlan_id: "{{ nd_network_base_vlan + 70 }}"
         vlan_name: ndnetstgadd_vlan
+        attach: "{{ nd_network_staged_primary_attach_block }}"
         deploy: false
       - network_name: ndnetstgremove
         is_l2only: true
         network_id: "{{ nd_network_base_id + 71 }}"
         vlan_id: "{{ nd_network_base_vlan + 71 }}"
         vlan_name: ndnetstgremove_vlan
-        attach: "{{ nd_network_staged_attach_block }}"
+        attach: "{{ nd_network_staged_primary_attach_block + nd_network_staged_secondary_attach_block }}"
+        deploy: false
+      - network_name: ndnetstgdetach
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 74 }}"
+        vlan_id: "{{ nd_network_base_vlan + 74 }}"
+        vlan_name: ndnetstgdetach_vlan
+        attach: "{{ nd_network_staged_primary_attach_block }}"
         deploy: false
       - network_name: ndnetstgomit
         is_l2only: true
         network_id: "{{ nd_network_base_id + 72 }}"
         vlan_id: "{{ nd_network_base_vlan + 72 }}"
         vlan_name: ndnetstgomit_vlan
-        attach: "{{ nd_network_staged_attach_block }}"
+        attach: "{{ nd_network_staged_primary_attach_block }}"
         deploy: false
     nd_network_staged_create_config:
       - network_name: ndnetstgcreate
@@ -71,7 +124,7 @@
         network_id: "{{ nd_network_base_id + 73 }}"
         vlan_id: "{{ nd_network_base_vlan + 73 }}"
         vlan_name: ndnetstgcreate_vlan
-        attach: "{{ nd_network_staged_attach_block }}"
+        attach: "{{ nd_network_staged_create_attach_block }}"
         deploy: true
     nd_network_staged_config:
       - network_name: ndnetstgcreate
@@ -79,20 +132,28 @@
         network_id: "{{ nd_network_base_id + 73 }}"
         vlan_id: "{{ nd_network_base_vlan + 73 }}"
         vlan_name: ndnetstgcreate_vlan
-        attach: "{{ nd_network_staged_attach_block }}"
+        attach: "{{ nd_network_staged_create_attach_block }}"
         deploy: true
       - network_name: ndnetstgadd
         is_l2only: true
         network_id: "{{ nd_network_base_id + 70 }}"
         vlan_id: "{{ nd_network_base_vlan + 70 }}"
         vlan_name: ndnetstgadd_vlan
-        attach: "{{ nd_network_staged_attach_block }}"
+        attach: "{{ nd_network_staged_primary_attach_block + nd_network_staged_secondary_attach_block }}"
         deploy: true
       - network_name: ndnetstgremove
         is_l2only: true
         network_id: "{{ nd_network_base_id + 71 }}"
         vlan_id: "{{ nd_network_base_vlan + 71 }}"
         vlan_name: ndnetstgremove_vlan
+        attach: "{{ nd_network_staged_primary_attach_block }}"
+        deploy: true
+      - network_name: ndnetstgdetach
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 74 }}"
+        vlan_id: "{{ nd_network_base_vlan + 74 }}"
+        vlan_name: ndnetstgdetach_vlan
+        attach: []
         deploy: true
   delegate_to: localhost
   tags: staged
@@ -196,6 +257,12 @@
         | selectattr("networkName", "equalto", "ndnetstgcreate")
         | selectattr("attach", "equalto", true)
         | list | length > 0
+      - >-
+        staged_create_attachment_rows
+        | selectattr("networkName", "equalto", "ndnetstgcreate")
+        | selectattr("attach", "equalto", true)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_network_run_standalone | bool
     - nd_network_run_staged | bool
@@ -232,6 +299,19 @@
   ansible.builtin.assert:
     that:
       - staged_result.changed == true
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC3 - Repeat Reconcile For Controller-State Idempotency
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_network_standalone_staged_conf }}"
+    output_level: debug
+  register: staged_repeat_result
   when:
     - nd_network_run_standalone | bool
     - nd_network_run_staged | bool
@@ -281,9 +361,23 @@
     that:
       - (staged_gather_result.after | default([]) | to_json) is search("ndnetstgomit")
       - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
-      - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgadd") | selectattr("attach", "equalto", true) | list | length > 0
-      - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - >-
+        (
+          staged_attachment_rows
+          | selectattr("networkName", "equalto", "ndnetstgadd")
+          | selectattr("attach", "equalto", true)
+          | list
+          | length
+        ) == (nd_network_staged_both_attach_count | int)
+      - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgremove") | selectattr("attach", "equalto", true) | list | length == 1
+      - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgdetach") | selectattr("attach", "equalto", true) | list | length == 0
       - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgomit") | selectattr("attach", "equalto", true) | list | length == 0
+      - staged_repeat_result.changed == false
+      - >-
+        staged_attachment_rows
+        | selectattr("networkName", "in", target_network_names)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_network_run_standalone | bool
     - nd_network_run_staged | bool

--- a/tests/integration/targets/nd_manage_networks/tests/standalone/staged.yaml
+++ b/tests/integration/targets/nd_manage_networks/tests/standalone/staged.yaml
@@ -151,17 +151,51 @@
     - nd_network_run_attach | bool
   tags: staged
 
-- name: Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+- name: Staged TC1 - Assert Staged Create Reported Change
   ansible.builtin.assert:
     that:
       - staged_create_result.changed == true
-      - staged_create_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
-      - staged_create_result.api_paths | default([]) | select("search", "validateInterfaces") | list | length > 0
-      - staged_create_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - staged_create_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
-      - (staged_create_result.api_payload | default([]) | to_json) is search("ndnetstgcreate")
-      - (staged_create_result.api_payload | default([]) | to_json) is search("attach")
-      - (staged_create_result.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC1 - Query Created Network Attachment
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ target_fabric }}/networkAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      networkNames:
+        - ndnetstgcreate
+  register: staged_create_attachment_query
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC1 - Normalize Created Network Attachment Rows
+  ansible.builtin.set_fact:
+    staged_create_attachment_rows: >-
+      {{
+        staged_create_attachment_query.current.attachments
+        | default(staged_create_attachment_query.current.items | default([]))
+      }}
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC1 - Assert Created Network Attachment State
+  ansible.builtin.assert:
+    that:
+      - >-
+        staged_create_attachment_rows
+        | selectattr("networkName", "equalto", "ndnetstgcreate")
+        | selectattr("attach", "equalto", true)
+        | list | length > 0
   when:
     - nd_network_run_standalone | bool
     - nd_network_run_staged | bool
@@ -194,19 +228,36 @@
     - nd_network_run_attach | bool
   tags: staged
 
-- name: Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+- name: Staged TC3 - Assert Staged Reconcile Reported Change
   ansible.builtin.assert:
     that:
       - staged_result.changed == true
-      - staged_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
-      - staged_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - staged_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
-      - (staged_result.api_payload | default([]) | to_json) is search("ndnetstgadd")
-      - (staged_result.api_payload | default([]) | to_json) is search("ndnetstgremove")
-      - (staged_result.api_payload | default([]) | to_json) is search("ndnetstgomit")
-      - (staged_result.api_payload | default([]) | to_json) is search("attach")
-      - (staged_result.api_payload | default([]) | to_json) is search("true")
-      - (staged_result.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC4 - Query Network Attachments
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ target_fabric }}/networkAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      networkNames: "{{ target_network_names }}"
+  register: staged_attachment_query
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC4 - Normalize Network Attachment Rows
+  ansible.builtin.set_fact:
+    staged_attachment_rows: >-
+      {{
+        staged_attachment_query.current.attachments
+        | default(staged_attachment_query.current.items | default([]))
+      }}
   when:
     - nd_network_run_standalone | bool
     - nd_network_run_staged | bool
@@ -229,6 +280,10 @@
   ansible.builtin.assert:
     that:
       - (staged_gather_result.after | default([]) | to_json) is search("ndnetstgomit")
+      - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
+      - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgadd") | selectattr("attach", "equalto", true) | list | length > 0
+      - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - staged_attachment_rows | selectattr("networkName", "equalto", "ndnetstgomit") | selectattr("attach", "equalto", true) | list | length == 0
   when:
     - nd_network_run_standalone | bool
     - nd_network_run_staged | bool

--- a/tests/integration/targets/nd_manage_networks/tests/standalone/staged.yaml
+++ b/tests/integration/targets/nd_manage_networks/tests/standalone/staged.yaml
@@ -1,0 +1,236 @@
+---
+- name: Test Entry Point - [nd_manage_networks - staged]
+  ansible.builtin.debug:
+    msg:
+      - "----------------------------------------------------------------"
+      - "+     Executing Staged Tests - [nd_manage_networks]              +"
+      - "----------------------------------------------------------------"
+  tags: staged
+
+- name: Staged - Build Standalone Attachment Data
+  ansible.builtin.set_fact:
+    target_fabric: "{{ nd_network_standalone_fabric }}"
+    target_network_names:
+      - ndnetstgcreate
+      - ndnetstgadd
+      - ndnetstgremove
+      - ndnetstgomit
+    target_network_delete_config:
+      - network_name: ndnetstgcreate
+        is_l2only: true
+      - network_name: ndnetstgadd
+        is_l2only: true
+      - network_name: ndnetstgremove
+        is_l2only: true
+      - network_name: ndnetstgomit
+        is_l2only: true
+    nd_network_staged_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_network_standalone_switch,
+            'interfaces': [
+              {
+                'mode': 'trunk',
+                'interface_range': nd_network_standalone_interface
+              }
+            ],
+            'deploy': true
+          }
+        ] if nd_network_run_attach | bool else []
+      }}
+  delegate_to: localhost
+  tags: staged
+
+- name: Staged - Build Standalone Test Data
+  ansible.builtin.set_fact:
+    nd_network_staged_seed:
+      - network_name: ndnetstgadd
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 70 }}"
+        vlan_id: "{{ nd_network_base_vlan + 70 }}"
+        vlan_name: ndnetstgadd_vlan
+        deploy: false
+      - network_name: ndnetstgremove
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 71 }}"
+        vlan_id: "{{ nd_network_base_vlan + 71 }}"
+        vlan_name: ndnetstgremove_vlan
+        attach: "{{ nd_network_staged_attach_block }}"
+        deploy: false
+      - network_name: ndnetstgomit
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 72 }}"
+        vlan_id: "{{ nd_network_base_vlan + 72 }}"
+        vlan_name: ndnetstgomit_vlan
+        attach: "{{ nd_network_staged_attach_block }}"
+        deploy: false
+    nd_network_staged_create_config:
+      - network_name: ndnetstgcreate
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 73 }}"
+        vlan_id: "{{ nd_network_base_vlan + 73 }}"
+        vlan_name: ndnetstgcreate_vlan
+        attach: "{{ nd_network_staged_attach_block }}"
+        deploy: true
+    nd_network_staged_config:
+      - network_name: ndnetstgcreate
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 73 }}"
+        vlan_id: "{{ nd_network_base_vlan + 73 }}"
+        vlan_name: ndnetstgcreate_vlan
+        attach: "{{ nd_network_staged_attach_block }}"
+        deploy: true
+      - network_name: ndnetstgadd
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 70 }}"
+        vlan_id: "{{ nd_network_base_vlan + 70 }}"
+        vlan_name: ndnetstgadd_vlan
+        attach: "{{ nd_network_staged_attach_block }}"
+        deploy: true
+      - network_name: ndnetstgremove
+        is_l2only: true
+        network_id: "{{ nd_network_base_id + 71 }}"
+        vlan_id: "{{ nd_network_base_vlan + 71 }}"
+        vlan_name: ndnetstgremove_vlan
+        deploy: true
+  delegate_to: localhost
+  tags: staged
+
+- name: Staged - Import Setup
+  ansible.builtin.import_tasks: ../../tasks/setup.yaml
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged - Prepare Seed Configuration
+  vars:
+    file: standalone_staged_seed
+    network_conf: "{{ nd_network_staged_seed }}"
+  ansible.builtin.import_tasks: ../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged - Prepare Create Configuration
+  vars:
+    file: standalone_staged_create
+    network_conf: "{{ nd_network_staged_create_config }}"
+  ansible.builtin.import_tasks: ../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged - Prepare Configuration
+  vars:
+    file: standalone_staged
+    network_conf: "{{ nd_network_staged_config }}"
+  ansible.builtin.import_tasks: ../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC1 - Create Network With Attachment
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_network_standalone_staged_create_conf }}"
+    output_level: debug
+  register: staged_create_result
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - staged_create_result.changed == true
+      - staged_create_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
+      - staged_create_result.api_paths | default([]) | select("search", "validateInterfaces") | list | length > 0
+      - staged_create_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - staged_create_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
+      - (staged_create_result.api_payload | default([]) | to_json) is search("ndnetstgcreate")
+      - (staged_create_result.api_payload | default([]) | to_json) is search("attach")
+      - (staged_create_result.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC2 - Seed Existing Networks
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: merged
+    config: "{{ nd_network_standalone_staged_seed_conf }}"
+    output_level: debug
+  register: staged_seed_result
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC3 - Reconcile Attachments Without Deploy Or Definition Delete
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_network_standalone_staged_conf }}"
+    output_level: debug
+  register: staged_result
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - staged_result.changed == true
+      - staged_result.api_paths | default([]) | select("search", "/networkAttachments") | list | length > 0
+      - staged_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - staged_result.api_paths | default([]) | select("search", "networkActions/remove") | list | length == 0
+      - (staged_result.api_payload | default([]) | to_json) is search("ndnetstgadd")
+      - (staged_result.api_payload | default([]) | to_json) is search("ndnetstgremove")
+      - (staged_result.api_payload | default([]) | to_json) is search("ndnetstgomit")
+      - (staged_result.api_payload | default([]) | to_json) is search("attach")
+      - (staged_result.api_payload | default([]) | to_json) is search("true")
+      - (staged_result.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC4 - Gather Networks
+  cisco.nd.nd_manage_networks:
+    fabric_name: "{{ target_fabric }}"
+    state: gathered
+    config: "{{ target_network_delete_config }}"
+  register: staged_gather_result
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged
+
+- name: Staged TC4 - Assert Omitted Network Definition Remains
+  ansible.builtin.assert:
+    that:
+      - (staged_gather_result.after | default([]) | to_json) is search("ndnetstgomit")
+  when:
+    - nd_network_run_standalone | bool
+    - nd_network_run_staged | bool
+    - nd_network_run_attach | bool
+  tags: staged

--- a/tests/integration/targets/nd_manage_vrfs/defaults/main.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/defaults/main.yaml
@@ -4,14 +4,17 @@ nd_vrf_test_topology: ""
 
 nd_vrf_standalone_fabric: "{{ ansible_it_fabric | default('') }}"
 nd_vrf_standalone_switch: "{{ ansible_switch1 | default('') }}"
+nd_vrf_standalone_switch2: "{{ ansible_switch2 | default('') }}"
 
 nd_vrf_msd_parent_fabric: "{{ ansible_msd_parent_fabric | default('msd_p') }}"
 nd_vrf_msd_child_fabric: "{{ ansible_msd_child_fabric | default('AK-VXLAN') }}"
 nd_vrf_msd_switch: "{{ ansible_msd_switch1 | default(ansible_switch1 | default('')) }}"
+nd_vrf_msd_switch2: "{{ ansible_msd_switch2 | default(ansible_switch2 | default('')) }}"
 
 nd_vrf_mcfg_parent_fabric: "{{ ansible_mcfg_parent_fabric | default('') }}"
 nd_vrf_mcfg_child_fabric: "{{ ansible_mcfg_child_fabric | default('') }}"
 nd_vrf_mcfg_switch: "{{ ansible_mcfg_switch1 | default('') }}"
+nd_vrf_mcfg_switch2: "{{ ansible_mcfg_switch2 | default('') }}"
 
 nd_vrf_run_standalone: "{{ nd_vrf_standalone_fabric | length > 0 }}"
 nd_vrf_run_msd: "{{ nd_vrf_msd_parent_fabric | length > 0 and nd_vrf_msd_child_fabric | length > 0 }}"

--- a/tests/integration/targets/nd_manage_vrfs/defaults/main.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/defaults/main.yaml
@@ -17,6 +17,7 @@ nd_vrf_run_standalone: "{{ nd_vrf_standalone_fabric | length > 0 }}"
 nd_vrf_run_msd: "{{ nd_vrf_msd_parent_fabric | length > 0 and nd_vrf_msd_child_fabric | length > 0 }}"
 nd_vrf_run_mcfg: "{{ nd_vrf_mcfg_parent_fabric | length > 0 and nd_vrf_mcfg_child_fabric | length > 0 }}"
 nd_vrf_run_overridden: true
+nd_vrf_run_staged: true
 
 nd_vrf_base_id: 9008800
 nd_vrf_base_vlan: 2800

--- a/tests/integration/targets/nd_manage_vrfs/tests/mcfg/staged.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/tests/mcfg/staged.yaml
@@ -1,0 +1,261 @@
+---
+- name: Test Entry Point - [nd_manage_vrfs - mcfg - staged]
+  ansible.builtin.debug:
+    msg:
+      - "----------------------------------------------------------------"
+      - "+     Executing MCFG Staged Tests - [nd_manage_vrfs]             +"
+      - "----------------------------------------------------------------"
+  tags:
+    - mcfg
+    - staged
+- name: MCFG Staged - Build Attachment Data
+  ansible.builtin.set_fact:
+    target_fabric: "{{ nd_vrf_mcfg_parent_fabric }}"
+    target_vrf_names:
+      - ndvrfmcfgstgcreate
+      - ndvrfmcfgstgadd
+      - ndvrfmcfgstgremove
+      - ndvrfmcfgstgomit
+    nd_vrf_mcfg_staged_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_vrf_mcfg_switch
+          }
+        ] if nd_vrf_mcfg_switch | length > 0 else []
+      }}
+  delegate_to: localhost
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Build Parent and Child Test Data
+  ansible.builtin.set_fact:
+    nd_vrf_mcfg_staged_seed:
+      - vrf_name: ndvrfmcfgstgadd
+        vrf_id: "{{ nd_vrf_base_id + 90 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 90 }}"
+        vrf_description: Ansible ND MCFG staged add seed
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
+            adv_host_routes: false
+      - vrf_name: ndvrfmcfgstgremove
+        vrf_id: "{{ nd_vrf_base_id + 91 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 91 }}"
+        vrf_description: Ansible ND MCFG staged remove seed
+        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
+            adv_host_routes: false
+      - vrf_name: ndvrfmcfgstgomit
+        vrf_id: "{{ nd_vrf_base_id + 92 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 92 }}"
+        vrf_description: Ansible ND MCFG staged omit seed
+        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
+            adv_host_routes: false
+    nd_vrf_mcfg_staged_create_config:
+      - vrf_name: ndvrfmcfgstgcreate
+        vrf_id: "{{ nd_vrf_base_id + 93 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 93 }}"
+        vrf_description: Ansible ND MCFG staged create
+        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
+            adv_host_routes: true
+    nd_vrf_mcfg_staged_config:
+      - vrf_name: ndvrfmcfgstgcreate
+        vrf_id: "{{ nd_vrf_base_id + 93 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 93 }}"
+        vrf_description: Ansible ND MCFG staged create
+        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
+            adv_host_routes: true
+      - vrf_name: ndvrfmcfgstgadd
+        vrf_id: "{{ nd_vrf_base_id + 90 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 90 }}"
+        vrf_description: Ansible ND MCFG staged add updated
+        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
+            adv_host_routes: true
+      - vrf_name: ndvrfmcfgstgremove
+        vrf_id: "{{ nd_vrf_base_id + 91 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 91 }}"
+        vrf_description: Ansible ND MCFG staged remove updated
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
+            adv_host_routes: true
+  delegate_to: localhost
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Import Setup
+  ansible.builtin.import_tasks: ../../../tasks/setup.yaml
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Prepare Seed Configuration
+  vars:
+    file: mcfg_staged_seed
+    vrf_conf: "{{ nd_vrf_mcfg_staged_seed }}"
+  ansible.builtin.import_tasks: ../../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Prepare Create Configuration
+  vars:
+    file: mcfg_staged_create
+    vrf_conf: "{{ nd_vrf_mcfg_staged_create_config }}"
+  ansible.builtin.import_tasks: ../../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged - Prepare Configuration
+  vars:
+    file: mcfg_staged
+    vrf_conf: "{{ nd_vrf_mcfg_staged_config }}"
+  ansible.builtin.import_tasks: ../../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Create VRF With Attachment
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_vrf_mcfg_staged_create_conf }}"
+    output_level: debug
+  register: mcfg_staged_create_result
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - mcfg_staged_create_result.changed == true
+      - mcfg_staged_create_result.fabric_type == "multicluster_parent"
+      - mcfg_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
+      - mcfg_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - mcfg_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
+      - (mcfg_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmcfgstgcreate")
+      - (mcfg_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("attach")
+      - (mcfg_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC2 - Seed Existing VRFs
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: merged
+    config: "{{ nd_vrf_mcfg_staged_seed_conf }}"
+    output_level: debug
+  register: mcfg_staged_seed_result
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC3 - Reconcile Attachments Without Deploy Or Definition Delete
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_vrf_mcfg_staged_conf }}"
+    output_level: debug
+  register: mcfg_staged_result
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - mcfg_staged_result.changed == true
+      - mcfg_staged_result.fabric_type == "multicluster_parent"
+      - mcfg_staged_result.parent_fabric.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
+      - mcfg_staged_result.parent_fabric.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - mcfg_staged_result.parent_fabric.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
+      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmcfgstgadd")
+      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmcfgstgremove")
+      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmcfgstgomit")
+      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("true")
+      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC4 - Gather Parent VRFs
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: gathered
+    config: []
+  register: mcfg_staged_gathered
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC4 - Assert Omitted VRF Definition Remains
+  ansible.builtin.assert:
+    that:
+      - (mcfg_staged_gathered.after | default([]) | to_json) is search("ndvrfmcfgstgomit")
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged

--- a/tests/integration/targets/nd_manage_vrfs/tests/mcfg/staged.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/tests/mcfg/staged.yaml
@@ -15,8 +15,9 @@
       - ndvrfmcfgstgcreate
       - ndvrfmcfgstgadd
       - ndvrfmcfgstgremove
+      - ndvrfmcfgstgdetach
       - ndvrfmcfgstgomit
-    nd_vrf_mcfg_staged_attach_block: >-
+    nd_vrf_mcfg_staged_primary_attach_block: >-
       {{
         [
           {
@@ -24,6 +25,27 @@
           }
         ] if nd_vrf_mcfg_switch | length > 0 else []
       }}
+    nd_vrf_mcfg_staged_secondary_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_vrf_mcfg_switch2
+          }
+        ] if nd_vrf_mcfg_switch2 | length > 0 else []
+      }}
+    nd_vrf_mcfg_staged_create_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_vrf_mcfg_switch2
+          }
+        ] if nd_vrf_mcfg_switch2 | length > 0 else [
+          {
+            'ip_address': nd_vrf_mcfg_switch
+          }
+        ]
+      }}
+    nd_vrf_mcfg_staged_both_attach_count: "{{ 2 if nd_vrf_mcfg_switch2 | length > 0 else 1 }}"
   delegate_to: localhost
   tags:
     - mcfg
@@ -36,6 +58,7 @@
         vrf_id: "{{ nd_vrf_base_id + 90 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 90 }}"
         vrf_description: Ansible ND MCFG staged add seed
+        attach: "{{ nd_vrf_mcfg_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
@@ -44,7 +67,16 @@
         vrf_id: "{{ nd_vrf_base_id + 91 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 91 }}"
         vrf_description: Ansible ND MCFG staged remove seed
-        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        attach: "{{ nd_vrf_mcfg_staged_primary_attach_block + nd_vrf_mcfg_staged_secondary_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
+            adv_host_routes: false
+      - vrf_name: ndvrfmcfgstgdetach
+        vrf_id: "{{ nd_vrf_base_id + 94 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 94 }}"
+        vrf_description: Ansible ND MCFG staged detach seed
+        attach: "{{ nd_vrf_mcfg_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
@@ -53,7 +85,7 @@
         vrf_id: "{{ nd_vrf_base_id + 92 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 92 }}"
         vrf_description: Ansible ND MCFG staged omit seed
-        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        attach: "{{ nd_vrf_mcfg_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
@@ -63,7 +95,7 @@
         vrf_id: "{{ nd_vrf_base_id + 93 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 93 }}"
         vrf_description: Ansible ND MCFG staged create
-        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        attach: "{{ nd_vrf_mcfg_staged_create_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
@@ -73,7 +105,7 @@
         vrf_id: "{{ nd_vrf_base_id + 93 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 93 }}"
         vrf_description: Ansible ND MCFG staged create
-        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        attach: "{{ nd_vrf_mcfg_staged_create_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
@@ -82,7 +114,7 @@
         vrf_id: "{{ nd_vrf_base_id + 90 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 90 }}"
         vrf_description: Ansible ND MCFG staged add updated
-        attach: "{{ nd_vrf_mcfg_staged_attach_block }}"
+        attach: "{{ nd_vrf_mcfg_staged_primary_attach_block + nd_vrf_mcfg_staged_secondary_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
@@ -91,6 +123,16 @@
         vrf_id: "{{ nd_vrf_base_id + 91 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 91 }}"
         vrf_description: Ansible ND MCFG staged remove updated
+        attach: "{{ nd_vrf_mcfg_staged_primary_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
+            adv_host_routes: true
+      - vrf_name: ndvrfmcfgstgdetach
+        vrf_id: "{{ nd_vrf_base_id + 94 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 94 }}"
+        vrf_description: Ansible ND MCFG staged detach updated
+        attach: []
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_mcfg_child_fabric }}"
@@ -216,6 +258,12 @@
         | selectattr("vrfName", "equalto", "ndvrfmcfgstgcreate")
         | selectattr("attach", "equalto", true)
         | list | length > 0
+      - >-
+        mcfg_staged_create_attachment_rows
+        | selectattr("vrfName", "equalto", "ndvrfmcfgstgcreate")
+        | selectattr("attach", "equalto", true)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_vrf_run_mcfg | bool
     - nd_vrf_run_staged | bool
@@ -259,6 +307,21 @@
     that:
       - mcfg_staged_result.changed == true
       - mcfg_staged_result.fabric_type == "multicluster_parent"
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC3 - Repeat Reconcile For Controller-State Idempotency
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_vrf_mcfg_staged_conf }}"
+    output_level: debug
+  register: mcfg_staged_repeat_result
   when:
     - nd_vrf_run_mcfg | bool
     - nd_vrf_run_staged | bool
@@ -316,9 +379,23 @@
     that:
       - (mcfg_staged_gathered.after | default([]) | to_json) is search("ndvrfmcfgstgomit")
       - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
-      - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgadd") | selectattr("attach", "equalto", true) | list | length > 0
-      - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - >-
+        (
+          mcfg_staged_attachment_rows
+          | selectattr("vrfName", "equalto", "ndvrfmcfgstgadd")
+          | selectattr("attach", "equalto", true)
+          | list
+          | length
+        ) == (nd_vrf_mcfg_staged_both_attach_count | int)
+      - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgremove") | selectattr("attach", "equalto", true) | list | length == 1
+      - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgdetach") | selectattr("attach", "equalto", true) | list | length == 0
       - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgomit") | selectattr("attach", "equalto", true) | list | length == 0
+      - mcfg_staged_repeat_result.changed == false
+      - >-
+        mcfg_staged_attachment_rows
+        | selectattr("vrfName", "in", target_vrf_names)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_vrf_run_mcfg | bool
     - nd_vrf_run_staged | bool

--- a/tests/integration/targets/nd_manage_vrfs/tests/mcfg/staged.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/tests/mcfg/staged.yaml
@@ -164,17 +164,58 @@
     - mcfg
     - staged
 
-- name: MCFG Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+- name: MCFG Staged TC1 - Assert Staged Create Reported Change
   ansible.builtin.assert:
     that:
       - mcfg_staged_create_result.changed == true
       - mcfg_staged_create_result.fabric_type == "multicluster_parent"
-      - mcfg_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
-      - mcfg_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - mcfg_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
-      - (mcfg_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmcfgstgcreate")
-      - (mcfg_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("attach")
-      - (mcfg_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Query Created VRF Attachment
+  cisco.nd.nd_rest:
+    path: "/api/v1/oneManage/manage/fabrics/{{ target_fabric }}/vrfAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      vrfNames:
+        - ndvrfmcfgstgcreate
+  register: mcfg_staged_create_attachment_query
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Normalize Created VRF Attachment Rows
+  ansible.builtin.set_fact:
+    mcfg_staged_create_attachment_rows: >-
+      {{
+        mcfg_staged_create_attachment_query.current.attachments
+        | default(mcfg_staged_create_attachment_query.current.items | default([]))
+      }}
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC1 - Assert Created VRF Attachment State
+  ansible.builtin.assert:
+    that:
+      - >-
+        mcfg_staged_create_attachment_rows
+        | selectattr("vrfName", "equalto", "ndvrfmcfgstgcreate")
+        | selectattr("attach", "equalto", true)
+        | list | length > 0
   when:
     - nd_vrf_run_mcfg | bool
     - nd_vrf_run_staged | bool
@@ -213,19 +254,41 @@
     - mcfg
     - staged
 
-- name: MCFG Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+- name: MCFG Staged TC3 - Assert Staged Reconcile Reported Change
   ansible.builtin.assert:
     that:
       - mcfg_staged_result.changed == true
       - mcfg_staged_result.fabric_type == "multicluster_parent"
-      - mcfg_staged_result.parent_fabric.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
-      - mcfg_staged_result.parent_fabric.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - mcfg_staged_result.parent_fabric.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
-      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmcfgstgadd")
-      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmcfgstgremove")
-      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmcfgstgomit")
-      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("true")
-      - (mcfg_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC4 - Query VRF Attachments
+  cisco.nd.nd_rest:
+    path: "/api/v1/oneManage/manage/fabrics/{{ target_fabric }}/vrfAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      vrfNames: "{{ target_vrf_names }}"
+  register: mcfg_staged_attachment_query
+  when:
+    - nd_vrf_run_mcfg | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_mcfg_switch | length > 0
+  tags:
+    - mcfg
+    - staged
+
+- name: MCFG Staged TC4 - Normalize VRF Attachment Rows
+  ansible.builtin.set_fact:
+    mcfg_staged_attachment_rows: >-
+      {{
+        mcfg_staged_attachment_query.current.attachments
+        | default(mcfg_staged_attachment_query.current.items | default([]))
+      }}
   when:
     - nd_vrf_run_mcfg | bool
     - nd_vrf_run_staged | bool
@@ -252,6 +315,10 @@
   ansible.builtin.assert:
     that:
       - (mcfg_staged_gathered.after | default([]) | to_json) is search("ndvrfmcfgstgomit")
+      - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
+      - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgadd") | selectattr("attach", "equalto", true) | list | length > 0
+      - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - mcfg_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmcfgstgomit") | selectattr("attach", "equalto", true) | list | length == 0
   when:
     - nd_vrf_run_mcfg | bool
     - nd_vrf_run_staged | bool

--- a/tests/integration/targets/nd_manage_vrfs/tests/msd/staged.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/tests/msd/staged.yaml
@@ -1,0 +1,261 @@
+---
+- name: Test Entry Point - [nd_manage_vrfs - msd - staged]
+  ansible.builtin.debug:
+    msg:
+      - "----------------------------------------------------------------"
+      - "+     Executing MSD Staged Tests - [nd_manage_vrfs]              +"
+      - "----------------------------------------------------------------"
+  tags:
+    - msd
+    - staged
+- name: MSD Staged - Build Attachment Data
+  ansible.builtin.set_fact:
+    target_fabric: "{{ nd_vrf_msd_parent_fabric }}"
+    target_vrf_names:
+      - ndvrfmsdstgcreate
+      - ndvrfmsdstgadd
+      - ndvrfmsdstgremove
+      - ndvrfmsdstgomit
+    nd_vrf_msd_staged_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_vrf_msd_switch
+          }
+        ] if nd_vrf_msd_switch | length > 0 else []
+      }}
+  delegate_to: localhost
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Build Parent and Child Test Data
+  ansible.builtin.set_fact:
+    nd_vrf_msd_staged_seed:
+      - vrf_name: ndvrfmsdstgadd
+        vrf_id: "{{ nd_vrf_base_id + 80 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 80 }}"
+        vrf_description: Ansible ND MSD staged add seed
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
+            adv_host_routes: false
+      - vrf_name: ndvrfmsdstgremove
+        vrf_id: "{{ nd_vrf_base_id + 81 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 81 }}"
+        vrf_description: Ansible ND MSD staged remove seed
+        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
+            adv_host_routes: false
+      - vrf_name: ndvrfmsdstgomit
+        vrf_id: "{{ nd_vrf_base_id + 82 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 82 }}"
+        vrf_description: Ansible ND MSD staged omit seed
+        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
+            adv_host_routes: false
+    nd_vrf_msd_staged_create_config:
+      - vrf_name: ndvrfmsdstgcreate
+        vrf_id: "{{ nd_vrf_base_id + 83 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 83 }}"
+        vrf_description: Ansible ND MSD staged create
+        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
+            adv_host_routes: true
+    nd_vrf_msd_staged_config:
+      - vrf_name: ndvrfmsdstgcreate
+        vrf_id: "{{ nd_vrf_base_id + 83 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 83 }}"
+        vrf_description: Ansible ND MSD staged create
+        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
+            adv_host_routes: true
+      - vrf_name: ndvrfmsdstgadd
+        vrf_id: "{{ nd_vrf_base_id + 80 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 80 }}"
+        vrf_description: Ansible ND MSD staged add updated
+        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
+            adv_host_routes: true
+      - vrf_name: ndvrfmsdstgremove
+        vrf_id: "{{ nd_vrf_base_id + 81 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 81 }}"
+        vrf_description: Ansible ND MSD staged remove updated
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
+            adv_host_routes: true
+  delegate_to: localhost
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Import Setup
+  ansible.builtin.import_tasks: ../../../tasks/setup.yaml
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Prepare Seed Configuration
+  vars:
+    file: msd_staged_seed
+    vrf_conf: "{{ nd_vrf_msd_staged_seed }}"
+  ansible.builtin.import_tasks: ../../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Prepare Create Configuration
+  vars:
+    file: msd_staged_create
+    vrf_conf: "{{ nd_vrf_msd_staged_create_config }}"
+  ansible.builtin.import_tasks: ../../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged - Prepare Configuration
+  vars:
+    file: msd_staged
+    vrf_conf: "{{ nd_vrf_msd_staged_config }}"
+  ansible.builtin.import_tasks: ../../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Create VRF With Attachment
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_vrf_msd_staged_create_conf }}"
+    output_level: debug
+  register: msd_staged_create_result
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - msd_staged_create_result.changed == true
+      - msd_staged_create_result.fabric_type == "multisite_parent"
+      - msd_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
+      - msd_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - msd_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
+      - (msd_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmsdstgcreate")
+      - (msd_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("attach")
+      - (msd_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC2 - Seed Existing VRFs
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: merged
+    config: "{{ nd_vrf_msd_staged_seed_conf }}"
+    output_level: debug
+  register: msd_staged_seed_result
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC3 - Reconcile Attachments Without Deploy Or Definition Delete
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_vrf_msd_staged_conf }}"
+    output_level: debug
+  register: msd_staged_result
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - msd_staged_result.changed == true
+      - msd_staged_result.fabric_type == "multisite_parent"
+      - msd_staged_result.parent_fabric.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
+      - msd_staged_result.parent_fabric.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - msd_staged_result.parent_fabric.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
+      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmsdstgadd")
+      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmsdstgremove")
+      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmsdstgomit")
+      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("true")
+      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC4 - Gather Parent VRFs
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: gathered
+    config: []
+  register: msd_staged_gathered
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC4 - Assert Omitted VRF Definition Remains
+  ansible.builtin.assert:
+    that:
+      - (msd_staged_gathered.after | default([]) | to_json) is search("ndvrfmsdstgomit")
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged

--- a/tests/integration/targets/nd_manage_vrfs/tests/msd/staged.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/tests/msd/staged.yaml
@@ -164,17 +164,58 @@
     - msd
     - staged
 
-- name: MSD Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+- name: MSD Staged TC1 - Assert Staged Create Reported Change
   ansible.builtin.assert:
     that:
       - msd_staged_create_result.changed == true
       - msd_staged_create_result.fabric_type == "multisite_parent"
-      - msd_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
-      - msd_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - msd_staged_create_result.parent_fabric.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
-      - (msd_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmsdstgcreate")
-      - (msd_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("attach")
-      - (msd_staged_create_result.parent_fabric.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Query Created VRF Attachment
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ target_fabric }}/vrfAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      vrfNames:
+        - ndvrfmsdstgcreate
+  register: msd_staged_create_attachment_query
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Normalize Created VRF Attachment Rows
+  ansible.builtin.set_fact:
+    msd_staged_create_attachment_rows: >-
+      {{
+        msd_staged_create_attachment_query.current.attachments
+        | default(msd_staged_create_attachment_query.current.items | default([]))
+      }}
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC1 - Assert Created VRF Attachment State
+  ansible.builtin.assert:
+    that:
+      - >-
+        msd_staged_create_attachment_rows
+        | selectattr("vrfName", "equalto", "ndvrfmsdstgcreate")
+        | selectattr("attach", "equalto", true)
+        | list | length > 0
   when:
     - nd_vrf_run_msd | bool
     - nd_vrf_run_staged | bool
@@ -213,19 +254,41 @@
     - msd
     - staged
 
-- name: MSD Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+- name: MSD Staged TC3 - Assert Staged Reconcile Reported Change
   ansible.builtin.assert:
     that:
       - msd_staged_result.changed == true
       - msd_staged_result.fabric_type == "multisite_parent"
-      - msd_staged_result.parent_fabric.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
-      - msd_staged_result.parent_fabric.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - msd_staged_result.parent_fabric.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
-      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmsdstgadd")
-      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmsdstgremove")
-      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("ndvrfmsdstgomit")
-      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("true")
-      - (msd_staged_result.parent_fabric.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC4 - Query VRF Attachments
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ target_fabric }}/vrfAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      vrfNames: "{{ target_vrf_names }}"
+  register: msd_staged_attachment_query
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC4 - Normalize VRF Attachment Rows
+  ansible.builtin.set_fact:
+    msd_staged_attachment_rows: >-
+      {{
+        msd_staged_attachment_query.current.attachments
+        | default(msd_staged_attachment_query.current.items | default([]))
+      }}
   when:
     - nd_vrf_run_msd | bool
     - nd_vrf_run_staged | bool
@@ -252,6 +315,10 @@
   ansible.builtin.assert:
     that:
       - (msd_staged_gathered.after | default([]) | to_json) is search("ndvrfmsdstgomit")
+      - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
+      - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgadd") | selectattr("attach", "equalto", true) | list | length > 0
+      - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgomit") | selectattr("attach", "equalto", true) | list | length == 0
   when:
     - nd_vrf_run_msd | bool
     - nd_vrf_run_staged | bool

--- a/tests/integration/targets/nd_manage_vrfs/tests/msd/staged.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/tests/msd/staged.yaml
@@ -15,8 +15,9 @@
       - ndvrfmsdstgcreate
       - ndvrfmsdstgadd
       - ndvrfmsdstgremove
+      - ndvrfmsdstgdetach
       - ndvrfmsdstgomit
-    nd_vrf_msd_staged_attach_block: >-
+    nd_vrf_msd_staged_primary_attach_block: >-
       {{
         [
           {
@@ -24,6 +25,27 @@
           }
         ] if nd_vrf_msd_switch | length > 0 else []
       }}
+    nd_vrf_msd_staged_secondary_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_vrf_msd_switch2
+          }
+        ] if nd_vrf_msd_switch2 | length > 0 else []
+      }}
+    nd_vrf_msd_staged_create_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_vrf_msd_switch2
+          }
+        ] if nd_vrf_msd_switch2 | length > 0 else [
+          {
+            'ip_address': nd_vrf_msd_switch
+          }
+        ]
+      }}
+    nd_vrf_msd_staged_both_attach_count: "{{ 2 if nd_vrf_msd_switch2 | length > 0 else 1 }}"
   delegate_to: localhost
   tags:
     - msd
@@ -36,6 +58,7 @@
         vrf_id: "{{ nd_vrf_base_id + 80 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 80 }}"
         vrf_description: Ansible ND MSD staged add seed
+        attach: "{{ nd_vrf_msd_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
@@ -44,7 +67,16 @@
         vrf_id: "{{ nd_vrf_base_id + 81 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 81 }}"
         vrf_description: Ansible ND MSD staged remove seed
-        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        attach: "{{ nd_vrf_msd_staged_primary_attach_block + nd_vrf_msd_staged_secondary_attach_block }}"
+        deploy: false
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
+            adv_host_routes: false
+      - vrf_name: ndvrfmsdstgdetach
+        vrf_id: "{{ nd_vrf_base_id + 84 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 84 }}"
+        vrf_description: Ansible ND MSD staged detach seed
+        attach: "{{ nd_vrf_msd_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
@@ -53,7 +85,7 @@
         vrf_id: "{{ nd_vrf_base_id + 82 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 82 }}"
         vrf_description: Ansible ND MSD staged omit seed
-        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        attach: "{{ nd_vrf_msd_staged_primary_attach_block }}"
         deploy: false
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
@@ -63,7 +95,7 @@
         vrf_id: "{{ nd_vrf_base_id + 83 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 83 }}"
         vrf_description: Ansible ND MSD staged create
-        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        attach: "{{ nd_vrf_msd_staged_create_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
@@ -73,7 +105,7 @@
         vrf_id: "{{ nd_vrf_base_id + 83 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 83 }}"
         vrf_description: Ansible ND MSD staged create
-        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        attach: "{{ nd_vrf_msd_staged_create_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
@@ -82,7 +114,7 @@
         vrf_id: "{{ nd_vrf_base_id + 80 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 80 }}"
         vrf_description: Ansible ND MSD staged add updated
-        attach: "{{ nd_vrf_msd_staged_attach_block }}"
+        attach: "{{ nd_vrf_msd_staged_primary_attach_block + nd_vrf_msd_staged_secondary_attach_block }}"
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
@@ -91,6 +123,16 @@
         vrf_id: "{{ nd_vrf_base_id + 81 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 81 }}"
         vrf_description: Ansible ND MSD staged remove updated
+        attach: "{{ nd_vrf_msd_staged_primary_attach_block }}"
+        deploy: true
+        child_fabric_config:
+          - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
+            adv_host_routes: true
+      - vrf_name: ndvrfmsdstgdetach
+        vrf_id: "{{ nd_vrf_base_id + 84 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 84 }}"
+        vrf_description: Ansible ND MSD staged detach updated
+        attach: []
         deploy: true
         child_fabric_config:
           - fabric_name: "{{ nd_vrf_msd_child_fabric }}"
@@ -216,6 +258,12 @@
         | selectattr("vrfName", "equalto", "ndvrfmsdstgcreate")
         | selectattr("attach", "equalto", true)
         | list | length > 0
+      - >-
+        msd_staged_create_attachment_rows
+        | selectattr("vrfName", "equalto", "ndvrfmsdstgcreate")
+        | selectattr("attach", "equalto", true)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_vrf_run_msd | bool
     - nd_vrf_run_staged | bool
@@ -259,6 +307,21 @@
     that:
       - msd_staged_result.changed == true
       - msd_staged_result.fabric_type == "multisite_parent"
+  when:
+    - nd_vrf_run_msd | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_msd_switch | length > 0
+  tags:
+    - msd
+    - staged
+
+- name: MSD Staged TC3 - Repeat Reconcile For Controller-State Idempotency
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_vrf_msd_staged_conf }}"
+    output_level: debug
+  register: msd_staged_repeat_result
   when:
     - nd_vrf_run_msd | bool
     - nd_vrf_run_staged | bool
@@ -316,9 +379,23 @@
     that:
       - (msd_staged_gathered.after | default([]) | to_json) is search("ndvrfmsdstgomit")
       - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
-      - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgadd") | selectattr("attach", "equalto", true) | list | length > 0
-      - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - >-
+        (
+          msd_staged_attachment_rows
+          | selectattr("vrfName", "equalto", "ndvrfmsdstgadd")
+          | selectattr("attach", "equalto", true)
+          | list
+          | length
+        ) == (nd_vrf_msd_staged_both_attach_count | int)
+      - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgremove") | selectattr("attach", "equalto", true) | list | length == 1
+      - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgdetach") | selectattr("attach", "equalto", true) | list | length == 0
       - msd_staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfmsdstgomit") | selectattr("attach", "equalto", true) | list | length == 0
+      - msd_staged_repeat_result.changed == false
+      - >-
+        msd_staged_attachment_rows
+        | selectattr("vrfName", "in", target_vrf_names)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_vrf_run_msd | bool
     - nd_vrf_run_staged | bool

--- a/tests/integration/targets/nd_manage_vrfs/tests/standalone/staged.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/tests/standalone/staged.yaml
@@ -1,0 +1,212 @@
+---
+- name: Test Entry Point - [nd_manage_vrfs - staged]
+  ansible.builtin.debug:
+    msg:
+      - "----------------------------------------------------------------"
+      - "+     Executing Staged Tests - [nd_manage_vrfs]                   +"
+      - "----------------------------------------------------------------"
+  tags: staged
+
+- name: Staged - Build Standalone Attachment Data
+  ansible.builtin.set_fact:
+    target_fabric: "{{ nd_vrf_standalone_fabric }}"
+    target_vrf_names:
+      - ndvrfstgcreate
+      - ndvrfstgadd
+      - ndvrfstgremove
+      - ndvrfstgomit
+    nd_vrf_staged_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_vrf_standalone_switch
+          }
+        ] if nd_vrf_standalone_switch | length > 0 else []
+      }}
+  delegate_to: localhost
+  tags: staged
+
+- name: Staged - Build Standalone Test Data
+  ansible.builtin.set_fact:
+    nd_vrf_staged_seed:
+      - vrf_name: ndvrfstgadd
+        vrf_id: "{{ nd_vrf_base_id + 70 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 70 }}"
+        vrf_description: Ansible ND staged add seed
+        deploy: false
+      - vrf_name: ndvrfstgremove
+        vrf_id: "{{ nd_vrf_base_id + 71 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 71 }}"
+        vrf_description: Ansible ND staged remove seed
+        attach: "{{ nd_vrf_staged_attach_block }}"
+        deploy: false
+      - vrf_name: ndvrfstgomit
+        vrf_id: "{{ nd_vrf_base_id + 72 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 72 }}"
+        vrf_description: Ansible ND staged omit seed
+        attach: "{{ nd_vrf_staged_attach_block }}"
+        deploy: false
+    nd_vrf_staged_create_config:
+      - vrf_name: ndvrfstgcreate
+        vrf_id: "{{ nd_vrf_base_id + 73 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 73 }}"
+        vrf_description: Ansible ND staged create
+        attach: "{{ nd_vrf_staged_attach_block }}"
+        deploy: true
+    nd_vrf_staged_config:
+      - vrf_name: ndvrfstgcreate
+        vrf_id: "{{ nd_vrf_base_id + 73 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 73 }}"
+        vrf_description: Ansible ND staged create
+        attach: "{{ nd_vrf_staged_attach_block }}"
+        deploy: true
+      - vrf_name: ndvrfstgadd
+        vrf_id: "{{ nd_vrf_base_id + 70 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 70 }}"
+        vrf_description: Ansible ND staged add updated
+        attach: "{{ nd_vrf_staged_attach_block }}"
+        deploy: true
+      - vrf_name: ndvrfstgremove
+        vrf_id: "{{ nd_vrf_base_id + 71 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 71 }}"
+        vrf_description: Ansible ND staged remove updated
+        deploy: true
+  delegate_to: localhost
+  tags: staged
+
+- name: Staged - Import Setup
+  ansible.builtin.import_tasks: ../../../tasks/setup.yaml
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged - Prepare Seed Configuration
+  vars:
+    file: standalone_staged_seed
+    vrf_conf: "{{ nd_vrf_staged_seed }}"
+  ansible.builtin.import_tasks: ../../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged - Prepare Create Configuration
+  vars:
+    file: standalone_staged_create
+    vrf_conf: "{{ nd_vrf_staged_create_config }}"
+  ansible.builtin.import_tasks: ../../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged - Prepare Configuration
+  vars:
+    file: standalone_staged
+    vrf_conf: "{{ nd_vrf_staged_config }}"
+  ansible.builtin.import_tasks: ../../../tasks/conf_prep_tasks.yaml
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC1 - Create VRF With Attachment
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_vrf_standalone_staged_create_conf }}"
+    output_level: debug
+  register: staged_create_result
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - staged_create_result.changed == true
+      - staged_create_result.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
+      - staged_create_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - staged_create_result.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
+      - (staged_create_result.api_payload | default([]) | to_json) is search("ndvrfstgcreate")
+      - (staged_create_result.api_payload | default([]) | to_json) is search("attach")
+      - (staged_create_result.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC2 - Seed Existing VRFs
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: merged
+    config: "{{ nd_vrf_standalone_staged_seed_conf }}"
+    output_level: debug
+  register: staged_seed_result
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC3 - Reconcile Attachments Without Deploy Or Definition Delete
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_vrf_standalone_staged_conf }}"
+    output_level: debug
+  register: staged_result
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+  ansible.builtin.assert:
+    that:
+      - staged_result.changed == true
+      - staged_result.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
+      - staged_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
+      - staged_result.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
+      - (staged_result.api_payload | default([]) | to_json) is search("ndvrfstgadd")
+      - (staged_result.api_payload | default([]) | to_json) is search("ndvrfstgremove")
+      - (staged_result.api_payload | default([]) | to_json) is search("ndvrfstgomit")
+      - (staged_result.api_payload | default([]) | to_json) is search("attach")
+      - (staged_result.api_payload | default([]) | to_json) is search("true")
+      - (staged_result.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC4 - Gather VRFs
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: gathered
+    config: []
+  register: staged_gather_result
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC4 - Assert Omitted VRF Definition Remains
+  ansible.builtin.assert:
+    that:
+      - (staged_gather_result.after | default([]) | to_json) is search("ndvrfstgomit")
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged

--- a/tests/integration/targets/nd_manage_vrfs/tests/standalone/staged.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/tests/standalone/staged.yaml
@@ -128,16 +128,51 @@
     - nd_vrf_standalone_switch | length > 0
   tags: staged
 
-- name: Staged TC1 - Assert Create Attachment Without Deploy Or Delete
+- name: Staged TC1 - Assert Staged Create Reported Change
   ansible.builtin.assert:
     that:
       - staged_create_result.changed == true
-      - staged_create_result.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
-      - staged_create_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - staged_create_result.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
-      - (staged_create_result.api_payload | default([]) | to_json) is search("ndvrfstgcreate")
-      - (staged_create_result.api_payload | default([]) | to_json) is search("attach")
-      - (staged_create_result.api_payload | default([]) | to_json) is search("true")
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC1 - Query Created VRF Attachment
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ target_fabric }}/vrfAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      vrfNames:
+        - ndvrfstgcreate
+  register: staged_create_attachment_query
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC1 - Normalize Created VRF Attachment Rows
+  ansible.builtin.set_fact:
+    staged_create_attachment_rows: >-
+      {{
+        staged_create_attachment_query.current.attachments
+        | default(staged_create_attachment_query.current.items | default([]))
+      }}
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC1 - Assert Created VRF Attachment State
+  ansible.builtin.assert:
+    that:
+      - >-
+        staged_create_attachment_rows
+        | selectattr("vrfName", "equalto", "ndvrfstgcreate")
+        | selectattr("attach", "equalto", true)
+        | list | length > 0
   when:
     - nd_vrf_run_standalone | bool
     - nd_vrf_run_staged | bool
@@ -170,19 +205,36 @@
     - nd_vrf_standalone_switch | length > 0
   tags: staged
 
-- name: Staged TC3 - Assert Attachment Reconciliation Without Deploy Or Delete
+- name: Staged TC3 - Assert Staged Reconcile Reported Change
   ansible.builtin.assert:
     that:
       - staged_result.changed == true
-      - staged_result.api_paths | default([]) | select("search", "/vrfAttachments") | list | length > 0
-      - staged_result.api_paths | default([]) | select("search", "deploy") | list | length == 0
-      - staged_result.api_paths | default([]) | select("search", "vrfActions/remove") | list | length == 0
-      - (staged_result.api_payload | default([]) | to_json) is search("ndvrfstgadd")
-      - (staged_result.api_payload | default([]) | to_json) is search("ndvrfstgremove")
-      - (staged_result.api_payload | default([]) | to_json) is search("ndvrfstgomit")
-      - (staged_result.api_payload | default([]) | to_json) is search("attach")
-      - (staged_result.api_payload | default([]) | to_json) is search("true")
-      - (staged_result.api_payload | default([]) | to_json) is search("false")
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC4 - Query VRF Attachments
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ target_fabric }}/vrfAttachments/query?includeAll=true&max=10000&offset=0"
+    method: post
+    content:
+      vrfNames: "{{ target_vrf_names }}"
+  register: staged_attachment_query
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC4 - Normalize VRF Attachment Rows
+  ansible.builtin.set_fact:
+    staged_attachment_rows: >-
+      {{
+        staged_attachment_query.current.attachments
+        | default(staged_attachment_query.current.items | default([]))
+      }}
   when:
     - nd_vrf_run_standalone | bool
     - nd_vrf_run_staged | bool
@@ -205,6 +257,10 @@
   ansible.builtin.assert:
     that:
       - (staged_gather_result.after | default([]) | to_json) is search("ndvrfstgomit")
+      - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
+      - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgadd") | selectattr("attach", "equalto", true) | list | length > 0
+      - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgomit") | selectattr("attach", "equalto", true) | list | length == 0
   when:
     - nd_vrf_run_standalone | bool
     - nd_vrf_run_staged | bool

--- a/tests/integration/targets/nd_manage_vrfs/tests/standalone/staged.yaml
+++ b/tests/integration/targets/nd_manage_vrfs/tests/standalone/staged.yaml
@@ -14,8 +14,9 @@
       - ndvrfstgcreate
       - ndvrfstgadd
       - ndvrfstgremove
+      - ndvrfstgdetach
       - ndvrfstgomit
-    nd_vrf_staged_attach_block: >-
+    nd_vrf_staged_primary_attach_block: >-
       {{
         [
           {
@@ -23,6 +24,27 @@
           }
         ] if nd_vrf_standalone_switch | length > 0 else []
       }}
+    nd_vrf_staged_secondary_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_vrf_standalone_switch2
+          }
+        ] if nd_vrf_standalone_switch2 | length > 0 else []
+      }}
+    nd_vrf_staged_create_attach_block: >-
+      {{
+        [
+          {
+            'ip_address': nd_vrf_standalone_switch2
+          }
+        ] if nd_vrf_standalone_switch2 | length > 0 else [
+          {
+            'ip_address': nd_vrf_standalone_switch
+          }
+        ]
+      }}
+    nd_vrf_staged_both_attach_count: "{{ 2 if nd_vrf_standalone_switch2 | length > 0 else 1 }}"
   delegate_to: localhost
   tags: staged
 
@@ -33,43 +55,57 @@
         vrf_id: "{{ nd_vrf_base_id + 70 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 70 }}"
         vrf_description: Ansible ND staged add seed
+        attach: "{{ nd_vrf_staged_primary_attach_block }}"
         deploy: false
       - vrf_name: ndvrfstgremove
         vrf_id: "{{ nd_vrf_base_id + 71 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 71 }}"
         vrf_description: Ansible ND staged remove seed
-        attach: "{{ nd_vrf_staged_attach_block }}"
+        attach: "{{ nd_vrf_staged_primary_attach_block + nd_vrf_staged_secondary_attach_block }}"
+        deploy: false
+      - vrf_name: ndvrfstgdetach
+        vrf_id: "{{ nd_vrf_base_id + 74 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 74 }}"
+        vrf_description: Ansible ND staged detach seed
+        attach: "{{ nd_vrf_staged_primary_attach_block }}"
         deploy: false
       - vrf_name: ndvrfstgomit
         vrf_id: "{{ nd_vrf_base_id + 72 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 72 }}"
         vrf_description: Ansible ND staged omit seed
-        attach: "{{ nd_vrf_staged_attach_block }}"
+        attach: "{{ nd_vrf_staged_primary_attach_block }}"
         deploy: false
     nd_vrf_staged_create_config:
       - vrf_name: ndvrfstgcreate
         vrf_id: "{{ nd_vrf_base_id + 73 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 73 }}"
         vrf_description: Ansible ND staged create
-        attach: "{{ nd_vrf_staged_attach_block }}"
+        attach: "{{ nd_vrf_staged_create_attach_block }}"
         deploy: true
     nd_vrf_staged_config:
       - vrf_name: ndvrfstgcreate
         vrf_id: "{{ nd_vrf_base_id + 73 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 73 }}"
         vrf_description: Ansible ND staged create
-        attach: "{{ nd_vrf_staged_attach_block }}"
+        attach: "{{ nd_vrf_staged_create_attach_block }}"
         deploy: true
       - vrf_name: ndvrfstgadd
         vrf_id: "{{ nd_vrf_base_id + 70 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 70 }}"
         vrf_description: Ansible ND staged add updated
-        attach: "{{ nd_vrf_staged_attach_block }}"
+        attach: "{{ nd_vrf_staged_primary_attach_block + nd_vrf_staged_secondary_attach_block }}"
         deploy: true
       - vrf_name: ndvrfstgremove
         vrf_id: "{{ nd_vrf_base_id + 71 }}"
         vlan_id: "{{ nd_vrf_base_vlan + 71 }}"
         vrf_description: Ansible ND staged remove updated
+        attach: "{{ nd_vrf_staged_primary_attach_block }}"
+        deploy: true
+      - vrf_name: ndvrfstgdetach
+        vrf_id: "{{ nd_vrf_base_id + 74 }}"
+        vlan_id: "{{ nd_vrf_base_vlan + 74 }}"
+        vrf_description: Ansible ND staged detach updated
+        attach: []
         deploy: true
   delegate_to: localhost
   tags: staged
@@ -173,6 +209,12 @@
         | selectattr("vrfName", "equalto", "ndvrfstgcreate")
         | selectattr("attach", "equalto", true)
         | list | length > 0
+      - >-
+        staged_create_attachment_rows
+        | selectattr("vrfName", "equalto", "ndvrfstgcreate")
+        | selectattr("attach", "equalto", true)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_vrf_run_standalone | bool
     - nd_vrf_run_staged | bool
@@ -209,6 +251,19 @@
   ansible.builtin.assert:
     that:
       - staged_result.changed == true
+  when:
+    - nd_vrf_run_standalone | bool
+    - nd_vrf_run_staged | bool
+    - nd_vrf_standalone_switch | length > 0
+  tags: staged
+
+- name: Staged TC3 - Repeat Reconcile For Controller-State Idempotency
+  cisco.nd.nd_manage_vrfs:
+    fabric_name: "{{ target_fabric }}"
+    state: staged
+    config: "{{ nd_vrf_standalone_staged_conf }}"
+    output_level: debug
+  register: staged_repeat_result
   when:
     - nd_vrf_run_standalone | bool
     - nd_vrf_run_staged | bool
@@ -258,9 +313,23 @@
     that:
       - (staged_gather_result.after | default([]) | to_json) is search("ndvrfstgomit")
       - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgcreate") | selectattr("attach", "equalto", true) | list | length > 0
-      - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgadd") | selectattr("attach", "equalto", true) | list | length > 0
-      - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgremove") | selectattr("attach", "equalto", true) | list | length == 0
+      - >-
+        (
+          staged_attachment_rows
+          | selectattr("vrfName", "equalto", "ndvrfstgadd")
+          | selectattr("attach", "equalto", true)
+          | list
+          | length
+        ) == (nd_vrf_staged_both_attach_count | int)
+      - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgremove") | selectattr("attach", "equalto", true) | list | length == 1
+      - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgdetach") | selectattr("attach", "equalto", true) | list | length == 0
       - staged_attachment_rows | selectattr("vrfName", "equalto", "ndvrfstgomit") | selectattr("attach", "equalto", true) | list | length == 0
+      - staged_repeat_result.changed == false
+      - >-
+        staged_attachment_rows
+        | selectattr("vrfName", "in", target_vrf_names)
+        | rejectattr("status", "equalto", "pending")
+        | list | length == 0
   when:
     - nd_vrf_run_standalone | bool
     - nd_vrf_run_staged | bool

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -210,7 +210,7 @@ class _ReplacedNetworkCoordinator:
 
 class _StagedNetworkCoordinator:
     def __init__(self):
-        self.module = _Module({"state": "staged"})
+        self.module = _Module({"state": "_staged"})
         self.calls = []
         self.state_machine = _FakeStateMachine(self.calls, existing=[_ExistingNetwork("BLUE_NET"), _ExistingNetwork("OMIT_NET")])
         self.current_attachment_details = [
@@ -297,24 +297,24 @@ class _StagedNetworkCoordinator:
 
     @staticmethod
     def _build_delete_deploy_payloads(_config, *_target_maps):
-        raise AssertionError("staged must not build delete deploy payloads")
+        raise AssertionError("_staged must not build delete deploy payloads")
 
     @staticmethod
     def _build_deploy_payloads(_config, *_target_maps):
-        raise AssertionError("staged must not build deploy payloads")
+        raise AssertionError("_staged must not build deploy payloads")
 
     @staticmethod
     def _build_pending_network_deploy_payloads(_result, _config, _module_args, _strategy):
-        raise AssertionError("staged must not build pending deploy payloads")
+        raise AssertionError("_staged must not build pending deploy payloads")
 
     def _query_current_networks_with_trace(self, *_args):
-        raise AssertionError("staged test should not need the fallback pending Network query")
+        raise AssertionError("_staged test should not need the fallback pending Network query")
 
     def _wait_for_network_attachments_delete_ready(self, _module_args, _strategy, network_names):
-        raise AssertionError(f"staged must not wait for attachment delete readiness: {network_names}")
+        raise AssertionError(f"_staged must not wait for attachment delete readiness: {network_names}")
 
     def _wait_for_networks_delete_ready(self, _module_args, _strategy, network_names):
-        raise AssertionError(f"staged must not wait for Network delete readiness: {network_names}")
+        raise AssertionError(f"_staged must not wait for Network delete readiness: {network_names}")
 
     def _restore_state_machine_params(self, original_config, original_state):
         self.calls.append(("restore", original_config, original_state))
@@ -342,7 +342,7 @@ def test_network_attachment_manager_staged_detaches_like_overridden():
     }
     desired = {("BLUE_NET", "SERIAL1"): {"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": True}}
 
-    assert manager.planned_detach_payloads("staged", [{"network_name": "BLUE_NET"}], current, desired) == [
+    assert manager.planned_detach_payloads("_staged", [{"network_name": "BLUE_NET"}], current, desired) == [
         {"networkName": "BLUE_NET", "switchId": "SERIAL2", "attach": False}
     ]
 
@@ -352,7 +352,7 @@ def test_network_staged_detaches_omitted_networks_without_running_overridden_cru
     state_machine = NetworkStateMachine(coordinator)
 
     result = state_machine.run(
-        {"state": "staged", "config": [{"network_name": "BLUE_NET", "attach": [{"switch_id": "SERIAL1"}]}]},
+        {"state": "_staged", "config": [{"network_name": "BLUE_NET", "attach": [{"switch_id": "SERIAL1"}]}]},
         StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"}),
     )
 

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -92,11 +92,17 @@ class _ParentStrategy:
 class _FakeStateMachine:
     existing = []
 
-    def __init__(self, calls):
+    def __init__(self, calls, existing=None):
         self.calls = calls
+        self.existing = existing or []
 
     def manage_state(self):
         self.calls.append(("manage_state",))
+
+
+class _ExistingNetwork:
+    def __init__(self, network_name):
+        self.network_name = network_name
 
 
 class _ReplacedNetworkCoordinator:
@@ -202,6 +208,121 @@ class _ReplacedNetworkCoordinator:
         self.calls.append(("trace", event))
 
 
+class _StagedNetworkCoordinator:
+    def __init__(self):
+        self.module = _Module({"state": "staged"})
+        self.calls = []
+        self.state_machine = _FakeStateMachine(self.calls, existing=[_ExistingNetwork("BLUE_NET"), _ExistingNetwork("OMIT_NET")])
+        self.current_attachment_details = [
+            {"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": True},
+            {"networkName": "BLUE_NET", "switchId": "SERIAL2", "attach": True},
+            {"networkName": "OMIT_NET", "switchId": "SERIAL3", "attach": True},
+        ]
+
+    @staticmethod
+    def _desired_attachment_map(_module_args, _strategy):
+        return {("BLUE_NET", "SERIAL1"): {"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": True}}
+
+    @staticmethod
+    def _configured_network_names(config):
+        return [network["network_name"] for network in config]
+
+    @staticmethod
+    def _deploy_enabled_by_network(config):
+        return {network["network_name"]: network.get("deploy", True) for network in config}
+
+    def _new_state_machine(self, module_args, _strategy):
+        self.calls.append(("new_state_machine", module_args["state"]))
+        return self.state_machine, "original-config", "original-state"
+
+    def _current_attachment_details_ignore_missing(self, _module_args, _strategy, network_names):
+        self.calls.append(("attachment_query", network_names))
+        return list(self.current_attachment_details)
+
+    @staticmethod
+    def _attachment_map_from_details(attachments, network_names=None):
+        return NetworkAttachmentManager.attachment_map_from_details(attachments, network_names)
+
+    @staticmethod
+    def _filter_attachment_details_by_network(attachments, network_names):
+        return NetworkAttachmentManager.filter_attachment_details_by_network(attachments, network_names)
+
+    def _ensure_networks_have_no_networks(self, _module_args, _strategy, network_names):
+        self.calls.append(("dependency_check", network_names))
+
+    def _apply_deleted_attachment_phase(self, _module_args, _strategy, network_names, attachment_details=None):
+        self.calls.append(("omitted_detach", network_names, attachment_details))
+        return {"changed": True, "payloads": [{"networkName": network_names[0], "switchId": "SERIAL3", "attach": False}], "deploy_targets": {}}
+
+    def _apply_attachment_phase(
+        self,
+        module_args,
+        _strategy,
+        phase,
+        desired=None,
+        current_network_names=None,
+        current=None,
+        attachment_details=None,
+    ):
+        self.calls.append(("attachment_phase", phase, module_args["state"], current_network_names, current, attachment_details))
+        if phase == "pre":
+            return {
+                "changed": True,
+                "payloads": NetworkAttachmentManager(self).planned_detach_payloads(
+                    module_args["state"],
+                    module_args.get("config") or [],
+                    current,
+                    desired,
+                ),
+                "current": current,
+                "desired": desired,
+                "deploy_targets": {},
+            }
+        return {"changed": False, "payloads": [], "current": current, "desired": desired, "deploy_targets": {}}
+
+    @staticmethod
+    def _attachment_map_after_detach(current, payloads):
+        return NetworkAttachmentManager.attachment_map_after_detach(current, payloads)
+
+    @staticmethod
+    def _format_state_machine_output(_state_machine):
+        return {"changed": True, "failed": False, "after": [{"network_name": "BLUE_NET"}]}
+
+    @staticmethod
+    def _merge_api_trace(result, trace, prepend=False):
+        if prepend:
+            result.setdefault("prepended", []).append(trace)
+        if trace.get("changed"):
+            result["changed"] = True
+
+    @staticmethod
+    def _build_delete_deploy_payloads(_config, *_target_maps):
+        return []
+
+    @staticmethod
+    def _build_deploy_payloads(_config, *_target_maps):
+        return []
+
+    @staticmethod
+    def _build_pending_network_deploy_payloads(_result, _config, _module_args, _strategy):
+        return []
+
+    def _query_current_networks_with_trace(self, *_args):
+        raise AssertionError("staged test should not need the fallback pending Network query")
+
+    def _wait_for_network_attachments_delete_ready(self, _module_args, _strategy, network_names):
+        self.calls.append(("wait_attachments_delete_ready", network_names))
+
+    def _wait_for_networks_delete_ready(self, _module_args, _strategy, network_names):
+        self.calls.append(("wait_networks_delete_ready", network_names))
+
+    def _restore_state_machine_params(self, original_config, original_state):
+        self.calls.append(("restore", original_config, original_state))
+
+    def _trace(self, event, **_details):
+        self.calls.append(("trace", event))
+
+
 def _orchestrator():
     strategy = StandaloneNetworkStrategy(
         fabric_name="fab1",
@@ -211,6 +332,39 @@ def _orchestrator():
         rest_send=RestSend({"state": "merged", "config": [], "check_mode": False}),
         strategy=strategy,
     )
+
+
+def test_network_attachment_manager_staged_detaches_like_overridden():
+    manager = NetworkAttachmentManager(coordinator=object())
+    current = {
+        ("BLUE_NET", "SERIAL1"): {"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": True},
+        ("BLUE_NET", "SERIAL2"): {"networkName": "BLUE_NET", "switchId": "SERIAL2", "attach": True},
+    }
+    desired = {("BLUE_NET", "SERIAL1"): {"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": True}}
+
+    assert manager.planned_detach_payloads("staged", [{"network_name": "BLUE_NET"}], current, desired) == [
+        {"networkName": "BLUE_NET", "switchId": "SERIAL2", "attach": False}
+    ]
+
+
+def test_network_staged_detaches_omitted_networks_without_running_overridden_crud_delete():
+    coordinator = _StagedNetworkCoordinator()
+    state_machine = NetworkStateMachine(coordinator)
+
+    result = state_machine.run(
+        {"state": "staged", "config": [{"network_name": "BLUE_NET", "attach": [{"switch_id": "SERIAL1"}]}]},
+        StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"}),
+    )
+
+    assert result["changed"] is True
+    assert ("new_state_machine", "replaced") in coordinator.calls
+    assert ("attachment_query", ["BLUE_NET", "OMIT_NET"]) in coordinator.calls
+    assert ("dependency_check", ["OMIT_NET"]) in coordinator.calls
+    assert (
+        "omitted_detach",
+        ["OMIT_NET"],
+        [{"networkName": "OMIT_NET", "switchId": "SERIAL3", "attach": True}],
+    ) in coordinator.calls
 
 
 def test_network_replaced_first_create_with_attachment_skips_missing_pre_query():

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -253,7 +253,7 @@ class _StagedNetworkCoordinator:
 
     def _new_state_machine(self, module_args, _strategy):
         self.state_machine.state = module_args["state"]
-        self.calls.append(("new_state_machine", module_args["state"]))
+        self.calls.append(("new_state_machine", module_args["state"], list(module_args.get("config") or [])))
         return self.state_machine, "original-config", "original-state"
 
     def _current_attachment_details_ignore_missing(self, _module_args, _strategy, network_names):
@@ -418,13 +418,15 @@ def test_network_staged_detaches_omitted_networks_without_running_overridden_cru
     coordinator = _StagedNetworkCoordinator()
     state_machine = NetworkStateMachine(coordinator)
 
+    config = [{"network_name": "BLUE_NET", "attach": [{"switch_id": "SERIAL1"}]}]
+
     result = state_machine.run(
-        {"state": "staged", "config": [{"network_name": "BLUE_NET", "attach": [{"switch_id": "SERIAL1"}]}]},
-        StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"}),
+        {"state": "staged", "config": config}, StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"})
     )
 
     assert result["changed"] is True
-    assert ("new_state_machine", "overridden") in coordinator.calls
+    assert ("new_state_machine", "overridden", []) in coordinator.calls
+    assert ("new_state_machine", "replaced", config) in coordinator.calls
     assert ("manage_state", "replaced") in coordinator.calls
     assert ("attachment_query", ["BLUE_NET", "OMIT_NET"]) in coordinator.calls
     assert (

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -57,6 +57,24 @@ class _Module:
         raise AssertionError(kwargs)
 
 
+class _NetworkAttachmentCoordinator:
+    def __init__(self):
+        self.traces = []
+
+    def _trace(self, event, **details):
+        self.traces.append((event, details))
+
+
+class _RecordingNetworkAttachmentManager(NetworkAttachmentManager):
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self.posts = []
+
+    def post_network_attachments(self, _module_args, _strategy, payloads, deploy_targets, operation_type):
+        self.posts.append((payloads, deploy_targets, operation_type))
+        return {"changed": True, "payloads": payloads, "deploy_targets": deploy_targets}
+
+
 class _ParentStrategy:
     config_model_cls = NetworkParentConfigModel
     fabric_data = {"members": [{"fabricName": "child1"}]}
@@ -348,6 +366,52 @@ def test_network_attachment_manager_staged_detaches_like_overridden():
     assert manager.planned_detach_payloads("staged", [{"network_name": "BLUE_NET"}], current, desired) == [
         {"networkName": "BLUE_NET", "switchId": "SERIAL2", "attach": False}
     ]
+
+
+def test_network_attachment_manager_staged_pre_phase_posts_detach():
+    coordinator = _NetworkAttachmentCoordinator()
+    manager = _RecordingNetworkAttachmentManager(coordinator)
+
+    trace = manager.apply_phase(
+        {"state": "staged", "config": [{"network_name": "BLUE_NET"}]},
+        StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"}),
+        phase="pre",
+        desired={},
+        current_network_names=["BLUE_NET"],
+        current={("BLUE_NET", "SERIAL1"): {"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": True, "vlanId": 100}},
+        attachment_details=[{"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": True, "vlanId": 100}],
+    )
+
+    assert trace["payloads"] == [{"networkName": "BLUE_NET", "switchId": "SERIAL1", "vlanId": 100, "attach": False}]
+    assert manager.posts[0][0] == trace["payloads"]
+    assert ("network_attachment_phase_skip", {"phase": "pre", "reason": "state_not_pre_detach"}) not in coordinator.traces
+
+
+def test_network_attachment_manager_staged_post_phase_posts_attach():
+    coordinator = _NetworkAttachmentCoordinator()
+    manager = _RecordingNetworkAttachmentManager(coordinator)
+    desired = {
+        ("BLUE_NET", "SERIAL1"): {
+            "networkName": "BLUE_NET",
+            "switchId": "SERIAL1",
+            "interfaces": [{"interfaceRange": "Ethernet1/1", "mode": "trunk"}],
+            "attach": True,
+        }
+    }
+
+    trace = manager.apply_phase(
+        {"state": "staged", "config": [{"network_name": "BLUE_NET", "attach": [{"switch_id": "SERIAL1"}]}]},
+        StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"}),
+        phase="post",
+        desired=desired,
+        current_network_names=["BLUE_NET"],
+        current={},
+        attachment_details=[{"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": False}],
+    )
+
+    assert trace["payloads"] == [desired[("BLUE_NET", "SERIAL1")]]
+    assert manager.posts[0][0] == trace["payloads"]
+    assert ("network_attachment_phase_skip", {"phase": "post", "reason": "state_not_post_attach"}) not in coordinator.traces
 
 
 def test_network_staged_detaches_omitted_networks_without_running_overridden_crud_delete():

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -269,7 +269,7 @@ class _StagedNetworkCoordinator:
         return NetworkAttachmentManager.filter_attachment_details_by_network(attachments, network_names)
 
     def _ensure_networks_have_no_networks(self, _module_args, _strategy, network_names):
-        self.calls.append(("dependency_check", network_names))
+        raise AssertionError(f"staged must not run Network deletion dependency checks: {network_names}")
 
     def _apply_deleted_attachment_phase(self, _module_args, _strategy, network_names, attachment_details=None):
         self.calls.append(("omitted_detach", network_names, attachment_details))
@@ -427,7 +427,6 @@ def test_network_staged_detaches_omitted_networks_without_running_overridden_cru
     assert ("new_state_machine", "overridden") in coordinator.calls
     assert ("manage_state", "replaced") in coordinator.calls
     assert ("attachment_query", ["BLUE_NET", "OMIT_NET"]) in coordinator.calls
-    assert ("dependency_check", ["OMIT_NET"]) in coordinator.calls
     assert (
         "omitted_detach",
         ["OMIT_NET"],

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -297,24 +297,24 @@ class _StagedNetworkCoordinator:
 
     @staticmethod
     def _build_delete_deploy_payloads(_config, *_target_maps):
-        return []
+        raise AssertionError("staged must not build delete deploy payloads")
 
     @staticmethod
     def _build_deploy_payloads(_config, *_target_maps):
-        return []
+        raise AssertionError("staged must not build deploy payloads")
 
     @staticmethod
     def _build_pending_network_deploy_payloads(_result, _config, _module_args, _strategy):
-        return []
+        raise AssertionError("staged must not build pending deploy payloads")
 
     def _query_current_networks_with_trace(self, *_args):
         raise AssertionError("staged test should not need the fallback pending Network query")
 
     def _wait_for_network_attachments_delete_ready(self, _module_args, _strategy, network_names):
-        self.calls.append(("wait_attachments_delete_ready", network_names))
+        raise AssertionError(f"staged must not wait for attachment delete readiness: {network_names}")
 
     def _wait_for_networks_delete_ready(self, _module_args, _strategy, network_names):
-        self.calls.append(("wait_networks_delete_ready", network_names))
+        raise AssertionError(f"staged must not wait for Network delete readiness: {network_names}")
 
     def _restore_state_machine_params(self, original_config, original_state):
         self.calls.append(("restore", original_config, original_state))

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -212,7 +212,7 @@ class _ReplacedNetworkCoordinator:
 
 class _StagedNetworkCoordinator:
     def __init__(self):
-        self.module = _Module({"state": "_staged"})
+        self.module = _Module({"state": "staged"})
         self.calls = []
         self.state_machine = _FakeStateMachine(self.calls, existing=[_ExistingNetwork("BLUE_NET"), _ExistingNetwork("OMIT_NET")])
         self.current_attachment_details = [
@@ -300,24 +300,24 @@ class _StagedNetworkCoordinator:
 
     @staticmethod
     def _build_delete_deploy_payloads(_config, *_target_maps):
-        raise AssertionError("_staged must not build delete deploy payloads")
+        raise AssertionError("staged must not build delete deploy payloads")
 
     @staticmethod
     def _build_deploy_payloads(_config, *_target_maps):
-        raise AssertionError("_staged must not build deploy payloads")
+        raise AssertionError("staged must not build deploy payloads")
 
     @staticmethod
     def _build_pending_network_deploy_payloads(_result, _config, _module_args, _strategy):
-        raise AssertionError("_staged must not build pending deploy payloads")
+        raise AssertionError("staged must not build pending deploy payloads")
 
     def _query_current_networks_with_trace(self, *_args):
-        raise AssertionError("_staged test should not need the fallback pending Network query")
+        raise AssertionError("staged test should not need the fallback pending Network query")
 
     def _wait_for_network_attachments_delete_ready(self, _module_args, _strategy, network_names):
-        raise AssertionError(f"_staged must not wait for attachment delete readiness: {network_names}")
+        raise AssertionError(f"staged must not wait for attachment delete readiness: {network_names}")
 
     def _wait_for_networks_delete_ready(self, _module_args, _strategy, network_names):
-        raise AssertionError(f"_staged must not wait for Network delete readiness: {network_names}")
+        raise AssertionError(f"staged must not wait for Network delete readiness: {network_names}")
 
     def _restore_state_machine_params(self, original_config, original_state):
         self.calls.append(("restore", original_config, original_state))
@@ -345,7 +345,7 @@ def test_network_attachment_manager_staged_detaches_like_overridden():
     }
     desired = {("BLUE_NET", "SERIAL1"): {"networkName": "BLUE_NET", "switchId": "SERIAL1", "attach": True}}
 
-    assert manager.planned_detach_payloads("_staged", [{"network_name": "BLUE_NET"}], current, desired) == [
+    assert manager.planned_detach_payloads("staged", [{"network_name": "BLUE_NET"}], current, desired) == [
         {"networkName": "BLUE_NET", "switchId": "SERIAL2", "attach": False}
     ]
 
@@ -355,7 +355,7 @@ def test_network_staged_detaches_omitted_networks_without_running_overridden_cru
     state_machine = NetworkStateMachine(coordinator)
 
     result = state_machine.run(
-        {"state": "_staged", "config": [{"network_name": "BLUE_NET", "attach": [{"switch_id": "SERIAL1"}]}]},
+        {"state": "staged", "config": [{"network_name": "BLUE_NET", "attach": [{"switch_id": "SERIAL1"}]}]},
         StandaloneNetworkStrategy(fabric_name="fab1", fabric_data={"managementType": "vxlanIbgp"}),
     )
 

--- a/tests/unit/module_utils/orchestrators/test_networks.py
+++ b/tests/unit/module_utils/orchestrators/test_networks.py
@@ -95,9 +95,10 @@ class _FakeStateMachine:
     def __init__(self, calls, existing=None):
         self.calls = calls
         self.existing = existing or []
+        self.state = None
 
     def manage_state(self):
-        self.calls.append(("manage_state",))
+        self.calls.append(("manage_state", self.state))
 
 
 class _ExistingNetwork:
@@ -137,7 +138,8 @@ class _ReplacedNetworkCoordinator:
     def _deploy_enabled_by_network(_config):
         return {"BLUE_NET": True}
 
-    def _new_state_machine(self, _module_args, _strategy):
+    def _new_state_machine(self, module_args, _strategy):
+        self.state_machine.state = module_args["state"]
         self.calls.append(("new_state_machine",))
         return self.state_machine, "original-config", "original-state"
 
@@ -232,6 +234,7 @@ class _StagedNetworkCoordinator:
         return {network["network_name"]: network.get("deploy", True) for network in config}
 
     def _new_state_machine(self, module_args, _strategy):
+        self.state_machine.state = module_args["state"]
         self.calls.append(("new_state_machine", module_args["state"]))
         return self.state_machine, "original-config", "original-state"
 
@@ -357,7 +360,8 @@ def test_network_staged_detaches_omitted_networks_without_running_overridden_cru
     )
 
     assert result["changed"] is True
-    assert ("new_state_machine", "replaced") in coordinator.calls
+    assert ("new_state_machine", "overridden") in coordinator.calls
+    assert ("manage_state", "replaced") in coordinator.calls
     assert ("attachment_query", ["BLUE_NET", "OMIT_NET"]) in coordinator.calls
     assert ("dependency_check", ["OMIT_NET"]) in coordinator.calls
     assert (
@@ -397,7 +401,7 @@ def test_network_replaced_first_create_with_attachment_skips_missing_pre_query()
 
     assert result["changed"] is True
     assert ("pre", [], {}, []) in coordinator.calls
-    assert ("manage_state",) in coordinator.calls
+    assert ("manage_state", "replaced") in coordinator.calls
     assert ("post_query", ["BLUE_NET"]) in coordinator.calls
     assert ("post", ["BLUE_NET"], {}, coordinator.post_attachment_details) in coordinator.calls
 

--- a/tests/unit/module_utils/orchestrators/test_staged_state_helpers.py
+++ b/tests/unit/module_utils/orchestrators/test_staged_state_helpers.py
@@ -1,0 +1,65 @@
+# Copyright: (c) 2026, Akshayanat C S (@achengam) <achengam@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for staged workflow state mapping helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.staged_state_helpers import (
+    crud_module_args,
+    prepare_crud_state,
+    query_module_args,
+)
+
+
+def test_staged_crud_module_args_maps_to_replaced_without_mutating_original():
+    module_args = {"state": "staged", "config": [{"name": "BLUE"}]}
+
+    result = crud_module_args(module_args)
+
+    assert result == {"state": "replaced", "config": [{"name": "BLUE"}]}
+    assert module_args["state"] == "staged"
+
+
+def test_staged_query_module_args_maps_to_overridden_without_mutating_original():
+    module_args = {"state": "staged", "config": [{"name": "BLUE"}]}
+
+    result = query_module_args(module_args)
+
+    assert result == {"state": "overridden", "config": [{"name": "BLUE"}]}
+    assert module_args["state"] == "staged"
+
+
+def test_non_staged_module_args_are_returned_unchanged():
+    module_args = {"state": "merged", "config": []}
+
+    assert crud_module_args(module_args) is module_args
+    assert query_module_args(module_args) is module_args
+
+
+def test_prepare_crud_state_maps_only_staged_to_replaced():
+    state_machine = SimpleNamespace(state="overridden", results=SimpleNamespace(state="overridden"))
+
+    prepare_crud_state(state_machine, "staged")
+
+    assert state_machine.state == "replaced"
+    assert state_machine.results.state == "staged"
+
+
+def test_prepare_crud_state_leaves_non_staged_state_unchanged():
+    state_machine = SimpleNamespace(state="overridden", results=SimpleNamespace(state="overridden"))
+
+    prepare_crud_state(state_machine, "overridden")
+
+    assert state_machine.state == "overridden"
+    assert state_machine.results.state == "overridden"
+
+
+def test_prepare_crud_state_handles_state_machine_without_results():
+    state_machine = SimpleNamespace(state="overridden")
+
+    prepare_crud_state(state_machine, "staged")
+
+    assert state_machine.state == "replaced"

--- a/tests/unit/module_utils/orchestrators/test_staged_state_helpers.py
+++ b/tests/unit/module_utils/orchestrators/test_staged_state_helpers.py
@@ -28,7 +28,7 @@ def test_staged_query_module_args_maps_to_overridden_without_mutating_original()
 
     result = query_module_args(module_args)
 
-    assert result == {"state": "overridden", "config": [{"name": "BLUE"}]}
+    assert result == {"state": "overridden", "config": []}
     assert module_args["state"] == "staged"
 
 

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -226,9 +226,10 @@ class _FakeStateMachine:
     def __init__(self, calls, existing=None):
         self.existing = existing or []
         self.calls = calls
+        self.state = None
 
     def manage_state(self):
-        self.calls.append(("manage_state",))
+        self.calls.append(("manage_state", self.state))
 
 
 class _ReplacedVrfCoordinator:
@@ -255,7 +256,8 @@ class _ReplacedVrfCoordinator:
     def _configured_vrf_names(config):
         return [vrf["vrf_name"] for vrf in config]
 
-    def _new_state_machine(self, _module_args, _strategy):
+    def _new_state_machine(self, module_args, _strategy):
+        self.state_machine.state = module_args["state"]
         self.calls.append(("new_state_machine",))
         return self.state_machine, "original-config", "original-state"
 
@@ -347,6 +349,7 @@ class _StagedVrfCoordinator:
         return [vrf["vrf_name"] for vrf in config]
 
     def _new_state_machine(self, module_args, _strategy):
+        self.state_machine.state = module_args["state"]
         self.calls.append(("new_state_machine", module_args["state"]))
         return self.state_machine, "original-config", "original-state"
 
@@ -453,7 +456,8 @@ def test_vrf_staged_detaches_omitted_vrfs_without_running_overridden_crud_delete
     )
 
     assert result["changed"] is True
-    assert ("new_state_machine", "replaced") in coordinator.calls
+    assert ("new_state_machine", "overridden") in coordinator.calls
+    assert ("manage_state", "replaced") in coordinator.calls
     assert ("attachment_query", ["BLUE", "OMIT"]) in coordinator.calls
     assert ("dependency_check", ["OMIT"]) in coordinator.calls
     assert (
@@ -481,7 +485,7 @@ def test_vrf_replaced_first_create_with_attachment_skips_missing_pre_query():
     assert result["changed"] is True
     assert ("initial_query", []) not in coordinator.calls
     assert ("post_query", ["BLUE"]) in coordinator.calls
-    assert ("manage_state",) in coordinator.calls
+    assert ("manage_state", "replaced") in coordinator.calls
     assert coordinator.posted_payloads[-1]["payloads"] == [
         {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True},
         {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": True},

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -399,7 +399,7 @@ class _StagedVrfCoordinator:
         return VrfAttachmentManager.filter_attachment_details_by_vrf(attachments, vrf_names)
 
     def _ensure_vrfs_have_no_networks(self, _module_args, _strategy, vrf_names):
-        self.calls.append(("dependency_check", vrf_names))
+        raise AssertionError(f"staged must not run VRF deletion dependency checks: {vrf_names}")
 
     def _apply_deleted_attachment_phase(self, _module_args, _strategy, vrf_names, attachment_details=None):
         self.calls.append(("omitted_detach", vrf_names, attachment_details))
@@ -529,7 +529,6 @@ def test_vrf_staged_detaches_omitted_vrfs_without_running_overridden_crud_delete
     assert ("new_state_machine", "overridden") in coordinator.calls
     assert ("manage_state", "replaced") in coordinator.calls
     assert ("attachment_query", ["BLUE", "OMIT"]) in coordinator.calls
-    assert ("dependency_check", ["OMIT"]) in coordinator.calls
     assert (
         "omitted_detach",
         ["OMIT"],

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -383,7 +383,7 @@ class _StagedVrfCoordinator:
 
     def _new_state_machine(self, module_args, _strategy):
         self.state_machine.state = module_args["state"]
-        self.calls.append(("new_state_machine", module_args["state"]))
+        self.calls.append(("new_state_machine", module_args["state"], list(module_args.get("config") or [])))
         return self.state_machine, "original-config", "original-state"
 
     def _current_attachment_details_ignore_missing(self, _module_args, _strategy, vrf_names):
@@ -520,13 +520,13 @@ def test_vrf_staged_detaches_omitted_vrfs_without_running_overridden_crud_delete
     coordinator = _StagedVrfCoordinator()
     state_machine = VrfStateMachine(coordinator)
 
-    result = state_machine.run(
-        {"state": "staged", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
-        _StandaloneStrategy(),
-    )
+    config = [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]
+
+    result = state_machine.run({"state": "staged", "config": config}, _StandaloneStrategy())
 
     assert result["changed"] is True
-    assert ("new_state_machine", "overridden") in coordinator.calls
+    assert ("new_state_machine", "overridden", []) in coordinator.calls
+    assert ("new_state_machine", "replaced", config) in coordinator.calls
     assert ("manage_state", "replaced") in coordinator.calls
     assert ("attachment_query", ["BLUE", "OMIT"]) in coordinator.calls
     assert (

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -329,7 +329,7 @@ class _ReplacedVrfCoordinator:
 
 class _StagedVrfCoordinator:
     def __init__(self):
-        self.module = _Module({"state": "staged"})
+        self.module = _Module({"state": "_staged"})
         self.calls = []
         self.state_machine = _FakeStateMachine(self.calls, existing=[_ExistingVrf("BLUE"), _ExistingVrf("OMIT")])
         self.current_attachment_details = [
@@ -398,11 +398,11 @@ class _StagedVrfCoordinator:
 
     @staticmethod
     def _build_deploy_payloads(_config, *_target_maps):
-        raise AssertionError("staged must not build deploy payloads")
+        raise AssertionError("_staged must not build deploy payloads")
 
     @staticmethod
     def _build_pending_vrf_deploy_payloads(_result, _config, _module_args, _strategy):
-        raise AssertionError("staged must not build pending deploy payloads")
+        raise AssertionError("_staged must not build pending deploy payloads")
 
     def _restore_state_machine_params(self, original_config, original_state):
         self.calls.append(("restore", original_config, original_state))
@@ -438,7 +438,9 @@ def test_vrf_attachment_manager_staged_detaches_like_overridden():
     }
     desired = {("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}}
 
-    assert manager.planned_detach_payloads("staged", [{"vrf_name": "BLUE"}], current, desired) == [{"vrfName": "BLUE", "switchId": "SERIAL2", "attach": False}]
+    assert manager.planned_detach_payloads("_staged", [{"vrf_name": "BLUE"}], current, desired) == [
+        {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": False}
+    ]
 
 
 def test_vrf_staged_detaches_omitted_vrfs_without_running_overridden_crud_delete():
@@ -446,7 +448,7 @@ def test_vrf_staged_detaches_omitted_vrfs_without_running_overridden_crud_delete
     state_machine = VrfStateMachine(coordinator)
 
     result = state_machine.run(
-        {"state": "staged", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
+        {"state": "_staged", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
         _StandaloneStrategy(),
     )
 

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -331,7 +331,7 @@ class _ReplacedVrfCoordinator:
 
 class _StagedVrfCoordinator:
     def __init__(self):
-        self.module = _Module({"state": "_staged"})
+        self.module = _Module({"state": "staged"})
         self.calls = []
         self.state_machine = _FakeStateMachine(self.calls, existing=[_ExistingVrf("BLUE"), _ExistingVrf("OMIT")])
         self.current_attachment_details = [
@@ -401,11 +401,11 @@ class _StagedVrfCoordinator:
 
     @staticmethod
     def _build_deploy_payloads(_config, *_target_maps):
-        raise AssertionError("_staged must not build deploy payloads")
+        raise AssertionError("staged must not build deploy payloads")
 
     @staticmethod
     def _build_pending_vrf_deploy_payloads(_result, _config, _module_args, _strategy):
-        raise AssertionError("_staged must not build pending deploy payloads")
+        raise AssertionError("staged must not build pending deploy payloads")
 
     def _restore_state_machine_params(self, original_config, original_state):
         self.calls.append(("restore", original_config, original_state))
@@ -441,7 +441,7 @@ def test_vrf_attachment_manager_staged_detaches_like_overridden():
     }
     desired = {("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}}
 
-    assert manager.planned_detach_payloads("_staged", [{"vrf_name": "BLUE"}], current, desired) == [
+    assert manager.planned_detach_payloads("staged", [{"vrf_name": "BLUE"}], current, desired) == [
         {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": False}
     ]
 
@@ -451,7 +451,7 @@ def test_vrf_staged_detaches_omitted_vrfs_without_running_overridden_crud_delete
     state_machine = VrfStateMachine(coordinator)
 
     result = state_machine.run(
-        {"state": "_staged", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
+        {"state": "staged", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
         _StandaloneStrategy(),
     )
 

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -441,9 +441,7 @@ def test_vrf_attachment_manager_staged_detaches_like_overridden():
     }
     desired = {("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}}
 
-    assert manager.planned_detach_payloads("staged", [{"vrf_name": "BLUE"}], current, desired) == [
-        {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": False}
-    ]
+    assert manager.planned_detach_payloads("staged", [{"vrf_name": "BLUE"}], current, desired) == [{"vrfName": "BLUE", "switchId": "SERIAL2", "attach": False}]
 
 
 def test_vrf_staged_detaches_omitted_vrfs_without_running_overridden_crud_delete():

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -327,6 +327,90 @@ class _ReplacedVrfCoordinator:
         self.calls.append(("trace", event))
 
 
+class _StagedVrfCoordinator:
+    def __init__(self):
+        self.module = _Module({"state": "staged"})
+        self.calls = []
+        self.state_machine = _FakeStateMachine(self.calls, existing=[_ExistingVrf("BLUE"), _ExistingVrf("OMIT")])
+        self.current_attachment_details = [
+            {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True},
+            {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": True},
+            {"vrfName": "OMIT", "switchId": "SERIAL3", "attach": True},
+        ]
+
+    @staticmethod
+    def _desired_attachment_map(_module_args, _strategy):
+        return {("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}}
+
+    @staticmethod
+    def _configured_vrf_names(config):
+        return [vrf["vrf_name"] for vrf in config]
+
+    def _new_state_machine(self, module_args, _strategy):
+        self.calls.append(("new_state_machine", module_args["state"]))
+        return self.state_machine, "original-config", "original-state"
+
+    def _current_attachment_details_ignore_missing(self, _module_args, _strategy, vrf_names):
+        self.calls.append(("attachment_query", vrf_names))
+        return list(self.current_attachment_details)
+
+    @staticmethod
+    def _attachment_map_from_details(attachments, vrf_names=None):
+        return VrfAttachmentManager.attachment_map_from_details(attachments, vrf_names)
+
+    @staticmethod
+    def _filter_attachment_details_by_vrf(attachments, vrf_names):
+        return VrfAttachmentManager.filter_attachment_details_by_vrf(attachments, vrf_names)
+
+    def _ensure_vrfs_have_no_networks(self, _module_args, _strategy, vrf_names):
+        self.calls.append(("dependency_check", vrf_names))
+
+    def _apply_deleted_attachment_phase(self, _module_args, _strategy, vrf_names, attachment_details=None):
+        self.calls.append(("omitted_detach", vrf_names, attachment_details))
+        return {"changed": True, "payloads": [{"vrfName": vrf_names[0], "switchId": "SERIAL3", "attach": False}], "deploy_targets": {}}
+
+    def _apply_attachment_phase(self, module_args, _strategy, phase, desired=None, current_vrf_names=None, current=None, attachment_details=None):
+        self.calls.append(("attachment_phase", phase, module_args["state"], current_vrf_names, current, attachment_details))
+        if phase == "pre":
+            return {
+                "changed": True,
+                "payloads": VrfAttachmentManager(self).planned_detach_payloads(module_args["state"], module_args.get("config") or [], current, desired),
+                "current": current,
+                "desired": desired,
+                "deploy_targets": {},
+            }
+        return {"changed": False, "payloads": [], "current": current, "desired": desired, "deploy_targets": {}}
+
+    @staticmethod
+    def _attachment_map_after_detach(current, payloads):
+        return VrfAttachmentManager(_AttachmentCoordinator()).attachment_map_after_detach(current, payloads)
+
+    @staticmethod
+    def _format_state_machine_output(_state_machine):
+        return {"changed": True, "failed": False, "after": [{"vrf_name": "BLUE"}]}
+
+    @staticmethod
+    def _merge_api_trace(result, trace, prepend=False):
+        if prepend:
+            result.setdefault("prepended", []).append(trace)
+        if trace.get("changed"):
+            result["changed"] = True
+
+    @staticmethod
+    def _build_deploy_payloads(_config, *_target_maps):
+        return []
+
+    @staticmethod
+    def _build_pending_vrf_deploy_payloads(_result, _config, _module_args, _strategy):
+        return []
+
+    def _restore_state_machine_params(self, original_config, original_state):
+        self.calls.append(("restore", original_config, original_state))
+
+    def _trace(self, event, **_details):
+        self.calls.append(("trace", event))
+
+
 def _unattached_vpc_attachment_rows(vrf_name="BLUE", switch_id="SERIAL1", peer_switch_id="SERIAL2"):
     return [
         {
@@ -344,6 +428,37 @@ def _unattached_vpc_attachment_rows(vrf_name="BLUE", switch_id="SERIAL1", peer_s
             "status": "notApplicable",
         },
     ]
+
+
+def test_vrf_attachment_manager_staged_detaches_like_overridden():
+    manager = VrfAttachmentManager(_AttachmentCoordinator())
+    current = {
+        ("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True},
+        ("BLUE", "SERIAL2"): {"vrfName": "BLUE", "switchId": "SERIAL2", "attach": True},
+    }
+    desired = {("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}}
+
+    assert manager.planned_detach_payloads("staged", [{"vrf_name": "BLUE"}], current, desired) == [{"vrfName": "BLUE", "switchId": "SERIAL2", "attach": False}]
+
+
+def test_vrf_staged_detaches_omitted_vrfs_without_running_overridden_crud_delete():
+    coordinator = _StagedVrfCoordinator()
+    state_machine = VrfStateMachine(coordinator)
+
+    result = state_machine.run(
+        {"state": "staged", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
+        _StandaloneStrategy(),
+    )
+
+    assert result["changed"] is True
+    assert ("new_state_machine", "replaced") in coordinator.calls
+    assert ("attachment_query", ["BLUE", "OMIT"]) in coordinator.calls
+    assert ("dependency_check", ["OMIT"]) in coordinator.calls
+    assert (
+        "omitted_detach",
+        ["OMIT"],
+        [{"vrfName": "OMIT", "switchId": "SERIAL3", "attach": True}],
+    ) in coordinator.calls
 
 
 def test_vrf_replaced_first_create_with_attachment_skips_missing_pre_query():

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -398,11 +398,11 @@ class _StagedVrfCoordinator:
 
     @staticmethod
     def _build_deploy_payloads(_config, *_target_maps):
-        return []
+        raise AssertionError("staged must not build deploy payloads")
 
     @staticmethod
     def _build_pending_vrf_deploy_payloads(_result, _config, _module_args, _strategy):
-        return []
+        raise AssertionError("staged must not build pending deploy payloads")
 
     def _restore_state_machine_params(self, original_config, original_state):
         self.calls.append(("restore", original_config, original_state))

--- a/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
+++ b/tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py
@@ -56,6 +56,39 @@ class _AttachmentCoordinator:
         return VrfAttachmentManager.attachment_matches(existing, desired)
 
 
+class _StagedVrfAttachmentCoordinator:
+    def __init__(self):
+        self.posts = []
+        self.traces = []
+
+    def _trace(self, event, **details):
+        self.traces.append((event, details))
+
+    @staticmethod
+    def _attachment_matches(existing, desired):
+        return VrfAttachmentManager.attachment_matches(existing, desired)
+
+    @staticmethod
+    def _expand_desired_attachments_with_vpc_peers(desired, _attachment_details):
+        return desired
+
+    def _planned_detach_payloads(self, state, config, current, desired):
+        return VrfAttachmentManager(self).planned_detach_payloads(state, config, current, desired)
+
+    def _planned_attach_payloads(self, current, desired):
+        return VrfAttachmentManager(self).planned_attach_payloads(current, desired)
+
+    @staticmethod
+    def _record_deploy_target(deploy_targets, vrf_name, switch_id):
+        deploy_targets.setdefault(vrf_name, set())
+        if switch_id:
+            deploy_targets[vrf_name].add(switch_id)
+
+    def _post_vrf_attachments(self, _module_args, _strategy, payloads, deploy_targets, operation_type):
+        self.posts.append((payloads, deploy_targets, operation_type))
+        return {"changed": True, "payloads": payloads, "deploy_targets": deploy_targets}
+
+
 def test_vrf_dependency_filter_is_encoded_once_in_network_query_path():
     requested_paths = []
 
@@ -442,6 +475,45 @@ def test_vrf_attachment_manager_staged_detaches_like_overridden():
     desired = {("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}}
 
     assert manager.planned_detach_payloads("staged", [{"vrf_name": "BLUE"}], current, desired) == [{"vrfName": "BLUE", "switchId": "SERIAL2", "attach": False}]
+
+
+def test_vrf_attachment_manager_staged_pre_phase_posts_detach():
+    coordinator = _StagedVrfAttachmentCoordinator()
+    manager = VrfAttachmentManager(coordinator)
+
+    trace = manager.apply_phase(
+        {"state": "staged", "config": [{"vrf_name": "BLUE"}]},
+        _StandaloneStrategy(),
+        phase="pre",
+        desired={},
+        current_vrf_names=["BLUE"],
+        current={("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}},
+        attachment_details=[{"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}],
+    )
+
+    assert trace["payloads"] == [{"vrfName": "BLUE", "switchId": "SERIAL1", "attach": False}]
+    assert coordinator.posts[0][0] == trace["payloads"]
+    assert ("vrf_attachment_phase_skip", {"phase": "pre", "reason": "state_not_pre_detach"}) not in coordinator.traces
+
+
+def test_vrf_attachment_manager_staged_post_phase_posts_attach():
+    coordinator = _StagedVrfAttachmentCoordinator()
+    manager = VrfAttachmentManager(coordinator)
+    desired = {("BLUE", "SERIAL1"): {"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}}
+
+    trace = manager.apply_phase(
+        {"state": "staged", "config": [{"vrf_name": "BLUE", "attach": [{"switch_id": "SERIAL1"}]}]},
+        _StandaloneStrategy(),
+        phase="post",
+        desired=desired,
+        current_vrf_names=["BLUE"],
+        current={},
+        attachment_details=[{"vrfName": "BLUE", "switchId": "SERIAL1", "attach": False}],
+    )
+
+    assert trace["payloads"] == [{"vrfName": "BLUE", "switchId": "SERIAL1", "attach": True}]
+    assert coordinator.posts[0][0] == trace["payloads"]
+    assert ("vrf_attachment_phase_skip", {"phase": "post", "reason": "state_not_post_attach"}) not in coordinator.traces
 
 
 def test_vrf_staged_detaches_omitted_vrfs_without_running_overridden_crud_delete():


### PR DESCRIPTION
## Related Issue(s)

Related to:

- https://github.com/CiscoDevNet/ansible-nd/issues/465
- https://github.com/CiscoDevNet/ansible-nd/issues/466

## Proposed Changes

Add a private/internal `_staged` workflow state for `nd_manage_vrfs` and `nd_manage_networks`.

The new workflow supports staged configuration removal where omitted resources should have attachments detached, but the omitted VRFs or Networks themselves should not be deleted.

Key behavior:

- `_staged` follows `overridden` attachment scope.
- Current VRF/Network attachments are queried across the full current resource set.
- Attachments omitted from desired config are detached.
- Generic CRUD execution is mapped to `replaced`, preventing overridden-style delete requests.
- Deployment is always suppressed for `_staged`.
- Delete deploy payloads, pending deploy fallback, and delete-readiness wait flows are not invoked.
- The implementation stays localized to the VRF/Network state machines and attachment managers.

## Test Notes

Commands run:

PYTHONPATH=/Users/achengam/Documents/Ansible_Dev/NDNetwork_empty_interfaces \
/Users/achengam/.pyenv/versions/ndfclab/bin/python \
-m pytest tests/unit/module_utils/orchestrators/test_networks.py -k staged -q

Result:

2 passed, 80 deselected

PYTHONPATH=/Users/achengam/Documents/Ansible_Dev/NDNetwork_empty_interfaces \
/Users/achengam/.pyenv/versions/ndfclab/bin/python \
-m pytest tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py -k staged -q

Result:

2 passed, 54 deselected

black -l 159 --check \
  plugins/module_utils/orchestrators/network_attachment_manager.py \
  plugins/module_utils/orchestrators/network_state_machine.py \
  plugins/module_utils/orchestrators/vrf_attachment_manager.py \
  plugins/module_utils/orchestrators/vrf_state_machine.py \
  plugins/modules/nd_manage_networks.py \
  plugins/modules/nd_manage_vrfs.py \
  tests/unit/module_utils/orchestrators/test_networks.py \
  tests/unit/module_utils/orchestrators/test_vrf_workflow_coordinator.py

Result:

8 files would be left unchanged.

## Cisco Nexus Dashboard Version

Workflow-layer change. No new API endpoint schema dependency introduced.

## Related ND API Resource Category

- [ ] analyze
- [ ] infra
- [x] manage
- [x] onemanage
- [ ] other

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] New or updates to documentation has been made accordingly
- [ ] Assigned the proper reviewers