### PR TITLE
Feature/fabric family gathered

### DIFF
--- a/changelogs/fragments/gathered_filtering.yml
+++ b/changelogs/fragments/gathered_filtering.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - Add opt-in gathered-state filtering to the shared state machine, with final local matching and model-specific normalization hooks.
+  - Enable server-side Lucene candidate filtering for gathered loopback interfaces, including switch routing,
+    interface-name filtering, pagination, response deduplication, and final local matching for unsupported fields.
+  - Enable local login-ID filtering for the nd_local_user gathered state.

--- a/changelogs/fragments/gathered_filtering.yml
+++ b/changelogs/fragments/gathered_filtering.yml
@@ -1,5 +1,0 @@
-minor_changes:
-  - Add opt-in gathered-state filtering to the shared state machine, with final local matching and model-specific normalization hooks.
-  - Enable server-side Lucene candidate filtering for gathered loopback interfaces, including switch routing,
-    interface-name filtering, pagination, response deduplication, and final local matching for unsupported fields.
-  - Enable local login-ID filtering for the nd_local_user gathered state.

--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -32,8 +32,12 @@ from __future__ import annotations
 from typing import ClassVar, Literal
 from urllib.parse import quote
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import (
     ClusterNameMixin,
     FabricNameMixin,
@@ -49,12 +53,21 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params im
     EndpointQueryParams,
     LuceneQueryParams,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import (
+    BasePath,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 
 
-class ManageInterfacesListEndpointParams(ClusterNameMixin, FilterMixin, MaxMixin, NetworkNameMixin, OffsetMixin, EndpointQueryParams):
+class ManageInterfacesListEndpointParams(
+    ClusterNameMixin,
+    FilterMixin,
+    MaxMixin,
+    NetworkNameMixin,
+    OffsetMixin,
+    EndpointQueryParams,
+):
     """
     Endpoint-specific query parameters for listing switch interfaces.
 
@@ -114,7 +127,13 @@ class _EpManageInterfacesBase(FabricNameMixin, SwitchSerialNumberMixin, Interfac
         if self._require_interface_name and self.interface_name is None:
             raise ValueError(f"{type(self).__name__}.path: interface_name must be set before accessing path.")
 
-        segments = ["fabrics", quote(self.fabric_name, safe=""), "switches", quote(self.switch_sn, safe=""), "interfaces"]
+        segments = [
+            "fabrics",
+            quote(self.fabric_name, safe=""),
+            "switches",
+            quote(self.switch_sn, safe=""),
+            "interfaces",
+        ]
         if self.interface_name is not None:
             segments.append(quote(self.interface_name, safe=""))
         base_path = BasePath.path(*segments)
@@ -156,7 +175,11 @@ class EpManageInterfacesGet(_EpManageInterfacesBase):
     - Via inherited `path` property if `fabric_name`, `switch_sn`, or `interface_name` is not set.
     """
 
-    class_name: Literal["EpManageInterfacesGet"] = Field(default="EpManageInterfacesGet", frozen=True, description="Class name for backward compatibility")
+    class_name: Literal["EpManageInterfacesGet"] = Field(
+        default="EpManageInterfacesGet",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
 
     @property
     def verb(self) -> HttpVerbEnum:
@@ -193,7 +216,9 @@ class EpManageInterfacesListGet(_EpManageInterfacesBase):
     _require_interface_name: ClassVar[bool] = False
 
     class_name: Literal["EpManageInterfacesListGet"] = Field(
-        default="EpManageInterfacesListGet", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesListGet",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
     endpoint_params: ManageInterfacesListEndpointParams = Field(
         default_factory=ManageInterfacesListEndpointParams,
@@ -213,17 +238,10 @@ class EpManageInterfacesListGet(_EpManageInterfacesBase):
             "sort": self.endpoint_params.sort,
         }
 
-        legacy_lucene_is_set = any(
-            value is not None
-            for value in legacy_lucene_values.values()
-        )
+        legacy_lucene_is_set = any(value is not None for value in legacy_lucene_values.values())
 
         if legacy_lucene_is_set and not self.lucene_params.is_empty():
-            raise ValueError(
-                "Set Lucene options using either "
-                "'endpoint_params.filter/max/offset/sort' or "
-                "'lucene_params', but not both."
-            )
+            raise ValueError("Set Lucene options using either " "'endpoint_params.filter/max/offset/sort' or " "'lucene_params', but not both.")
 
         query_params = CompositeQueryParams().add(self.endpoint_params)
 
@@ -266,7 +284,11 @@ class EpManageInterfacesPost(_EpManageInterfacesBase):
 
     _require_interface_name: ClassVar[bool] = False
 
-    class_name: Literal["EpManageInterfacesPost"] = Field(default="EpManageInterfacesPost", frozen=True, description="Class name for backward compatibility")
+    class_name: Literal["EpManageInterfacesPost"] = Field(
+        default="EpManageInterfacesPost",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
 
     @property
     def verb(self) -> HttpVerbEnum:
@@ -298,7 +320,11 @@ class EpManageInterfacesPut(_EpManageInterfacesBase):
     - Via inherited `path` property if `fabric_name`, `switch_sn`, or `interface_name` is not set.
     """
 
-    class_name: Literal["EpManageInterfacesPut"] = Field(default="EpManageInterfacesPut", frozen=True, description="Class name for backward compatibility")
+    class_name: Literal["EpManageInterfacesPut"] = Field(
+        default="EpManageInterfacesPut",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
 
     @property
     def verb(self) -> HttpVerbEnum:
@@ -341,7 +367,9 @@ class EpManageInterfacesDelete(_EpManageInterfacesBase):
     """
 
     class_name: Literal["EpManageInterfacesDelete"] = Field(
-        default="EpManageInterfacesDelete", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesDelete",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
 
     @property
@@ -376,7 +404,9 @@ class EpManageInterfacesDeploy(FabricNameMixin, NDEndpointBaseModel):
     """
 
     class_name: Literal["EpManageInterfacesDeploy"] = Field(
-        default="EpManageInterfacesDeploy", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesDeploy",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
 
     @property
@@ -428,7 +458,9 @@ class EpManageInterfacesNormalize(FabricNameMixin, NDEndpointBaseModel):
     """
 
     class_name: Literal["EpManageInterfacesNormalize"] = Field(
-        default="EpManageInterfacesNormalize", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesNormalize",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
 
     @property
@@ -480,7 +512,9 @@ class EpManageInterfacesRemove(FabricNameMixin, NDEndpointBaseModel):
     """
 
     class_name: Literal["EpManageInterfacesRemove"] = Field(
-        default="EpManageInterfacesRemove", frozen=True, description="Class name for backward compatibility"
+        default="EpManageInterfacesRemove",
+        frozen=True,
+        description="Class name for backward compatibility",
     )
 
     @property

--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -44,7 +44,11 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import (
     OffsetMixin,
     SwitchSerialNumberMixin,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import (
+    CompositeQueryParams,
+    EndpointQueryParams,
+    LuceneQueryParams,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
@@ -56,6 +60,9 @@ class ManageInterfacesListEndpointParams(ClusterNameMixin, FilterMixin, MaxMixin
 
     These match the query parameters exposed by
     ``/fabrics/{fabricName}/switches/{switchId}/interfaces`` in manage.json.
+    ``filter``, ``max``, ``offset``, and ``sort`` remain available here for
+    backward compatibility. New filtering callers should use
+    ``EpManageInterfacesListGet.lucene_params`` for URL-encoded Lucene values.
     """
 
     sort: str | None = Field(default=None, min_length=1, description="Sort field and direction")
@@ -192,10 +199,38 @@ class EpManageInterfacesListGet(_EpManageInterfacesBase):
         default_factory=ManageInterfacesListEndpointParams,
         description="Endpoint-specific query parameters",
     )
+    lucene_params: LuceneQueryParams = Field(
+        default_factory=LuceneQueryParams,
+        description="Lucene filtering, pagination, and sorting parameters",
+    )
 
     def _query_string(self) -> str:
-        """Return list endpoint query string."""
-        return self.endpoint_params.to_query_string()
+        """Return endpoint-specific and Lucene query parameters."""
+        legacy_lucene_values = {
+            "filter": self.endpoint_params.filter,
+            "max": self.endpoint_params.max,
+            "offset": self.endpoint_params.offset,
+            "sort": self.endpoint_params.sort,
+        }
+
+        legacy_lucene_is_set = any(
+            value is not None
+            for value in legacy_lucene_values.values()
+        )
+
+        if legacy_lucene_is_set and not self.lucene_params.is_empty():
+            raise ValueError(
+                "Set Lucene options using either "
+                "'endpoint_params.filter/max/offset/sort' or "
+                "'lucene_params', but not both."
+            )
+
+        query_params = CompositeQueryParams().add(self.endpoint_params)
+
+        if not legacy_lucene_is_set:
+            query_params.add(self.lucene_params)
+
+        return query_params.to_query_string()
 
     @property
     def verb(self) -> HttpVerbEnum:

--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -32,12 +32,8 @@ from __future__ import annotations
 from typing import ClassVar, Literal
 from urllib.parse import quote
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
-    Field,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
-    NDEndpointBaseModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import (
     ClusterNameMixin,
     FabricNameMixin,
@@ -53,9 +49,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params im
     EndpointQueryParams,
     LuceneQueryParams,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import (
-    BasePath,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.base_path import BasePath
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.types import IdentifierKey
 

--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -241,7 +241,7 @@ class EpManageInterfacesListGet(_EpManageInterfacesBase):
         legacy_lucene_is_set = any(value is not None for value in legacy_lucene_values.values())
 
         if legacy_lucene_is_set and not self.lucene_params.is_empty():
-            raise ValueError("Set Lucene options using either " "'endpoint_params.filter/max/offset/sort' or " "'lucene_params', but not both.")
+            raise ValueError("Set Lucene options using either 'endpoint_params.filter/max/offset/sort' or 'lucene_params', but not both.")
 
         query_params = CompositeQueryParams().add(self.endpoint_params)
 

--- a/plugins/module_utils/fabric_context.py
+++ b/plugins/module_utils/fabric_context.py
@@ -30,7 +30,7 @@ class FabricContext:
     Cached fabric metadata with pre-flight validation for fabric-level orchestrators.
 
     Lazily fetches fabric summary and switch inventory on first access. Provides simple
-    boolean checks and a `validate_for_mutation` method that raises `RuntimeError` with
+    boolean checks and a `validate_for_read` / `validate_for_mutation` method that raises `RuntimeError` with
     a clear message when the fabric cannot be modified.
 
     ## Raises
@@ -278,6 +278,36 @@ class FabricContext:
         except KeyError as e:
             raise RuntimeError(f"No switch found with switchId '{switch_id}' in fabric '{self._fabric_name}'.") from e
 
+    def validate_for_read(self) -> None:
+        """
+        # Summary
+
+        Run pre-flight checks required before reading resources from this fabric. Raises `RuntimeError` with a clear,
+        actionable message on the first failing check.
+
+        Deployment freeze is deliberately not checked here: freeze blocks configuration changes reaching the
+        switches, and does not affect the caller's ability to read existing configuration.
+
+        ## Checks
+
+        1. Fabric exists (on any node in the cluster).
+        2. Fabric is owned by the controller this `RestSend` is connected to.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the fabric does not exist.
+        - If the fabric is owned by a different controller in the cluster.
+        """
+        if not self.fabric_exists():
+            raise RuntimeError(f"Fabric '{self._fabric_name}' not found. Verify the fabric name and ensure you are targeting the correct ND node.")
+        if not self.fabric_is_local():
+            raise RuntimeError(
+                f"Fabric '{self._fabric_name}' is owned by a different controller in this cluster. "
+                "Connect to the controller that owns this fabric to make configuration changes."
+            )
+
     def validate_for_mutation(self) -> None:
         """
         # Summary
@@ -299,13 +329,7 @@ class FabricContext:
         - If the fabric is owned by a different controller in the cluster.
         - If the fabric is in deployment freeze mode.
         """
-        if not self.fabric_exists():
-            raise RuntimeError(f"Fabric '{self._fabric_name}' not found. Verify the fabric name and ensure you are targeting the correct ND node.")
-        if not self.fabric_is_local():
-            raise RuntimeError(
-                f"Fabric '{self._fabric_name}' is owned by a different controller in this cluster. "
-                "Connect to the controller that owns this fabric to make configuration changes."
-            )
+        self.validate_for_read()
         if self.fabric_is_deployment_frozen():
             raise RuntimeError(
                 f"Fabric '{self._fabric_name}' is in deployment freeze mode. Configuration changes cannot be deployed to switches "

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -71,6 +71,7 @@ def build_lucene_expressions(
     can union and deduplicate their responses to preserve gathered-state OR
     semantics without relying on endpoint-specific Lucene OR support.
     """
+    # TODO(4.2.1) interface-lucene-or-silently-empty
     filter_items = filters or [{}]
     expressions: list[str] = []
 

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -203,13 +203,15 @@ def filter_gathered_response(
     filters: list[dict[str, Any]],
     model_class: type[NDBaseModel],
     normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
-) -> list[dict[str, Any]]:
+) -> list[NDBaseModel]:
     """
-    Apply gathered filters to raw API objects.
+    Apply gathered filters to raw API objects and return validated models.
 
     Criteria inside one filter item use AND semantics.
     Multiple filter items use OR semantics.
-    Returned objects remain in API shape for NDConfigCollection.from_api_response().
+
+    Returns validated model instances directly so callers can construct an
+    NDConfigCollection without redundant from_response() calls.
     """
     # Validation duplicates validate_gathered_filters() intentionally so this
     # function remains safe to call standalone (e.g., from unit tests).
@@ -227,7 +229,7 @@ def filter_gathered_response(
 
         active_filters.append(normalized)
 
-    filtered: list[dict[str, Any]] = []
+    filtered_models: list[NDBaseModel] = []
     seen_identifiers = set()
 
     for response_item in response_data:
@@ -243,9 +245,9 @@ def filter_gathered_response(
             continue
 
         seen_identifiers.add(identifier)
-        filtered.append(response_item)
+        filtered_models.append(model)
 
-    return filtered
+    return filtered_models
 
 
 def validate_gathered_filters(

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -108,6 +108,102 @@ def _contains_active_value(value: Any) -> bool:
     # valid loopback fields and are treated as absent criteria.
     return value not in (None, "")
 
+def _extract_active_leaf_paths(data: dict[str, Any], prefix: str = "") -> set[str]:
+    """Return dot-paths for every non-None, non-empty leaf value in a nested dict.
+
+    Given a gathered filter dict (which may be nested due to Ansible's argument
+    spec structure), this walks the tree and identifies which properties the user
+    actually supplied a value for.
+
+    Ansible pads all omitted suboptions with None after argument validation.
+    Those Nones are not user-supplied criteria and are correctly skipped.
+
+    Args:
+        data: A (possibly nested) filter dict from the user's config item.
+        prefix: Internal recursion prefix — callers should not pass this.
+
+    Returns:
+        A set of dot-path strings representing active (non-None) leaf values.
+
+    Examples:
+        >>> _extract_active_leaf_paths({"switch_ip": "10.1.1.1", "interface_name": None})
+        {"switch_ip"}
+
+        >>> _extract_active_leaf_paths({
+        ...     "config_data": {"network_os": {"policy": {"vrf": "mgmt", "ip": None}}}
+        ... })
+        {"config_data.network_os.policy.vrf"}
+
+        >>> _extract_active_leaf_paths({"login_id": "admin"})
+        {"login_id"}
+
+        >>> _extract_active_leaf_paths({"config_data": None})
+        set()  # None at any level is skipped
+    """
+    paths: set[str] = set()
+    for key, value in data.items():
+        full_path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            paths |= _extract_active_leaf_paths(value, full_path)
+        elif value not in (None, "", []):
+            # False and 0 ARE active values (e.g., admin_state: false)
+            paths.add(full_path)
+    return paths
+
+
+def _reject_unsupported_filter_properties(
+    filter_item: dict[str, Any],
+    supported_properties: tuple[str, ...],
+    index: int,
+) -> None:
+    """Raise ValueError if a filter item contains properties not in the supported set.
+
+    This is the enforcement function for the model's gathered_filter_properties
+    declaration. Called exactly once per filter item during pre-flight validation,
+    before any API request or normalization.
+
+    Args:
+        filter_item: One raw filter dict from the user's config list.
+        supported_properties: The model's declared tuple of allowed dot-paths.
+        index: The position of this filter item in the config list (for error messages).
+
+    Raises:
+        ValueError: With a message listing unsupported properties and the full
+            set of supported properties. Formatted for direct use in Ansible's
+            module.fail_json(msg=...).
+
+    Examples:
+        # Passes (switch_ip is supported):
+        >>> _reject_unsupported_filter_properties(
+        ...     {"switch_ip": "10.1.1.1"},
+        ...     ("switch_ip", "interface_name"),
+        ...     index=0,
+        ... )  # No error
+
+        # Fails (extra_config is not supported):
+        >>> _reject_unsupported_filter_properties(
+        ...     {"config_data": {"network_os": {"policy": {"extra_config": "cli"}}}},
+        ...     ("switch_ip", "interface_name", "config_data.network_os.policy.vrf"),
+        ...     index=0,
+        ... )
+        # ValueError: "Gathered filter at index 0 contains unsupported properties: 
+        #   'config_data.network_os.policy.extra_config'. 
+        #   Supported gathered filter properties: 'switch_ip', 'interface_name', ..."
+    """
+    supplied_paths = _extract_active_leaf_paths(filter_item)
+    supported_set = set(supported_properties)
+    unsupported = sorted(supplied_paths - supported_set)
+    if unsupported:
+        raise ValueError(
+            "Gathered filter at index {0} contains unsupported properties: {1}. "
+            "Supported gathered filter properties: {2}".format(
+                index,
+                ", ".join("'{0}'".format(p) for p in unsupported),
+                ", ".join("'{0}'".format(p) for p in supported_properties),
+            )
+        )
+
+
 
 def filter_gathered_response(
     response_data: list[dict[str, Any]],
@@ -160,24 +256,54 @@ def filter_gathered_response(
 def validate_gathered_filters(
         filters: list[Any],
         normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        supported_properties: tuple[str, ...] = (),
 ) -> None:
     """ 
     Pre-flight validation for gathered filter items.
 
-    Raises ValueError if any filter item is malformed or contains no actionable 
-    criteria. Call this before making API requests so that invalid input is r
-    rejected without wasted network I/O.
+    Validates each filter item through a strict pipeline:
+      1. Type check — must be a dict
+      2. Property check — all active properties must be in the supported set
+      3. Normalize — transform values to canonical form (e.g., lowercase)
+      4. Active check — at least one non-None criterion must exist
+
+    Property validation runs BEFORE normalization because:
+      - It checks KEYS (property paths), normalization transforms VALUES.
+      - Unsupported properties should be rejected without wasting normalization effort.
+      - Error messages should show what the user wrote, not the normalized form.
+
+    Args:
+        filters: The raw config list from module.params["config"].
+            Example: [{"switch_ip": "10.1.1.1", "interface_name": "loopback0"}]
+
+        normalize_filter: Model-specific value transformer (e.g., lowercase interface_name).
+            Signature: (dict) -> dict. May be None if no normalization needed.
+
+        supported_properties: The model's gathered_filter_properties tuple.
+            Example: ("switch_ip", "interface_name", "config_data.network_os.policy.vrf")
+            Empty tuple means property validation is skipped (backward-compatible).
+
+    Raises:
+        ValueError: If any filter item fails any validation step.
     """
     for idx, filter_item in enumerate(filters):
+        # Step 1: Type check
         if not isinstance(filter_item, dict):
             raise ValueError(
                 f"Each gathered filter item must be a dictionary, "
                 f"got {type(filter_item).__name__} at index {idx}."
             )
+        
+        # Step 2: Property validation (before normalize - checks keys, not values)
+        if supported_properties:
+            _reject_unsupported_filter_properties(filter_item, supported_properties, idx)
+
+        # Step 3: Normalize values to canonical form
         normalized = deepcopy(filter_item)
         if normalize_filter is not None:
             normalized = normalize_filter(normalized)
         
+        #Step 4: Active value check
         if not _contains_active_value(normalized):
             raise ValueError(
                 f"Gathered filter item at index {idx} must contain "

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -1,4 +1,4 @@
-# Copyright: (c) 2026, Deeksha Pandey (deekpand-cisco)  deekpand@cisco.com
+# Copyright: (c) 2026, Deeksha Pandey (@deekpand) <deekpand@cisco.com>
 
 """Generic local and server-side filtering helpers for gathered-state responses."""
 
@@ -191,12 +191,10 @@ def _reject_unsupported_filter_properties(
     unsupported = sorted(supplied_paths - supported_set)
     if unsupported:
         raise ValueError(
-            "Gathered filter at index {0} contains unsupported properties: {1}. "
-            "Supported gathered filter properties: {2}".format(
-                index,
-                ", ".join("'{0}'".format(p) for p in unsupported),
-                ", ".join("'{0}'".format(p) for p in supported_properties),
-            )
+            f"Gathered filter at index {index} contains unsupported properties: "
+            f"{', '.join(repr(p) for p in unsupported)}. "
+            f"Supported gathered filter properties: "
+            f"{', '.join(repr(p) for p in supported_properties)}"
         )
 
 
@@ -213,7 +211,8 @@ def filter_gathered_response(
     Multiple filter items use OR semantics.
     Returned objects remain in API shape for NDConfigCollection.from_api_response().
     """
-
+    # Validation duplicates validate_gathered_filters() intentionally so this
+    # function remains safe to call standalone (e.g., from unit tests).
     active_filters: list[dict[str, Any]] = []
     for filter_item in filters or []:
         if not isinstance(filter_item, dict):

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -1,6 +1,4 @@
-# Copyright: (c) 2026, Cisco and/or its affiliates.
-
-# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Copyright: (c) 2026, Deeksha Pandey (deekpand-cisco)  deekpand@cisco.com
 
 """Generic local and server-side filtering helpers for gathered-state responses."""
 
@@ -77,10 +75,7 @@ def build_lucene_expressions(
     expressions: list[str] = []
 
     for filter_item in filter_items:
-        terms = [
-            f"{field_name}:{format_lucene_value(value)}"
-            for field_name, value in spec.base_terms
-        ]
+        terms = [f"{field_name}:{format_lucene_value(value)}" for field_name, value in spec.base_terms]
 
         for config_path, api_field in spec.field_map.items():
             value = get_nested_value(filter_item, config_path)
@@ -107,6 +102,7 @@ def _contains_active_value(value: Any) -> bool:
     # False and 0 can be meaningful filter values. Empty strings cannot match
     # valid loopback fields and are treated as absent criteria.
     return value not in (None, "")
+
 
 def _extract_active_leaf_paths(data: dict[str, Any], prefix: str = "") -> set[str]:
     """Return dot-paths for every non-None, non-empty leaf value in a nested dict.
@@ -186,8 +182,8 @@ def _reject_unsupported_filter_properties(
         ...     ("switch_ip", "interface_name", "config_data.network_os.policy.vrf"),
         ...     index=0,
         ... )
-        # ValueError: "Gathered filter at index 0 contains unsupported properties: 
-        #   'config_data.network_os.policy.extra_config'. 
+        # ValueError: "Gathered filter at index 0 contains unsupported properties:
+        #   'config_data.network_os.policy.extra_config'.
         #   Supported gathered filter properties: 'switch_ip', 'interface_name', ..."
     """
     supplied_paths = _extract_active_leaf_paths(filter_item)
@@ -202,7 +198,6 @@ def _reject_unsupported_filter_properties(
                 ", ".join("'{0}'".format(p) for p in supported_properties),
             )
         )
-
 
 
 def filter_gathered_response(
@@ -220,7 +215,7 @@ def filter_gathered_response(
     """
 
     active_filters: list[dict[str, Any]] = []
-    for filter_item in (filters or []):
+    for filter_item in filters or []:
         if not isinstance(filter_item, dict):
             raise ValueError("Each gathered filter item must be a dictionary.")
 
@@ -253,12 +248,13 @@ def filter_gathered_response(
 
     return filtered
 
+
 def validate_gathered_filters(
-        filters: list[Any],
-        normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
-        supported_properties: tuple[str, ...] = (),
+    filters: list[Any],
+    normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    supported_properties: tuple[str, ...] = (),
 ) -> None:
-    """ 
+    """
     Pre-flight validation for gathered filter items.
 
     Validates each filter item through a strict pipeline:
@@ -289,11 +285,8 @@ def validate_gathered_filters(
     for idx, filter_item in enumerate(filters):
         # Step 1: Type check
         if not isinstance(filter_item, dict):
-            raise ValueError(
-                f"Each gathered filter item must be a dictionary, "
-                f"got {type(filter_item).__name__} at index {idx}."
-            )
-        
+            raise ValueError(f"Each gathered filter item must be a dictionary, " f"got {type(filter_item).__name__} at index {idx}.")
+
         # Step 2: Property validation (before normalize - checks keys, not values)
         if supported_properties:
             _reject_unsupported_filter_properties(filter_item, supported_properties, idx)
@@ -302,11 +295,7 @@ def validate_gathered_filters(
         normalized = deepcopy(filter_item)
         if normalize_filter is not None:
             normalized = normalize_filter(normalized)
-        
-        #Step 4: Active value check
-        if not _contains_active_value(normalized):
-            raise ValueError(
-                f"Gathered filter item at index {idx} must contain "
-                f"at least one filtering criterion."
-            )
 
+        # Step 4: Active value check
+        if not _contains_active_value(normalized):
+            raise ValueError(f"Gathered filter item at index {idx} must contain " f"at least one filtering criterion.")

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -1,0 +1,160 @@
+# Copyright: (c) 2026, Cisco and/or its affiliates.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Generic local and server-side filtering helpers for gathered-state responses."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from enum import Enum
+import re
+from typing import Any, Callable, Mapping
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+
+FieldPath = tuple[str, ...]
+_MISSING = object()
+_SAFE_UNQUOTED = re.compile(r"^[A-Za-z0-9_.]+$")
+
+
+@dataclass(frozen=True)
+class GatheredLuceneSpec:
+    """Describe fields supported by an endpoint's Lucene filter.
+
+    ``base_terms`` are included in every generated expression. ``field_map``
+    maps structured Ansible config paths to controller-supported field names.
+    """
+
+    base_terms: tuple[tuple[str, Any], ...] = ()
+    field_map: Mapping[FieldPath, str] = field(default_factory=dict)
+
+
+def format_lucene_value(value: Any) -> str:
+    """Format one value as an exact-match Lucene literal.
+
+    Values are generated from structured module input, never accepted as raw
+    Lucene syntax. Strings containing reserved punctuation or whitespace are
+    quoted and escaped.
+    """
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, Enum):
+        value = value.value
+    if isinstance(value, (int, float)):
+        return str(value)
+
+    text = str(value)
+    if _SAFE_UNQUOTED.fullmatch(text):
+        return text
+
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def get_nested_value(data: dict[str, Any], path: FieldPath) -> Any:
+    """Return a nested filter value, or an internal missing-value marker."""
+    current: Any = data
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return _MISSING
+        current = current[key]
+    return current
+
+
+def build_lucene_expressions(
+    filters: list[dict[str, Any]],
+    spec: GatheredLuceneSpec,
+) -> list[str]:
+    """Build one server-side AND expression per gathered config item.
+
+    Separate config items intentionally remain separate expressions. Callers
+    can union and deduplicate their responses to preserve gathered-state OR
+    semantics without relying on endpoint-specific Lucene OR support.
+    """
+    filter_items = filters or [{}]
+    expressions: list[str] = []
+
+    for filter_item in filter_items:
+        terms = [
+            f"{field_name}:{format_lucene_value(value)}"
+            for field_name, value in spec.base_terms
+        ]
+
+        for config_path, api_field in spec.field_map.items():
+            value = get_nested_value(filter_item, config_path)
+            # False and zero are meaningful criteria and must not be skipped.
+            if value is _MISSING or value in (None, ""):
+                continue
+            terms.append(f"{api_field}:{format_lucene_value(value)}")
+
+        expression = " AND ".join(terms)
+        if expression and expression not in expressions:
+            expressions.append(expression)
+
+    return expressions
+
+
+def _contains_active_value(value: Any) -> bool:
+    """Return whether a filter value contains an explicitly supplied criterion."""
+    if isinstance(value, dict):
+        return any(_contains_active_value(item) for item in value.values())
+
+    if isinstance(value, list):
+        return bool(value)
+
+    # False and 0 can be meaningful filter values. Empty strings cannot match
+    # valid loopback fields and are treated as absent criteria.
+    return value not in (None, "")
+
+
+def filter_gathered_response(
+    response_data: list[dict[str, Any]],
+    filters: list[dict[str, Any]],
+    model_class: type[NDBaseModel],
+    normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Apply gathered filters to raw API objects.
+
+    Criteria inside one filter item use AND semantics.
+    Multiple filter items use OR semantics.
+    Returned objects remain in API shape for NDConfigCollection.from_api_response().
+    """
+
+    if not filters:
+        return response_data
+
+    active_filters: list[dict[str, Any]] = []
+    for filter_item in filters:
+        if not isinstance(filter_item, dict):
+            raise ValueError("Each gathered filter item must be a dictionary.")
+
+        normalized = deepcopy(filter_item)
+        if normalize_filter is not None:
+            normalized = normalize_filter(normalized)
+
+        if not _contains_active_value(normalized):
+            raise ValueError("A gathered filter item must contain at least one filtering criterion.")
+
+        active_filters.append(normalized)
+
+    filtered: list[dict[str, Any]] = []
+    seen_identifiers = set()
+
+    for response_item in response_data:
+        model = model_class.from_response(response_item)
+        candidate = model.to_config()
+
+        if not any(model_class.matches_gathered_filter(criteria, candidate) for criteria in active_filters):
+            continue
+
+        identifier = model.get_identifier_value()
+        if identifier in seen_identifiers:
+            continue
+
+        seen_identifiers.add(identifier)
+        filtered.append(response_item)
+
+    return filtered

--- a/plugins/module_utils/gathered_filter.py
+++ b/plugins/module_utils/gathered_filter.py
@@ -123,11 +123,8 @@ def filter_gathered_response(
     Returned objects remain in API shape for NDConfigCollection.from_api_response().
     """
 
-    if not filters:
-        return response_data
-
     active_filters: list[dict[str, Any]] = []
-    for filter_item in filters:
+    for filter_item in (filters or []):
         if not isinstance(filter_item, dict):
             raise ValueError("Each gathered filter item must be a dictionary.")
 
@@ -145,10 +142,11 @@ def filter_gathered_response(
 
     for response_item in response_data:
         model = model_class.from_response(response_item)
-        candidate = model.to_config()
 
-        if not any(model_class.matches_gathered_filter(criteria, candidate) for criteria in active_filters):
-            continue
+        if active_filters:
+            candidate = model.to_config()
+            if not any(model_class.matches_gathered_filter(criteria, candidate) for criteria in active_filters):
+                continue
 
         identifier = model.get_identifier_value()
         if identifier in seen_identifiers:
@@ -158,3 +156,31 @@ def filter_gathered_response(
         filtered.append(response_item)
 
     return filtered
+
+def validate_gathered_filters(
+        filters: list[Any],
+        normalize_filter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> None:
+    """ 
+    Pre-flight validation for gathered filter items.
+
+    Raises ValueError if any filter item is malformed or contains no actionable 
+    criteria. Call this before making API requests so that invalid input is r
+    rejected without wasted network I/O.
+    """
+    for idx, filter_item in enumerate(filters):
+        if not isinstance(filter_item, dict):
+            raise ValueError(
+                f"Each gathered filter item must be a dictionary, "
+                f"got {type(filter_item).__name__} at index {idx}."
+            )
+        normalized = deepcopy(filter_item)
+        if normalize_filter is not None:
+            normalized = normalize_filter(normalized)
+        
+        if not _contains_active_value(normalized):
+            raise ValueError(
+                f"Gathered filter item at index {idx} must contain "
+                f"at least one filtering criterion."
+            )
+

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -60,6 +60,7 @@ class NDBaseModel(BaseModel, ABC):
     # --- Gathered Filtering Configuration ---
 
     supports_gathered_filtering: ClassVar[bool] = False
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = ()
 
     @classmethod
     def normalize_gathered_filter(cls, filter_item: dict) -> dict:

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -57,6 +57,29 @@ class NDBaseModel(BaseModel, ABC):
     identifiers: ClassVar[Optional[List[str]]] = None
     identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "singleton"
 
+    # --- Gathered Filtering Configuration ---
+
+    supports_gathered_filtering: ClassVar[bool] = False
+
+    @classmethod
+    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
+        """
+        Normalize one gathered-state filter item.
+
+        The base implementation makes no changes. Models can override this
+        when filter values require module-specific normalization.
+        """
+        return filter_item
+
+    @classmethod
+    def matches_gathered_filter(
+        cls,
+        criteria: dict,
+        candidate: dict,
+    ) -> bool:
+        """Return whether a gathered candidate matches one filter item."""
+        return issubset(criteria, candidate)
+
     # --- Serialization Configuration ---
 
     exclude_from_diff: ClassVar[Set[str]] = set()

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -134,6 +134,43 @@ class NDBaseModel(BaseModel, ABC):
 
         return result
 
+    @classmethod
+    def secret_field_keys(cls, by_alias: bool = False) -> Set[str]:
+        """Names of fields tagged ``json_schema_extra={"secret": True}``.
+
+        Aliases when ``by_alias`` is True (payload shape), else Python field
+        names (config/input shape). The single source of truth for which fields
+        are secret, used both to keep them out of output and to register their
+        values for ``no_log`` masking.
+        """
+        keys: Set[str] = set()
+        for field_name, field_info in cls.model_fields.items():
+            extra = field_info.json_schema_extra
+            if isinstance(extra, dict) and extra.get("secret"):
+                keys.add((field_info.alias or field_name) if by_alias else field_name)
+        return keys
+
+    @classmethod
+    def collect_secret_values(cls, config_item: Dict[str, Any]) -> Set[str]:
+        """Secret string values in a raw Ansible config item, for no_log masking.
+
+        Ansible auto-masks ``no_log`` argument-spec params, but not values in
+        free-form/nested dicts it does not statically model. ``NDStateMachine``
+        registers whatever this returns with ``module.no_log_values`` so the
+        value-based scrubber strips them from the invocation echo and result.
+
+        Default: top-level fields tagged secret. Models with secrets nested in a
+        free-form dict (e.g. links ``template_inputs``) override to add those.
+        """
+        values: Set[str] = set()
+        if not isinstance(config_item, dict):
+            return values
+        for key in cls.secret_field_keys(by_alias=False):
+            value = config_item.get(key)
+            if value:
+                values.add(value)
+        return values
+
     def to_payload(self, **kwargs) -> Dict[str, Any]:
         """Convert model to API payload format (aliased keys, nested structures)."""
         data = self.model_dump(
@@ -147,12 +184,17 @@ class NDBaseModel(BaseModel, ABC):
         return self._build_payload_nested(data)
 
     def to_config(self, **kwargs) -> Dict[str, Any]:
-        """Convert model to Ansible config format (Python field names, flat structure)."""
+        """Convert model to Ansible config format (Python field names, flat structure).
+
+        Secret-tagged fields are excluded so they never surface in output
+        (after/before/proposed/gathered); they remain only in to_payload().
+        """
+        exclude = set(self.config_exclude_fields) | self.secret_field_keys(by_alias=False)
         return self.model_dump(
             by_alias=False,
             exclude_none=True,
             context={"mode": "config"},
-            exclude=self.config_exclude_fields or None,
+            exclude=exclude or None,
             **kwargs,
         )
 
@@ -229,11 +271,17 @@ class NDBaseModel(BaseModel, ABC):
     # --- Diff & Merge ---
 
     def to_diff_dict(self, **kwargs) -> Dict[str, Any]:
-        """Export for diff comparison, excluding sensitive fields."""
+        """Export for diff comparison, excluding sensitive fields.
+
+        Secret-tagged fields are excluded from the comparison so a change to
+        only a secret is not (and cannot be) detected as a diff, keeping runs
+        idempotent when the controller does not echo secrets back on read.
+        """
+        exclude = set(self.exclude_from_diff) | self.secret_field_keys(by_alias=False)
         return self.model_dump(
             by_alias=True,
             exclude_none=True,
-            exclude=self.exclude_from_diff or None,
+            exclude=exclude or None,
             mode="json",
             **kwargs,
         )

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -81,6 +81,16 @@ class NDBaseModel(BaseModel, ABC):
         """Return whether a gathered candidate matches one filter item."""
         return issubset(criteria, candidate)
 
+    @classmethod
+    def get_argument_spec(cls) -> dict[str, Any]:
+        """Return the Ansible argument spec for this model's module.
+
+        Used by the state machine to derive gathered output pruning. Models
+        that support gathered state should override this to return the full
+        module argument spec including ``config.options``.
+        """
+        return {}
+
     # --- Serialization Configuration ---
 
     exclude_from_diff: ClassVar[Set[str]] = set()

--- a/plugins/module_utils/models/base.py
+++ b/plugins/module_utils/models/base.py
@@ -169,7 +169,7 @@ class NDBaseModel(BaseModel, ABC):
         return result
 
     @classmethod
-    def secret_field_keys(cls, by_alias: bool = False) -> Set[str]:
+    def secret_field_keys(cls, by_alias: bool = False) -> set[str]:
         """Names of fields tagged ``json_schema_extra={"secret": True}``.
 
         Aliases when ``by_alias`` is True (payload shape), else Python field
@@ -177,7 +177,7 @@ class NDBaseModel(BaseModel, ABC):
         are secret, used both to keep them out of output and to register their
         values for ``no_log`` masking.
         """
-        keys: Set[str] = set()
+        keys: set[str] = set()
         for field_name, field_info in cls.model_fields.items():
             extra = field_info.json_schema_extra
             if isinstance(extra, dict) and extra.get("secret"):
@@ -185,7 +185,7 @@ class NDBaseModel(BaseModel, ABC):
         return keys
 
     @classmethod
-    def collect_secret_values(cls, config_item: Dict[str, Any]) -> Set[str]:
+    def collect_secret_values(cls, config_item: dict[str, Any]) -> set[str]:
         """Secret string values in a raw Ansible config item, for no_log masking.
 
         Ansible auto-masks ``no_log`` argument-spec params, but not values in
@@ -196,7 +196,7 @@ class NDBaseModel(BaseModel, ABC):
         Default: top-level fields tagged secret. Models with secrets nested in a
         free-form dict (e.g. links ``template_inputs``) override to add those.
         """
-        values: Set[str] = set()
+        values: set[str] = set()
         if not isinstance(config_item, dict):
             return values
         for key in cls.secret_field_keys(by_alias=False):

--- a/plugins/module_utils/models/fabric_update_group/fabric_update_group.py
+++ b/plugins/module_utils/models/fabric_update_group/fabric_update_group.py
@@ -13,9 +13,14 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Literal
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field, model_validator
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    model_validator,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import (
+    NDNestedModel,
+)
 
 
 class InstallImageDataModel(NDNestedModel):
@@ -77,7 +82,12 @@ ExecutionLiteral = Literal["parallel", "serial"]
 ContingencyLiteral = Literal["continue", "pause"]
 AnalysisLiteral = Literal["snapshot", "noAnalysis", "fullAnalysis", "usePreExistingAnalysis"]
 ReportSelectionLiteral = Literal["noReport", "basic", "advanced"]
-ReportsLiteral = Literal["noReport", "usePreExistingReports", "useDefaultPreAndPostReports", "useAdvancePreAndPostReports"]
+ReportsLiteral = Literal[
+    "noReport",
+    "usePreExistingReports",
+    "useDefaultPreAndPostReports",
+    "useAdvancePreAndPostReports",
+]
 
 
 class FabricUpdateGroupModel(NDBaseModel):
@@ -97,6 +107,16 @@ class FabricUpdateGroupModel(NDBaseModel):
     identifiers: ClassVar[list[str] | None] = ["update_group_name"]
     identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
 
+    # --- Gathered Filtering Configuration ---
+    supports_gathered_filtering: ClassVar[bool] = True
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = (
+        "update_group_name",
+        "execution",
+        "contingency",
+        "analysis",
+        "is_maintenance",
+        "is_disruptive_update",
+    )
     # TODO(4.2.1) ND silently drops `installationOrderDevices` on the updateGroups create/update endpoints.
     # The POST/PUT accept the field without error, but GET (single and list) never echoes it back. We still
     # send it (ND may consume it during the actual upgrade run), but it must be excluded from the idempotency
@@ -156,17 +176,22 @@ class FabricUpdateGroupModel(NDBaseModel):
                 type="list",
                 elements="dict",
                 options=dict(
-                    update_group_name=dict(type="str", required=True),
+                    update_group_name=dict(type="str", required=False),
                     execution=dict(type="str", choices=["parallel", "serial"]),
                     contingency=dict(type="str", choices=["continue", "pause"]),
                     analysis=dict(
                         type="str",
-                        choices=["snapshot", "noAnalysis", "fullAnalysis", "usePreExistingAnalysis"],
+                        choices=[
+                            "snapshot",
+                            "noAnalysis",
+                            "fullAnalysis",
+                            "usePreExistingAnalysis",
+                        ],
                     ),
                     is_maintenance=dict(type="bool"),
                     is_disruptive_update=dict(type="bool"),
                     update_group_switches=dict(type="list", elements="str"),
-                    force_created=dict(type="bool", default=False),
+                    force_created=dict(type="bool"),
                     install_image_data=dict(
                         type="dict",
                         options=dict(
@@ -202,6 +227,6 @@ class FabricUpdateGroupModel(NDBaseModel):
             state=dict(
                 type="str",
                 default="merged",
-                choices=["merged", "replaced", "overridden", "deleted"],
+                choices=["merged", "replaced", "overridden", "deleted", "gathered"],
             ),
         )

--- a/plugins/module_utils/models/fabric_update_group/fabric_update_group.py
+++ b/plugins/module_utils/models/fabric_update_group/fabric_update_group.py
@@ -18,9 +18,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
     model_validator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.nested import (
-    NDNestedModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 
 
 class InstallImageDataModel(NDNestedModel):

--- a/plugins/module_utils/models/interfaces/ethernet_access_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_access_interface.py
@@ -47,15 +47,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     SpeedEnum,
     StormControlActionEnum,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import (
-    StormControlMutexMixin,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.models.nested import (
-    NDNestedModel,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.models.types import (
-    AsciiDescription,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
 # Module-level so it stays a real re.Pattern; Pydantic v2 wraps any leading-underscore
 # class attribute in ModelPrivateAttr regardless of ClassVar annotation.

--- a/plugins/module_utils/models/interfaces/ethernet_access_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_access_interface.py
@@ -26,6 +26,7 @@ wrapping or flattening.
 from __future__ import annotations
 
 import re
+from copy import deepcopy
 from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -46,9 +47,15 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     SpeedEnum,
     StormControlActionEnum,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
-from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import (
+    StormControlMutexMixin,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import (
+    NDNestedModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import (
+    AsciiDescription,
+)
 
 # Module-level so it stays a real re.Pattern; Pydantic v2 wraps any leading-underscore
 # class attribute in ModelPrivateAttr regardless of ClassVar annotation.
@@ -99,25 +106,72 @@ class EthernetAccessPolicyModel(StormControlMutexMixin):
     }
 
     admin_state: bool | None = Field(default=None, alias="adminState", description="Enable or disable the interface")
-    access_vlan: int | None = Field(default=None, alias="accessVlan", ge=1, le=4094, description="VLAN for this access port")
-    bandwidth: int | None = Field(default=None, alias="bandwidth", ge=1, le=100000000, description="Bandwidth in kilobits")
-    bpdu_filter: BpduFilterEnum | None = Field(default=None, alias="bpduFilter", description="Configure spanning-tree BPDU filter")
+    access_vlan: int | None = Field(
+        default=None,
+        alias="accessVlan",
+        ge=1,
+        le=4094,
+        description="VLAN for this access port",
+    )
+    bandwidth: int | None = Field(
+        default=None,
+        alias="bandwidth",
+        ge=1,
+        le=100000000,
+        description="Bandwidth in kilobits",
+    )
+    bpdu_filter: BpduFilterEnum | None = Field(
+        default=None,
+        alias="bpduFilter",
+        description="Configure spanning-tree BPDU filter",
+    )
     bpdu_guard: BpduGuardEnum | None = Field(default=None, alias="bpduGuard", description="Enable spanning-tree BPDU guard")
     cdp: bool | None = Field(default=None, alias="cdp", description="Enable CDP on the interface")
-    debounce_timer: int | None = Field(default=None, alias="debounceTimer", ge=0, le=20000, description="Link debounce timer in milliseconds")
-    debounce_linkup_timer: int | None = Field(
-        default=None, alias="debounceLinkupTimer", ge=1000, le=10000, description="Link debounce link-up timer in milliseconds"
+    debounce_timer: int | None = Field(
+        default=None,
+        alias="debounceTimer",
+        ge=0,
+        le=20000,
+        description="Link debounce timer in milliseconds",
     )
-    description: AsciiDescription = Field(default=None, alias="description", max_length=254, description="Interface description")
+    debounce_linkup_timer: int | None = Field(
+        default=None,
+        alias="debounceLinkupTimer",
+        ge=1000,
+        le=10000,
+        description="Link debounce link-up timer in milliseconds",
+    )
+    description: AsciiDescription = Field(
+        default=None,
+        alias="description",
+        max_length=254,
+        description="Interface description",
+    )
     duplex_mode: DuplexModeEnum | None = Field(default=None, alias="duplexMode", description="Port duplex mode")
-    error_detection_acl: bool | None = Field(default=None, alias="errorDetectionAcl", description="Enable error detection for ACL installation failures")
-    extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional CLI for the interface")
+    error_detection_acl: bool | None = Field(
+        default=None,
+        alias="errorDetectionAcl",
+        description="Enable error detection for ACL installation failures",
+    )
+    extra_config: str | None = Field(
+        default=None,
+        alias="extraConfig",
+        description="Additional CLI for the interface",
+    )
     fec: FecEnum | None = Field(default=None, alias="fec", description="Forward error correction mode")
     inherit_bandwidth: int | None = Field(
-        default=None, alias="inheritBandwidth", ge=1, le=100000000, description="Inherit bandwidth in kilobits for sub-interfaces"
+        default=None,
+        alias="inheritBandwidth",
+        ge=1,
+        le=100000000,
+        description="Inherit bandwidth in kilobits for sub-interfaces",
     )
     link_type: LinkTypeEnum | None = Field(default=None, alias="linkType", description="Spanning-tree link type")
-    monitor: bool | None = Field(default=None, alias="monitor", description="Enable switchport monitor for SPAN/ERSPAN")
+    monitor: bool | None = Field(
+        default=None,
+        alias="monitor",
+        description="Enable switchport monitor for SPAN/ERSPAN",
+    )
     mtu: MtuEnum | None = Field(default=None, alias="mtu", description="Interface MTU")
     negotiate_auto: bool | None = Field(default=None, alias="negotiateAuto", description="Enable link auto-negotiation")
     netflow: bool | None = Field(default=None, alias="netflow", description="Enable Netflow on the interface")
@@ -126,16 +180,29 @@ class EthernetAccessPolicyModel(StormControlMutexMixin):
     orphan_port: bool | None = Field(default=None, alias="orphanPort", description="Enable vPC orphan port")
     pfc: bool | None = Field(default=None, alias="pfc", description="Enable priority flow control")
     policy_type: AccessHostPolicyTypeEnum = Field(
-        default=AccessHostPolicyTypeEnum.ACCESS_HOST, alias="policyType", frozen=True, description="Interface policy type (hardcoded for this module)"
+        default=AccessHostPolicyTypeEnum.ACCESS_HOST,
+        alias="policyType",
+        frozen=True,
+        description="Interface policy type (hardcoded for this module)",
     )
-    port_type_edge_trunk: bool | None = Field(default=None, alias="portTypeEdgeTrunk", description="Enable spanning-tree edge port behavior")
-    qos: bool | None = Field(default=None, alias="qos", description="Enable QoS configuration for this interface")
+    port_type_edge_trunk: bool | None = Field(
+        default=None,
+        alias="portTypeEdgeTrunk",
+        description="Enable spanning-tree edge port behavior",
+    )
+    qos: bool | None = Field(
+        default=None,
+        alias="qos",
+        description="Enable QoS configuration for this interface",
+    )
     qos_policy: str | None = Field(default=None, alias="qosPolicy", description="Custom QoS policy name")
     queuing_policy: str | None = Field(default=None, alias="queuingPolicy", description="Custom queuing policy name")
     speed: SpeedEnum | None = Field(default=None, alias="speed", description="Interface speed")
     storm_control: bool | None = Field(default=None, alias="stormControl", description="Enable traffic storm control")
     storm_control_action: StormControlActionEnum | None = Field(
-        default=None, alias="stormControlAction", description="Storm control action on threshold violation"
+        default=None,
+        alias="stormControlAction",
+        description="Storm control action on threshold violation",
     )
     storm_control_broadcast_level: float | None = Field(
         default=None,
@@ -265,6 +332,15 @@ class EthernetAccessInterfaceModel(NDBaseModel):
     identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
     identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
 
+    # --- Gathered Filtering Configuration ---
+
+    supports_gathered_filtering: ClassVar[bool] = True
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = (
+        "switch_ip",
+        "interface_name",
+        "config_data.network_os.policy.admin_state",
+        "config_data.network_os.policy.access_vlan",
+    )
     # --- Serialization Configuration ---
 
     payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
@@ -313,6 +389,26 @@ class EthernetAccessInterfaceModel(NDBaseModel):
             return _CANONICAL_INTERFACE_TYPE + rest
         return prefix[0].upper() + prefix[1:].lower() + rest
 
+    @classmethod
+    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
+        """
+        Normalize a partial gathered-state filter.
+
+        Gathered filters are not complete EthernetAccessInterfaceModel instances,
+        so the normal Pydantic interface_name validator does not run against them.
+        """
+        normalized = deepcopy(filter_item)
+        interface_name = normalized.get("interface_name")
+        if isinstance(interface_name, str) and interface_name:
+            match = _INTERFACE_NAME_PREFIX_RE.match(interface_name)
+            if match:
+                prefix, rest = match.groups()
+                if _CANONICAL_INTERFACE_TYPE.lower().startswith(prefix.lower()):
+                    normalized["interface_name"] = _CANONICAL_INTERFACE_TYPE + rest
+                else:
+                    normalized["interface_name"] = prefix[0].upper() + prefix[1:].lower() + rest
+        return normalized
+
     # --- Argument Spec ---
 
     @classmethod
@@ -331,10 +427,10 @@ class EthernetAccessInterfaceModel(NDBaseModel):
             config=dict(
                 type="list",
                 elements="dict",
-                required=True,
+                required=False,
                 options=dict(
-                    switch_ip=dict(type="str", required=True),
-                    interface_names=dict(type="list", elements="str", required=True),
+                    switch_ip=dict(type="str", required=False),
+                    interface_names=dict(type="list", elements="str", required=False),
                     config_data=dict(
                         type="dict",
                         options=dict(
@@ -347,20 +443,38 @@ class EthernetAccessInterfaceModel(NDBaseModel):
                                             admin_state=dict(type="bool"),
                                             access_vlan=dict(type="int"),
                                             bandwidth=dict(type="int"),
-                                            bpdu_filter=dict(type="str", choices=[e.value for e in BpduFilterEnum]),
-                                            bpdu_guard=dict(type="str", choices=[e.value for e in BpduGuardEnum]),
+                                            bpdu_filter=dict(
+                                                type="str",
+                                                choices=[e.value for e in BpduFilterEnum],
+                                            ),
+                                            bpdu_guard=dict(
+                                                type="str",
+                                                choices=[e.value for e in BpduGuardEnum],
+                                            ),
                                             cdp=dict(type="bool"),
                                             debounce_timer=dict(type="int"),
                                             debounce_linkup_timer=dict(type="int"),
                                             description=dict(type="str"),
-                                            duplex_mode=dict(type="str", choices=[e.value for e in DuplexModeEnum]),
+                                            duplex_mode=dict(
+                                                type="str",
+                                                choices=[e.value for e in DuplexModeEnum],
+                                            ),
                                             error_detection_acl=dict(type="bool"),
                                             extra_config=dict(type="str"),
-                                            fec=dict(type="str", choices=[e.value for e in FecEnum]),
+                                            fec=dict(
+                                                type="str",
+                                                choices=[e.value for e in FecEnum],
+                                            ),
                                             inherit_bandwidth=dict(type="int"),
-                                            link_type=dict(type="str", choices=[e.value for e in LinkTypeEnum]),
+                                            link_type=dict(
+                                                type="str",
+                                                choices=[e.value for e in LinkTypeEnum],
+                                            ),
                                             monitor=dict(type="bool"),
-                                            mtu=dict(type="str", choices=[e.value for e in MtuEnum]),
+                                            mtu=dict(
+                                                type="str",
+                                                choices=[e.value for e in MtuEnum],
+                                            ),
                                             negotiate_auto=dict(type="bool"),
                                             netflow=dict(type="bool"),
                                             netflow_monitor=dict(type="str"),
@@ -371,9 +485,15 @@ class EthernetAccessInterfaceModel(NDBaseModel):
                                             qos=dict(type="bool"),
                                             qos_policy=dict(type="str"),
                                             queuing_policy=dict(type="str"),
-                                            speed=dict(type="str", choices=[e.value for e in SpeedEnum]),
+                                            speed=dict(
+                                                type="str",
+                                                choices=[e.value for e in SpeedEnum],
+                                            ),
                                             storm_control=dict(type="bool"),
-                                            storm_control_action=dict(type="str", choices=[e.value for e in StormControlActionEnum]),
+                                            storm_control_action=dict(
+                                                type="str",
+                                                choices=[e.value for e in StormControlActionEnum],
+                                            ),
                                             storm_control_broadcast_level=dict(type="float"),
                                             storm_control_broadcast_level_pps=dict(type="int"),
                                             storm_control_multicast_level=dict(type="float"),
@@ -391,6 +511,6 @@ class EthernetAccessInterfaceModel(NDBaseModel):
             state=dict(
                 type="str",
                 default="merged",
-                choices=["merged", "replaced", "overridden", "deleted"],
+                choices=["merged", "replaced", "overridden", "deleted", "gathered"],
             ),
         )

--- a/plugins/module_utils/models/interfaces/ethernet_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_trunk_host_interface.py
@@ -28,6 +28,7 @@ wrapping or flattening.
 from __future__ import annotations
 
 import re
+from copy import deepcopy
 from typing import Annotated, Any, ClassVar, Literal, Optional  # Optional needed for Annotated runtime expr (see types.py)
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -446,6 +447,17 @@ class EthernetTrunkHostInterfaceModel(NDBaseModel):
     identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
     identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
 
+    # --- Gathered Filtering Configuration ---
+
+    supports_gathered_filtering: ClassVar[bool] = True
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = (
+        "switch_ip",
+        "interface_name",
+        "config_data.network_os.policy.admin_state",
+        "config_data.network_os.policy.allowed_vlans",
+        "config_data.network_os.policy.native_vlan",
+    )
+
     # --- Serialization Configuration ---
 
     payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
@@ -494,6 +506,36 @@ class EthernetTrunkHostInterfaceModel(NDBaseModel):
             return _CANONICAL_INTERFACE_TYPE + rest
         return prefix[0].upper() + prefix[1:].lower() + rest
 
+    @classmethod
+    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
+        """
+        # Summary
+
+        Normalize a partial gathered-state filter.
+
+        Gathered filters are not complete EthernetTrunkHostInterfaceModel instances,
+        so the normal Pydantic interface_name validator does not run against them.
+        This method applies the same canonical prefix normalization so that filter
+        matching works regardless of user-supplied casing or abbreviation.
+
+        ## Raises
+
+        None
+        """
+        normalized = deepcopy(filter_item)
+
+        interface_name = normalized.get("interface_name")
+        if isinstance(interface_name, str) and interface_name:
+            match = _INTERFACE_NAME_PREFIX_RE.match(interface_name)
+            if match:
+                prefix, rest = match.groups()
+                if _CANONICAL_INTERFACE_TYPE.lower().startswith(prefix.lower()):
+                    normalized["interface_name"] = _CANONICAL_INTERFACE_TYPE + rest
+                else:
+                    normalized["interface_name"] = prefix[0].upper() + prefix[1:].lower() + rest
+
+        return normalized
+
     # --- Argument Spec ---
 
     @classmethod
@@ -512,10 +554,10 @@ class EthernetTrunkHostInterfaceModel(NDBaseModel):
             config=dict(
                 type="list",
                 elements="dict",
-                required=True,
+                required=False,
                 options=dict(
-                    switch_ip=dict(type="str", required=True),
-                    interface_names=dict(type="list", elements="str", required=True),
+                    switch_ip=dict(type="str", required=False),
+                    interface_names=dict(type="list", elements="str", required=False),
                     config_data=dict(
                         type="dict",
                         options=dict(
@@ -584,6 +626,6 @@ class EthernetTrunkHostInterfaceModel(NDBaseModel):
             state=dict(
                 type="str",
                 default="merged",
-                choices=["merged", "replaced", "overridden", "deleted"],
+                choices=["merged", "replaced", "overridden", "deleted", "gathered"],
             ),
         )

--- a/plugins/module_utils/models/interfaces/loopback_interface.py
+++ b/plugins/module_utils/models/interfaces/loopback_interface.py
@@ -502,10 +502,16 @@ class LoopbackInterfaceModel(NDBaseModel):
     @classmethod
     def normalize_gathered_filter(cls, filter_item: dict) -> dict:
         """
+        # Summary
+
         Normalize a partial gathered-state filter.
 
         Gathered filters are not complete LoopbackInterfaceModel instances, so
         the normal Pydantic interface_name validator does not run against them.
+
+        ## Raises
+
+        None
         """
         normalized = deepcopy(filter_item)
 

--- a/plugins/module_utils/models/interfaces/loopback_interface.py
+++ b/plugins/module_utils/models/interfaces/loopback_interface.py
@@ -447,6 +447,14 @@ class LoopbackInterfaceModel(NDBaseModel):
     # --- Gathered Filtering Configuration ---
 
     supports_gathered_filtering: ClassVar[bool] = True
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = (
+        "switch_ip",
+        "interface_name",
+        "config_data.network_os.policy.admin_state",
+        "config_data.network_os.policy.ip",
+        "config_data.network_os.policy.ipv6",
+        "config_data.network_os.policy.vrf",
+    )
 
     # --- Serialization Configuration ---
 

--- a/plugins/module_utils/models/interfaces/loopback_interface.py
+++ b/plugins/module_utils/models/interfaces/loopback_interface.py
@@ -31,6 +31,7 @@ work via standard Pydantic serialization with no custom wrapping or flattening.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -443,6 +444,10 @@ class LoopbackInterfaceModel(NDBaseModel):
     identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
     identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
 
+    # --- Gathered Filtering Configuration ---
+
+    supports_gathered_filtering: ClassVar[bool] = True
+
     # --- Serialization Configuration ---
 
     payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
@@ -486,6 +491,22 @@ class LoopbackInterfaceModel(NDBaseModel):
             return value.lower()
         return value
 
+    @classmethod
+    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
+        """
+        Normalize a partial gathered-state filter.
+
+        Gathered filters are not complete LoopbackInterfaceModel instances, so
+        the normal Pydantic interface_name validator does not run against them.
+        """
+        normalized = deepcopy(filter_item)
+
+        interface_name = normalized.get("interface_name")
+        if isinstance(interface_name, str):
+            normalized["interface_name"] = interface_name.lower()
+
+        return normalized
+
     # --- Argument Spec ---
 
     @classmethod
@@ -504,10 +525,10 @@ class LoopbackInterfaceModel(NDBaseModel):
             config=dict(
                 type="list",
                 elements="dict",
-                required=True,
+                required=False,
                 options=dict(
-                    switch_ip=dict(type="str", required=True),
-                    interface_name=dict(type="str", required=True),
+                    switch_ip=dict(type="str"),
+                    interface_name=dict(type="str"),
                     config_data=dict(
                         type="dict",
                         options=dict(
@@ -560,6 +581,6 @@ class LoopbackInterfaceModel(NDBaseModel):
             state=dict(
                 type="str",
                 default="merged",
-                choices=["merged", "replaced", "overridden", "deleted"],
+                choices=["merged", "replaced", "overridden", "deleted", "gathered"],
             ),
         )

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -82,25 +82,12 @@ class LocalUserModel(NDBaseModel):
     # --- Gathered Filtering Configuration ---
 
     supports_gathered_filtering: ClassVar[bool] = True
-
-    @classmethod
-    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
-        """
-        Validate that one gathered-state filter contains only login_id.
-        """
-        normalized = deepcopy(filter_item)
-
-        unsupported_fields = [
-            field_name
-            for field_name, value in normalized.items()
-            if field_name != "login_id" and value not in (None, "", [])
-        ]
-        if unsupported_fields:
-            raise ValueError(
-                "Only login_id can be used as a gathered-state filter for "
-                f"local users. Unsupported fields: {unsupported_fields}"
-            )
-        return normalized
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = (
+        "login_id",
+        "email",
+        "first_name",
+        "last_name", 
+    )
 
     # --- Serialization Configuration ---
 

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from copy import deepcopy
 from typing import Any, ClassVar, Dict, List, Literal, Optional
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -86,7 +86,7 @@ class LocalUserModel(NDBaseModel):
         "login_id",
         "email",
         "first_name",
-        "last_name", 
+        "last_name",
     )
 
     # --- Serialization Configuration ---

--- a/plugins/module_utils/models/local_user/local_user.py
+++ b/plugins/module_utils/models/local_user/local_user.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from copy import deepcopy
 from typing import Any, ClassVar, Dict, List, Literal, Optional
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -78,6 +79,29 @@ class LocalUserModel(NDBaseModel):
     identifiers: ClassVar[Optional[List[str]]] = ["login_id"]
     identifier_strategy: ClassVar[Optional[Literal["single", "composite", "hierarchical", "singleton"]]] = "single"
 
+    # --- Gathered Filtering Configuration ---
+
+    supports_gathered_filtering: ClassVar[bool] = True
+
+    @classmethod
+    def normalize_gathered_filter(cls, filter_item: dict) -> dict:
+        """
+        Validate that one gathered-state filter contains only login_id.
+        """
+        normalized = deepcopy(filter_item)
+
+        unsupported_fields = [
+            field_name
+            for field_name, value in normalized.items()
+            if field_name != "login_id" and value not in (None, "", [])
+        ]
+        if unsupported_fields:
+            raise ValueError(
+                "Only login_id can be used as a gathered-state filter for "
+                f"local users. Unsupported fields: {unsupported_fields}"
+            )
+        return normalized
+
     # --- Serialization Configuration ---
 
     exclude_from_diff: ClassVar[set] = {"user_password"}
@@ -108,7 +132,11 @@ class LocalUserModel(NDBaseModel):
     email: Optional[str] = Field(default=None, alias="email")
     first_name: Optional[str] = Field(default=None, alias="firstName")
     last_name: Optional[str] = Field(default=None, alias="lastName")
-    user_password: Optional[SecretStr] = Field(default=None, alias="password")
+    user_password: Optional[SecretStr] = Field(
+        default=None,
+        alias="password",
+        json_schema_extra={"secret": True},
+    )
     reuse_limitation: Optional[int] = Field(default=None, alias="reuseLimitation")
     time_interval_limitation: Optional[int] = Field(default=None, alias="timeIntervalLimitation")
     security_domains: Optional[List[LocalUserSecurityDomainModel]] = Field(default=None, alias="rbac")
@@ -152,6 +180,9 @@ class LocalUserModel(NDBaseModel):
         """
         if not isinstance(data, dict):
             return data
+
+        # Pydantic before-validators should not mutate the caller's dictionary.
+        data = dict(data)
 
         policy = data.pop("passwordPolicy", None)
         if isinstance(policy, dict):
@@ -199,10 +230,10 @@ class LocalUserModel(NDBaseModel):
             config=dict(
                 type="list",
                 elements="dict",
-                required=True,
+                required=False,
                 options=dict(
                     email=dict(type="str"),
-                    login_id=dict(type="str", required=True),
+                    login_id=dict(type="str"),
                     first_name=dict(type="str"),
                     last_name=dict(type="str"),
                     user_password=dict(type="str", no_log=True),
@@ -235,6 +266,6 @@ class LocalUserModel(NDBaseModel):
             state=dict(
                 type="str",
                 default="merged",
-                choices=["merged", "replaced", "overridden", "deleted"],
+                choices=["merged", "replaced", "overridden", "deleted", "gathered"],
             ),
         )

--- a/plugins/module_utils/models/manage_fabric/manage_fabric_base.py
+++ b/plugins/module_utils/models/manage_fabric/manage_fabric_base.py
@@ -193,7 +193,8 @@ def _build_options_from_model(model_cls, exclude_fields: set[str] | None = None)
         # - Fields not provided by the user stay out of model_fields_set
         # - Merged state only diffs/merges user-specified fields
         if field_info.is_required():
-            if not is_optional:
+            identifiers = getattr(model_cls, "identifiers", None) or []
+            if not is_optional and field_name not in identifiers:
                 spec["required"] = True
 
         options[field_name] = spec
@@ -226,7 +227,12 @@ class FabricBaseModel(NDBaseModel):
         if not hasattr(cls, "_fabric_type"):
             raise TypeError(f"{cls.__name__} must define a '_fabric_type' ClassVar with a FabricTypeEnum value")
 
-    model_config = ConfigDict(str_strip_whitespace=True, validate_assignment=True, populate_by_name=True, extra="allow")
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        populate_by_name=True,
+        extra="allow",
+    )
 
     # ── ClassVars (shared across all fabric models) ──
     identifiers: ClassVar[list[str] | None] = ["fabric_name"]
@@ -235,22 +241,46 @@ class FabricBaseModel(NDBaseModel):
     # Subclass must set this to the appropriate FabricTypeEnum member
     _fabric_type: ClassVar[FabricTypeEnum]
 
+    # -─ Gathered state filtering ──
+    supports_gathered_filtering: ClassVar[bool] = True
+    gathered_filter_properties: ClassVar[tuple[str, ...]] = (
+        "fabric_name",
+        "license_tier",
+        "security_domain",
+        "alert_suspend",
+        "telemetry_collection",
+    )
+
     # ── Basic Fabric Properties ──
     category: Literal["fabric"] = Field(description="Resource category", default="fabric")
     fabric_name: NdFabricName
     location: LocationModel | None = Field(description="Geographic location of the fabric", default=None)
 
     # ── License, Telemetry, and Operations ──
-    license_tier: LicenseTierEnum = Field(alias="licenseTier", description="License Tier for fabric.", default=LicenseTierEnum.ESSENTIALS)
-    alert_suspend: AlertSuspendEnum = Field(
-        alias="alertSuspend", description="Alert Suspend state configured on the fabric.", default=AlertSuspendEnum.DISABLED
+    license_tier: LicenseTierEnum = Field(
+        alias="licenseTier",
+        description="License Tier for fabric.",
+        default=LicenseTierEnum.ESSENTIALS,
     )
-    telemetry_collection: bool = Field(alias="telemetryCollection", description="Enable telemetry collection.", default=False)
+    alert_suspend: AlertSuspendEnum = Field(
+        alias="alertSuspend",
+        description="Alert Suspend state configured on the fabric.",
+        default=AlertSuspendEnum.DISABLED,
+    )
+    telemetry_collection: bool = Field(
+        alias="telemetryCollection",
+        description="Enable telemetry collection.",
+        default=False,
+    )
     telemetry_collection_type: TelemetryCollectionTypeEnum = Field(
-        alias="telemetryCollectionType", description="Telemetry collection method.", default=TelemetryCollectionTypeEnum.IN_BAND
+        alias="telemetryCollectionType",
+        description="Telemetry collection method.",
+        default=TelemetryCollectionTypeEnum.IN_BAND,
     )
     telemetry_streaming_protocol: TelemetryStreamingProtocolEnum = Field(
-        alias="telemetryStreamingProtocol", description="Telemetry Streaming Protocol.", default=TelemetryStreamingProtocolEnum.IPV4
+        alias="telemetryStreamingProtocol",
+        description="Telemetry Streaming Protocol.",
+        default=TelemetryStreamingProtocolEnum.IPV4,
     )
     telemetry_source_interface: str = Field(
         alias="telemetrySourceInterface",
@@ -258,16 +288,24 @@ class FabricBaseModel(NDBaseModel):
         default="loopback0",
     )
     telemetry_source_vrf: str = Field(
-        alias="telemetrySourceVrf", description="VRF over which telemetry is streamed, valid only if Telemetry Collection is set to inBand.", default="default"
+        alias="telemetrySourceVrf",
+        description="VRF over which telemetry is streamed, valid only if Telemetry Collection is set to inBand.",
+        default="default",
     )
-    security_domain: str = Field(alias="securityDomain", description="Security Domain associated with the fabric.", default="all")
+    security_domain: str = Field(
+        alias="securityDomain",
+        description="Security Domain associated with the fabric.",
+        default="all",
+    )
 
     # ── Optional Advanced Settings ──
     # NOTE: `management` is intentionally NOT defined here — subclasses define it
     # with their specific management model type.
     telemetry_settings: TelemetrySettingsModel | None = Field(alias="telemetrySettings", description="Telemetry configuration", default=None)
     external_streaming_settings: ExternalStreamingSettingsModel = Field(
-        alias="externalStreamingSettings", description="External streaming settings", default_factory=ExternalStreamingSettingsModel
+        alias="externalStreamingSettings",
+        description="External streaming settings",
+        default_factory=ExternalStreamingSettingsModel,
     )
 
     # ── Validators ──
@@ -313,6 +351,16 @@ class FabricBaseModel(NDBaseModel):
         pass
 
     @classmethod
+    def get_required_if(cls) -> list[tuple[str, str, list[str]]]:
+        """Require config for every mutating fabric state."""
+        return [
+            ("state", "merged", ["config"]),
+            ("state", "replaced", ["config"]),
+            ("state", "overridden", ["config"]),
+            ("state", "deleted", ["config"]),
+        ]
+
+    @classmethod
     def get_argument_spec(cls) -> dict:
         """Auto-generate Ansible argument spec from pydantic model fields.
 
@@ -326,7 +374,7 @@ class FabricBaseModel(NDBaseModel):
             state={
                 "type": "str",
                 "default": "merged",
-                "choices": ["merged", "replaced", "deleted", "overridden"],
+                "choices": ["merged", "replaced", "deleted", "overridden", "gathered"],
             },
             config={
                 "required": False,
@@ -340,7 +388,11 @@ class FabricBaseModel(NDBaseModel):
                 "options": {
                     "save": {"type": "bool", "default": False},
                     "deploy": {"type": "bool", "default": False},
-                    "type": {"type": "str", "default": "switch", "choices": ["switch", "global"]},
+                    "type": {
+                        "type": "str",
+                        "default": "switch",
+                        "choices": ["switch", "global"],
+                    },
                 },
             },
         )

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -6,7 +6,9 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Any, Dict, List, Optional, Union
 
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+    NDConfigCollection,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.utils import prune_to_spec
 
@@ -58,9 +60,9 @@ class NDOutput:
         output = {
             "output_level": self._output_level,
             "changed": self._changed,
-            "after": self._after.to_ansible_config() if isinstance(self._after, NDConfigCollection) else self._after,
-            "before": self._before.to_ansible_config() if isinstance(self._before, NDConfigCollection) else self._before,
-            "diff": self._diff.to_ansible_config() if isinstance(self._diff, NDConfigCollection) else self._diff,
+            "after": (self._after.to_ansible_config() if isinstance(self._after, NDConfigCollection) else self._after),
+            "before": (self._before.to_ansible_config() if isinstance(self._before, NDConfigCollection) else self._before),
+            "diff": (self._diff.to_ansible_config() if isinstance(self._diff, NDConfigCollection) else self._diff),
         }
 
         if self._output_level in ("debug", "info"):

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -6,9 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Any, Dict, List, Optional, Union
 
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
-    NDConfigCollection,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.utils import prune_to_spec
 
@@ -45,10 +43,15 @@ class NDOutput:
             gathered_output = {
                 "output_level": self._output_level,
                 "changed": False,
+                "before": [],
+                "after": [],
+                "diff": [],
                 "gathered": gathered_items,
             }
-            if self._output_level == "debug":
-                gathered_output["logs"] = self._logs
+            if self._output_level in ("debug", "info"):
+                gathered_output["proposed"] = []
+                if self._output_level == "debug":
+                    gathered_output["logs"] = self._logs
             if self._extra:
                 gathered_output.update(self._extra)
             gathered_output.update(**kwargs)

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -25,6 +25,10 @@ class NDOutput:
         # Argument-spec ``config.options`` mapping used to prune gathered output
         # down to valid module arguments so it round-trips as ``config``.
         self._gathered_spec: Dict[str, Any] = {}
+        # Optional callable that reshapes each gathered item before pruning.
+        # Used by modules whose input format differs from the model's internal
+        # representation (e.g. interface_names plural vs interface_name singular).
+        self._gathered_transform = None
 
     def format(self, **kwargs) -> Dict[str, Any]:
         # Read-only gathered state follows the Ansible resource-module
@@ -32,6 +36,8 @@ class NDOutput:
         # omit the change-oriented before/after/diff/proposed keys.
         if self._state == "gathered":
             gathered_items = self._after.to_ansible_config() if isinstance(self._after, NDConfigCollection) else self._after
+            if self._gathered_transform and isinstance(gathered_items, list):
+                gathered_items = [self._gathered_transform(item) for item in gathered_items]
             if self._gathered_spec and isinstance(gathered_items, list):
                 gathered_items = [prune_to_spec(item, self._gathered_spec) for item in gathered_items]
             gathered_output = {
@@ -126,6 +132,7 @@ class NDOutput:
         proposed: Optional[NDConfigCollection] = None,
         logs: Optional[List] = None,
         gathered_spec: Optional[Dict[str, Any]] = None,
+        gathered_transform=None,
         **kwargs,
     ) -> None:
         if isinstance(after, NDConfigCollection):
@@ -140,4 +147,6 @@ class NDOutput:
             self._logs = logs
         if isinstance(gathered_spec, dict):
             self._gathered_spec = gathered_spec
+        if gathered_transform is not None:
+            self._gathered_transform = gathered_transform
         self._extra.update(**kwargs)

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -8,11 +8,13 @@ from typing import Any, Dict, List, Optional, Union
 
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
+from ansible_collections.cisco.nd.plugins.module_utils.utils import prune_to_spec
 
 
 class NDOutput:
-    def __init__(self, output_level: str):
+    def __init__(self, output_level: str, state: str = ""):
         self._output_level: str = output_level
+        self._state: str = state
         self._changed: bool = False
         self._before: Union[NDConfigCollection, List] = []
         self._after: Union[NDConfigCollection, List] = []
@@ -20,8 +22,30 @@ class NDOutput:
         self._proposed: Union[NDConfigCollection, List] = []
         self._logs: List = []
         self._extra: Dict[str, Any] = {}
+        # Argument-spec ``config.options`` mapping used to prune gathered output
+        # down to valid module arguments so it round-trips as ``config``.
+        self._gathered_spec: Dict[str, Any] = {}
 
     def format(self, **kwargs) -> Dict[str, Any]:
+        # Read-only gathered state follows the Ansible resource-module
+        # convention: return the fetched objects under a ``gathered`` key and
+        # omit the change-oriented before/after/diff/proposed keys.
+        if self._state == "gathered":
+            gathered_items = self._after.to_ansible_config() if isinstance(self._after, NDConfigCollection) else self._after
+            if self._gathered_spec and isinstance(gathered_items, list):
+                gathered_items = [prune_to_spec(item, self._gathered_spec) for item in gathered_items]
+            gathered_output = {
+                "output_level": self._output_level,
+                "changed": False,
+                "gathered": gathered_items,
+            }
+            if self._output_level == "debug":
+                gathered_output["logs"] = self._logs
+            if self._extra:
+                gathered_output.update(self._extra)
+            gathered_output.update(**kwargs)
+            return gathered_output
+
         if isinstance(self._before, NDConfigCollection) and isinstance(self._after, NDConfigCollection) and self._before.get_diff_collection(self._after):
             self._changed = True
 
@@ -101,6 +125,7 @@ class NDOutput:
         diff: Optional[NDConfigCollection] = None,
         proposed: Optional[NDConfigCollection] = None,
         logs: Optional[List] = None,
+        gathered_spec: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         if isinstance(after, NDConfigCollection):
@@ -113,4 +138,6 @@ class NDOutput:
             self._proposed = proposed
         if isinstance(logs, List):
             self._logs = logs
+        if isinstance(gathered_spec, dict):
+            self._gathered_spec = gathered_spec
         self._extra.update(**kwargs)

--- a/plugins/module_utils/nd_output.py
+++ b/plugins/module_utils/nd_output.py
@@ -2,7 +2,7 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 
@@ -24,7 +24,7 @@ class NDOutput:
         self._extra: Dict[str, Any] = {}
         # Argument-spec ``config.options`` mapping used to prune gathered output
         # down to valid module arguments so it round-trips as ``config``.
-        self._gathered_spec: Dict[str, Any] = {}
+        self._gathered_spec: dict[str, Any] = {}
         # Optional callable that reshapes each gathered item before pruning.
         # Used by modules whose input format differs from the model's internal
         # representation (e.g. interface_names plural vs interface_name singular).
@@ -136,7 +136,7 @@ class NDOutput:
         diff: Optional[NDConfigCollection] = None,
         proposed: Optional[NDConfigCollection] = None,
         logs: Optional[List] = None,
-        gathered_spec: Optional[Dict[str, Any]] = None,
+        gathered_spec: dict[str, Any] | None = None,
         gathered_transform=None,
         **kwargs,
     ) -> None:

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, annotations, division, print_function
 from typing import Any, Callable
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
@@ -75,7 +76,33 @@ class NDStateMachine:
 
         # Initialize collections
         try:
-            response_data = self.model_orchestrator.query_all()
+            raw_config = self.module.params.get("config") or []
+            gathered_filtering_enabled = self.state == "gathered" and getattr(
+                self.model_class,
+                "supports_gathered_filtering",
+                False,
+            )
+            lucene_candidate_filtering_enabled = gathered_filtering_enabled and getattr(
+                self.model_orchestrator,
+                "supports_gathered_lucene_filtering",
+                False,
+            )
+            query_kwargs = {}
+            if lucene_candidate_filtering_enabled:
+                query_kwargs["gathered_filters"] = raw_config
+
+            response_data = self.model_orchestrator.query_all(**query_kwargs)
+
+            # Always retain the generic final filter. The server query only
+            # reduces candidate resources.
+            if gathered_filtering_enabled:
+                response_data = filter_gathered_response(
+                    response_data=response_data,
+                    filters=raw_config,
+                    model_class=self.model_class,
+                    normalize_filter=self.model_class.normalize_gathered_filter,
+                )
+
             # State of configuration objects in ND before change execution
             self.before = NDConfigCollection.from_api_response(response_data=response_data, model_class=self.model_class)
             # State of current configuration objects in ND during change execution
@@ -86,9 +113,15 @@ class NDStateMachine:
             # ``context={"state": ...}`` is threaded into pydantic validation so models can apply
             # state-aware validation (e.g. require certain fields for write states while accepting
             # identifier-only items for ``deleted``). Models that do not read the context ignore it.
-            self.proposed = NDConfigCollection.from_ansible_config(
-                data=self.module.params.get("config", []), model_class=self.model_class, context={"state": self.state}
-            )
+
+
+            # For opted-in gathered filtering, config contains query criteria,
+            # not complete desired resources. Preserve the original proposed
+            # config flow for every state/model that has not opted in.
+            proposed_config = [] if gathered_filtering_enabled else raw_config
+            proposed_config = self.model_orchestrator.prepare_config_data(proposed_config)
+            self.proposed = NDConfigCollection.from_ansible_config(data=proposed_config, model_class=self.model_class, context={"state": self.state})
+
 
             # Argument-spec ``config.options`` drives pruning of gathered output
             # so it round-trips cleanly as ``config``. Derived from the model,

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -95,6 +95,7 @@ class NDStateMachine:
                 validate_gathered_filters(
                     filters=raw_config,
                     normalize_filter=self.model_class.normalize_gathered_filter,
+                    supported_properties=self.model_class.gathered_filter_properties,
                 )
 
             response_data = self.model_orchestrator.query_all(**query_kwargs)
@@ -136,8 +137,10 @@ class NDStateMachine:
             get_argument_spec = getattr(self.model_class, "get_argument_spec", None)
             if callable(get_argument_spec):
                 gathered_spec = get_argument_spec().get("config", {}).get("options", {}) or {}
+            
+            gathered_transform = getattr(self.model_orchestrator, "gathered_transform", None)
 
-            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed, gathered_spec=gathered_spec)
+            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed, gathered_spec=gathered_spec, gathered_transform=gathered_transform)
 
         except Exception as e:
             raise NDStateMachineError(f"Initialization failed: {str(e)}") from e

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -41,7 +41,7 @@ class NDStateMachine:
         self.rest_send.response_handler = ResponseHandler()
 
         # Operation tracking
-        self.output = NDOutput(output_level=module.params.get("output_level", "normal"))
+        self.output = NDOutput(output_level=module.params.get("output_level", "normal"), state=module.params.get("state", ""), )
         self.results = Results()
         self.results.state = self.module.params.get("state", "")
         self.results.check_mode = self.module.check_mode
@@ -65,6 +65,14 @@ class NDStateMachine:
         self.supports_bulk_create = self.model_orchestrator.supports_bulk_create
         self.supports_bulk_delete = self.model_orchestrator.supports_bulk_delete
 
+        # Mask secret input values in the invocation echo. Ansible auto-masks
+        # ``no_log`` argument-spec params, but secrets in free-form/nested dicts
+        # have no static suboption to flag; the model declares them via
+        # ``collect_secret_values`` and we register them here, generically for
+        # every module rather than per-module boilerplate.
+        for config_item in self.module.params.get("config") or []:
+            self.module.no_log_values |= self.model_class.collect_secret_values(config_item)
+
         # Initialize collections
         try:
             response_data = self.model_orchestrator.query_all()
@@ -82,7 +90,15 @@ class NDStateMachine:
                 data=self.module.params.get("config", []), model_class=self.model_class, context={"state": self.state}
             )
 
-            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed)
+            # Argument-spec ``config.options`` drives pruning of gathered output
+            # so it round-trips cleanly as ``config``. Derived from the model,
+            # so it is generic across modules and needs no per-module wiring.
+            gathered_spec = {}
+            get_argument_spec = getattr(self.model_class, "get_argument_spec", None)
+            if callable(get_argument_spec):
+                gathered_spec = get_argument_spec().get("config", {}).get("options", {}) or {}
+
+            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed, gathered_spec=gathered_spec)
 
         except Exception as e:
             raise NDStateMachineError(f"Initialization failed: {str(e)}") from e

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -13,23 +13,13 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     filter_gathered_response,
     validate_gathered_filters,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
-    NDStateMachineError,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
-    NDConfigCollection,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import (
-    NDBaseOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
-    ResponseType,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
-    ResponseHandler,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -8,14 +8,27 @@ from __future__ import absolute_import, annotations, division, print_function
 from typing import Any, Callable
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response, validate_gathered_filters
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    filter_gathered_response,
+    validate_gathered_filters,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+    NDConfigCollection,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import (
+    NDBaseOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
@@ -26,7 +39,11 @@ class NDStateMachine:
     Generic State Machine for Nexus Dashboard (Bulk Support).
     """
 
-    def __init__(self, module: AnsibleModule, model_orchestrator: type[NDBaseOrchestrator] | NDBaseOrchestrator):
+    def __init__(
+        self,
+        module: AnsibleModule,
+        model_orchestrator: type[NDBaseOrchestrator] | NDBaseOrchestrator,
+    ):
         """
         Initialize the ND State Machine.
         """
@@ -42,7 +59,10 @@ class NDStateMachine:
         self.rest_send.response_handler = ResponseHandler()
 
         # Operation tracking
-        self.output = NDOutput(output_level=module.params.get("output_level", "normal"), state=module.params.get("state", ""), )
+        self.output = NDOutput(
+            output_level=module.params.get("output_level", "normal"),
+            state=module.params.get("state", ""),
+        )
         self.results = Results()
         self.results.state = self.module.params.get("state", "")
         self.results.check_mode = self.module.check_mode
@@ -90,7 +110,7 @@ class NDStateMachine:
             query_kwargs = {}
             if lucene_candidate_filtering_enabled:
                 query_kwargs["gathered_filters"] = raw_config
-            
+
             if gathered_filtering_enabled and raw_config:
                 validate_gathered_filters(
                     filters=raw_config,
@@ -121,14 +141,16 @@ class NDStateMachine:
             # state-aware validation (e.g. require certain fields for write states while accepting
             # identifier-only items for ``deleted``). Models that do not read the context ignore it.
 
-
             # For opted-in gathered filtering, config contains query criteria,
             # not complete desired resources. Preserve the original proposed
             # config flow for every state/model that has not opted in.
             proposed_config = [] if gathered_filtering_enabled else raw_config
             proposed_config = self.model_orchestrator.prepare_config_data(proposed_config)
-            self.proposed = NDConfigCollection.from_ansible_config(data=proposed_config, model_class=self.model_class, context={"state": self.state})
-
+            self.proposed = NDConfigCollection.from_ansible_config(
+                data=proposed_config,
+                model_class=self.model_class,
+                context={"state": self.state},
+            )
 
             # Argument-spec ``config.options`` drives pruning of gathered output
             # so it round-trips cleanly as ``config``. Derived from the model,
@@ -137,10 +159,16 @@ class NDStateMachine:
             get_argument_spec = getattr(self.model_class, "get_argument_spec", None)
             if callable(get_argument_spec):
                 gathered_spec = get_argument_spec().get("config", {}).get("options", {}) or {}
-            
+
             gathered_transform = getattr(self.model_orchestrator, "gathered_transform", None)
 
-            self.output.assign(after=self.existing, before=self.before, proposed=self.proposed, gathered_spec=gathered_spec, gathered_transform=gathered_transform)
+            self.output.assign(
+                after=self.existing,
+                before=self.before,
+                proposed=self.proposed,
+                gathered_spec=gathered_spec,
+                gathered_transform=gathered_transform,
+            )
 
         except Exception as e:
             raise NDStateMachineError(f"Initialization failed: {str(e)}") from e
@@ -188,6 +216,11 @@ class NDStateMachine:
             # Capability preflight intentionally NOT run for deletes: removing configuration does not
             # depend on a switch's capability to host the interface type (PR #275 scope decision).
             self._manage_delete_state()
+
+        elif self.state == "gathered":
+            # Read-only state: __init__ already queried the existing objects and
+            # assigned them as ``after`` in the output, so no changes are made.
+            pass
 
         else:
             raise NDStateMachineError(f"Invalid state: {self.state}")
@@ -264,15 +297,27 @@ class NDStateMachine:
 
         # Execute updates (always individual)
         for item in items_to_update:
-            self._execute_operation(self.model_orchestrator.update, item, error_msg_prefix=f"Failed to update {item.get_identifier_value()}")
+            self._execute_operation(
+                self.model_orchestrator.update,
+                item,
+                error_msg_prefix=f"Failed to update {item.get_identifier_value()}",
+            )
 
         # Execute creates (bulk or individual)
         if items_to_create:
             if self.supports_bulk_create:
-                self._execute_operation(self.model_orchestrator.create_bulk, items_to_create, error_msg_prefix="Failed to create in bulk")
+                self._execute_operation(
+                    self.model_orchestrator.create_bulk,
+                    items_to_create,
+                    error_msg_prefix="Failed to create in bulk",
+                )
             else:
                 for item in items_to_create:
-                    self._execute_operation(self.model_orchestrator.create, item, error_msg_prefix=f"Failed to create {item.get_identifier_value()}")
+                    self._execute_operation(
+                        self.model_orchestrator.create,
+                        item,
+                        error_msg_prefix=f"Failed to create {item.get_identifier_value()}",
+                    )
 
         # Mark as sent only after successful API operations
         successfully_sent = items_to_update + items_to_create
@@ -304,10 +349,18 @@ class NDStateMachine:
 
         # Execute deletes (bulk or individual)
         if self.supports_bulk_delete:
-            self._execute_operation(self.model_orchestrator.delete_bulk, items, error_msg_prefix="Failed to delete in bulk")
+            self._execute_operation(
+                self.model_orchestrator.delete_bulk,
+                items,
+                error_msg_prefix="Failed to delete in bulk",
+            )
         else:
             for item in items:
-                self._execute_operation(self.model_orchestrator.delete, item, error_msg_prefix=f"Failed to delete {item.get_identifier_value()}")
+                self._execute_operation(
+                    self.model_orchestrator.delete,
+                    item,
+                    error_msg_prefix=f"Failed to delete {item.get_identifier_value()}",
+                )
 
         # Batch remove from collection (single index rebuild)
         keys_to_delete = [item.get_identifier_value() for item in items]

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -5,6 +5,7 @@
 
 from __future__ import absolute_import, annotations, division, print_function
 
+from copy import deepcopy
 from typing import Any, Callable
 
 from ansible.module_utils.basic import AnsibleModule
@@ -94,73 +95,49 @@ class NDStateMachine:
         for config_item in self.module.params.get("config") or []:
             self.module.no_log_values |= self.model_class.collect_secret_values(config_item)
 
-        # Initialize collections
+        # Validate user input and build proposed — fail fast on bad config
+        # before spending time on network queries. Filter validation errors
+        # are user-input errors, not initialization failures.
+        raw_config = self.module.params.get("config") or []
+        self.gathered_filtering_enabled = self.state == "gathered" and self.model_class.supports_gathered_filtering
+
+        if self.gathered_filtering_enabled and raw_config:
+            validate_gathered_filters(
+                filters=raw_config,
+                normalize_filter=self.model_class.normalize_gathered_filter,
+                supported_properties=self.model_class.gathered_filter_properties,
+            )
+            # Normalize once — downstream consumers receive canonical filters.
+            raw_config = [self.model_class.normalize_gathered_filter(deepcopy(item)) for item in raw_config]
+
+        proposed_config = [] if self.gathered_filtering_enabled else raw_config
+        proposed_config = self.model_orchestrator.prepare_config_data(proposed_config)
+        self.proposed = NDConfigCollection.from_ansible_config(
+            data=proposed_config,
+            model_class=self.model_class,
+            context={"state": self.state},
+        )
+
+        # Query ND and build state collections.
+
         try:
-            raw_config = self.module.params.get("config") or []
-            gathered_filtering_enabled = self.state == "gathered" and getattr(
-                self.model_class,
-                "supports_gathered_filtering",
-                False,
-            )
-            lucene_candidate_filtering_enabled = gathered_filtering_enabled and getattr(
-                self.model_orchestrator,
-                "supports_gathered_lucene_filtering",
-                False,
-            )
-            query_kwargs = {}
-            if lucene_candidate_filtering_enabled:
-                query_kwargs["gathered_filters"] = raw_config
-
-            if gathered_filtering_enabled and raw_config:
-                validate_gathered_filters(
-                    filters=raw_config,
-                    normalize_filter=self.model_class.normalize_gathered_filter,
-                    supported_properties=self.model_class.gathered_filter_properties,
-                )
-
-            response_data = self.model_orchestrator.query_all(**query_kwargs)
-
-            # Always retain the generic final filter. The server query only
-            # reduces candidate resources.
-            if gathered_filtering_enabled:
-                response_data = filter_gathered_response(
-                    response_data=response_data,
-                    filters=raw_config,
-                    model_class=self.model_class,
-                    normalize_filter=self.model_class.normalize_gathered_filter,
-                )
-
+            response_data = self._query_existing(raw_config)
             # State of configuration objects in ND before change execution
-            self.before = NDConfigCollection.from_api_response(response_data=response_data, model_class=self.model_class)
+            if self.gathered_filtering_enabled:
+                # Models already built and filtered — use directly.
+                self.before = NDConfigCollection(model_class=self.model_class, items=response_data)
+            else:
+                self.before = NDConfigCollection.from_api_response(response_data=response_data, model_class=self.model_class)
             # State of current configuration objects in ND during change execution
             self.existing = self.before.copy()
             # Ongoing collection of configuration objects that were changed
             self.sent = NDConfigCollection(model_class=self.model_class)
-            # Collection of configuration objects given by user.
-            # ``context={"state": ...}`` is threaded into pydantic validation so models can apply
-            # state-aware validation (e.g. require certain fields for write states while accepting
-            # identifier-only items for ``deleted``). Models that do not read the context ignore it.
-
-            # For opted-in gathered filtering, config contains query criteria,
-            # not complete desired resources. Preserve the original proposed
-            # config flow for every state/model that has not opted in.
-            proposed_config = [] if gathered_filtering_enabled else raw_config
-            proposed_config = self.model_orchestrator.prepare_config_data(proposed_config)
-            self.proposed = NDConfigCollection.from_ansible_config(
-                data=proposed_config,
-                model_class=self.model_class,
-                context={"state": self.state},
-            )
 
             # Argument-spec ``config.options`` drives pruning of gathered output
             # so it round-trips cleanly as ``config``. Derived from the model,
             # so it is generic across modules and needs no per-module wiring.
-            gathered_spec = {}
-            get_argument_spec = getattr(self.model_class, "get_argument_spec", None)
-            if callable(get_argument_spec):
-                gathered_spec = get_argument_spec().get("config", {}).get("options", {}) or {}
-
-            gathered_transform = getattr(self.model_orchestrator, "gathered_transform", None)
+            gathered_spec = self.model_class.get_argument_spec().get("config", {}).get("options", {}) or {}
+            gathered_transform = self.model_orchestrator.gathered_transform
 
             self.output.assign(
                 after=self.existing,
@@ -172,6 +149,32 @@ class NDStateMachine:
 
         except Exception as e:
             raise NDStateMachineError(f"Initialization failed: {str(e)}") from e
+
+    def _query_existing(self, raw_config: list) -> list[dict[str, Any]] | list[NDBaseModel]:
+        """
+        Query existing resources from ND.
+
+        When gathered filtering is active, returns pre-built model instances
+        (already validated and deduplicated). When inactive, returns raw API
+        response dicts for NDConfigCollection.from_api_response().
+        """
+        server_filtering_enabled = self.gathered_filtering_enabled and self.model_orchestrator.supports_gathered_server_filtering
+
+        query_kwargs = {}
+        if server_filtering_enabled:
+            query_kwargs["gathered_filters"] = raw_config
+
+        response_data = self.model_orchestrator.query_all(**query_kwargs)
+
+        if self.gathered_filtering_enabled:
+            response_data = filter_gathered_response(
+                response_data=response_data,
+                filters=raw_config,
+                model_class=self.model_class,
+                normalize_filter=None,
+            )
+
+        return response_data
 
     # State Management (core function)
     def manage_state(self) -> None:

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, annotations, division, print_function
 from typing import Any, Callable
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response, validate_gathered_filters
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
@@ -90,6 +90,12 @@ class NDStateMachine:
             query_kwargs = {}
             if lucene_candidate_filtering_enabled:
                 query_kwargs["gathered_filters"] = raw_config
+            
+            if gathered_filtering_enabled and raw_config:
+                validate_gathered_filters(
+                    filters=raw_config,
+                    normalize_filter=self.model_class.normalize_gathered_filter,
+                )
 
             response_data = self.model_orchestrator.query_all(**query_kwargs)
 

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -67,6 +67,10 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     # e.g. "links" for /api/v1/manage/links POST.
     bulk_payload_key: ClassVar[str] = "items"
 
+    # Module states that never mutate configuration. Any state not listed here is treated as a
+    # mutation, so an unrecognised or absent state keeps the stricter pre-flight.
+    read_only_states: ClassVar[frozenset[str]] = frozenset({"gathered"})
+
     # NOTE: if not defined by subclasses, return an error as they are required
     create_endpoint: type[NDEndpointBaseModel]
     update_endpoint: type[NDEndpointBaseModel]
@@ -81,6 +85,12 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     # REST infrastructure
     rest_send: RestSend
     results: Optional[Results] = None
+
+    @property
+    def is_read_only_operation(self) -> bool:
+        """Whether the module's current state performs no configuration changes."""
+        params = self.rest_send.params if self.rest_send else None
+        return bool(params) and params.get("state") in self.read_only_states
 
     def _register_api_call(
         self,

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -50,6 +50,13 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     model_class: ClassVar[type[NDBaseModel]] = NDBaseModel
     supports_bulk_create: ClassVar[bool] = False
     supports_bulk_delete: ClassVar[bool] = False
+    
+    # Opt-in. Existing orchestrators do not receive gathered filters.
+    supports_gathered_lucene_filtering: ClassVar[bool] = False
+
+    # bulk_payload_key is the JSON wrapper key the bulk endpoint expects,
+    # e.g. "links" for /api/v1/manage/links POST.
+    bulk_payload_key: ClassVar[str] = "items"
 
     # NOTE: if not defined by subclasses, return an error as they are required
     create_endpoint: type[NDEndpointBaseModel]

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -8,11 +8,22 @@ from collections.abc import Sequence
 from functools import wraps
 from typing import Any, ClassVar, Dict, Generic, Optional, TypeVar
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import BaseModel, ConfigDict, model_validator
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    BaseModel,
+    ConfigDict,
+    model_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import (
+    HttpVerbEnum,
+    OperationType,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
@@ -50,7 +61,6 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     model_class: ClassVar[type[NDBaseModel]] = NDBaseModel
     supports_bulk_create: ClassVar[bool] = False
     supports_bulk_delete: ClassVar[bool] = False
-    
     # Opt-in. Existing orchestrators do not receive gathered filters.
     supports_gathered_lucene_filtering: ClassVar[bool] = False
 
@@ -73,7 +83,13 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     rest_send: RestSend
     results: Optional[Results] = None
 
-    def _register_api_call(self, path: str, verb: HttpVerbEnum, operation_type: OperationType, payload: Optional[Dict[str, Any]] = None) -> None:
+    def _register_api_call(
+        self,
+        path: str,
+        verb: HttpVerbEnum,
+        operation_type: OperationType,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Register the most recent REST call with Results for observability."""
         if self.results is None:
             return
@@ -165,7 +181,12 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     def create(self, model_instance: ModelType, **kwargs) -> ResponseType:
         try:
             api_endpoint = self.create_endpoint()
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload(), operation_type=OperationType.CREATE)
+            return self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                data=model_instance.to_payload(),
+                operation_type=OperationType.CREATE,
+            )
         except Exception as e:
             raise Exception(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -173,7 +194,12 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.update_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=model_instance.to_payload(), operation_type=OperationType.UPDATE)
+            return self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                data=model_instance.to_payload(),
+                operation_type=OperationType.UPDATE,
+            )
         except Exception as e:
             raise Exception(f"Update failed for {model_instance.get_identifier_value()}: {e}") from e
 
@@ -181,7 +207,11 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
         try:
             api_endpoint = self.delete_endpoint()
             api_endpoint.set_identifiers(model_instance.get_identifier_value())
-            return self._request(path=api_endpoint.path, verb=api_endpoint.verb, operation_type=OperationType.DELETE)
+            return self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                operation_type=OperationType.DELETE,
+            )
         except Exception as e:
             raise Exception(f"Delete failed for {model_instance.get_identifier_value()}: {e}") from e
 

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -62,7 +62,10 @@ class NDBaseOrchestrator(BaseModel, Generic[ModelType]):
     supports_bulk_create: ClassVar[bool] = False
     supports_bulk_delete: ClassVar[bool] = False
     # Opt-in. Existing orchestrators do not receive gathered filters.
-    supports_gathered_lucene_filtering: ClassVar[bool] = False
+    supports_gathered_server_filtering: ClassVar[bool] = False
+    # Optional callable to reshape gathered items before output pruning.
+    # Orchestrators that need it (e.g., ethernet_base) override as a @staticmethod.
+    gathered_transform: ClassVar[Any] = None
 
     # bulk_payload_key is the JSON wrapper key the bulk endpoint expects,
     # e.g. "links" for /api/v1/manage/links POST.

--- a/plugins/module_utils/orchestrators/base.py
+++ b/plugins/module_utils/orchestrators/base.py
@@ -13,17 +13,13 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
     ConfigDict,
     model_validator,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
-    NDEndpointBaseModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.enums import (
     HttpVerbEnum,
     OperationType,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
-    ResponseType,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -17,13 +17,16 @@ with interface-type-specific payload construction and query filtering.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesDeploy,
     EpManageInterfacesRemove,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    build_lucene_expressions,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.interface_capability_preflight import InterfaceCapabilityPreflight
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import ModelType, NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
@@ -60,6 +63,12 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
     # opts out — used by interface types with no capability endpoint (e.g. future breakout).
     interface_type: ClassVar[str] = ""
     interface_mode: ClassVar[str] = ""
+
+    # Subclasses opt in to server-side gathered filtering by setting gathered_lucene_spec.
+    # _MAX_EXPRESSIONS_PER_SWITCH caps fan-out: beyond this threshold a single broad query
+    # is cheaper than N targeted ones; the local post-filter guarantees correctness.
+    gathered_lucene_spec: ClassVar[Any] = None
+    _MAX_EXPRESSIONS_PER_SWITCH: ClassVar[int] = 3
 
     _fabric_context: FabricContext | None = None
     _capability_preflight: InterfaceCapabilityPreflight | None = None
@@ -333,6 +342,136 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         api_endpoint.fabric_name = self.fabric_name
         api_endpoint.switch_sn = switch_sn
         return api_endpoint
+
+    def _build_gathered_query_plan(self, gathered_filters: list[dict]) -> dict[str, tuple[str, set[str]]]:
+        """
+        # Summary
+
+        Build one or more Lucene expressions for each target switch from gathered filters.
+
+        Uses the orchestrator's ``gathered_lucene_spec`` ClassVar to map Ansible filter fields to Lucene
+        fields names. Each filter item produces a separate expression (the interface endpoint does not
+        reliably support Lucene OR). If a filter item includes ``switch_ip``, only that switch is targeted;
+        otherwise all switches in the fabric are queried.
+
+        Per-switch fan-out capping: if more than ``_MAX_EXPRESSIONS_PER_SWITCH`` expressions accumulate
+        for one switch, they collapse to the base expression. The local post-filter guarantees correctness;
+        the server filter only reduces candidate volume.
+
+        ## Raises
+
+        ### ValueError
+
+        - If a filter references a ``switch_ip`` that does not exist in the fabric.
+        """
+        switch_map = self.fabric_context.switch_map
+        query_plan: dict[str, tuple[str, set[str]]] = {}
+        base_expression = build_lucene_expressions(filters=[], spec=self.gathered_lucene_spec)[0]
+
+        filter_items = gathered_filters or [{}]
+
+        for filter_item in filter_items:
+            requested_switch_ip = filter_item.get("switch_ip")
+            if requested_switch_ip:
+                switch_id = switch_map.get(requested_switch_ip)
+                if switch_id is None:
+                    raise ValueError(
+                        f"Gathered filter references switch_ip '{requested_switch_ip}' " f"which does not exist in fabric '{self.fabric_context.fabric_name}'."
+                    )
+                target_switches = {requested_switch_ip: switch_id}
+            else:
+                target_switches = switch_map
+
+            expressions = build_lucene_expressions(
+                filters=[filter_item],
+                spec=self.gathered_lucene_spec,
+            )
+
+            for switch_ip, switch_id in target_switches.items():
+                if switch_ip not in query_plan:
+                    query_plan[switch_ip] = (switch_id, set())
+
+                planned_expressions = query_plan[switch_ip][1]
+                for expression in expressions:
+                    if expression == base_expression:
+                        planned_expressions.clear()
+                        planned_expressions.add(base_expression)
+                    elif base_expression not in planned_expressions:
+                        planned_expressions.add(expression)
+
+        for switch_ip, (switch_id, expressions) in query_plan.items():
+            if len(expressions) > self._MAX_EXPRESSIONS_PER_SWITCH:
+                expressions.clear()
+                expressions.add(base_expression)
+        return query_plan
+
+    def _query_interfaces_with_lucene(self, switch_id: str, expression: str) -> list[dict]:
+        """
+        # Summary
+
+        Execute one paginated Lucene query against the interfaces endpoint for a single switch.
+
+        Pages through results using ``meta.counts.remaining``. Returns raw API dicts (not yet
+        enriched with ``switchIp`` or filtered by ``policyType``).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If pagination exceeds 100 pages (50,000 interfaces), indicating a possible runaway query.
+        """
+        page_size = 500
+        max_pages = 100
+        offset = 0
+        candidates: list[dict] = []
+
+        for _page_number in range(max_pages):
+            api_endpoint = self._configure_endpoint(
+                self.query_all_endpoint(),
+                switch_sn=switch_id,
+            )
+            api_endpoint.lucene_params.filter = expression
+            api_endpoint.lucene_params.max = page_size
+            api_endpoint.lucene_params.offset = offset
+
+            result = self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                not_found_ok=True,
+            )
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("interfaces", []) or []
+            candidates.extend(page)
+
+            if not page:
+                break
+
+            meta = result.get("meta") or {}
+            counts = meta.get("counts") or {}
+            remaining_raw = counts.get("remaining")
+
+            if remaining_raw is not None:
+                try:
+                    remaining = int(remaining_raw)
+                except (TypeError, ValueError):
+                    remaining = None
+            else:
+                remaining = None
+
+            if remaining is not None and remaining <= 0:
+                break
+            if remaining is None and len(page) < page_size:
+                break
+
+            offset += len(page)
+        else:
+            raise RuntimeError(
+                f"Pagination limit reached ({max_pages} pages, {len(candidates)} candidates collected) "
+                f"for switch '{switch_id}'. Results may be incomplete."
+            )
+        return candidates
 
     def _queue_deploy(self, interface_name: str, switch_id: str) -> None:
         """

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -64,6 +64,11 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
     _fabric_context: FabricContext | None = None
     _capability_preflight: InterfaceCapabilityPreflight | None = None
 
+    # Maximum Lucene expressions per switch before collapsing to the base query
+    # Beyond this threshold, a single broad query is cheaper than N targeted ones.
+    _MAX_EXPRESSIONS_PER_SWITCH: ClassVar[int] = 3
+    _MAX_TOTAL_REQUESTS: ClassVar[int] = 300
+
     def model_post_init(self, __context) -> None:
         """
         # Summary

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -65,18 +65,15 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
     interface_mode: ClassVar[str] = ""
 
     # Subclasses opt in to server-side gathered filtering by setting gathered_lucene_spec.
-    # _MAX_EXPRESSIONS_PER_SWITCH caps fan-out: beyond this threshold a single broad query
-    # is cheaper than N targeted ones; the local post-filter guarantees correctness.
+    # _MAX_EXPRESSIONS_PER_SWITCH caps per-switch fan-out and _MAX_TOTAL_REQUESTS caps fabric-wide
+    # fan-out: beyond these thresholds a single broad query is cheaper than N targeted ones;
+    # the local post-filter guarantees correctness.
     gathered_lucene_spec: ClassVar[Any] = None
     _MAX_EXPRESSIONS_PER_SWITCH: ClassVar[int] = 3
+    _MAX_TOTAL_REQUESTS: ClassVar[int] = 300
 
     _fabric_context: FabricContext | None = None
     _capability_preflight: InterfaceCapabilityPreflight | None = None
-
-    # Maximum Lucene expressions per switch before collapsing to the base query
-    # Beyond this threshold, a single broad query is cheaper than N targeted ones.
-    _MAX_EXPRESSIONS_PER_SWITCH: ClassVar[int] = 3
-    _MAX_TOTAL_REQUESTS: ClassVar[int] = 300
 
     def model_post_init(self, __context) -> None:
         """
@@ -355,8 +352,9 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         otherwise all switches in the fabric are queried.
 
         Per-switch fan-out capping: if more than ``_MAX_EXPRESSIONS_PER_SWITCH`` expressions accumulate
-        for one switch, they collapse to the base expression. The local post-filter guarantees correctness;
-        the server filter only reduces candidate volume.
+        for one switch, they collapse to the base expression. Fabric-wide filters are additionally budgeted
+        against ``_MAX_TOTAL_REQUESTS`` before being expanded across switches. The local post-filter
+        guarantees correctness; the server filter only reduces candidate volume.
 
         ## Raises
 
@@ -364,11 +362,15 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         - If a filter references a ``switch_ip`` that does not exist in the fabric.
         """
+        # TODO(4.2.1) interface-lucene-or-silently-empty
         switch_map = self.fabric_context.switch_map
         query_plan: dict[str, tuple[str, set[str]]] = {}
         base_expression = build_lucene_expressions(filters=[], spec=self.gathered_lucene_spec)[0]
 
         filter_items = gathered_filters or [{}]
+
+        fabric_wide_filters: list[dict] = []
+        switch_scoped_filters: list[tuple[str, str, dict]] = []
 
         for filter_item in filter_items:
             requested_switch_ip = filter_item.get("switch_ip")
@@ -378,32 +380,53 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
                     raise ValueError(
                         f"Gathered filter references switch_ip '{requested_switch_ip}' " f"which does not exist in fabric '{self.fabric_context.fabric_name}'."
                     )
-                target_switches = {requested_switch_ip: switch_id}
+                switch_scoped_filters.append((requested_switch_ip, switch_id, filter_item))
             else:
-                target_switches = switch_map
+                fabric_wide_filters.append(filter_item)
 
-            expressions = build_lucene_expressions(
-                filters=[filter_item],
-                spec=self.gathered_lucene_spec,
-            )
+        if fabric_wide_filters:
+            fabric_wide_expressions: set[str] | None = set()
+            for expression in build_lucene_expressions(fabric_wide_filters, self.gathered_lucene_spec):
+                if expression == base_expression:
+                    fabric_wide_expressions = {base_expression}
+                    break
+                fabric_wide_expressions.add(expression)
 
-            for switch_ip, switch_id in target_switches.items():
-                if switch_ip not in query_plan:
-                    query_plan[switch_ip] = (switch_id, set())
+            # Budget the fabric-wide fan-out before expanding it across every switch.
+            if len(switch_map) * len(fabric_wide_expressions) > self._MAX_TOTAL_REQUESTS:
+                fabric_wide_expressions = {base_expression}
+        else:
+            fabric_wide_expressions = None
 
-                planned_expressions = query_plan[switch_ip][1]
-                for expression in expressions:
-                    if expression == base_expression:
-                        planned_expressions.clear()
-                        planned_expressions.add(base_expression)
-                    elif base_expression not in planned_expressions:
-                        planned_expressions.add(expression)
+        if fabric_wide_expressions is not None:
+            for switch_ip, switch_id in switch_map.items():
+                query_plan[switch_ip] = (switch_id, set(fabric_wide_expressions))
+
+        for switch_ip, switch_id, filter_item in switch_scoped_filters:
+            if switch_ip not in query_plan:
+                query_plan[switch_ip] = (switch_id, set())
+            planned_expressions = query_plan[switch_ip][1]
+            for expression in build_lucene_expressions([filter_item], self.gathered_lucene_spec):
+                if expression == base_expression:
+                    planned_expressions.clear()
+                    planned_expressions.add(base_expression)
+                elif base_expression not in planned_expressions:
+                    planned_expressions.add(expression)
 
         for switch_ip, (switch_id, expressions) in query_plan.items():
             if len(expressions) > self._MAX_EXPRESSIONS_PER_SWITCH:
                 expressions.clear()
                 expressions.add(base_expression)
         return query_plan
+
+    def _configure_lucene_endpoint(self, api_endpoint) -> None:
+        """
+        Hook for subclasses to set endpoint-specific params before a Lucene query.
+
+        The default implementation is a no-op. Loopback overrides this to set
+        ``config_only = False`` because the full config is needed for local filtering.
+        """
+        pass
 
     def _query_interfaces_with_lucene(self, switch_id: str, expression: str) -> list[dict]:
         """
@@ -430,6 +453,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
                 self.query_all_endpoint(),
                 switch_sn=switch_id,
             )
+            self._configure_lucene_endpoint(api_endpoint)
             api_endpoint.lucene_params.filter = expression
             api_endpoint.lucene_params.max = page_size
             api_endpoint.lucene_params.offset = offset

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -24,9 +24,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesRemove,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
-    build_lucene_expressions,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import build_lucene_expressions
 from ansible_collections.cisco.nd.plugins.module_utils.interface_capability_preflight import InterfaceCapabilityPreflight
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import ModelType, NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
@@ -49,7 +47,8 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
     ### RuntimeError
 
-    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `validate_prerequisites` if the fabric does not exist, or is in deployment-freeze mode for a state
+      that mutates configuration.
     - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
     - Via `deploy_pending` if the bulk deploy API request fails.
     - Via `deploy_accepted_mutations` if the failure-path deploy API request fails.
@@ -315,15 +314,24 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         """
         # Summary
 
-        Run pre-flight validation before any CRUD operations. Checks that the fabric exists and is modifiable.
+        Run pre-flight validation before any CRUD operations. Read-only states (see `read_only_states`) require
+        only that the fabric exists and is reachable through the targeted controller. Every other state also
+        requires the fabric to accept configuration changes, so deployment freeze is rejected.
+
+        `query_all` is the single entry point common to every state, so the read/mutation distinction is derived
+        from the module state here rather than passed in by `NDStateMachine`.
 
         ## Raises
 
         ### RuntimeError
 
         - If the fabric does not exist on the target ND node.
-        - If the fabric is in deployment-freeze mode.
+        - If the fabric is owned by a different controller in the cluster.
+        - If the fabric is in deployment-freeze mode and the state is not read-only.
         """
+        if self.is_read_only_operation:
+            self.fabric_context.validate_for_read()
+            return
         self.fabric_context.validate_for_mutation()
 
     def _configure_endpoint(self, api_endpoint, switch_sn: str):

--- a/plugins/module_utils/orchestrators/ethernet_access_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_access_interface.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Type
 
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import AccessHostPolicyTypeEnum
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import (
@@ -39,6 +40,17 @@ class EthernetAccessInterfaceOrchestrator(EthernetBaseOrchestrator):
     """
 
     model_class: ClassVar[Type[NDBaseModel]] = EthernetAccessInterfaceModel
+
+    supports_gathered_server_filtering: ClassVar[bool] = True
+    gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
+        base_terms=(
+            ("interfaceType", "ethernet"),
+            ("policyType", "accessHost"),
+        ),
+        field_map={
+            ("interface_name",): "interfaceName",
+        },
+    )
 
     def _managed_policy_types(self) -> set[str]:
         """

--- a/plugins/module_utils/orchestrators/ethernet_access_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_access_interface.py
@@ -17,9 +17,7 @@ from typing import ClassVar, Type
 from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import AccessHostPolicyTypeEnum
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import (
-    EthernetAccessInterfaceModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import EthernetAccessInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import EthernetBaseOrchestrator
 
 

--- a/plugins/module_utils/orchestrators/ethernet_base.py
+++ b/plugins/module_utils/orchestrators/ethernet_base.py
@@ -30,9 +30,7 @@ from typing import ClassVar
 
 logger = logging.getLogger(__name__)
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
-    NDEndpointBaseModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesGet,
     EpManageInterfacesListGet,
@@ -41,15 +39,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import (
-    InterfaceDefaultConfig,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
-    NDBaseInterfaceOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
-    ResponseType,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import InterfaceDefaultConfig
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 ModelType = NDBaseModel
 
@@ -73,7 +65,8 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
 
     ### RuntimeError
 
-    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `validate_prerequisites` if the fabric does not exist, or is in deployment-freeze mode for a state
+      that mutates configuration.
     - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
     - Via `_check_port_channel_restrictions` if a non-whitelisted field is modified on a port-channel member.
     - Via `create` if the create API request fails.
@@ -667,7 +660,7 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         ### RuntimeError
 
         - If the fabric does not exist on the target ND node.
-        - If the fabric is in deployment-freeze mode.
+        - If the fabric is in deployment-freeze mode and the state mutates configuration.
         - If the query API request fails.
         """
         managed_types = self._managed_policy_types()

--- a/plugins/module_utils/orchestrators/ethernet_base.py
+++ b/plugins/module_utils/orchestrators/ethernet_base.py
@@ -642,30 +642,6 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
-    def _switches_to_query(self) -> dict[str, str]:
-        """
-        # Summary
-
-        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
-
-        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
-        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
-        config, so only those switches are returned. This keeps the interface-list request count proportional to
-        config size rather than fabric size.
-
-        ## Raises
-
-        ### RuntimeError
-
-        - Via `FabricContext.switch_map` if the switches API query fails.
-        """
-        switch_map = self.fabric_context.switch_map
-        if self.rest_send.params.get("state") in ("overridden", "gathered"):
-            return switch_map
-        config_items = self.rest_send.params.get("config") or []
-        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
-        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
-
     def query_all(self, model_instance: ModelType | None = None, gathered_filters: list[dict] | None = None, **kwargs) -> ResponseType:
         """
         # Summary
@@ -673,8 +649,9 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         Validate the fabric context and query interfaces, filtering for ethernet interfaces with policy types
         managed by this orchestrator (as defined by `_managed_policy_types()`).
 
-        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`,
-        and limited to switches named in the user config for all other states.
+        For management states, switches are determined by `_switches_to_query`: fabric-wide for
+        `state: overridden`, config-scoped for others. For `state: gathered`, the query plan is
+        built from gathered filters via `_build_gathered_query_plan`.
 
         Port-channel member interfaces are included in the results (they exist on the switch and need to be visible
         for port-channel restriction checks in `create` / `update`). `delete_bulk` skips PC members when invoked

--- a/plugins/module_utils/orchestrators/ethernet_base.py
+++ b/plugins/module_utils/orchestrators/ethernet_base.py
@@ -30,7 +30,9 @@ from typing import ClassVar
 
 logger = logging.getLogger(__name__)
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesGet,
     EpManageInterfacesListGet,
@@ -39,9 +41,15 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import InterfaceDefaultConfig
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import (
+    InterfaceDefaultConfig,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
+    NDBaseInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
 
 ModelType = NDBaseModel
 
@@ -91,7 +99,24 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
     # template body (InterfaceDefaultConfig), which resets the interface and drops it from type-specific query filters.
     delete_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesNormalize
 
-    PORT_CHANNEL_MODIFIABLE_FIELDS: ClassVar[set[str]] = {"description", "admin_state", "extra_config"}
+    PORT_CHANNEL_MODIFIABLE_FIELDS: ClassVar[set[str]] = {
+        "description",
+        "admin_state",
+        "extra_config",
+    }
+
+    @staticmethod
+    def gathered_transform(item: dict) -> dict:
+        """
+        Recombine interface_name back into interface_names for gathered output.
+
+        This is the inverse of expand_config which splits interface_names into
+        interface_name on the way in. Lives on the shared ethernet base so both
+        ethernet_access and ethernet_trunk_host get it automatically.
+        """
+        if "interface_name" in item:
+            item["interface_names"] = [item.pop("interface_name")]
+        return item
 
     def model_post_init(self, __context) -> None:
         """
@@ -617,7 +642,31 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
-    def query_all(self, model_instance: ModelType | None = None, **kwargs) -> ResponseType:
+    def _switches_to_query(self) -> dict[str, str]:
+        """
+        # Summary
+
+        Return the `{switch_ip: switch_id}` subset that `query_all` should scan.
+
+        For `state: overridden` the scope is fabric-wide, so the full switch map is returned. For every other state
+        the state machine only consults existing interfaces identified by `switch_ip` values present in the user
+        config, so only those switches are returned. This keeps the interface-list request count proportional to
+        config size rather than fabric size.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Via `FabricContext.switch_map` if the switches API query fails.
+        """
+        switch_map = self.fabric_context.switch_map
+        if self.rest_send.params.get("state") in ("overridden", "gathered"):
+            return switch_map
+        config_items = self.rest_send.params.get("config") or []
+        config_ips = {item.get("switch_ip") for item in config_items if item.get("switch_ip")}
+        return {ip: sid for ip, sid in switch_map.items() if ip in config_ips}
+
+    def query_all(self, model_instance: ModelType | None = None, gathered_filters: list[dict] | None = None, **kwargs) -> ResponseType:
         """
         # Summary
 
@@ -647,18 +696,69 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         managed_types = self._managed_policy_types()
         try:
             self.validate_prerequisites()
-            all_interfaces = []
-            for switch_ip, switch_id in self._switches_to_query().items():
-                interfaces = list(self._switch_interfaces(switch_id).values())
-                ethernet_interfaces = [iface for iface in interfaces if iface.get("interfaceType") == "ethernet"]
+
+            if gathered_filters is not None and self.gathered_lucene_spec is not None:
+                return self._query_all_for_gathered(gathered_filters, managed_types)
+
+            return self._query_all_for_management_states(managed_types)
+        except Exception as e:
+            raise RuntimeError(f"Query all failed: {e}") from e
+
+    def _query_all_for_management_states(self, managed_types: set[str]) -> list[dict]:
+        """
+        # Summary
+
+        Preserve the existing list-all behaviour used by merged, replaced, overridden, and deleted states.
+
+        ## Raises
+
+        ### RuntimeError
+        - Via `_switch_interfaces` if the interface-list API request fails.
+        """
+        all_interfaces = []
+        for switch_ip, switch_id in self._switches_to_query().items():
+            interfaces = list(self._switch_interfaces(switch_id).values())
+            ethernet_interfaces = [iface for iface in interfaces if iface.get("interfaceType") == "ethernet"]
+            managed = [
+                iface for iface in ethernet_interfaces if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
+            ]
+            for iface in managed:
+                iface["switchIp"] = switch_ip
+            all_interfaces.extend(managed)
+        return all_interfaces
+
+    def _query_all_for_gathered(self, gathered_filters: list[dict], managed_types: set[str]) -> list[dict]:
+        """
+        # Summary
+
+        Run server-filtered gathered requests using Lucene expressions built from the orchestrator's
+        ``gathered_lucene_spec``. Each expression targets one switch with one Lucene filter. Results
+        are post-filtered by ``policyType`` and enriched with ``switchIp``.
+
+        ## Raises
+
+        ### ValueError
+
+        - Via `_build_gathered_query_plan` if a filter references a non-existent switch_ip.
+
+        ### RuntimeError
+
+        - Via `_query_interfaces_with_lucene` if pagination limits are exceeded.
+        """
+        query_plan = self._build_gathered_query_plan(gathered_filters)
+
+        all_interfaces = []
+        for switch_ip, (switch_id, expressions) in query_plan.items():
+            for expression in sorted(expressions):
+                candidates = self._query_interfaces_with_lucene(
+                    switch_id=switch_id,
+                    expression=expression,
+                )
                 managed = [
-                    iface
-                    for iface in ethernet_interfaces
-                    if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
+                    iface for iface in candidates if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types
                 ]
                 for iface in managed:
                     iface["switchIp"] = switch_ip
                 all_interfaces.extend(managed)
-            return all_interfaces
-        except Exception as e:
-            raise RuntimeError(f"Query all failed: {e}") from e
+
+        return all_interfaces

--- a/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
@@ -16,6 +16,7 @@ from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import TrunkHostPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import (
     EthernetTrunkHostInterfaceModel,
 )
@@ -48,6 +49,17 @@ class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
     """
 
     model_class: ClassVar[type[NDBaseModel]] = EthernetTrunkHostInterfaceModel
+
+    supports_gathered_server_filtering: ClassVar[bool] = True
+    gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
+        base_terms=(
+            ("interfaceType", "ethernet"),
+            ("policyType", "trunkHost"),
+        ),
+        field_map={
+            ("interface_name",): "interfaceName",
+        },
+    )
 
     def _managed_policy_types(self) -> set[str]:
         """
@@ -100,7 +112,7 @@ class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
             return False
         return True
 
-    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs) -> ResponseType:
+    def query_all(self, model_instance: NDBaseModel | None = None, gathered_filters: list[dict] | None = None, **kwargs) -> ResponseType:
         """
         # Summary
 
@@ -114,7 +126,9 @@ class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
 
         - Propagated from `EthernetBaseOrchestrator.query_all` on query failure.
         """
-        result = super().query_all(model_instance=model_instance, **kwargs)
+        result = super().query_all(model_instance=model_instance, gathered_filters=gathered_filters, **kwargs)
         if not isinstance(result, list):
+            return result
+        if self.rest_send.params.get("state") == "gathered":
             return result
         return [iface for iface in result if not self._is_unconfigured_default(iface)]

--- a/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
@@ -17,9 +17,7 @@ from typing import ClassVar
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import TrunkHostPolicyTypeEnum
 from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import (
-    EthernetTrunkHostInterfaceModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import EthernetTrunkHostInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import InterfaceDefaultConfig
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import EthernetBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType

--- a/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
@@ -129,6 +129,4 @@ class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
         result = super().query_all(model_instance=model_instance, gathered_filters=gathered_filters, **kwargs)
         if not isinstance(result, list):
             return result
-        if self.rest_send.params.get("state") == "gathered":
-            return result
         return [iface for iface in result if not self._is_unconfigured_default(iface)]

--- a/plugins/module_utils/orchestrators/fabric_update_group.py
+++ b/plugins/module_utils/orchestrators/fabric_update_group.py
@@ -102,6 +102,7 @@ class FabricUpdateGroupOrchestrator(NDBaseOrchestrator[FabricUpdateGroupModel]):
 
     model_class: ClassVar[Type[NDBaseModel]] = FabricUpdateGroupModel
     supports_bulk_create: ClassVar[bool] = True
+    supports_gathered_server_filtering: ClassVar[bool] = False
 
     create_endpoint: Type[NDEndpointBaseModel] = EpFabricSoftwareUpdatePlanAttachGroup
     update_endpoint: Type[NDEndpointBaseModel] = EpFabricUpdateGroupPut

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -5,9 +5,7 @@
 from __future__ import absolute_import, division, print_function
 
 from typing import ClassVar
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
-    NDEndpointBaseModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.infra.aaa_local_users import (
     EpInfraAaaLocalUsersDelete,
     EpInfraAaaLocalUsersGet,
@@ -15,15 +13,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.infra.aaa_lo
     EpInfraAaaLocalUsersPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
-    LocalUserModel,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import (
-    NDBaseOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
-    ResponseType,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 
 class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -5,7 +5,9 @@
 from __future__ import absolute_import, division, print_function
 
 from typing import ClassVar
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.infra.aaa_local_users import (
     EpInfraAaaLocalUsersDelete,
     EpInfraAaaLocalUsersGet,
@@ -13,9 +15,15 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.infra.aaa_lo
     EpInfraAaaLocalUsersPut,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
+    LocalUserModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import (
+    NDBaseOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
 
 
 class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -28,7 +28,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types impor
 
 class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):
     model_class: ClassVar[type[NDBaseModel]] = LocalUserModel
-    supports_gathered_lucene_filtering: ClassVar[bool] = False
+    supports_gathered_server_filtering: ClassVar[bool] = False
 
     create_endpoint: type[NDEndpointBaseModel] = EpInfraAaaLocalUsersPost
     update_endpoint: type[NDEndpointBaseModel] = EpInfraAaaLocalUsersPut

--- a/plugins/module_utils/orchestrators/local_user.py
+++ b/plugins/module_utils/orchestrators/local_user.py
@@ -20,6 +20,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types impor
 
 class LocalUserOrchestrator(NDBaseOrchestrator[LocalUserModel]):
     model_class: ClassVar[type[NDBaseModel]] = LocalUserModel
+    supports_gathered_lucene_filtering: ClassVar[bool] = False
 
     create_endpoint: type[NDEndpointBaseModel] = EpInfraAaaLocalUsersPost
     update_endpoint: type[NDEndpointBaseModel] = EpInfraAaaLocalUsersPut

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -126,7 +126,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     supports_bulk_delete: ClassVar[bool] = True
     interface_type: ClassVar[str] = "loopback"
     interface_mode: ClassVar[str] = "managed"
-    supports_gathered_lucene_filtering: ClassVar[bool] = True
+    supports_gathered_server_filtering: ClassVar[bool] = True
     gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
         base_terms=(
             ("interfaceType", "loopback"),
@@ -136,6 +136,9 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             ("interface_name",): "interfaceName",
         },
     )
+    # Maximum Lucene expressions per switch before collapsing to the base query
+    # Beyond this threshold, a single broad query is cheaper than N targeted ones.
+    _MAX_EXPRESSIONS_PER_SWITCH: ClassVar[int] = 3
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -339,21 +342,21 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
 
         filter_items = gathered_filters or [{}]
 
-        for raw_filter in filter_items:
-            normalized_filter = self.model_class.normalize_gathered_filter(raw_filter)
-            requested_switch_ip = normalized_filter.get("switch_ip")
+        for filter_item in filter_items:
+            requested_switch_ip = filter_item.get("switch_ip")
             if requested_switch_ip:
                 switch_id = switch_map.get(requested_switch_ip)
                 if switch_id is None:
-                    # This filter item cannot match an unknown switch.
-                    continue
+                    raise ValueError(
+                        f"Gathered filter references switch_ip '{requested_switch_ip}' " f"which does not exist in fabric '{self.fabric_context.fabric_name}'."
+                    )
                 target_switches = {
                     requested_switch_ip: switch_id,
                 }
             else:
                 target_switches = switch_map
             expressions = build_lucene_expressions(
-                filters=[normalized_filter],
+                filters=[filter_item],
                 spec=self.gathered_lucene_spec,
             )
             for switch_ip, switch_id in target_switches.items():
@@ -370,6 +373,14 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
                         planned_expressions.add(base_expression)
                     elif base_expression not in planned_expressions:
                         planned_expressions.add(expression)
+
+        # Cap fan-out: if a switch accumulated more expressions than the threshold,
+        # collapse to the base expression. The local filter guarantees correctness;
+        # the server filter only reduces candidate volume.
+        for switch_ip, (switch_id, expressions) in query_plan.items():
+            if len(expressions) > self._MAX_EXPRESSIONS_PER_SWITCH:
+                expressions.clear()
+                expressions.add(base_expression)
         return query_plan
 
     def _query_interfaces_with_lucene(
@@ -427,6 +438,11 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             if remaining is None and len(page) < page_size:
                 break
             offset += len(page)
+        else:
+            raise RuntimeError(
+                f"Pagination limit reached ({max_pages} pages, {len(candidates)} candidates collected) "
+                f"for switch '{switch_id}'. Results may be incomplete."
+            )
         return candidates
 
     def query_all(

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -42,7 +42,6 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
 )
 from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     GatheredLuceneSpec,
-    build_lucene_expressions,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import LoopbackPolicyTypeEnum, XeLoopbackPolicyTypeEnum
@@ -321,133 +320,11 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         managed_policy_types = {pt.value for pt in LoopbackPolicyTypeEnum} | {pt.value for pt in XeLoopbackPolicyTypeEnum}
         return policy_type in managed_policy_types
 
-    def _build_gathered_query_plan(self, gathered_filters: list[dict]) -> dict[str, tuple[str, set[str]]]:
+    def _configure_lucene_endpoint(self, api_endpoint) -> None:
         """
-        Build one or more Lucene expressions for each target switch.
-
-        Multiple filter items remain separate expressions because the
-        interface endpoint does not reliably support Lucene OR.
+        Include the complete config in Lucene results for local filtering.
         """
-        switch_map = self.fabric_context.switch_map
-        query_plan: dict[str, tuple[str, set[str]]] = {}
-        base_expression = build_lucene_expressions(
-            filters=[],
-            spec=self.gathered_lucene_spec,
-        )[0]
-
-        filter_items = gathered_filters or [{}]
-
-        fabric_wide_filters: list[dict] = []
-        switch_scoped_filters: list[tuple[str, str, dict]] = []
-
-        for filter_item in filter_items:
-            requested_switch_ip = filter_item.get("switch_ip")
-            if requested_switch_ip:
-                switch_id = switch_map.get(requested_switch_ip)
-                if switch_id is None:
-                    raise ValueError(
-                        f"Gathered filter references switch_ip '{requested_switch_ip}' " f"which does not exist in fabric '{self.fabric_context.fabric_name}'."
-                    )
-                switch_scoped_filters.append((requested_switch_ip, switch_id, filter_item))
-            else:
-                fabric_wide_filters.append(filter_item)
-
-        if fabric_wide_filters:
-            fabric_wide_expressions: set[str] = set()
-            for expr in build_lucene_expressions(fabric_wide_filters, self.gathered_lucene_spec):
-                if expr == base_expression:
-                    fabric_wide_expressions = {base_expression}
-                    break
-                fabric_wide_expressions.add(expr)
-
-            if len(switch_map) * len(fabric_wide_expressions) > self._MAX_TOTAL_REQUESTS:
-                fabric_wide_expressions = {base_expression}
-        else:
-            fabric_wide_expressions = None
-
-        if fabric_wide_expressions is not None:
-            for switch_ip, switch_id in switch_map.items():
-                query_plan[switch_ip] = (switch_id, set(fabric_wide_expressions))
-
-        for switch_ip, switch_id, filter_item in switch_scoped_filters:
-            if switch_ip not in query_plan:
-                query_plan[switch_ip] = (switch_id, set())
-            planned = query_plan[switch_ip][1]
-            for expr in build_lucene_expressions([filter_item], self.gathered_lucene_spec):
-                if expr == base_expression:
-                    planned.clear()
-                    planned.add(base_expression)
-                elif base_expression not in planned:
-                    planned.add(expr)
-
-        for switch_ip, (switch_id, expressions) in query_plan.items():
-            if len(expressions) > self._MAX_EXPRESSIONS_PER_SWITCH:
-                expressions.clear()
-                expressions.add(base_expression)
-
-        return query_plan
-
-    def _query_interfaces_with_lucene(
-        self,
-        switch_id: str,
-        expression: str,
-    ) -> list[dict]:
-        """Query every page for one Lucene expression."""
-        page_size = 500
-        max_pages = 100
-        offset = 0
-        candidates: list[dict] = []
-
-        for _page_number in range(max_pages):
-            api_endpoint = self._configure_endpoint(
-                self.query_all_endpoint(),
-                switch_sn=switch_id,
-            )
-
-            # The complete config is needed for final local filtering.
-            api_endpoint.endpoint_params.config_only = False
-
-            api_endpoint.lucene_params.filter = expression
-            api_endpoint.lucene_params.max = page_size
-            api_endpoint.lucene_params.offset = offset
-
-            result = self._request(
-                path=api_endpoint.path,
-                verb=api_endpoint.verb,
-                not_found_ok=True,
-            )
-
-            if not isinstance(result, dict):
-                break
-
-            page = result.get("interfaces", []) or []
-            candidates.extend(page)
-
-            if not page:
-                break
-
-            meta = result.get("meta") or {}
-            counts = meta.get("counts") or {}
-            remaining_raw = counts.get("remaining")
-
-            if remaining_raw is not None:
-                try:
-                    remaining = int(remaining_raw)
-                except (TypeError, ValueError):
-                    remaining = None
-            else:
-                remaining = None
-            if remaining is not None and remaining <= 0:
-                break
-            if remaining is None and len(page) < page_size:
-                break
-            offset += len(page)
-        else:
-            raise RuntimeError(
-                f"Pagination limit reached ({max_pages} pages, {len(candidates)} candidates collected) "
-                f"for switch '{switch_id}'. Results may be incomplete."
-            )
-        return candidates
+        api_endpoint.endpoint_params.config_only = False
 
     def query_all(
         self,

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -383,10 +383,11 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     ) -> list[dict]:
         """Query every page for one Lucene expression."""
         page_size = 500
+        max_pages = 100
         offset = 0
         candidates: list[dict] = []
 
-        while True:
+        for _page_number in range(max_pages):
             api_endpoint = self._configure_endpoint(
                 self.query_all_endpoint(),
                 switch_sn=switch_id,
@@ -411,18 +412,25 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             page = result.get("interfaces", []) or []
             candidates.extend(page)
 
-            meta = result.get("meta") or {}
-            counts = meta.get("counts") or {}
-            try:
-                remaining = int(counts.get("remaining", 0))
-            except (TypeError, ValueError):
-                remaining = 0
-
-            if not page or remaining <= 0:
+            if not page:
                 break
 
-            offset += len(page)
+            meta = result.get("meta") or {}
+            counts = meta.get("counts") or {}
+            remaining_raw = counts.get("remaining")
 
+            if remaining_raw is not None:
+                try:
+                    remaining = int(remaining_raw)
+                except (TypeError, ValueError):
+                    remaining = None
+            else:
+                remaining = None         
+            if remaining is not None and remaining <= 0:
+                break           
+            if remaining is None and len(page) < page_size:
+                break
+            offset += len(page)
         return candidates
 
     def query_all(

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -32,9 +32,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import ClassVar
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
-    NDEndpointBaseModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesGet,
     EpManageInterfacesListGet,
@@ -136,9 +134,6 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             ("interface_name",): "interfaceName",
         },
     )
-    # Maximum Lucene expressions per switch before collapsing to the base query
-    # Beyond this threshold, a single broad query is cheaper than N targeted ones.
-    _MAX_EXPRESSIONS_PER_SWITCH: ClassVar[int] = 3
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -342,6 +337,9 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
 
         filter_items = gathered_filters or [{}]
 
+        fabric_wide_filters: list[dict] = []
+        switch_scoped_filters: list[tuple[str, str, dict]] = []
+
         for filter_item in filter_items:
             requested_switch_ip = filter_item.get("switch_ip")
             if requested_switch_ip:
@@ -350,37 +348,43 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
                     raise ValueError(
                         f"Gathered filter references switch_ip '{requested_switch_ip}' " f"which does not exist in fabric '{self.fabric_context.fabric_name}'."
                     )
-                target_switches = {
-                    requested_switch_ip: switch_id,
-                }
+                switch_scoped_filters.append((requested_switch_ip, switch_id, filter_item))
             else:
-                target_switches = switch_map
-            expressions = build_lucene_expressions(
-                filters=[filter_item],
-                spec=self.gathered_lucene_spec,
-            )
-            for switch_ip, switch_id in target_switches.items():
-                if switch_ip not in query_plan:
-                    query_plan[switch_ip] = (switch_id, set())
+                fabric_wide_filters.append(filter_item)
 
-                planned_expressions = query_plan[switch_ip][1]
-                for expression in expressions:
-                    # The base query already returns every managed loopback on
-                    # this switch, so any narrower interface-name query would
-                    # only duplicate candidates and REST calls.
-                    if expression == base_expression:
-                        planned_expressions.clear()
-                        planned_expressions.add(base_expression)
-                    elif base_expression not in planned_expressions:
-                        planned_expressions.add(expression)
+        if fabric_wide_filters:
+            fabric_wide_expressions: set[str] = set()
+            for expr in build_lucene_expressions(fabric_wide_filters, self.gathered_lucene_spec):
+                if expr == base_expression:
+                    fabric_wide_expressions = {base_expression}
+                    break
+                fabric_wide_expressions.add(expr)
 
-        # Cap fan-out: if a switch accumulated more expressions than the threshold,
-        # collapse to the base expression. The local filter guarantees correctness;
-        # the server filter only reduces candidate volume.
+            if len(switch_map) * len(fabric_wide_expressions) > self._MAX_TOTAL_REQUESTS:
+                fabric_wide_expressions = {base_expression}
+        else:
+            fabric_wide_expressions = None
+
+        if fabric_wide_expressions is not None:
+            for switch_ip, switch_id in switch_map.items():
+                query_plan[switch_ip] = (switch_id, set(fabric_wide_expressions))
+
+        for switch_ip, switch_id, filter_item in switch_scoped_filters:
+            if switch_ip not in query_plan:
+                query_plan[switch_ip] = (switch_id, set())
+            planned = query_plan[switch_ip][1]
+            for expr in build_lucene_expressions([filter_item], self.gathered_lucene_spec):
+                if expr == base_expression:
+                    planned.clear()
+                    planned.add(base_expression)
+                elif base_expression not in planned:
+                    planned.add(expr)
+
         for switch_ip, (switch_id, expressions) in query_plan.items():
             if len(expressions) > self._MAX_EXPRESSIONS_PER_SWITCH:
                 expressions.clear()
                 expressions.add(base_expression)
+
         return query_plan
 
     def _query_interfaces_with_lucene(

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -40,9 +40,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesPut,
     EpManageInterfacesRemove,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
-    GatheredLuceneSpec,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import LoopbackPolicyTypeEnum, XeLoopbackPolicyTypeEnum
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
@@ -107,7 +105,8 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
 
     ### RuntimeError
 
-    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `validate_prerequisites` if the fabric does not exist, or is in deployment-freeze mode for a state
+      that mutates configuration.
     - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
     - Via `create` if the create API request fails, or if the response's per-item `results[]` reports a failure.
     - Via `create_bulk` if any create API request fails, or if a response's per-item `results[]` reports a failure.
@@ -360,7 +359,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         ### RuntimeError
 
         - If the fabric does not exist on the target ND node.
-        - If the fabric is in deployment-freeze mode.
+        - If the fabric is in deployment-freeze mode and the state mutates configuration.
         - If the query API request fails.
         """
         try:

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -40,6 +40,10 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesPut,
     EpManageInterfacesRemove,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    GatheredLuceneSpec,
+    build_lucene_expressions,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import LoopbackPolicyTypeEnum, XeLoopbackPolicyTypeEnum
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
@@ -120,6 +124,17 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
     supports_bulk_delete: ClassVar[bool] = True
     interface_type: ClassVar[str] = "loopback"
     interface_mode: ClassVar[str] = "managed"
+    supports_gathered_lucene_filtering: ClassVar[bool] = True
+    gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
+        base_terms=(
+            ("interfaceType", "loopback"),
+            ("policyType", "loopback"),
+        ),
+        field_map={
+            ("interface_name",): "interfaceName",
+        },
+    )
+
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -290,7 +305,132 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         except Exception as e:
             raise RuntimeError(f"Query failed for {model_instance.get_identifier_value()}: {e}") from e
 
-    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs) -> ResponseType:
+    @staticmethod
+    def _is_managed_loopback(interface: dict) -> bool:
+        """
+        Return whether an interface belongs to this module.
+
+        The interface must be a loopback using a policy type managed by this module - the union of
+        NX-OS (`LoopbackPolicyTypeEnum`) and IOS-XE (`XeLoopbackPolicyTypeEnum`) policy types.
+        System-managed underlay loopbacks and other system-provisioned policy types are intentionally excluded.
+        """
+        if interface.get("interfaceType") != "loopback":
+            return False
+
+        policy_type = (
+            interface.get("configData", {})
+            .get("networkOS", {})
+            .get("policy", {})
+            .get("policyType")
+        )
+
+        managed_policy_types = {pt.value for pt in LoopbackPolicyTypeEnum} | {pt.value for pt in XeLoopbackPolicyTypeEnum}
+        return policy_type in managed_policy_types
+
+    def _build_gathered_query_plan(self, gathered_filters: list[dict]) -> dict[str, tuple[str, set[str]]]:
+        """
+        Build one or more Lucene expressions for each target switch.
+
+        Multiple filter items remain separate expressions because the
+        interface endpoint does not reliably support Lucene OR.
+        """
+        switch_map = self.fabric_context.switch_map
+        query_plan: dict[str, tuple[str, set[str]]] = {}
+        base_expression = build_lucene_expressions(
+            filters=[],
+            spec=self.gathered_lucene_spec,
+        )[0]
+
+        filter_items = gathered_filters or [{}]
+
+        for raw_filter in filter_items:
+            normalized_filter = self.model_class.normalize_gathered_filter(raw_filter)
+            requested_switch_ip = normalized_filter.get("switch_ip")
+            if requested_switch_ip:
+                switch_id = switch_map.get(requested_switch_ip)
+                if switch_id is None:
+                    # This filter item cannot match an unknown switch.
+                    continue
+                target_switches = {
+                    requested_switch_ip: switch_id,
+                }
+            else:
+                target_switches = switch_map
+            expressions = build_lucene_expressions(
+                filters=[normalized_filter],
+                spec=self.gathered_lucene_spec,
+            )
+            for switch_ip, switch_id in target_switches.items():
+                if switch_ip not in query_plan:
+                    query_plan[switch_ip] = (switch_id, set())
+
+                planned_expressions = query_plan[switch_ip][1]
+                for expression in expressions:
+                    # The base query already returns every managed loopback on
+                    # this switch, so any narrower interface-name query would
+                    # only duplicate candidates and REST calls.
+                    if expression == base_expression:
+                        planned_expressions.clear()
+                        planned_expressions.add(base_expression)
+                    elif base_expression not in planned_expressions:
+                        planned_expressions.add(expression)
+        return query_plan
+
+    def _query_interfaces_with_lucene(
+        self,
+        switch_id: str,
+        expression: str,
+    ) -> list[dict]:
+        """Query every page for one Lucene expression."""
+        page_size = 500
+        offset = 0
+        candidates: list[dict] = []
+
+        while True:
+            api_endpoint = self._configure_endpoint(
+                self.query_all_endpoint(),
+                switch_sn=switch_id,
+            )
+
+            # The complete config is needed for final local filtering.
+            api_endpoint.endpoint_params.config_only = False
+
+            api_endpoint.lucene_params.filter = expression
+            api_endpoint.lucene_params.max = page_size
+            api_endpoint.lucene_params.offset = offset
+
+            result = self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                not_found_ok=True,
+            )
+
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("interfaces", []) or []
+            candidates.extend(page)
+
+            meta = result.get("meta") or {}
+            counts = meta.get("counts") or {}
+            try:
+                remaining = int(counts.get("remaining", 0))
+            except (TypeError, ValueError):
+                remaining = 0
+
+            if not page or remaining <= 0:
+                break
+
+            offset += len(page)
+
+        return candidates
+
+    def query_all(
+        self,
+        model_instance: NDBaseModel | None = None,
+        gathered_filters: list[dict] | None = None,
+        **kwargs,
+    ) -> ResponseType:
         """
         # Summary
 
@@ -301,13 +441,13 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         wire name is lab-verified (2026-07-18): the ND 4.2.1 OpenAPI READ schema lists it as `csrIntLoopback`, but
         the wire echoes `csrLoopback` on reads too (drift recorded in the bug-tracker vault).
 
-        The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`,
-        and limited to switches named in the user config for all other states.
-
         IOS-XE's `iosXeUnderlayLoopback` is user-creatable (unlike NX-OS's `underlayLoopback`, which is
         system-provisioned) and is therefore included in the managed set above. System-provisioned loopbacks (e.g.
         NX-OS Loopback0 routing, Loopback1 VTEP with `policyType: "underlayLoopback"`) and the `userDefined` policy
         type are excluded - those are out of scope for this module.
+
+        For gathered state, switch and interface-name criteria reduce the endpoint query scope; all other criteria
+        are applied by the generic local gathered filter.
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
 
@@ -324,17 +464,87 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         """
         try:
             self.validate_prerequisites()
-            all_loopbacks = []
-            managed_policy_types = {policy_type.value for policy_type in LoopbackPolicyTypeEnum} | {
-                policy_type.value for policy_type in XeLoopbackPolicyTypeEnum
-            }
-            for switch_ip, switch_id in self._switches_to_query().items():
-                interfaces = list(self._switch_interfaces(switch_id).values())
-                loopbacks = [iface for iface in interfaces if iface.get("interfaceType") == "loopback"]
-                managed = [lb for lb in loopbacks if lb.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_policy_types]
-                for iface in managed:
-                    iface["switchIp"] = switch_ip
-                all_loopbacks.extend(managed)
-            return all_loopbacks
+            if gathered_filters is None:
+                return self._query_all_for_management_states()
+            return self._query_all_for_gathered(gathered_filters)
+
         except Exception as e:
             raise RuntimeError(f"Query all failed: {e}") from e
+
+    def _query_all_for_management_states(self) -> list[dict]:
+        """
+        Preserve the existing list-all behavior used by merged,
+        replaced, overridden, and deleted states.
+        """
+        candidates_by_switch: list[tuple[str, list[dict]]] = []
+
+        for switch_ip, switch_id in self.fabric_context.switch_map.items():
+            api_endpoint = self._configure_endpoint(
+                self.query_all_endpoint(),
+                switch_sn=switch_id,
+            )
+
+            result = self._request(
+                path=api_endpoint.path,
+                verb=api_endpoint.verb,
+                not_found_ok=True,
+            )
+
+            candidates = []
+            if isinstance(result, dict):
+                candidates = result.get("interfaces", []) or []
+
+            candidates_by_switch.append((switch_ip, candidates))
+
+        return self._collect_managed_loopbacks(candidates_by_switch)
+
+    def _query_all_for_gathered(self, gathered_filters: list[dict]) -> list[dict]:
+        """Run server-filtered gathered requests."""
+        candidates_by_switch: list[tuple[str, list[dict]]] = []
+
+        query_plan = self._build_gathered_query_plan(gathered_filters)
+
+        for switch_ip, (switch_id, expressions) in query_plan.items():
+            switch_candidates = []
+
+            for expression in sorted(expressions):
+                switch_candidates.extend(
+                    self._query_interfaces_with_lucene(
+                        switch_id=switch_id,
+                        expression=expression,
+                    )
+                )
+
+            candidates_by_switch.append((switch_ip, switch_candidates))
+
+        return self._collect_managed_loopbacks(candidates_by_switch)
+
+    def _collect_managed_loopbacks(
+        self,
+        candidates_by_switch: list[tuple[str, list[dict]]],
+    ) -> list[dict]:
+        """Validate, enrich, and deduplicate responses."""
+        all_loopbacks = []
+        seen_identifiers: set[tuple[str, str]] = set()
+
+        for switch_ip, candidates in candidates_by_switch:
+            for interface in candidates:
+                if not self._is_managed_loopback(interface):
+                    continue
+
+                interface_name = interface.get("interfaceName")
+                if not interface_name:
+                    continue
+
+                identifier = (switch_ip, interface_name)
+
+                if identifier in seen_identifiers:
+                    continue
+
+                enriched = dict(interface)
+                enriched["switchIp"] = switch_ip
+
+                seen_identifiers.add(identifier)
+                all_loopbacks.append(enriched)
+
+        return all_loopbacks

--- a/plugins/module_utils/orchestrators/loopback_interface.py
+++ b/plugins/module_utils/orchestrators/loopback_interface.py
@@ -32,7 +32,9 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import ClassVar
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesGet,
     EpManageInterfacesListGet,
@@ -134,7 +136,6 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
             ("interface_name",): "interfaceName",
         },
     )
-
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -317,12 +318,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         if interface.get("interfaceType") != "loopback":
             return False
 
-        policy_type = (
-            interface.get("configData", {})
-            .get("networkOS", {})
-            .get("policy", {})
-            .get("policyType")
-        )
+        policy_type = interface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType")
 
         managed_policy_types = {pt.value for pt in LoopbackPolicyTypeEnum} | {pt.value for pt in XeLoopbackPolicyTypeEnum}
         return policy_type in managed_policy_types
@@ -425,9 +421,9 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
                 except (TypeError, ValueError):
                     remaining = None
             else:
-                remaining = None         
+                remaining = None
             if remaining is not None and remaining <= 0:
-                break           
+                break
             if remaining is None and len(page) < page_size:
                 break
             offset += len(page)
@@ -486,7 +482,7 @@ class LoopbackInterfaceOrchestrator(NDBaseInterfaceOrchestrator[LoopbackInterfac
         """
         candidates_by_switch: list[tuple[str, list[dict]]] = []
 
-        for switch_ip, switch_id in self.fabric_context.switch_map.items():
+        for switch_ip, switch_id in self._switches_to_query().items():
             api_endpoint = self._configure_endpoint(
                 self.query_all_endpoint(),
                 switch_sn=switch_id,

--- a/plugins/module_utils/orchestrators/maintenance_mode.py
+++ b/plugins/module_utils/orchestrators/maintenance_mode.py
@@ -77,7 +77,8 @@ class MaintenanceModeOrchestrator(NDBaseInterfaceOrchestrator[MaintenanceModeMod
 
     ### RuntimeError
 
-    - Via `validate_prerequisites` if the fabric does not exist, is not local, or is in deployment-freeze mode.
+    - Via `validate_prerequisites` if the fabric does not exist, is not local, or is in deployment-freeze mode
+      for a state that mutates configuration.
     - Via `query_all` if a user-supplied `switch_ip` is not found in the fabric.
     - Via `query_all` if any switch is currently in `migration` mode.
     - Via `update` if the POST changeSystemMode request fails or the 207 body contains per-switch failures.

--- a/plugins/module_utils/orchestrators/manage_fabric_ai_ebgp_vxlan.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_ai_ebgp_vxlan.py
@@ -4,7 +4,7 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type
 
@@ -22,10 +22,26 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageFabricsPut,
     EpManageFabricsDelete,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec, build_lucene_expressions
 
 
 class ManageAiEbgpVxlanFabricOrchestrator(ConfigActionsMixin, NDBaseOrchestrator):
     model_class: ClassVar[type[NDBaseModel]] = FabricAiEbgpVxlanModel
+
+    supports_gathered_server_filtering: ClassVar[bool] = True
+    gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
+        base_terms=(("type", "aimlVxlanEbgp"),),
+        field_map={
+            ("fabric_name",): "name",
+            ("license_tier",): "licenseTier",
+            ("security_domain",): "securityDomain",
+            ("alert_suspend",): "alertSuspend",
+            ("telemetry_collection",): "telemetryCollection",
+        },
+    )
+
+    _FABRIC_TYPE_FILTER: ClassVar[str] = "aimlVxlanEbgp"
+    _MAX_LUCENE_EXPRESSIONS: ClassVar[int] = 3
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPut
@@ -33,15 +49,123 @@ class ManageAiEbgpVxlanFabricOrchestrator(ConfigActionsMixin, NDBaseOrchestrator
     query_one_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
     query_all_endpoint: type[NDEndpointBaseModel] = EpManageFabricsListGet
 
-    def query_all(self) -> ResponseType:
-        """
-        Custom query_all action to extract 'fabrics' from response,
-        filtered to only aimlVxlanEbgp fabric types.
-        """
+    def query_all(self, model_instance=None, gathered_filters=None, **kwargs) -> ResponseType:
+        """Query fabrics, optionally narrowing via server-side Lucene filters."""
         try:
-            api_endpoint = self.query_all_endpoint()
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-            fabrics = result.get("fabrics", []) or []
-            return [f for f in fabrics if f.get("management", {}).get("type") == "aimlVxlanEbgp"]
+            if gathered_filters is not None and self.gathered_lucene_spec is not None:
+                return self._query_all_for_gathered(gathered_filters)
+            return self._query_all_for_management_states()
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
+
+    def _query_all_for_management_states(self) -> ResponseType:
+        """Fetch all fabrics and filter to aimlVxlanEbgp client-side."""
+        api_endpoint = self.query_all_endpoint()
+        result = self._request(
+            path=api_endpoint.path,
+            verb=api_endpoint.verb,
+            not_found_ok=True,
+        )
+        fabrics = result.get("fabrics", []) or []
+        return [fabric for fabric in fabrics if fabric.get("management", {}).get("type") == self._FABRIC_TYPE_FILTER]
+
+    def _fetch_fabrics_paginated(self, expression: str | None = None) -> list[dict]:
+        """Fetch fabrics with bounded pagination, optionally filtered by a Lucene expression."""
+        page_size = 500
+        max_pages = 100
+        offset = 0
+        all_results: list[dict] = []
+
+        for _page in range(max_pages):
+            api_endpoint = self.query_all_endpoint()
+            api_endpoint.endpoint_params.max = page_size
+            api_endpoint.endpoint_params.offset = offset
+            if expression:
+                api_endpoint.endpoint_params.filter = expression
+
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("fabrics", []) or []
+            all_results.extend(page)
+
+            if not page:
+                break
+
+            counts = (result.get("meta") or {}).get("counts") or {}
+            remaining_raw = counts.get("remaining")
+
+            try:
+                remaining = int(remaining_raw) if remaining_raw is not None else None
+            except (TypeError, ValueError):
+                remaining = None
+
+            if remaining is not None and remaining <= 0:
+                break
+            if remaining is None and len(page) < page_size:
+                break
+
+            offset += len(page)
+        else:
+            raise RuntimeError(f"Fabric pagination exceeded {max_pages} pages ({len(all_results)} fabrics). " "Results may be incomplete.")
+        return all_results
+
+    def _query_one_by_name(self, fabric_name: str) -> list[dict]:
+        """Fetch a single fabric by exact name via the resource endpoint."""
+        api_endpoint = self.query_one_endpoint()
+        api_endpoint.set_identifiers(fabric_name)
+        result = self._request(
+            path=api_endpoint.path,
+            verb=api_endpoint.verb,
+            not_found_ok=True,
+        )
+        if not result or not isinstance(result, dict):
+            return []
+        if result.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+            return []
+        return [result]
+
+    def _query_all_for_gathered(self, gathered_filters) -> ResponseType:
+        """Use server-side Lucene to narrow fabric results before client-side type check."""
+        all_fabrics = []
+        seen_names: set[str] = set()
+
+        lucene_filters = []
+        for filter_item in gathered_filters or [{}]:
+            fabric_name = filter_item.get("fabric_name")
+            other_keys = {k for k, v in filter_item.items() if v not in (None, "") and k != "fabric_name"}
+            if fabric_name and not other_keys:
+                for fabric in self._query_one_by_name(fabric_name):
+                    name = fabric.get("name")
+                    if name and name not in seen_names:
+                        seen_names.add(name)
+                        all_fabrics.append(fabric)
+            else:
+                lucene_filters.append(filter_item)
+
+        if not lucene_filters:
+            return all_fabrics
+
+        expressions = build_lucene_expressions(
+            lucene_filters,
+            spec=self.gathered_lucene_spec,
+        )
+
+        if not expressions or len(expressions) > self._MAX_LUCENE_EXPRESSIONS or any('"' in expression for expression in expressions):
+            expressions = build_lucene_expressions(filters=[], spec=self.gathered_lucene_spec)
+
+        for expression in expressions:
+            fabrics = self._fetch_fabrics_paginated(expression)
+            for fabric in fabrics:
+                if fabric.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+                    continue
+
+                name = fabric.get("name")
+                if not name or name in seen_names:
+                    continue
+
+                seen_names.add(name)
+                all_fabrics.append(fabric)
+
+        return all_fabrics

--- a/plugins/module_utils/orchestrators/manage_fabric_ai_ibgp_vxlan.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_ai_ibgp_vxlan.py
@@ -4,7 +4,7 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type
 
@@ -22,10 +22,26 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageFabricsPut,
     EpManageFabricsDelete,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec, build_lucene_expressions
 
 
 class ManageAiIbgpVxlanFabricOrchestrator(ConfigActionsMixin, NDBaseOrchestrator):
     model_class: ClassVar[type[NDBaseModel]] = FabricAiIbgpVxlanModel
+
+    supports_gathered_server_filtering: ClassVar[bool] = True
+    gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
+        base_terms=(("type", "aimlVxlanIbgp"),),
+        field_map={
+            ("fabric_name",): "name",
+            ("license_tier",): "licenseTier",
+            ("security_domain",): "securityDomain",
+            ("alert_suspend",): "alertSuspend",
+            ("telemetry_collection",): "telemetryCollection",
+        },
+    )
+
+    _FABRIC_TYPE_FILTER: ClassVar[str] = "aimlVxlanIbgp"
+    _MAX_LUCENE_EXPRESSIONS: ClassVar[int] = 3
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPut
@@ -33,15 +49,123 @@ class ManageAiIbgpVxlanFabricOrchestrator(ConfigActionsMixin, NDBaseOrchestrator
     query_one_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
     query_all_endpoint: type[NDEndpointBaseModel] = EpManageFabricsListGet
 
-    def query_all(self) -> ResponseType:
-        """
-        Custom query_all action to extract 'fabrics' from response,
-        filtered to only aimlVxlanIbgp fabric types.
-        """
+    def query_all(self, model_instance=None, gathered_filters=None, **kwargs) -> ResponseType:
+        """Query fabrics, optionally narrowing via server-side Lucene filters."""
         try:
-            api_endpoint = self.query_all_endpoint()
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-            fabrics = result.get("fabrics", []) or []
-            return [f for f in fabrics if f.get("management", {}).get("type") == "aimlVxlanIbgp"]
+            if gathered_filters is not None and self.gathered_lucene_spec is not None:
+                return self._query_all_for_gathered(gathered_filters)
+            return self._query_all_for_management_states()
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
+
+    def _query_all_for_management_states(self) -> ResponseType:
+        """Fetch all fabrics and filter to aimlVxlanIbgp client-side."""
+        api_endpoint = self.query_all_endpoint()
+        result = self._request(
+            path=api_endpoint.path,
+            verb=api_endpoint.verb,
+            not_found_ok=True,
+        )
+        fabrics = result.get("fabrics", []) or []
+        return [fabric for fabric in fabrics if fabric.get("management", {}).get("type") == self._FABRIC_TYPE_FILTER]
+
+    def _fetch_fabrics_paginated(self, expression: str | None = None) -> list[dict]:
+        """Fetch fabrics with bounded pagination, optionally filtered by a Lucene expression."""
+        page_size = 500
+        max_pages = 100
+        offset = 0
+        all_results: list[dict] = []
+
+        for _page in range(max_pages):
+            api_endpoint = self.query_all_endpoint()
+            api_endpoint.endpoint_params.max = page_size
+            api_endpoint.endpoint_params.offset = offset
+            if expression:
+                api_endpoint.endpoint_params.filter = expression
+
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("fabrics", []) or []
+            all_results.extend(page)
+
+            if not page:
+                break
+
+            counts = (result.get("meta") or {}).get("counts") or {}
+            remaining_raw = counts.get("remaining")
+
+            try:
+                remaining = int(remaining_raw) if remaining_raw is not None else None
+            except (TypeError, ValueError):
+                remaining = None
+
+            if remaining is not None and remaining <= 0:
+                break
+            if remaining is None and len(page) < page_size:
+                break
+
+            offset += len(page)
+        else:
+            raise RuntimeError(f"Fabric pagination exceeded {max_pages} pages ({len(all_results)} fabrics). " "Results may be incomplete.")
+        return all_results
+
+    def _query_one_by_name(self, fabric_name: str) -> list[dict]:
+        """Fetch a single fabric by exact name via the resource endpoint."""
+        api_endpoint = self.query_one_endpoint()
+        api_endpoint.set_identifiers(fabric_name)
+        result = self._request(
+            path=api_endpoint.path,
+            verb=api_endpoint.verb,
+            not_found_ok=True,
+        )
+        if not result or not isinstance(result, dict):
+            return []
+        if result.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+            return []
+        return [result]
+
+    def _query_all_for_gathered(self, gathered_filters) -> ResponseType:
+        """Use server-side Lucene to narrow fabric results before client-side type check."""
+        all_fabrics = []
+        seen_names: set[str] = set()
+
+        lucene_filters = []
+        for filter_item in gathered_filters or [{}]:
+            fabric_name = filter_item.get("fabric_name")
+            other_keys = {k for k, v in filter_item.items() if v not in (None, "") and k != "fabric_name"}
+            if fabric_name and not other_keys:
+                for fabric in self._query_one_by_name(fabric_name):
+                    name = fabric.get("name")
+                    if name and name not in seen_names:
+                        seen_names.add(name)
+                        all_fabrics.append(fabric)
+            else:
+                lucene_filters.append(filter_item)
+
+        if not lucene_filters:
+            return all_fabrics
+
+        expressions = build_lucene_expressions(
+            lucene_filters,
+            spec=self.gathered_lucene_spec,
+        )
+
+        if not expressions or len(expressions) > self._MAX_LUCENE_EXPRESSIONS or any('"' in expression for expression in expressions):
+            expressions = build_lucene_expressions(filters=[], spec=self.gathered_lucene_spec)
+
+        for expression in expressions:
+            fabrics = self._fetch_fabrics_paginated(expression)
+            for fabric in fabrics:
+                if fabric.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+                    continue
+
+                name = fabric.get("name")
+                if not name or name in seen_names:
+                    continue
+
+                seen_names.add(name)
+                all_fabrics.append(fabric)
+
+        return all_fabrics

--- a/plugins/module_utils/orchestrators/manage_fabric_ebgp_vxlan.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_ebgp_vxlan.py
@@ -4,7 +4,7 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type
 
@@ -18,6 +18,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageFabricsPost,
     EpManageFabricsPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec, build_lucene_expressions
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ebgp_vxlan import FabricEbgpModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
@@ -28,21 +29,137 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types impor
 class ManageEbgpFabricOrchestrator(ConfigActionsMixin, NDBaseOrchestrator):
     model_class: ClassVar[type[NDBaseModel]] = FabricEbgpModel
 
+    supports_gathered_server_filtering: ClassVar[bool] = True
+    gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
+        base_terms=(("type", "vxlanEbgp"),),
+        field_map={
+            ("fabric_name",): "name",
+            ("license_tier",): "licenseTier",
+            ("security_domain",): "securityDomain",
+            ("alert_suspend",): "alertSuspend",
+            ("telemetry_collection",): "telemetryCollection",
+        },
+    )
+
+    _FABRIC_TYPE_FILTER: ClassVar[str] = "vxlanEbgp"
+    _MAX_LUCENE_EXPRESSIONS: ClassVar[int] = 3
+
     create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPut
     delete_endpoint: type[NDEndpointBaseModel] = EpManageFabricsDelete
     query_one_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
     query_all_endpoint: type[NDEndpointBaseModel] = EpManageFabricsListGet
 
-    def query_all(self) -> ResponseType:
-        """
-        Custom query_all action to extract 'fabrics' from response,
-        filtered to only vxlanEbgp fabric types.
-        """
+    def query_all(self, model_instance=None, gathered_filters=None, **kwargs) -> ResponseType:
+        """Query fabrics, optionally narrowing via server-side Lucene filters."""
         try:
-            api_endpoint = self.query_all_endpoint()
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-            fabrics = result.get("fabrics", []) or []
-            return [f for f in fabrics if f.get("management", {}).get("type") == "vxlanEbgp"]
+            if gathered_filters is not None and self.gathered_lucene_spec is not None:
+                return self._query_all_for_gathered(gathered_filters)
+            return self._query_all_for_management_states()
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
+
+    def _query_all_for_management_states(self) -> ResponseType:
+        """Fetch all fabrics and filter to vxlanEbgp client-side."""
+        api_endpoint = self.query_all_endpoint()
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        fabrics = result.get("fabrics", []) or []
+        return [f for f in fabrics if f.get("management", {}).get("type") == self._FABRIC_TYPE_FILTER]
+
+    def _fetch_fabrics_paginated(self, expression: str | None = None) -> list[dict]:
+        """Fetch fabrics with bounded pagination, optionally filtered by a Lucene expression."""
+        page_size = 500
+        max_pages = 100
+        offset = 0
+        all_results: list[dict] = []
+
+        for _page in range(max_pages):
+            api_endpoint = self.query_all_endpoint()
+            api_endpoint.endpoint_params.max = page_size
+            api_endpoint.endpoint_params.offset = offset
+            if expression:
+                api_endpoint.endpoint_params.filter = expression
+
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("fabrics", []) or []
+            all_results.extend(page)
+
+            if not page:
+                break
+
+            counts = (result.get("meta") or {}).get("counts") or {}
+            remaining_raw = counts.get("remaining")
+
+            try:
+                remaining = int(remaining_raw) if remaining_raw is not None else None
+            except (TypeError, ValueError):
+                remaining = None
+
+            if remaining is not None and remaining <= 0:
+                break
+            if remaining is None and len(page) < page_size:
+                break
+
+            offset += len(page)
+        else:
+            raise RuntimeError(f"Fabric pagination exceeded {max_pages} pages ({len(all_results)} fabrics). " "Results may be incomplete.")
+        return all_results
+
+    def _query_one_by_name(self, fabric_name: str) -> list[dict]:
+        """Fetch a single fabric by exact name via the resource endpoint."""
+        api_endpoint = self.query_one_endpoint()
+        api_endpoint.set_identifiers(fabric_name)
+        result = self._request(
+            path=api_endpoint.path,
+            verb=api_endpoint.verb,
+            not_found_ok=True,
+        )
+        if not result or not isinstance(result, dict):
+            return []
+        if result.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+            return []
+        return [result]
+
+    def _query_all_for_gathered(self, gathered_filters) -> ResponseType:
+        """Use server-side Lucene to narrow fabric results before client-side type check."""
+        all_fabrics = []
+        seen_names: set[str] = set()
+
+        # fabric_name-only filters use the exact endpoint, bypassing Lucene
+        # quoting issues with hyphens and special characters.
+        lucene_filters = []
+        for filter_item in gathered_filters or [{}]:
+            fabric_name = filter_item.get("fabric_name")
+            other_keys = {k for k, v in filter_item.items() if v not in (None, "") and k != "fabric_name"}
+            if fabric_name and not other_keys:
+                for fabric in self._query_one_by_name(fabric_name):
+                    name = fabric.get("name")
+                    if name and name not in seen_names:
+                        seen_names.add(name)
+                        all_fabrics.append(fabric)
+            else:
+                lucene_filters.append(filter_item)
+
+        if not lucene_filters:
+            return all_fabrics
+
+        expressions = build_lucene_expressions(lucene_filters, spec=self.gathered_lucene_spec)
+
+        if not expressions or len(expressions) > self._MAX_LUCENE_EXPRESSIONS or any('"' in expr for expr in expressions):
+            expressions = build_lucene_expressions(filters=[], spec=self.gathered_lucene_spec)
+
+        for expression in expressions:
+            fabrics = self._fetch_fabrics_paginated(expression)
+            for f in fabrics:
+                if f.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+                    continue
+                name = f.get("name")
+                if not name or name in seen_names:
+                    continue
+                seen_names.add(name)
+                all_fabrics.append(f)
+
+        return all_fabrics

--- a/plugins/module_utils/orchestrators/manage_fabric_external.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_external.py
@@ -4,7 +4,7 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type
 
@@ -18,6 +18,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageFabricsPost,
     EpManageFabricsPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec, build_lucene_expressions
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_external import FabricExternalConnectivityModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
@@ -28,21 +29,135 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types impor
 class ManageExternalFabricOrchestrator(ConfigActionsMixin, NDBaseOrchestrator):
     model_class: ClassVar[type[NDBaseModel]] = FabricExternalConnectivityModel
 
+    supports_gathered_server_filtering: ClassVar[bool] = True
+    gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
+        base_terms=(("type", "externalConnectivity"),),
+        field_map={
+            ("fabric_name",): "name",
+            ("license_tier",): "licenseTier",
+            ("security_domain",): "securityDomain",
+            ("alert_suspend",): "alertSuspend",
+            ("telemetry_collection",): "telemetryCollection",
+        },
+    )
+
+    _FABRIC_TYPE_FILTER: ClassVar[str] = "externalConnectivity"
+    _MAX_LUCENE_EXPRESSIONS: ClassVar[int] = 3
+
     create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPut
     delete_endpoint: type[NDEndpointBaseModel] = EpManageFabricsDelete
     query_one_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
     query_all_endpoint: type[NDEndpointBaseModel] = EpManageFabricsListGet
 
-    def query_all(self) -> ResponseType:
-        """
-        Custom query_all action to extract 'fabrics' from response,
-        filtered to only externalConnectivity fabric types.
-        """
+    def query_all(self, model_instance=None, gathered_filters=None, **kwargs) -> ResponseType:
+        """Query fabrics, optionally narrowing via server-side Lucene filters."""
         try:
-            api_endpoint = self.query_all_endpoint()
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-            fabrics = result.get("fabrics", []) or []
-            return [f for f in fabrics if f.get("management", {}).get("type") == "externalConnectivity"]
+            if gathered_filters is not None and self.gathered_lucene_spec is not None:
+                return self._query_all_for_gathered(gathered_filters)
+            return self._query_all_for_management_states()
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
+
+    def _query_all_for_management_states(self) -> ResponseType:
+        """Fetch all fabrics and filter to externalConnectivity client-side."""
+        api_endpoint = self.query_all_endpoint()
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+        fabrics = result.get("fabrics", []) or []
+        return [f for f in fabrics if f.get("management", {}).get("type") == self._FABRIC_TYPE_FILTER]
+
+    def _fetch_fabrics_paginated(self, expression: str | None = None) -> list[dict]:
+        """Fetch fabrics with bounded pagination, optionally filtered by a Lucene expression."""
+        page_size = 500
+        max_pages = 100
+        offset = 0
+        all_results: list[dict] = []
+
+        for _page in range(max_pages):
+            api_endpoint = self.query_all_endpoint()
+            api_endpoint.endpoint_params.max = page_size
+            api_endpoint.endpoint_params.offset = offset
+            if expression:
+                api_endpoint.endpoint_params.filter = expression
+
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("fabrics", []) or []
+            all_results.extend(page)
+
+            if not page:
+                break
+
+            counts = (result.get("meta") or {}).get("counts") or {}
+            remaining_raw = counts.get("remaining")
+
+            try:
+                remaining = int(remaining_raw) if remaining_raw is not None else None
+            except (TypeError, ValueError):
+                remaining = None
+
+            if remaining is not None and remaining <= 0:
+                break
+            if remaining is None and len(page) < page_size:
+                break
+
+            offset += len(page)
+        else:
+            raise RuntimeError(f"Fabric pagination exceeded {max_pages} pages ({len(all_results)} fabrics). " "Results may be incomplete.")
+        return all_results
+
+    def _query_one_by_name(self, fabric_name: str) -> list[dict]:
+        """Fetch a single fabric by exact name via the resource endpoint."""
+        api_endpoint = self.query_one_endpoint()
+        api_endpoint.set_identifiers(fabric_name)
+        result = self._request(
+            path=api_endpoint.path,
+            verb=api_endpoint.verb,
+            not_found_ok=True,
+        )
+        if not result or not isinstance(result, dict):
+            return []
+        if result.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+            return []
+        return [result]
+
+    def _query_all_for_gathered(self, gathered_filters) -> ResponseType:
+        """Use server-side Lucene to narrow fabric results before client-side type check."""
+        all_fabrics = []
+        seen_names: set[str] = set()
+
+        lucene_filters = []
+        for filter_item in gathered_filters or [{}]:
+            fabric_name = filter_item.get("fabric_name")
+            other_keys = {k for k, v in filter_item.items() if v not in (None, "") and k != "fabric_name"}
+            if fabric_name and not other_keys:
+                for fabric in self._query_one_by_name(fabric_name):
+                    name = fabric.get("name")
+                    if name and name not in seen_names:
+                        seen_names.add(name)
+                        all_fabrics.append(fabric)
+            else:
+                lucene_filters.append(filter_item)
+
+        if not lucene_filters:
+            return all_fabrics
+
+        expressions = build_lucene_expressions(lucene_filters, spec=self.gathered_lucene_spec)
+
+        if not expressions or len(expressions) > self._MAX_LUCENE_EXPRESSIONS or any('"' in expr for expr in expressions):
+            expressions = build_lucene_expressions(filters=[], spec=self.gathered_lucene_spec)
+
+        for expression in expressions:
+            fabrics = self._fetch_fabrics_paginated(expression)
+            for f in fabrics:
+                if f.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+                    continue
+                name = f.get("name")
+                if not name or name in seen_names:
+                    continue
+                seen_names.add(name)
+                all_fabrics.append(f)
+
+        return all_fabrics

--- a/plugins/module_utils/orchestrators/manage_fabric_ibgp_vxlan.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_ibgp_vxlan.py
@@ -4,7 +4,7 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type
 
@@ -18,6 +18,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageFabricsPost,
     EpManageFabricsPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import GatheredLuceneSpec, build_lucene_expressions
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ibgp_vxlan import FabricIbgpModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
@@ -28,21 +29,144 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types impor
 class ManageIbgpFabricOrchestrator(ConfigActionsMixin, NDBaseOrchestrator):
     model_class: ClassVar[type[NDBaseModel]] = FabricIbgpModel
 
+    supports_gathered_server_filtering: ClassVar[bool] = True
+    gathered_lucene_spec: ClassVar[GatheredLuceneSpec] = GatheredLuceneSpec(
+        base_terms=(("type", "vxlanIbgp"),),
+        field_map={
+            ("fabric_name",): "name",
+            ("license_tier",): "licenseTier",
+            ("security_domain",): "securityDomain",
+            ("alert_suspend",): "alertSuspend",
+            ("telemetry_collection",): "telemetryCollection",
+        },
+    )
+
+    _FABRIC_TYPE_FILTER: ClassVar[str] = "vxlanIbgp"
+    _MAX_LUCENE_EXPRESSIONS: ClassVar[int] = 3
+
     create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPut
     delete_endpoint: type[NDEndpointBaseModel] = EpManageFabricsDelete
     query_one_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
     query_all_endpoint: type[NDEndpointBaseModel] = EpManageFabricsListGet
 
-    def query_all(self) -> ResponseType:
-        """
-        Custom query_all action to extract 'fabrics' from response,
-        filtered to only vxlanIbgp fabric types.
-        """
+    def query_all(self, model_instance=None, gathered_filters=None, **kwargs) -> ResponseType:
+        """Query fabrics, optionally narrowing via server-side Lucene filters."""
         try:
-            api_endpoint = self.query_all_endpoint()
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-            fabrics = result.get("fabrics", []) or []
-            return [f for f in fabrics if f.get("management", {}).get("type") == "vxlanIbgp"]
+            if gathered_filters is not None and self.gathered_lucene_spec is not None:
+                return self._query_all_for_gathered(gathered_filters)
+            return self._query_all_for_management_states()
         except Exception as e:
             raise Exception(f"Query all failed: {e}") from e
+
+    def _query_all_for_management_states(self) -> ResponseType:
+        """Fetch all fabrics and filter to vxlanIbgp client-side."""
+        api_endpoint = self.query_all_endpoint()
+        result = self._request(
+            path=api_endpoint.path,
+            verb=api_endpoint.verb,
+            not_found_ok=True,
+        )
+        fabrics = result.get("fabrics", []) or []
+        return [fabric for fabric in fabrics if fabric.get("management", {}).get("type") == self._FABRIC_TYPE_FILTER]
+
+    def _fetch_fabrics_paginated(self, expression: str | None = None) -> list[dict]:
+        """Fetch fabrics with bounded pagination, optionally filtered by a Lucene expression."""
+        page_size = 500
+        max_pages = 100
+        offset = 0
+        all_results: list[dict] = []
+
+        for _page in range(max_pages):
+            api_endpoint = self.query_all_endpoint()
+            api_endpoint.endpoint_params.max = page_size
+            api_endpoint.endpoint_params.offset = offset
+            if expression:
+                api_endpoint.endpoint_params.filter = expression
+
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("fabrics", []) or []
+            all_results.extend(page)
+
+            if not page:
+                break
+
+            counts = (result.get("meta") or {}).get("counts") or {}
+            remaining_raw = counts.get("remaining")
+
+            try:
+                remaining = int(remaining_raw) if remaining_raw is not None else None
+            except (TypeError, ValueError):
+                remaining = None
+
+            if remaining is not None and remaining <= 0:
+                break
+            if remaining is None and len(page) < page_size:
+                break
+
+            offset += len(page)
+        else:
+            raise RuntimeError(f"Fabric pagination exceeded {max_pages} pages ({len(all_results)} fabrics). " "Results may be incomplete.")
+        return all_results
+
+    def _query_one_by_name(self, fabric_name: str) -> list[dict]:
+        """Fetch a single fabric by exact name via the resource endpoint."""
+        api_endpoint = self.query_one_endpoint()
+        api_endpoint.set_identifiers(fabric_name)
+        result = self._request(
+            path=api_endpoint.path,
+            verb=api_endpoint.verb,
+            not_found_ok=True,
+        )
+        if not result or not isinstance(result, dict):
+            return []
+        if result.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+            return []
+        return [result]
+
+    def _query_all_for_gathered(self, gathered_filters) -> ResponseType:
+        """Use server-side Lucene to narrow fabric results before client-side type checking."""
+        all_fabrics = []
+        seen_names: set[str] = set()
+
+        lucene_filters = []
+        for filter_item in gathered_filters or [{}]:
+            fabric_name = filter_item.get("fabric_name")
+            other_keys = {k for k, v in filter_item.items() if v not in (None, "") and k != "fabric_name"}
+            if fabric_name and not other_keys:
+                for fabric in self._query_one_by_name(fabric_name):
+                    name = fabric.get("name")
+                    if name and name not in seen_names:
+                        seen_names.add(name)
+                        all_fabrics.append(fabric)
+            else:
+                lucene_filters.append(filter_item)
+
+        if not lucene_filters:
+            return all_fabrics
+
+        expressions = build_lucene_expressions(
+            lucene_filters,
+            spec=self.gathered_lucene_spec,
+        )
+
+        if not expressions or len(expressions) > self._MAX_LUCENE_EXPRESSIONS or any('"' in expression for expression in expressions):
+            expressions = build_lucene_expressions(filters=[], spec=self.gathered_lucene_spec)
+
+        for expression in expressions:
+            fabrics = self._fetch_fabrics_paginated(expression)
+            for fabric in fabrics:
+                if fabric.get("management", {}).get("type") != self._FABRIC_TYPE_FILTER:
+                    continue
+
+                name = fabric.get("name")
+                if not name or name in seen_names:
+                    continue
+
+                seen_names.add(name)
+                all_fabrics.append(fabric)
+
+        return all_fabrics

--- a/plugins/module_utils/orchestrators/port_channel_base.py
+++ b/plugins/module_utils/orchestrators/port_channel_base.py
@@ -65,7 +65,8 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
 
     ### RuntimeError
 
-    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `validate_prerequisites` if the fabric does not exist, or is in deployment-freeze mode for a state
+      that mutates configuration.
     - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
     - Via `create` if the create API request fails.
     - Via `update` if the update API request fails.
@@ -263,7 +264,7 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         ### RuntimeError
 
         - If the fabric does not exist on the target ND node.
-        - If the fabric is in deployment-freeze mode.
+        - If the fabric is in deployment-freeze mode and the state mutates configuration.
         - If the query API request fails.
         """
         managed_types = self._managed_policy_types()

--- a/plugins/module_utils/orchestrators/subinterface_managed_interface.py
+++ b/plugins/module_utils/orchestrators/subinterface_managed_interface.py
@@ -58,7 +58,8 @@ class SubinterfaceManagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[Subin
 
     ### RuntimeError
 
-    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `validate_prerequisites` if the fabric does not exist, or is in deployment-freeze mode for a state
+      that mutates configuration.
     - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
     - Via `create` if the create API request fails.
     - Via `update` if the update API request fails.
@@ -241,7 +242,7 @@ class SubinterfaceManagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[Subin
         ### RuntimeError
 
         - If the fabric does not exist on the target ND node.
-        - If the fabric is in deployment-freeze mode.
+        - If the fabric is in deployment-freeze mode and the state mutates configuration.
         - If the query API request fails.
         """
         managed_policy_types = {e.value for e in SubinterfaceManagedPolicyTypeEnum}

--- a/plugins/module_utils/orchestrators/subinterface_unmanaged_interface.py
+++ b/plugins/module_utils/orchestrators/subinterface_unmanaged_interface.py
@@ -223,7 +223,7 @@ class SubinterfaceUnmanagedInterfaceOrchestrator(NDBaseInterfaceOrchestrator[Sub
         ### RuntimeError
 
         - If the fabric does not exist on the target ND node.
-        - If the fabric is in deployment-freeze mode.
+        - If the fabric is in deployment-freeze mode and the state mutates configuration.
         - If the query API request fails.
         """
         unmanaged_policy_types = {e.value for e in SubinterfaceUnmanagedPolicyTypeEnum}

--- a/plugins/module_utils/orchestrators/svi_interface.py
+++ b/plugins/module_utils/orchestrators/svi_interface.py
@@ -57,7 +57,8 @@ class SviInterfaceOrchestrator(NDBaseInterfaceOrchestrator[SviInterfaceModel]):
 
     ### RuntimeError
 
-    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `validate_prerequisites` if the fabric does not exist, or is in deployment-freeze mode for a state
+      that mutates configuration.
     - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
     - Via `create` if the create API request fails.
     - Via `update` if the update API request fails.
@@ -239,7 +240,7 @@ class SviInterfaceOrchestrator(NDBaseInterfaceOrchestrator[SviInterfaceModel]):
         ### RuntimeError
 
         - If the fabric does not exist on the target ND node.
-        - If the fabric is in deployment-freeze mode.
+        - If the fabric is in deployment-freeze mode and the state mutates configuration.
         - If the query API request fails.
         """
         managed_policy_types = {e.value for e in SviPolicyTypeEnum}

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -35,9 +35,7 @@ from collections.abc import Sequence
 from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switches_vpc_pair import (
-    EpVpcPairGet,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switches_vpc_pair import EpVpcPairGet
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesDelete,
     EpManageInterfacesGet,
@@ -73,7 +71,8 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
 
     ### RuntimeError
 
-    - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
+    - Via `validate_prerequisites` if the fabric does not exist, or is in deployment-freeze mode for a state
+      that mutates configuration.
     - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
     - Via `_resolve_peer_switch_id` if the switch is not in a vPC pair.
     - Via `create` if the create API request fails.
@@ -493,7 +492,7 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         ### RuntimeError
 
         - If the fabric does not exist on the target ND node.
-        - If the fabric is in deployment-freeze mode.
+        - If the fabric is in deployment-freeze mode and the state mutates configuration.
         - If the query API request fails.
         - If an interface echo omits `peerSwitchId` and its switch's vPC pair cannot be resolved.
         """

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -8,15 +8,9 @@ import logging
 from copy import deepcopy
 from typing import Any
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_config_save import (
-    EpFabricConfigSavePost,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_deploy import (
-    EpFabricDeployPost,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switchactions import (
-    EpManageFabricsSwitchActionsDeployPost,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_config_save import EpFabricConfigSavePost
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_actions_deploy import EpFabricDeployPost
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switchactions import EpManageFabricsSwitchActionsDeployPost
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -129,6 +129,50 @@ def has_removals(existing_data: Any, proposed_data: Any) -> bool:
     return False
 
 
+def prune_to_spec(data: Any, options_spec: dict) -> Any:
+    """Prune a dict to only the keys defined by an Ansible argument spec.
+
+    Why this exists: read-only ``gathered`` output is meant to be copy-pasted
+    back as ``config``. The model can carry more than the module exposes
+    (response-only fields such as ``link_id``), and Ansible validates suboptions
+    at every nesting level, so any stray key would fail with "Unsupported
+    parameters". Pruning to the argument spec guarantees a clean round-trip.
+
+    Walks ``data`` in lockstep with ``options_spec`` (an argument spec
+    ``options`` mapping) and keeps only keys the spec declares, recursing into
+    nested ``dict`` and ``list`` of ``dict`` suboptions that carry their own
+    ``options``. Suboptions without an ``options`` mapping (scalars, lists of
+    scalars, free-form dicts) are copied verbatim; recursion stops there so
+    free-form content (e.g. ``template_inputs``) is preserved untouched.
+
+    ``no_log`` suboptions are dropped entirely: a read cannot round-trip a
+    secret, so omitting the key keeps the output idempotent (absent == no
+    change) rather than surfacing an API-returned secret in gathered output.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    pruned = {}
+    for key, value in data.items():
+        if key not in options_spec:
+            continue
+
+        sub_spec = options_spec[key]
+        if isinstance(sub_spec, dict) and sub_spec.get("no_log"):
+            continue
+
+        sub_options = sub_spec.get("options") if isinstance(sub_spec, dict) else None
+
+        if sub_options and sub_spec.get("type") == "dict":
+            pruned[key] = prune_to_spec(value, sub_options) if isinstance(value, dict) else value
+        elif sub_options and sub_spec.get("type") == "list" and sub_spec.get("elements") == "dict":
+            pruned[key] = [prune_to_spec(item, sub_options) for item in value] if isinstance(value, list) else value
+        else:
+            pruned[key] = value
+
+    return pruned
+
+
 def remove_unwanted_keys(data: dict, unwanted_keys: list[str | list[str]]) -> dict:
     """Remove unwanted keys from dict (supports nested paths)."""
     data = deepcopy(data)

--- a/plugins/modules/nd_fabric_update_group.py
+++ b/plugins/modules/nd_fabric_update_group.py
@@ -258,26 +258,14 @@ import logging
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
-    require_pydantic,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.models.fabric_update_group.fabric_update_group import (
-    FabricUpdateGroupModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.fabric_update_group.fabric_update_group import FabricUpdateGroupModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
-    NDConfigCollection,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
-    NDStateMachine,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.fabric_update_group import (
-    FabricUpdateGroupOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
-    ResponseHandler,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.fabric_update_group import FabricUpdateGroupOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender

--- a/plugins/modules/nd_fabric_update_group.py
+++ b/plugins/modules/nd_fabric_update_group.py
@@ -5,7 +5,11 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -28,6 +32,13 @@ options:
   config:
     description:
     - The list of fabric update groups to configure.
+    - Required for O(state=merged) (when O(auto_assign) is not used), O(state=replaced), O(state=overridden), and O(state=deleted).
+    - When provided with O(state=gathered), each item acts as a filter criterion.
+    - For O(state=gathered), every supplied field is a filter criterion. Criteria within one list item use AND semantics,
+      while multiple list items use OR semantics.
+    - "Supported gathered filter properties: O(config.update_group_name), O(config.execution), O(config.contingency),
+      O(config.analysis), O(config.is_maintenance), O(config.is_disruptive_update), O(config.report_selection),
+      O(config.reports)."
     type: list
     elements: dict
     suboptions:
@@ -35,8 +46,9 @@ options:
         description:
         - The name of the update group.
         - The O(config.update_group_name) must be defined when creating, updating or deleting an update group.
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       execution:
         description:
         - The execution strategy for the upgrade run.
@@ -85,7 +97,6 @@ options:
         - When V(false), an ND warning (for example, that upgrading the selected switches would impact all
           roles in the fabric) fails the task. Set V(true) to acknowledge such warnings and apply anyway.
         type: bool
-        default: false
       installation_order_devices:
         description:
         - The order in which switches are upgraded when O(config.execution=serial).
@@ -175,9 +186,11 @@ options:
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       Update groups on ND but not in the configuration will be deleted. Use with caution.
     - Use O(state=deleted) to delete the update groups specified in the configuration.
+    - Use O(state=gathered) to read all user-managed fabric update groups in the fabric without making changes.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
 extends_documentation_fragment:
 - cisco.nd.modules
 - cisco.nd.check_mode
@@ -224,6 +237,18 @@ EXAMPLES = r"""
     fabric_name: SITE1
     auto_assign: roleBased
     state: merged
+
+- name: Gather all fabric update groups
+  cisco.nd.nd_fabric_update_group:
+    fabric_name: SITE1
+    state: gathered
+
+- name: Gather only the update group named leaf_group
+  cisco.nd.nd_fabric_update_group:
+    fabric_name: SITE1
+    config:
+      - update_group_name: leaf_group
+    state: gathered
 """
 
 RETURN = r"""
@@ -233,14 +258,26 @@ import logging
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
-from ansible_collections.cisco.nd.plugins.module_utils.models.fabric_update_group.fabric_update_group import FabricUpdateGroupModel
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.fabric_update_group.fabric_update_group import (
+    FabricUpdateGroupModel,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+    NDConfigCollection,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.fabric_update_group import FabricUpdateGroupOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.fabric_update_group import (
+    FabricUpdateGroupOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
@@ -313,7 +350,7 @@ def _validate_report_analysis_exclusion(module: AnsibleModule) -> None:
 
     Calls `module.fail_json` (which raises) on a conflicting config item.
     """
-    if module.params.get("state") == "deleted":
+    if module.params.get("state") in ("deleted", "gathered"):
         return
     for item in module.params.get("config") or []:
         if not isinstance(item, dict):
@@ -339,6 +376,11 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         mutually_exclusive=[["config", "auto_assign"]],
+        required_if=[
+            ("state", "replaced", ("config",)),
+            ("state", "overridden", ("config",)),
+            ("state", "deleted", ("config",)),
+        ],
     )
     require_pydantic(module)
     setup_logging(module)
@@ -357,7 +399,11 @@ def main():
 
         output = NDOutput(output_level=module.params.get("output_level", "normal"))
         try:
-            module_log.debug("auto_assign begin auto_assign=%s check_mode=%s", auto_assign, module.check_mode)
+            module_log.debug(
+                "auto_assign begin auto_assign=%s check_mode=%s",
+                auto_assign,
+                module.check_mode,
+            )
             _run_auto_assign(module, output)
             module_log.debug("auto_assign end")
             module.exit_json(**output.format())
@@ -372,7 +418,11 @@ def main():
     )
 
     try:
-        module_log.debug("manage_state begin state=%s check_mode=%s", module.params.get("state"), module.check_mode)
+        module_log.debug(
+            "manage_state begin state=%s check_mode=%s",
+            module.params.get("state"),
+            module.check_mode,
+        )
         nd_state_machine.manage_state()
         module_log.debug("manage_state end")
         module.exit_json(**nd_state_machine.output.format())

--- a/plugins/modules/nd_interface_ethernet_access.py
+++ b/plugins/modules/nd_interface_ethernet_access.py
@@ -4,7 +4,11 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -32,23 +36,30 @@ options:
     - Each item specifies the target switch, a list of interface names, and a shared configuration.
     - Multiple switches can be configured in a single task.
     - The structure mirrors the ND Manage Interfaces API payload.
+    - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
+    - Not required for O(state=gathered).
+    - For O(state=gathered), every supplied field is a filter criterion. Criteria within one list item use AND semantics,
+      while multiple list items use OR semantics.
     type: list
     elements: dict
-    required: true
+    required: false
     suboptions:
       switch_ip:
         description:
         - The management IP address of the switch on which to manage the ethernet interfaces.
         - This is resolved to the switch serial number (switchId) internally.
+        - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       interface_names:
         description:
         - The list of ethernet interface names to configure with the same settings.
         - Each name should be in the format C(Ethernet1/1), C(Ethernet1/2), etc.
+        - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
         type: list
         elements: str
-        required: true
+        required: false
       config_data:
         description:
         - The configuration data shared by all interfaces in O(config[].interface_names), following the ND API structure.
@@ -284,9 +295,11 @@ options:
     - Use O(state=deleted) to reset the specified interfaces to their fabric default configuration via the
       C(interfaceActions/normalize) API. Physical ethernet interfaces cannot be truly deleted from a switch;
       this operation is the API equivalent of the NX-OS C(default interface) CLI command.
+    - Use O(state=gathered) to read all accessHost ethernet interfaces in the fabric without making changes.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
 extends_documentation_fragment:
 - cisco.nd.modules
 - cisco.nd.check_mode
@@ -406,6 +419,20 @@ EXAMPLES = r"""
     config_actions:
       deploy: false
     state: merged
+
+- name: Gather all user-managed accessHost interfaces in a fabric
+  cisco.nd.nd_interface_ethernet_access:
+    fabric_name: my_fabric
+    state: gathered
+  register: gathered_access
+
+- name: Gather accessHost interfaces from a specific switch
+  cisco.nd.nd_interface_ethernet_access:
+    fabric_name: my_fabric
+    state: gathered
+    config:
+      - switch_ip: 192.168.1.1
+  register: gathered_access_switch1
 """
 
 RETURN = r"""
@@ -416,7 +443,9 @@ import logging
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import EthernetAccessInterfaceModel
@@ -552,6 +581,34 @@ def expand_config(config_list: list[dict]) -> list[dict]:
     return expanded
 
 
+def expand_gathered_filters(config_list):
+    """
+    Expand interface_names in gathered filter items to singular interface_name.
+
+    Each filter item with interface_names: [A, B] becomes two filter items:
+    {interface_name: A, ...} and {interface_name: B, ...}.
+    Multiple filter items use OR semantics, so this correctly expresses "show me A or B".
+
+    This is the gathered-filter counterpart of expand_config(), which performs
+    the same name-flattening for mutation states. Both exist because the user-facing
+    argspec uses interface_names (list) while the internal model uses interface_name (singular).
+    """
+    if not config_list:
+        return config_list
+    expanded = []
+    for item in config_list:
+        names = item.get("interface_names") or []
+        if names:
+            for name in names:
+                new_item = copy.deepcopy(item)
+                new_item.pop("interface_names", None)
+                new_item["interface_name"] = name
+                expanded.append(new_item)
+        else:
+            expanded.append(copy.deepcopy(item))
+    return expanded
+
+
 def main() -> None:
     """
     # Summary
@@ -571,21 +628,34 @@ def main() -> None:
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=[
+            ("state", "merged", ["config"]),
+            ("state", "replaced", ["config"]),
+            ("state", "overridden", ["config"]),
+            ("state", "deleted", ["config"]),
+        ],
     )
     require_pydantic(module)
     setup_logging(module)
     module_log = logging.getLogger("nd.nd_interface_ethernet_access")
 
     # Expand grouped config (interface_names list) into flat config items (interface_name singular)
-    try:
-        module.params["config"] = expand_config(module.params["config"])
-    except ValueError as e:
-        module.fail_json(msg=f"Configuration error: {e}")
-    module_log.debug(
-        "expand_config done items=%d switches=%d",
-        len(module.params["config"]),
-        len({item.get("switch_ip") for item in module.params["config"]}),
-    )
+    # For gathered state, config may be None or contain filter criteria - expand names only.
+    if module.params["state"] != "gathered":
+        try:
+            module.params["config"] = expand_config(module.params["config"] or [])
+        except ValueError as e:
+            module.fail_json(msg=f"Configuration error: {e}")
+        module_log.debug(
+            "expand_config done items=%d switches=%d",
+            len(module.params["config"]),
+            len({item.get("switch_ip") for item in module.params["config"]}),
+        )
+    else:
+        try:
+            module.params["config"] = expand_gathered_filters(module.params.get("config"))
+        except (ValueError, TypeError) as e:
+            module.fail_json(msg=f"Gathered filter error: {e}")
 
     nd_state_machine = None
 
@@ -614,7 +684,7 @@ def main() -> None:
         module_log.debug("manage_state end")
 
         # Execute all queued bulk operations
-        if not module.check_mode:
+        if not module.check_mode and module.params["state"] != "gathered":
             nd_state_machine.model_orchestrator.remove_pending()
             nd_state_machine.model_orchestrator.deploy_pending()
 

--- a/plugins/modules/nd_interface_ethernet_access.py
+++ b/plugins/modules/nd_interface_ethernet_access.py
@@ -443,9 +443,7 @@ import logging
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
-    NDStateMachineError,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import EthernetAccessInterfaceModel

--- a/plugins/modules/nd_interface_ethernet_trunk_host.py
+++ b/plugins/modules/nd_interface_ethernet_trunk_host.py
@@ -32,23 +32,29 @@ options:
     - Each item specifies the target switch, a list of interface names, and a shared configuration.
     - Multiple switches can be configured in a single task.
     - The structure mirrors the ND Manage Interfaces API payload.
+    - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
+    - Not required for O(state=gathered).
+    - For O(state=gathered), every supplied field is a filter criterion. Criteria within one list item use AND semantics,
+      while multiple list items use OR semantics.
     type: list
     elements: dict
-    required: true
+    required: false
     suboptions:
       switch_ip:
         description:
         - The management IP address of the switch on which to manage the ethernet interfaces.
         - This is resolved to the switch serial number (switchId) internally.
+        - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
         type: str
-        required: true
+        required: false
       interface_names:
         description:
         - The list of ethernet interface names to configure with the same settings.
         - Each name should be in the format C(Ethernet1/1), C(Ethernet1/2), etc.
+        - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
         type: list
         elements: str
-        required: true
+        required: false
       config_data:
         description:
         - The configuration data shared by all interfaces in O(config[].interface_names), following the ND API structure.
@@ -305,9 +311,11 @@ options:
     - Use O(state=deleted) to reset the specified interfaces to their fabric default configuration via the
       C(interfaceActions/normalize) API. Physical ethernet interfaces cannot be truly deleted from a switch;
       this operation is the API equivalent of the NX-OS C(default interface) CLI command.
+    - Use O(state=gathered) to read all user-managed trunkHost interfaces in the fabric without making changes.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
 extends_documentation_fragment:
 - cisco.nd.modules
 - cisco.nd.check_mode
@@ -468,6 +476,43 @@ EXAMPLES = r"""
     config_actions:
       deploy: false
     state: merged
+
+- name: Gather all user-managed trunkHost interfaces in a fabric
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    fabric_name: my_fabric
+    state: gathered
+  register: gathered_trunks
+
+- name: Gather trunkHost interfaces from a specific switch
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    fabric_name: my_fabric
+    state: gathered
+    config:
+      - switch_ip: 192.168.1.1
+  register: gathered_trunks_switch1
+
+- name: Gather trunkHost interfaces with admin_state filter
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    fabric_name: my_fabric
+    state: gathered
+    config:
+      - config_data:
+          network_os:
+            policy:
+              admin_state: false
+  register: shutdown_trunks
+
+- name: Gather trunkHost interfaces with a specific allowed_vlans on a switch
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    fabric_name: my_fabric
+    state: gathered
+    config:
+      - switch_ip: 192.168.1.1
+        config_data:
+          network_os:
+            policy:
+              allowed_vlans: "100-200"
+  register: vlan_100_200_trunks
 """
 
 RETURN = r"""
@@ -551,6 +596,13 @@ msg:
   returned: on failure
   type: str
   sample: "Configuration error: ..."
+gathered:
+  description:
+  - User-managed trunkHost interfaces matching the supplied O(config) filters.
+  - Returned in reusable Ansible configuration format.
+  returned: when O(state=gathered)
+  type: list
+  elements: dict
 """
 
 import copy
@@ -694,6 +746,36 @@ def expand_config(config_list: list[dict]) -> list[dict]:
     return expanded
 
 
+def expand_gathered_filters(config_list):
+    """
+    Expand interface_names in gathered filter items to singular interface_name.
+
+    Each filter item with interface_names: [A, B] becomes two filter items:
+    {interface_name: A, ...} and {interface_name: B, ...}.
+    Multiple filter items use OR semantics, so this correctly expresses
+    "show me A OR B".
+
+    This is the gathered-filter counterpart of expand_config(), which performs
+    the same name-flattening for mutation states. Both exist because the user-facing
+    argspec uses interface_names (list) while the internal model uses interface_name
+    (singular).
+    """
+    if not config_list:
+        return config_list
+    expanded = []
+    for item in config_list:
+        names = item.get("interface_names", None) or []
+        if names:
+            for name in names:
+                new_item = copy.deepcopy(item)
+                new_item.pop("interface_names", None)
+                new_item["interface_name"] = name
+                expanded.append(new_item)
+        else:
+            expanded.append(copy.deepcopy(item))
+    return expanded
+
+
 def main() -> None:
     """
     # Summary
@@ -720,21 +802,33 @@ def main() -> None:
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=[
+            ("state", "merged", ["config"]),
+            ("state", "replaced", ["config"]),
+            ("state", "overridden", ["config"]),
+            ("state", "deleted", ["config"]),
+        ],
     )
     require_pydantic(module)
     setup_logging(module)
     module_log = logging.getLogger("nd.nd_interface_ethernet_trunk_host")
 
     # Expand grouped config (interface_names list) into flat config items (interface_name singular)
-    try:
-        module.params["config"] = expand_config(module.params["config"])
-    except ValueError as e:
-        module.fail_json(msg=f"Configuration error: {e}")
-    module_log.debug(
-        "expand_config done items=%d switches=%d",
-        len(module.params["config"]),
-        len({item.get("switch_ip") for item in module.params["config"]}),
-    )
+    if module.params["state"] != "gathered":
+        try:
+            module.params["config"] = expand_config(module.params["config"])
+        except ValueError as e:
+            module.fail_json(msg=f"Configuration error: {e}")
+        module_log.debug(
+            "expand_config done items=%d switches=%d",
+            len(module.params["config"]),
+            len({item.get("switch_ip") for item in module.params["config"]}),
+        )
+    else:
+        try:
+            module.params["config"] = expand_gathered_filters(module.params.get("config"))
+        except (ValueError, TypeError) as e:
+            module.fail_json(msg=f"Gathered filter error: {e}")
 
     nd_state_machine = None
 
@@ -763,7 +857,7 @@ def main() -> None:
         module_log.debug("manage_state end")
 
         # Execute all queued bulk operations
-        if not module.check_mode:
+        if not module.check_mode and module.params["state"] != "gathered":
             nd_state_machine.model_orchestrator.remove_pending()
             nd_state_machine.model_orchestrator.deploy_pending()
 

--- a/plugins/modules/nd_interface_loopback.py
+++ b/plugins/modules/nd_interface_loopback.py
@@ -32,21 +32,31 @@ options:
     - Each item specifies the target switch and interface configuration.
     - Multiple switches can be configured in a single task.
     - The structure mirrors the ND Manage Interfaces API payload.
+    - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
+    - Not required for O(state=gathered).
+    - For O(state=gathered), every supplied field is a filter criterion. Criteria within one list item use AND semantics,
+      while multiple list items use OR semantics.
+    - Supported endpoint criteria are used to reduce candidates with server-side Lucene queries. All criteria are then
+      evaluated locally to preserve complete and consistent matching semantics.
     type: list
     elements: dict
-    required: true
+    required: false
     suboptions:
       switch_ip:
         description:
         - The management IP address of the switch on which to manage this loopback interface.
         - This is resolved to the switch serial number (switchId) internally.
+        - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       interface_name:
         description:
         - The name of the loopback interface (e.g., C(loopback0), C(Loopback10)).
+        - Required for O(state=merged), O(state=replaced), O(state=overridden), and O(state=deleted).
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       config_data:
         description:
         - The configuration data for the interface, following the ND API structure.
@@ -222,9 +232,11 @@ options:
       Loopback interfaces with any other policy type, such as the system-provisioned NX-OS C(underlayLoopback) or C(userDefined),
       are never modified or deleted by this module.
     - Use O(state=deleted) to remove the resources specified in the configuration from the Cisco Nexus Dashboard.
+    - Use O(state=gathered) to read all user-managed loopback interfaces in the fabric without making changes.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
 extends_documentation_fragment:
 - cisco.nd.modules
 - cisco.nd.check_mode
@@ -594,6 +606,21 @@ EXAMPLES = r"""
     config_actions:
       deploy: true
     state: merged
+
+- name: Gather all user-managed loopback interfaces in a fabric
+  cisco.nd.nd_interface_loopback:
+    fabric_name: my_fabric
+    state: gathered
+  register: gathered_loopbacks
+
+- name: Gather one loopback interface from a specific switch
+  cisco.nd.nd_interface_loopback:
+    fabric_name: my_fabric
+    state: gathered
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Loopback10
+  register: gathered_loopback10
 """
 
 RETURN = r"""
@@ -647,6 +674,13 @@ after:
           admin_state: true
           ip: 10.1.1.2
           vrf: management
+gathered:
+  description:
+  - User-managed loopback interfaces matching the supplied O(config) filters.
+  - Returned in reusable Ansible configuration format.
+  returned: when O(state=gathered)
+  type: list
+  elements: dict
 diff:
   description: The per-interface difference between C(before) and C(after).
   returned: always
@@ -687,6 +721,7 @@ msg:
   returned: on failure
   type: str
   sample: "Configuration error: ..."
+
 """
 # pylint: disable=wrong-import-position
 
@@ -755,6 +790,12 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=[
+            ("state", "merged", ["config"]),
+            ("state", "replaced", ["config"]),
+            ("state", "overridden", ["config"]),
+            ("state", "deleted", ["config"]),
+        ],
     )
     require_pydantic(module)
     setup_logging(module)
@@ -787,7 +828,7 @@ def main():
         module_log.debug("manage_state end")
 
         # Execute all queued bulk operations
-        if not module.check_mode:
+        if not module.check_mode and module.params["state"] != "gathered":
             nd_state_machine.model_orchestrator.remove_pending()
             nd_state_machine.model_orchestrator.deploy_pending()
 

--- a/plugins/modules/nd_interface_loopback.py
+++ b/plugins/modules/nd_interface_loopback.py
@@ -729,7 +729,9 @@ import logging
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel

--- a/plugins/modules/nd_interface_loopback.py
+++ b/plugins/modules/nd_interface_loopback.py
@@ -729,9 +729,7 @@ import logging
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
-    NDStateMachineError,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
@@ -804,6 +802,7 @@ def main():
     module_log = logging.getLogger("nd.nd_interface_loopback")
 
     nd_state_machine = None
+    verbosity = module._verbosity
 
     try:
         # Initialize StateMachine
@@ -834,11 +833,11 @@ def main():
             nd_state_machine.model_orchestrator.remove_pending()
             nd_state_machine.model_orchestrator.deploy_pending()
 
-        module.exit_json(**nd_state_machine.output.format())
+        module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except NDStateMachineError as e:
         module_log.exception("NDStateMachineError during module execution")
-        output = nd_state_machine.output.format() if nd_state_machine else {}
+        output = nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results) if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
         error_msg += _finalize_accepted_intent(nd_state_machine, module, module_log)
         if module.params.get("output_level") == "debug":

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -13,16 +13,18 @@ version_added: "1.6.0"
 short_description: Manage local users on Cisco Nexus Dashboard
 description:
 - Manage local users on Cisco Nexus Dashboard (ND).
-- It supports creating, updating, and deleting local users.
+- It supports creating, updating, deleting, gathering, and filtering local users.
 author:
 - Gaspard Micol (@gmicol)
 options:
   config:
     description:
     - The list of the local users to configure.
+    - When O(state=gathered), O(config) may be omitted to return all local users or contain O(config.login_id) to filter the results.
+      Other configuration options are not supported as gathered-state filters.
     type: list
     elements: dict
-    required: True
+    required: false
     suboptions:
       email:
         description:
@@ -32,8 +34,10 @@ options:
         description:
         - The login ID of the local user.
         - The O(config.login_id) must be defined when creating, updating or deleting a local user.
+        - Required for local-user resources in write states.
+        - Optional as a filtering criterion when O(state=gathered).
         type: str
-        required: true
+        required: false
       first_name:
         description:
         - The first name of the local user.
@@ -100,9 +104,11 @@ options:
       The resources on ND will be modified to exactly match the configuration.
       Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
     - Use O(state=deleted) to remove the resources specified in the configuration from the Cisco Nexus Dashboard.
+    - Use O(state=gathered) to return local users matching O(config).
+      When O(config) is omitted, all local users are returned.
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
 extends_documentation_fragment:
 - cisco.nd.modules
 - cisco.nd.check_mode
@@ -166,6 +172,19 @@ EXAMPLES = r"""
     config:
       - login_id: local_user
     state: deleted
+
+- name: Gather all local users
+  cisco.nd.nd_local_user:
+    state: gathered
+  register: gathered_local_users
+
+- name: Gather a local user by login ID
+  cisco.nd.nd_local_user:
+    state: gathered
+    config:
+      - login_id: local_user
+  register: gathered_local_user
+
 """
 
 RETURN = r"""
@@ -186,8 +205,16 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=[
+            ("state", "merged", ["config"]),
+            ("state", "replaced", ["config"]),
+            ("state", "overridden", ["config"]),
+            ("state", "deleted", ["config"]),
+        ],
     )
     require_pydantic(module)
+
+    nd_state_machine = None
 
     try:
         # Initialize StateMachine
@@ -203,7 +230,8 @@ def main():
         module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
 
     except Exception as e:
-        module.fail_json(msg=f"Module execution failed: {str(e)}", **nd_state_machine.output.format())
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        module.fail_json(msg=f"Module execution failed: {str(e)}", **output)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -20,8 +20,9 @@ options:
   config:
     description:
     - The list of the local users to configure.
-    - When O(state=gathered), O(config) may be omitted to return all local users or contain O(config.login_id) to filter the results.
-      Other configuration options are not supported as gathered-state filters.
+    - When O(state=gathered), O(config) may be omitted to return all local users or provided with filter criteria.
+      Supported gathered filter properties are O(config.login_id), O(config.email), O(config.first_name), and O(config.last_name).
+      Unsupported filter properties cause the module to fail before any API requests are made.
     type: list
     elements: dict
     required: false
@@ -29,6 +30,7 @@ options:
       email:
         description:
         - The email address of the local user.
+        - Optional filter for O(state=gathered).
         type: str
       login_id:
         description:
@@ -41,10 +43,12 @@ options:
       first_name:
         description:
         - The first name of the local user.
+        - Optional filter for O(state=gathered).
         type: str
       last_name:
         description:
         - The last name of the local user.
+        - Optional filter for O(state=gathered).
         type: str
       user_password:
         description:

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -4,7 +4,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -188,7 +192,6 @@ EXAMPLES = r"""
     config:
       - login_id: local_user
   register: gathered_local_user
-
 """
 
 RETURN = r"""
@@ -196,10 +199,18 @@ RETURN = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
+    LocalUserModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import (
+    LocalUserOrchestrator,
+)
 
 
 def main():

--- a/plugins/modules/nd_local_user.py
+++ b/plugins/modules/nd_local_user.py
@@ -199,18 +199,10 @@ RETURN = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
-    NDStateMachine,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
-    require_pydantic,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
-    LocalUserModel,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import (
-    LocalUserOrchestrator,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
 
 
 def main():

--- a/plugins/modules/nd_manage_fabric_ai_ebgp_vxlan.py
+++ b/plugins/modules/nd_manage_fabric_ai_ebgp_vxlan.py
@@ -18,7 +18,7 @@ version_added: "2.0.0"
 short_description: Manage AI/ML eBGP VXLAN fabrics on Cisco Nexus Dashboard
 description:
 - Manage AI/ML eBGP VXLAN fabrics on Cisco Nexus Dashboard (ND).
-- It supports creating, updating, replacing, and deleting AI/ML eBGP VXLAN fabrics.
+- It supports creating, updating, replacing, deleting and gathering AI/ML eBGP VXLAN fabrics.
 - AI/ML eBGP VXLAN fabrics are optimized for AI and machine learning workloads using eBGP underlay with VXLAN overlay.
 - The AI/ML eBGP VXLAN fabric type (C(aimlVxlanEbgp)) shares the same management properties as the standard eBGP VXLAN
   fabric type (C(vxlanEbgp)), but is specifically designated for AI/ML workloads.
@@ -28,16 +28,25 @@ options:
   config:
     description:
     - The list of AI/ML eBGP VXLAN fabrics to configure.
+    - For O(state=gathered), O(config) may be omitted to return all AI/ML eBGP VXLAN fabrics.
+    - When O(config) is provided with O(state=gathered), every supplied supported property acts as a filter criterion.
+      Criteria within one list item use AND semantics, while multiple list items use OR semantics.
+    - Omitted properties are not used as gathered filter criteria, even when those properties have documented defaults.
+    - "Supported gathered filter properties: O(config.fabric_name), O(config.license_tier),
+      O(config.security_domain), O(config.alert_suspend), and O(config.telemetry_collection)."
+    - Other properties, including properties under O(config.management), are not supported as gathered filter criteria.
     type: list
     elements: dict
+    required: false
     suboptions:
       fabric_name:
         description:
         - The name of the fabric.
         - Only letters, numbers, underscores, and hyphens are allowed.
         - The O(config.fabric_name) must be defined when creating, updating or deleting a fabric.
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       location:
         description:
         - The geographic location of the fabric.
@@ -56,18 +65,21 @@ options:
       license_tier:
         description:
         - The License Tier for fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: essentials
         choices: [ essentials, advantage, premier ]
       alert_suspend:
         description:
         - The Alert Suspend state configured on the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: disabled
         choices: [ enabled, disabled ]
       telemetry_collection:
         description:
         - Enable telemetry collection.
+        - Optional filter for O(state=gathered).
         type: bool
         default: false
       telemetry_collection_type:
@@ -95,6 +107,7 @@ options:
       security_domain:
         description:
         - The Security Domain associated with the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: all
       management:
@@ -1363,14 +1376,18 @@ options:
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       Any fabric existing on ND but not present in the configuration will be deleted. Use with extra caution.
     - Use O(state=deleted) to remove the fabrics specified in the configuration from the Cisco Nexus Dashboard.
+    - Use O(state=gathered) to read AI/ML eBGP VXLAN fabric configurations from Nexus Dashboard without making changes.
+      Omit O(config) to gather all AI/ML eBGP VXLAN fabrics, or provide O(config) to return matching fabrics.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
   config_actions:
     description:
     - Controls save and deploy behavior after fabric configuration is updated.
     - Save writes pending configuration to the controller.
     - Deploy pushes the saved configuration to switches.
+    - Must not enable O(config_actions.save) or O(config_actions.deploy) when O(state=gathered).
     - Skipped automatically when O(state=deleted) or when no changes are made.
     type: dict
     suboptions:
@@ -1653,6 +1670,22 @@ EXAMPLES = r"""
       - fabric_name: fabric_west
       - fabric_name: fabric_old
   register: result
+
+- name: Gather all AI/ML eBGP VXLAN fabrics
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    state: gathered
+  register: result
+
+- name: Gather selected AI/ML eBGP VXLAN fabrics
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    state: gathered
+    config:
+      - fabric_name: ai_fabric_east
+      - license_tier: premier
+        security_domain: production
+        alert_suspend: disabled
+        telemetry_collection: true
+  register: filtered_result
 """
 
 RETURN = r"""
@@ -1745,6 +1778,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=FabricAiEbgpVxlanModel.get_required_if(),
     )
 
     require_pydantic(module)
@@ -1757,6 +1791,9 @@ def main():
     deploy = config_actions.get("deploy", False)
     deploy_type = config_actions.get("type", "switch")
     state = module.params.get("state", "merged")
+
+    if state == "gathered" and (save or deploy):
+        module.fail_json(msg="config_actions.save and config_actions.deploy are not valid with state=gathered.")
 
     try:
         ManageAiEbgpVxlanFabricOrchestrator.validate_config_actions(save=save, deploy=deploy, deploy_type=deploy_type)

--- a/plugins/modules/nd_manage_fabric_ai_ibgp_vxlan.py
+++ b/plugins/modules/nd_manage_fabric_ai_ibgp_vxlan.py
@@ -18,7 +18,7 @@ version_added: "2.0.0"
 short_description: Manage AI/ML iBGP VXLAN fabrics on Cisco Nexus Dashboard
 description:
 - Manage AI/ML iBGP VXLAN fabrics on Cisco Nexus Dashboard (ND).
-- It supports creating, updating, replacing, and deleting AI/ML iBGP VXLAN fabrics.
+- It supports creating, updating, replacing, deleting, and gathering AI/ML iBGP VXLAN fabrics.
 - AI/ML iBGP VXLAN fabrics are optimized for AI and machine learning workloads using iBGP underlay with VXLAN overlay.
 - The AI/ML iBGP VXLAN fabric type (C(aimlVxlanIbgp)) shares the same management properties as the standard iBGP VXLAN
   fabric type (C(vxlanIbgp)), but is specifically designated for AI/ML workloads.
@@ -28,16 +28,25 @@ options:
   config:
     description:
     - The list of AI/ML iBGP VXLAN fabrics to configure.
+    - For O(state=gathered), O(config) may be omitted to return all AI/ML iBGP VXLAN fabrics.
+    - When O(config) is provided with O(state=gathered), every supplied supported property acts as a filter criterion.
+      Criteria within one list item use AND semantics, while multiple list items use OR semantics.
+    - Omitted properties are not used as gathered filter criteria, even when those properties have documented defaults.
+    - "Supported gathered filter properties: O(config.fabric_name), O(config.license_tier),
+      O(config.security_domain), O(config.alert_suspend), and O(config.telemetry_collection)."
+    - Other properties, including properties under O(config.management), are not supported as gathered filter criteria.
     type: list
     elements: dict
+    required: false
     suboptions:
       fabric_name:
         description:
         - The name of the fabric.
         - Only letters, numbers, underscores, and hyphens are allowed.
         - The O(config.fabric_name) must be defined when creating, updating or deleting a fabric.
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       location:
         description:
         - The geographic location of the fabric.
@@ -56,18 +65,21 @@ options:
       license_tier:
         description:
         - The License Tier for fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: essentials
         choices: [ essentials, advantage, premier ]
       alert_suspend:
         description:
         - The Alert Suspend state configured on the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: disabled
         choices: [ enabled, disabled ]
       telemetry_collection:
         description:
         - Enable telemetry collection.
+        - Optional filter for O(state=gathered).
         type: bool
         default: false
       telemetry_collection_type:
@@ -95,6 +107,7 @@ options:
       security_domain:
         description:
         - The Security Domain associated with the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: all
       management:
@@ -1562,14 +1575,18 @@ options:
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       Any fabric existing on ND but not present in the configuration will be deleted. Use with extra caution.
     - Use O(state=deleted) to remove the fabrics specified in the configuration from the Cisco Nexus Dashboard.
+    - Use O(state=gathered) to read AI/ML iBGP VXLAN fabric configurations from Nexus Dashboard without making changes.
+      Omit O(config) to gather all AI/ML iBGP VXLAN fabrics, or provide O(config) to return matching fabrics.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
   config_actions:
     description:
     - Controls save and deploy behavior after fabric configuration is updated.
     - Save writes pending configuration to the controller.
     - Deploy pushes the saved configuration to switches.
+    - Must not enable O(config_actions.save) or O(config_actions.deploy) when O(state=gathered).
     - Skipped automatically when O(state=deleted) or when no changes are made.
     type: dict
     suboptions:
@@ -1676,6 +1693,22 @@ EXAMPLES = r"""
       - fabric_name: ai_ibgp_fabric_1
       - fabric_name: ai_ibgp_fabric_2
   register: result
+
+- name: Gather all AI/ML iBGP VXLAN fabrics
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    state: gathered
+  register: result
+
+- name: Gather selected AI/ML iBGP VXLAN fabrics
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    state: gathered
+    config:
+      - fabric_name: ai_ibgp_fabric_east
+      - license_tier: premier
+        security_domain: production
+        alert_suspend: disabled
+        telemetry_collection: true
+  register: filtered_result
 """
 
 RETURN = r"""
@@ -1768,6 +1801,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=FabricAiIbgpVxlanModel.get_required_if(),
     )
 
     require_pydantic(module)
@@ -1780,6 +1814,9 @@ def main():
     deploy = config_actions.get("deploy", False)
     deploy_type = config_actions.get("type", "switch")
     state = module.params.get("state", "merged")
+
+    if state == "gathered" and (save or deploy):
+        module.fail_json(msg="config_actions.save and config_actions.deploy are not valid with state=gathered.")
 
     try:
         ManageAiIbgpVxlanFabricOrchestrator.validate_config_actions(save=save, deploy=deploy, deploy_type=deploy_type)

--- a/plugins/modules/nd_manage_fabric_ebgp_vxlan.py
+++ b/plugins/modules/nd_manage_fabric_ebgp_vxlan.py
@@ -9,7 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -18,7 +22,7 @@ version_added: "2.0.0"
 short_description: Manage eBGP VXLAN fabrics on Cisco Nexus Dashboard
 description:
 - Manage eBGP VXLAN fabrics on Cisco Nexus Dashboard (ND).
-- It supports creating, updating, replacing, and deleting eBGP VXLAN fabrics.
+- It supports creating, updating, replacing, deleting, and gathering eBGP VXLAN fabrics.
 author:
 - Mike Wiebe (@mwiebe)
 - Matt Tarkington (@mtarking)
@@ -26,16 +30,25 @@ options:
   config:
     description:
     - The list of eBGP VXLAN fabrics to configure.
+    - For O(state=gathered), O(config) may be omitted to return all eBGP VXLAN fabrics.
+    - When O(config) is provided with O(state=gathered), every supplied property acts as a filter criterion.
+      Criteria within one list item use AND semantics, while multiple list items use OR semantics.
+    - Omitted properties are not used as gathered filter criteria, even when those properties have documented defaults.
+    - "Supported gathered filter properties: O(config.fabric_name), O(config.license_tier),
+      O(config.security_domain), O(config.alert_suspend), and O(config.telemetry_collection)."
+    - Other properties, including properties under O(config.management), are not supported as gathered filter criteria.
     type: list
     elements: dict
+    required: false
     suboptions:
       fabric_name:
         description:
         - The name of the fabric.
         - Only letters, numbers, underscores, and hyphens are allowed.
         - The O(config.fabric_name) must be defined when creating, updating or deleting a fabric.
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       location:
         description:
         - The geographic location of the fabric.
@@ -54,18 +67,21 @@ options:
       license_tier:
         description:
         - The license tier for the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: essentials
         choices: [ essentials, advantage, premier ]
       alert_suspend:
         description:
         - The alert suspension state for the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: disabled
         choices: [ enabled, disabled ]
       telemetry_collection:
         description:
         - Enable telemetry collection for the fabric.
+        - Optional filter for O(state=gathered).
         type: bool
         default: false
       telemetry_collection_type:
@@ -91,6 +107,7 @@ options:
       security_domain:
         description:
         - The security domain associated with the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: all
       management:
@@ -1353,14 +1370,18 @@ options:
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       Any fabric existing on ND but not present in the configuration will be deleted. Use with extra caution.
     - Use O(state=deleted) to remove the fabrics specified in the configuration from the Cisco Nexus Dashboard.
+    - Use O(state=gathered) to read eBGP VXLAN fabric configurations from Nexus Dashboard without making changes.
+      Omit O(config) to gather all eBGP VXLAN fabrics, or provide O(config) to return matching fabrics.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
   config_actions:
     description:
     - Controls save and deploy behavior after fabric configuration is updated.
     - Save writes pending configuration to the controller.
     - Deploy pushes the saved configuration to switches.
+    - Must not enable O(config_actions.save) or O(config_actions.deploy) when O(state=gathered).
     - Skipped automatically when O(state=deleted) or when no changes are made.
     type: dict
     suboptions:
@@ -1643,6 +1664,22 @@ EXAMPLES = r"""
       - fabric_name: fabric_west
       - fabric_name: fabric_old
   register: result
+
+- name: Gather all eBGP VXLAN fabrics
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    state: gathered
+  register: result
+
+- name: Gather selected eBGP VXLAN fabrics
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    state: gathered
+    config:
+      - fabric_name: fabric_east
+      - license_tier: advantage
+        security_domain: production
+        alert_suspend: disabled
+        telemetry_collection: true
+  register: filtered_result
 """
 
 RETURN = r"""
@@ -1721,11 +1758,21 @@ api_payload:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ebgp_vxlan import FabricEbgpModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ebgp_vxlan import ManageEbgpFabricOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ebgp_vxlan import (
+    FabricEbgpModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ebgp_vxlan import (
+    ManageEbgpFabricOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
 
 
 def main():
@@ -1735,6 +1782,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=FabricEbgpModel.get_required_if(),
     )
 
     require_pydantic(module)
@@ -1747,6 +1795,9 @@ def main():
     deploy = config_actions.get("deploy", False)
     deploy_type = config_actions.get("type", "switch")
     state = module.params.get("state", "merged")
+
+    if state == "gathered" and (save or deploy):
+        module.fail_json(msg="config_actions.save and config_actions.deploy are not valid with state=gathered.")
 
     try:
         ManageEbgpFabricOrchestrator.validate_config_actions(save=save, deploy=deploy, deploy_type=deploy_type)

--- a/plugins/modules/nd_manage_fabric_external.py
+++ b/plugins/modules/nd_manage_fabric_external.py
@@ -9,7 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -18,7 +22,7 @@ version_added: "2.0.0"
 short_description: Manage External Connectivity fabrics on Cisco Nexus Dashboard
 description:
 - Manage External Connectivity fabrics on Cisco Nexus Dashboard (ND).
-- It supports creating, updating, replacing, and deleting External Connectivity fabrics.
+- It supports creating, updating, replacing, deleting, and gathering External Connectivity fabrics.
 author:
 - Mike Wiebe (@mwiebe)
 - Matt Tarkington (@mtarking)
@@ -26,16 +30,25 @@ options:
   config:
     description:
     - The list of External Connectivity fabrics to configure.
+    - For O(state=gathered), O(config) may be omitted to return all External Connectivity fabrics.
+    - When O(config) is provided with O(state=gathered), every supplied supported property acts as a filter criterion.
+      Criteria within one list item use AND semantics, while multiple list items use OR semantics.
+    - Omitted properties are not used as gathered filter criteria, even when those properties have documented defaults.
+    - "Supported gathered filter properties: O(config.fabric_name), O(config.license_tier),
+      O(config.security_domain), O(config.alert_suspend), and O(config.telemetry_collection)."
+    - Other properties are not supported as gathered filter criteria.
     type: list
     elements: dict
+    required: false
     suboptions:
       fabric_name:
         description:
         - The name of the fabric.
         - Only letters, numbers, underscores, and hyphens are allowed.
         - The O(config.fabric_name) must be defined when creating, updating or deleting a fabric.
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       location:
         description:
         - The geographic location of the fabric.
@@ -54,18 +67,21 @@ options:
       license_tier:
         description:
         - License Tier value of a fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: essentials
         choices: [ essentials, advantage, premier ]
       alert_suspend:
         description:
         - Alert Suspend state configured on the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: disabled
         choices: [ enabled, disabled ]
       telemetry_collection:
         description:
         - Enable telemetry collection for the fabric.
+        - Optional filter for O(state=gathered).
         type: bool
         default: false
       telemetry_collection_type:
@@ -93,6 +109,7 @@ options:
       security_domain:
         description:
         - Security Domain associated with the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: all
       management:
@@ -599,14 +616,18 @@ options:
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       Any fabric existing on ND but not present in the configuration will be deleted. Use with extra caution.
     - Use O(state=deleted) to remove the fabrics specified in the configuration from the Cisco Nexus Dashboard.
+    - Use O(state=gathered) to read External Connectivity fabric configurations from Nexus Dashboard without making changes.
+      Omit O(config) to gather all External Connectivity fabrics, or provide O(config) to return matching fabrics.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
   config_actions:
     description:
     - Controls save and deploy behavior after fabric configuration is updated.
     - Save writes pending configuration to the controller.
     - Deploy pushes the saved configuration to switches.
+    - Must not enable O(config_actions.save) or O(config_actions.deploy) when O(state=gathered).
     - Skipped automatically when O(state=deleted) or when no changes are made.
     type: dict
     suboptions:
@@ -746,6 +767,22 @@ EXAMPLES = r"""
       - fabric_name: ext_fabric_east
       - fabric_name: ext_fabric_west
   register: result
+
+- name: Gather all External Connectivity fabrics
+  cisco.nd.nd_manage_fabric_external:
+    state: gathered
+  register: result
+
+- name: Gather selected External Connectivity fabrics
+  cisco.nd.nd_manage_fabric_external:
+    state: gathered
+    config:
+      - fabric_name: ext_fabric_east
+      - license_tier: advantage
+        security_domain: production
+        alert_suspend: disabled
+        telemetry_collection: true
+  register: filtered_result
 """
 
 RETURN = r"""
@@ -824,11 +861,21 @@ api_payload:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_external import FabricExternalConnectivityModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_external import ManageExternalFabricOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_external import (
+    FabricExternalConnectivityModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_external import (
+    ManageExternalFabricOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
 
 
 def main():
@@ -838,6 +885,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=FabricExternalConnectivityModel.get_required_if(),
     )
 
     require_pydantic(module)
@@ -850,6 +898,9 @@ def main():
     deploy = config_actions.get("deploy", False)
     deploy_type = config_actions.get("type", "switch")
     state = module.params.get("state", "merged")
+
+    if state == "gathered" and (save or deploy):
+        module.fail_json(msg="config_actions.save and config_actions.deploy are not valid with state=gathered.")
 
     try:
         ManageExternalFabricOrchestrator.validate_config_actions(save=save, deploy=deploy, deploy_type=deploy_type)

--- a/plugins/modules/nd_manage_fabric_ibgp_vxlan.py
+++ b/plugins/modules/nd_manage_fabric_ibgp_vxlan.py
@@ -9,7 +9,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -18,7 +22,7 @@ version_added: "2.0.0"
 short_description: Manage iBGP VXLAN fabrics on Cisco Nexus Dashboard
 description:
 - Manage iBGP VXLAN fabrics on Cisco Nexus Dashboard (ND).
-- It supports creating, updating, replacing, and deleting iBGP VXLAN fabrics.
+- It supports creating, updating, replacing, deleting, and gathering iBGP VXLAN fabrics.
 author:
 - Mike Wiebe (@mwiebe)
 - Matt Tarkington (@mtarking)
@@ -26,16 +30,25 @@ options:
   config:
     description:
     - The list of iBGP VXLAN fabrics to configure.
+    - For O(state=gathered), O(config) may be omitted to return all iBGP VXLAN fabrics.
+    - When O(config) is provided with O(state=gathered), every supplied supported property acts as a filter criterion.
+      Criteria within one list item use AND semantics, while multiple list items use OR semantics.
+    - Omitted properties are not used as gathered filter criteria, even when those properties have documented defaults.
+    - "Supported gathered filter properties: O(config.fabric_name), O(config.license_tier),
+      O(config.security_domain), O(config.alert_suspend), and O(config.telemetry_collection)."
+    - Other properties, including properties under O(config.management), are not supported as gathered filter criteria.
     type: list
     elements: dict
+    required: false
     suboptions:
       fabric_name:
         description:
         - The name of the fabric.
         - Only letters, numbers, underscores, and hyphens are allowed.
         - The O(config.fabric_name) must be defined when creating, updating or deleting a fabric.
+        - Optional filter for O(state=gathered).
         type: str
-        required: true
+        required: false
       location:
         description:
         - The geographic location of the fabric.
@@ -54,18 +67,21 @@ options:
       license_tier:
         description:
         - The license tier for the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: essentials
         choices: [ essentials, advantage, premier ]
       alert_suspend:
         description:
         - The alert suspension state for the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: disabled
         choices: [ enabled, disabled ]
       telemetry_collection:
         description:
         - Enable telemetry collection for the fabric.
+        - Optional filter for O(state=gathered).
         type: bool
         default: false
       telemetry_collection_type:
@@ -91,6 +107,7 @@ options:
       security_domain:
         description:
         - The security domain associated with the fabric.
+        - Optional filter for O(state=gathered).
         type: str
         default: all
       management:
@@ -1558,14 +1575,18 @@ options:
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       Any fabric existing on ND but not present in the configuration will be deleted. Use with extra caution.
     - Use O(state=deleted) to remove the fabrics specified in the configuration from the Cisco Nexus Dashboard.
+    - Use O(state=gathered) to read iBGP VXLAN fabric configurations from Nexus Dashboard without making changes.
+      Omit O(config) to gather all iBGP VXLAN fabrics, or provide O(config) to return matching fabrics.
+      The result is returned under C(gathered) in a format that can be reused as O(config).
     type: str
     default: merged
-    choices: [ merged, replaced, overridden, deleted ]
+    choices: [ merged, replaced, overridden, deleted, gathered ]
   config_actions:
     description:
     - Controls save and deploy behavior after fabric configuration is updated.
     - Save writes pending configuration to the controller.
     - Deploy pushes the saved configuration to switches.
+    - Must not enable O(config_actions.save) or O(config_actions.deploy) when O(state=gathered).
     - Skipped automatically when O(state=deleted) or when no changes are made.
     type: dict
     suboptions:
@@ -1850,6 +1871,22 @@ EXAMPLES = r"""
       - fabric_name: fabric_west
       - fabric_name: fabric_old
   register: result
+
+- name: Gather all iBGP VXLAN fabrics
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    state: gathered
+  register: result
+
+- name: Gather selected iBGP VXLAN fabrics
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    state: gathered
+    config:
+      - fabric_name: fabric_east
+      - license_tier: advantage
+        security_domain: production
+        alert_suspend: disabled
+        telemetry_collection: true
+  register: filtered_result
 """
 
 RETURN = r"""
@@ -1928,11 +1965,21 @@ api_payload:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ibgp_vxlan import FabricIbgpModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ibgp_vxlan import ManageIbgpFabricOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ibgp_vxlan import (
+    FabricIbgpModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ibgp_vxlan import (
+    ManageIbgpFabricOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
 
 
 def main():
@@ -1942,6 +1989,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=FabricIbgpModel.get_required_if(),
     )
 
     require_pydantic(module)
@@ -1954,6 +2002,9 @@ def main():
     deploy = config_actions.get("deploy", False)
     deploy_type = config_actions.get("type", "switch")
     state = module.params.get("state", "merged")
+
+    if state == "gathered" and (save or deploy):
+        module.fail_json(msg="config_actions.save and config_actions.deploy are not valid with state=gathered.")
 
     try:
         ManageIbgpFabricOrchestrator.validate_config_actions(save=save, deploy=deploy, deploy_type=deploy_type)

--- a/tests/integration/targets/nd_fabric_update_group/tasks/gathered.yaml
+++ b/tests/integration/targets/nd_fabric_update_group/tasks/gathered.yaml
@@ -1,0 +1,313 @@
+---
+# Gathered state tests for nd_fabric_update_group
+# Copyright: (c) 2026, Deeksha Pandey (@deekpand)
+#
+# Prerequisites: merged.yaml must run first so ansible_leaf_group and ansible_spine_group exist.
+# At this point in the test suite:
+#   ansible_leaf_group  → execution: parallel, contingency: pause, is_maintenance: true, is_disruptive_update: false
+#   ansible_spine_group → execution: parallel, contingency: continue, is_maintenance: false, is_disruptive_update: false
+#
+# (leaf was updated by merged.yaml to parallel/pause/advanced; spine was created with parallel/continue/noReport)
+
+# =============================================================================
+# GATHERED: No filter (all groups)
+# =============================================================================
+
+- name: "GATHERED: Gather all update groups (no filter)"
+  cisco.nd.nd_fabric_update_group: &gather_all
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+  register: nm_gathered_all
+
+- name: "GATHERED: Verify structure and changed=false"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_all is not changed
+      - nm_gathered_all.gathered is defined
+      - nm_gathered_all.gathered is iterable
+      - nm_gathered_all.gathered | length >= 2
+      - nm_gathered_all.gathered | selectattr('update_group_name', 'equalto', 'ansible_leaf_group') | list | length == 1
+      - nm_gathered_all.gathered | selectattr('update_group_name', 'equalto', 'ansible_spine_group') | list | length == 1
+
+- name: "GATHERED: Verify None default group is not in output"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_all.gathered | selectattr('update_group_name', 'equalto', 'None') | list | length == 0
+
+# =============================================================================
+# GATHERED: Idempotency (two runs produce same result)
+# =============================================================================
+
+- name: "GATHERED IDEMPOTENT: Gather again"
+  cisco.nd.nd_fabric_update_group: *gather_all
+  register: nm_gathered_idem
+
+- name: "GATHERED IDEMPOTENT: Verify identical"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_idem is not changed
+      - nm_gathered_idem.gathered == nm_gathered_all.gathered
+
+# =============================================================================
+# GATHERED: Check mode (same behavior as normal — read-only)
+# =============================================================================
+
+- name: "GATHERED CHECK MODE: Gather in check mode"
+  cisco.nd.nd_fabric_update_group: *gather_all
+  check_mode: true
+  register: cm_gathered_all
+
+- name: "GATHERED CHECK MODE: Verify same as normal"
+  ansible.builtin.assert:
+    that:
+      - cm_gathered_all is not changed
+      - cm_gathered_all.gathered == nm_gathered_all.gathered
+
+# =============================================================================
+# GATHERED: Filter by update_group_name (identifier)
+# =============================================================================
+
+- name: "GATHERED FILTER NAME: Filter by ansible_leaf_group"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - update_group_name: ansible_leaf_group
+    state: gathered
+  register: nm_gathered_by_name
+
+- name: "GATHERED FILTER NAME: Verify only leaf returned"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_by_name is not changed
+      - nm_gathered_by_name.gathered | length == 1
+      - nm_gathered_by_name.gathered[0].update_group_name == "ansible_leaf_group"
+
+- name: "GATHERED FILTER NAME: Non-existent name returns empty"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - update_group_name: this_group_does_not_exist
+    state: gathered
+  register: nm_gathered_name_missing
+
+- name: "GATHERED FILTER NAME: Verify empty"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_name_missing is not changed
+      - nm_gathered_name_missing.gathered | length == 0
+
+# =============================================================================
+# GATHERED: Filter by execution
+# =============================================================================
+
+- name: "GATHERED FILTER EXECUTION: execution=parallel"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - execution: parallel
+    state: gathered
+  register: nm_gathered_parallel
+
+- name: "GATHERED FILTER EXECUTION: Verify both groups have parallel"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_parallel is not changed
+      - nm_gathered_parallel.gathered | length == 2
+      - nm_gathered_parallel.gathered | selectattr('update_group_name', 'equalto', 'ansible_leaf_group') | list | length == 1
+      - nm_gathered_parallel.gathered | selectattr('update_group_name', 'equalto', 'ansible_spine_group') | list | length == 1
+
+- name: "GATHERED FILTER EXECUTION: execution=serial returns empty (neither group is serial)"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - execution: serial
+    state: gathered
+  register: nm_gathered_serial
+
+- name: "GATHERED FILTER EXECUTION: Verify empty"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_serial is not changed
+      - nm_gathered_serial.gathered | length == 0
+
+# =============================================================================
+# GATHERED: Filter by contingency (selectivity — groups differ here)
+# =============================================================================
+
+- name: "GATHERED FILTER CONTINGENCY: contingency=pause → only leaf"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - contingency: pause
+    state: gathered
+  register: nm_gathered_pause
+
+- name: "GATHERED FILTER CONTINGENCY: Verify only leaf returned"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_pause is not changed
+      - nm_gathered_pause.gathered | length == 1
+      - nm_gathered_pause.gathered[0].update_group_name == "ansible_leaf_group"
+
+- name: "GATHERED FILTER CONTINGENCY: contingency=continue → only spine"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - contingency: continue
+    state: gathered
+  register: nm_gathered_continue
+
+- name: "GATHERED FILTER CONTINGENCY: Verify only spine returned"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_continue is not changed
+      - nm_gathered_continue.gathered | length == 1
+      - nm_gathered_continue.gathered[0].update_group_name == "ansible_spine_group"
+
+# =============================================================================
+# GATHERED: Boolean filter (is_maintenance — groups differ here)
+# =============================================================================
+
+- name: "GATHERED FILTER BOOL: is_maintenance=true → only leaf"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - is_maintenance: true
+    state: gathered
+  register: nm_gathered_maint_true
+
+- name: "GATHERED FILTER BOOL: Verify only leaf (maintenance=true)"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_maint_true is not changed
+      - nm_gathered_maint_true.gathered | length == 1
+      - nm_gathered_maint_true.gathered[0].update_group_name == "ansible_leaf_group"
+
+- name: "GATHERED FILTER BOOL: is_maintenance=false → only spine"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - is_maintenance: false
+    state: gathered
+  register: nm_gathered_maint_false
+
+- name: "GATHERED FILTER BOOL: Verify only spine (maintenance=false)"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_maint_false is not changed
+      - nm_gathered_maint_false.gathered | length == 1
+      - nm_gathered_maint_false.gathered[0].update_group_name == "ansible_spine_group"
+
+# =============================================================================
+# GATHERED: AND semantics (multiple criteria in one item — ALL must match)
+# =============================================================================
+
+- name: "GATHERED FILTER AND: execution=parallel AND contingency=pause → only leaf"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - execution: parallel
+        contingency: pause
+    state: gathered
+  register: nm_gathered_and_match
+
+- name: "GATHERED FILTER AND: Verify only leaf"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_and_match is not changed
+      - nm_gathered_and_match.gathered | length == 1
+      - nm_gathered_and_match.gathered[0].update_group_name == "ansible_leaf_group"
+
+- name: "GATHERED FILTER AND: execution=parallel AND contingency=pause AND is_maintenance=false → empty (no group has all three)"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - execution: parallel
+        contingency: pause
+        is_maintenance: false
+    state: gathered
+  register: nm_gathered_and_nomatch
+
+- name: "GATHERED FILTER AND: Verify empty (cross-group criteria)"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_and_nomatch is not changed
+      - nm_gathered_and_nomatch.gathered | length == 0
+
+# =============================================================================
+# GATHERED: OR semantics (multiple items — ANY match includes the group)
+# =============================================================================
+
+- name: "GATHERED FILTER OR: contingency=pause OR contingency=continue → both groups"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - contingency: pause
+      - contingency: continue
+    state: gathered
+  register: nm_gathered_or_both
+
+- name: "GATHERED FILTER OR: Verify both groups returned"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_or_both is not changed
+      - nm_gathered_or_both.gathered | length == 2
+
+- name: "GATHERED FILTER OR: is_maintenance=true OR contingency=continue → both (each item matches different group)"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - is_maintenance: true
+      - contingency: continue
+    state: gathered
+  register: nm_gathered_or_cross
+
+- name: "GATHERED FILTER OR: Verify cross-property OR returns both"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_or_cross is not changed
+      - nm_gathered_or_cross.gathered | length == 2
+
+- name: "GATHERED FILTER OR: neither item matches → empty"
+  cisco.nd.nd_fabric_update_group:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    config:
+      - execution: serial
+        contingency: pause
+      - execution: serial
+        contingency: continue
+    state: gathered
+  register: nm_gathered_or_empty
+
+- name: "GATHERED FILTER OR: Verify empty (neither item matches)"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_or_empty is not changed
+      - nm_gathered_or_empty.gathered | length == 0
+
+# =============================================================================
+# GATHERED: Switch IP denormalization (switchIds → IPs)
+# =============================================================================
+
+- name: "GATHERED SWITCHIP: Verify switches are IPs not switchIds"
+  vars:
+    leaf_group: "{{ nm_gathered_all.gathered | selectattr('update_group_name', 'equalto', 'ansible_leaf_group') | first }}"
+  ansible.builtin.assert:
+    that:
+      - leaf_group.update_group_switches is defined
+      - leaf_group.update_group_switches | length > 0
+      - "'.' in leaf_group.update_group_switches[0]"

--- a/tests/integration/targets/nd_fabric_update_group/tasks/main.yaml
+++ b/tests/integration/targets/nd_fabric_update_group/tasks/main.yaml
@@ -36,6 +36,9 @@
     - name: Run merged state tests
       ansible.builtin.include_tasks: merged.yaml
 
+    - name: Run gathered state tests
+      ansible.builtin.include_tasks: gathered.yaml
+
     - name: Run replaced state tests
       ansible.builtin.include_tasks: replaced.yaml
 

--- a/tests/integration/targets/nd_interface_ethernet_access/tasks/gathered.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_access/tasks/gathered.yaml
@@ -1,0 +1,202 @@
+---
+# Integration tests for nd_interface_ethernet_access gathered state.
+#
+# These tests run AFTER merged.yaml has seeded the fabric with known access host
+# interface configurations from vars/main.yaml.
+
+- name: "GATHERED: Read all accessHost interfaces in the fabric"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+  register: nm_gathered_all
+
+- name: "GATHERED: Verify read-only behavior"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_all is not changed
+      - nm_gathered_all.gathered is defined
+      - nm_gathered_all.gathered | type_debug == "list"
+      - nm_gathered_all.before is not defined
+      - nm_gathered_all.after is not defined
+      - nm_gathered_all.diff is not defined
+      - nm_gathered_all.proposed is not defined
+
+- name: "GATHERED: Read all interfaces with explicit empty config"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config: []
+  register: nm_gathered_empty_config
+
+- name: "GATHERED: Verify explicit empty config gathers all"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_empty_config is not changed
+      - nm_gathered_empty_config.gathered == nm_gathered_all.gathered
+
+- name: "GATHERED: Filter by switch only"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+  register: nm_gathered_switch
+
+- name: "GATHERED: Verify switch-only filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_switch is not changed
+      - nm_gathered_switch.gathered | length >= 1
+      - nm_gathered_switch.gathered | rejectattr('switch_ip', 'equalto', test_switch_ip) | list | length == 0
+
+- name: "GATHERED: Filter by switch and interface name"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/41
+  register: nm_gathered_exact
+
+- name: "GATHERED: Verify exact switch and interface filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_exact is not changed
+      - nm_gathered_exact.gathered | length == 1
+      - nm_gathered_exact.gathered[0].switch_ip == test_switch_ip
+      - nm_gathered_exact.gathered[0].interface_names == ["Ethernet1/41"]
+
+- name: "GATHERED: Reuse gathered output as config in check mode"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: merged
+    config: "{{ nm_gathered_exact.gathered }}"
+  check_mode: true
+  register: cm_reuse_gathered
+
+- name: "GATHERED: Verify gathered output round-trips as config"
+  ansible.builtin.assert:
+    that:
+      - cm_reuse_gathered is not changed
+
+- name: "GATHERED: Filter by nested local criterion (access_vlan)"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - config_data:
+          network_os:
+            policy:
+              access_vlan: 100
+  register: nm_gathered_vlan
+
+- name: "GATHERED: Verify VLAN filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_vlan is not changed
+      - nm_gathered_vlan.gathered | length >= 1
+      - nm_gathered_vlan.gathered | map(attribute='config_data') | map(attribute='network_os') | map(attribute='policy') | map(attribute='access_vlan') | reject('equalto', 100) | list | length == 0
+
+- name: "GATHERED: Combine server and local criteria (AND semantics)"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/41
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+  register: nm_gathered_mixed_and
+
+- name: "GATHERED: Verify server and local criteria use AND semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_mixed_and is not changed
+      - nm_gathered_mixed_and.gathered | length == 1
+      - nm_gathered_mixed_and.gathered[0].interface_names == ["Ethernet1/41"]
+
+- name: "GATHERED: Filter with multiple OR criteria"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/41
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/42
+  register: nm_gathered_multiple
+
+- name: "GATHERED: Verify multiple filters use OR semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_multiple is not changed
+      - nm_gathered_multiple.gathered | length == 2
+
+- name: "GATHERED: Filter with no matching interface"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - config_data:
+          network_os:
+            policy:
+              access_vlan: 4094
+  register: nm_gathered_no_match
+
+- name: "GATHERED: Verify no-match filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_no_match is not changed
+      - nm_gathered_no_match.gathered == []
+
+- name: "GATHERED: Reject unsupported filter property"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - config_data:
+          network_os:
+            policy:
+              speed: auto
+  register: nm_gathered_unsupported
+  ignore_errors: true
+
+- name: "GATHERED: Verify unsupported property is rejected"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_unsupported is failed
+      - "'speed' in nm_gathered_unsupported.msg"
+
+- name: "GATHERED: Verify abbreviated interface name normalizes correctly"
+  cisco.nd.nd_interface_ethernet_access:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - eth1/41
+  register: nm_gathered_abbrev
+
+- name: "GATHERED: Verify eth1/41 resolved to Ethernet1/41"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_abbrev is not changed
+      - nm_gathered_abbrev.gathered | length == 1
+      - nm_gathered_abbrev.gathered[0].interface_names == ["Ethernet1/41"]

--- a/tests/integration/targets/nd_interface_ethernet_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_access/tasks/main.yaml
@@ -56,6 +56,9 @@
     - name: Run nd_interface_ethernet_access overridden state tests
       ansible.builtin.include_tasks: overridden.yaml
 
+    - name: Run nd_interface_ethernet_access gathered state tests
+      ansible.builtin.include_tasks: gathered.yaml
+
     - name: Run nd_interface_ethernet_access deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
   environment:

--- a/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/gathered.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/gathered.yaml
@@ -1,0 +1,259 @@
+---
+# Integration tests for nd_interface_ethernet_trunk_host gathered state.
+#
+# These tests run AFTER merged.yaml has seeded the fabric with known trunk host
+# interface configurations (ethernet_41 through ethernet_44 from vars/main.yaml).
+
+- name: "GATHERED: Read all trunkHost interfaces in the fabric"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+  register: nm_gathered_all
+
+- name: "GATHERED: Verify read-only behavior"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_all is not changed
+      - nm_gathered_all.gathered is defined
+      - nm_gathered_all.gathered | type_debug == "list"
+      - nm_gathered_all.before is not defined
+      - nm_gathered_all.after is not defined
+      - nm_gathered_all.diff is not defined
+      - nm_gathered_all.proposed is not defined
+
+- name: "GATHERED: Read all interfaces with explicit empty config"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config: []
+  register: nm_gathered_empty_config
+
+- name: "GATHERED: Verify explicit empty config gathers all"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_empty_config is not changed
+      - nm_gathered_empty_config.gathered == nm_gathered_all.gathered
+
+- name: "GATHERED: Filter by switch only"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+  register: nm_gathered_switch
+
+- name: "GATHERED: Verify switch-only filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_switch is not changed
+      - nm_gathered_switch.gathered | length >= 1
+      - nm_gathered_switch.gathered | rejectattr('switch_ip', 'equalto', test_switch_ip) | list | length == 0
+
+- name: "GATHERED: Filter by switch and interface name"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/41
+  register: nm_gathered_exact
+
+- name: "GATHERED: Verify exact switch and interface filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_exact is not changed
+      - nm_gathered_exact.gathered | length == 1
+      - nm_gathered_exact.gathered[0].switch_ip == test_switch_ip
+      - nm_gathered_exact.gathered[0].interface_names == ["Ethernet1/41"]
+
+- name: "GATHERED: Reuse gathered output as config in check mode"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: merged
+    config: "{{ nm_gathered_exact.gathered }}"
+  check_mode: true
+  register: cm_reuse_gathered
+
+- name: "GATHERED: Verify gathered output round-trips as config"
+  ansible.builtin.assert:
+    that:
+      - cm_reuse_gathered is not changed
+
+- name: "GATHERED: Filter by nested local criterion (allowed_vlans)"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - config_data:
+          network_os:
+            policy:
+              allowed_vlans: "100-200"
+  register: nm_gathered_nested
+
+- name: "GATHERED: Verify nested local filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_nested is not changed
+      - nm_gathered_nested.gathered | length >= 1
+      - nm_gathered_nested.gathered | map(attribute='config_data') | map(attribute='network_os') | map(attribute='policy') | map(attribute='allowed_vlans') | reject('equalto', '100-200') | list | length == 0
+
+- name: "GATHERED: Combine server and local criteria (AND semantics)"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/41
+        config_data:
+          network_os:
+            policy:
+              description: "Ansible integration test Ethernet1/41"
+  register: nm_gathered_mixed_and
+
+- name: "GATHERED: Verify server and local criteria use AND semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_mixed_and is not changed
+      - nm_gathered_mixed_and.gathered | length == 1
+      - nm_gathered_mixed_and.gathered[0].interface_names == ["Ethernet1/41"]
+
+- name: "GATHERED: Filter with multiple OR criteria"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/41
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/42
+  register: nm_gathered_multiple
+
+- name: "GATHERED: Verify multiple filters use OR semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_multiple is not changed
+      - nm_gathered_multiple.gathered | length == 2
+
+- name: "GATHERED: Apply overlapping filters"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/41
+      - config_data:
+          network_os:
+            policy:
+              description: "Ansible integration test Ethernet1/41"
+  register: nm_gathered_deduplicated
+
+- name: "GATHERED: Verify overlapping filters do not duplicate results"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_deduplicated is not changed
+      - nm_gathered_deduplicated.gathered | length == 1
+      - nm_gathered_deduplicated.gathered[0].interface_names == ["Ethernet1/41"]
+
+- name: "GATHERED: Filter with no matching interface"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - config_data:
+          network_os:
+            policy:
+              native_vlan: 4094
+  register: nm_gathered_no_match
+
+- name: "GATHERED: Verify no-match filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_no_match is not changed
+      - nm_gathered_no_match.gathered == []
+
+- name: "GATHERED: Reject unsupported filter property"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - config_data:
+          network_os:
+            policy:
+              speed: auto
+  register: nm_gathered_unsupported
+  ignore_errors: true
+
+- name: "GATHERED: Verify unsupported property is rejected"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_unsupported is failed
+      - "'speed' in nm_gathered_unsupported.msg"
+
+- name: "GATHERED: Verify abbreviated interface name normalizes correctly"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - eth1/41
+  register: nm_gathered_abbrev
+
+- name: "GATHERED: Verify eth1/41 resolved to Ethernet1/41"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_abbrev is not changed
+      - nm_gathered_abbrev.gathered | length == 1
+      - nm_gathered_abbrev.gathered[0].interface_names == ["Ethernet1/41"]
+
+- name: "GATHERED: Preview a merged change without applying it"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: merged
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/41
+        config_data:
+          network_os:
+            policy:
+              description: "CHECK MODE ONLY - must not reach controller"
+  check_mode: true
+  register: cm_gathered_merge_preview
+
+- name: "GATHERED: Read interface after merged check-mode preview"
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_names:
+          - Ethernet1/41
+  register: nm_gathered_after_preview
+
+- name: "GATHERED: Verify merged check mode did not change controller configuration"
+  ansible.builtin.assert:
+    that:
+      - cm_gathered_merge_preview is changed
+      - nm_gathered_after_preview is not changed
+      - nm_gathered_after_preview.gathered | length == 1
+      - nm_gathered_after_preview.gathered[0].config_data.network_os.policy.description == 'Ansible integration test Ethernet1/41'

--- a/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/main.yaml
@@ -56,6 +56,9 @@
     - name: Run nd_interface_ethernet_trunk_host overridden state tests
       ansible.builtin.include_tasks: overridden.yaml
 
+    - name: Run nd_interface_ethernet_trunk_host gathered state tests
+      ansible.builtin.include_tasks: gathered.yaml
+
     - name: Run nd_interface_ethernet_trunk_host deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
   environment:

--- a/tests/integration/targets/nd_interface_loopback/tasks/gathered.yaml
+++ b/tests/integration/targets/nd_interface_loopback/tasks/gathered.yaml
@@ -44,7 +44,7 @@
   ansible.builtin.assert:
     that:
       - nm_gathered_switch is not changed
-      - nm_gathered_switch.gathered | length == 2
+      - nm_gathered_switch.gathered | length >= 1
       - nm_gathered_switch.gathered | rejectattr('switch_ip', 'equalto', test_switch_ip) | list | length == 0
 
 - name: "GATHERED: Filter by switch and interface name"

--- a/tests/integration/targets/nd_interface_loopback/tasks/gathered.yaml
+++ b/tests/integration/targets/nd_interface_loopback/tasks/gathered.yaml
@@ -1,0 +1,223 @@
+---
+- name: "GATHERED: Read all user-managed loopback interfaces"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+  register: nm_gathered_all
+
+- name: "GATHERED: Verify read-only behavior"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_all is not changed
+      - nm_gathered_all.gathered is defined
+      - nm_gathered_all.gathered | type_debug == "list"
+      - nm_gathered_all.before is not defined
+      - nm_gathered_all.after is not defined
+      - nm_gathered_all.diff is not defined
+      - nm_gathered_all.proposed is not defined
+
+- name: "GATHERED: Read all interfaces with explicit empty config"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config: []
+  register: nm_gathered_empty_config
+
+- name: "GATHERED: Verify explicit empty config gathers all"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_empty_config is not changed
+      - nm_gathered_empty_config.gathered == nm_gathered_all.gathered
+
+- name: "GATHERED: Filter by switch only"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+  register: nm_gathered_switch
+
+- name: "GATHERED: Verify switch-only filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_switch is not changed
+      - nm_gathered_switch.gathered | length == 2
+      - nm_gathered_switch.gathered | rejectattr('switch_ip', 'equalto', test_switch_ip) | list | length == 0
+
+- name: "GATHERED: Filter by switch and interface name"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: Loopback101
+  register: nm_gathered_exact
+
+- name: "GATHERED: Verify exact switch and interface filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_exact is not changed
+      - nm_gathered_exact.gathered | length == 1
+      - nm_gathered_exact.gathered[0].switch_ip == test_switch_ip
+      - nm_gathered_exact.gathered[0].interface_name == "loopback101"
+
+- name: "GATHERED: Reuse gathered output as config in check mode"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: merged
+    config: "{{ nm_gathered_exact.gathered }}"
+  check_mode: true
+  register: cm_reuse_gathered_loopback
+
+- name: "GATHERED: Verify gathered output round-trips as config"
+  ansible.builtin.assert:
+    that:
+      - cm_reuse_gathered_loopback is not changed
+      - cm_reuse_gathered_loopback.proposed | length == 1
+      - cm_reuse_gathered_loopback.proposed.0.switch_ip == test_switch_ip
+      - cm_reuse_gathered_loopback.proposed.0.interface_name == "loopback101"
+
+- name: "GATHERED: Filter by nested local criterion"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - config_data:
+          network_os:
+            policy:
+              description: "Ansible integration test loopback102"
+  register: nm_gathered_nested
+
+- name: "GATHERED: Verify nested local filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_nested is not changed
+      - nm_gathered_nested.gathered | length == 1
+      - nm_gathered_nested.gathered[0].interface_name == "loopback102"
+
+- name: "GATHERED: Combine server and local criteria"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: Loopback101
+        config_data:
+          network_os:
+            policy:
+              description: "Ansible integration test loopback101"
+  register: nm_gathered_mixed_and
+
+- name: "GATHERED: Verify server and local criteria use AND semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_mixed_and is not changed
+      - nm_gathered_mixed_and.gathered | length == 1
+      - nm_gathered_mixed_and.gathered.0.interface_name == "loopback101"
+
+- name: "GATHERED: Filter with multiple OR criteria"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - interface_name: loopback101
+      - interface_name: loopback102
+  register: nm_gathered_multiple
+
+- name: "GATHERED: Verify multiple filters use OR semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_multiple is not changed
+      - nm_gathered_multiple.gathered | length == 2
+      - nm_gathered_multiple.gathered | map(attribute='interface_name') | sort | list == ['loopback101', 'loopback102']
+
+- name: "GATHERED: Apply overlapping filters"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - interface_name: loopback101
+      - config_data:
+          network_os:
+            policy:
+              description: "Ansible integration test loopback101"
+  register: nm_gathered_deduplicated
+
+- name: "GATHERED: Verify overlapping filters do not duplicate results"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_deduplicated is not changed
+      - nm_gathered_deduplicated.gathered | length == 1
+      - nm_gathered_deduplicated.gathered.0.interface_name == "loopback101"
+
+- name: "GATHERED: Filter with no matching interface"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - interface_name: loopback999
+  register: nm_gathered_no_match
+
+- name: "GATHERED: Verify no-match filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_no_match is not changed
+      - nm_gathered_no_match.gathered == []
+
+- name: "GATHERED: Filter by a switch outside the fabric"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "192.0.2.250"
+  register: nm_gathered_unknown_switch
+
+- name: "GATHERED: Verify unknown switch returns no results"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_unknown_switch is not changed
+      - nm_gathered_unknown_switch.gathered == []
+
+- name: "GATHERED: Preview a merged change without applying it"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: merged
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: loopback101
+        config_data:
+          network_os:
+            policy:
+              description: "CHECK MODE ONLY - must not reach controller"
+  check_mode: true
+  register: cm_gathered_merge_preview
+
+- name: "GATHERED: Read interface after merged check-mode preview"
+  cisco.nd.nd_interface_loopback:
+    output_level: "{{ nd_info.output_level }}"
+    fabric_name: "{{ test_fabric_name }}"
+    state: gathered
+    config:
+      - switch_ip: "{{ test_switch_ip }}"
+        interface_name: loopback101
+  register: nm_gathered_after_preview
+
+- name: "GATHERED: Verify merged check mode did not change controller configuration"
+  ansible.builtin.assert:
+    that:
+      - cm_gathered_merge_preview is changed
+      - nm_gathered_after_preview is not changed
+      - nm_gathered_after_preview.gathered | length == 1
+      - nm_gathered_after_preview.gathered.0.config_data.network_os.policy.description == 'Ansible integration test loopback101'

--- a/tests/integration/targets/nd_interface_loopback/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_loopback/tasks/main.yaml
@@ -50,6 +50,9 @@
     - name: Run nd_interface_loopback overridden state tests
       ansible.builtin.include_tasks: overridden.yaml
 
+    - name: Run nd_interface_loopback gathered state tests
+      ansible.builtin.include_tasks: gathered.yaml
+
     - name: Run nd_interface_loopback deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
 

--- a/tests/integration/targets/nd_local_user/tasks/gathered.yml
+++ b/tests/integration/targets/nd_local_user/tasks/gathered.yml
@@ -100,12 +100,28 @@
       - nm_gathered_no_match_local_user is not changed
       - nm_gathered_no_match_local_user.gathered == []
 
-- name: "GATHERED: Reject a non-login-ID filter"
+- name: "GATHERED: Filter by email returns matching user"
   cisco.nd.nd_local_user:
     output_level: "{{ nd_info.output_level }}"
     state: gathered
     config:
       - email: ansibleuser@example.com
+  register: nm_gathered_by_email
+
+- name: "GATHERED: Verify email filter returns correct user"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_by_email is not changed
+      - nm_gathered_by_email.gathered | length == 1
+      - nm_gathered_by_email.gathered.0.login_id == "ansible_local_user"
+      - nm_gathered_by_email.gathered.0.email == "ansibleuser@example.com"
+
+- name: "GATHERED: Reject an unsupported filter property"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - reuse_limitation: 20
   register: nm_gathered_unsupported_filter
   ignore_errors: true
 
@@ -113,8 +129,8 @@
   ansible.builtin.assert:
     that:
       - nm_gathered_unsupported_filter is failed
-      - "'Only login_id can be used as a gathered-state filter' in nm_gathered_unsupported_filter.msg"
-      - "'email' in nm_gathered_unsupported_filter.msg"
+      - "'unsupported properties' in nm_gathered_unsupported_filter.msg"
+      - "'reuse_limitation' in nm_gathered_unsupported_filter.msg"
 
 - name: "GATHERED: Reject an empty filter item"
   cisco.nd.nd_local_user:

--- a/tests/integration/targets/nd_local_user/tasks/gathered.yml
+++ b/tests/integration/targets/nd_local_user/tasks/gathered.yml
@@ -1,0 +1,132 @@
+---
+# Gathered-state tests run after the initial merged-state creation. At this
+# point ansible_local_user and ansible_local_user_2 have deterministic values.
+
+- name: "GATHERED: Read all local users"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+  register: nm_gathered_all_local_users
+
+- name: "GATHERED: Verify read-only output and password secrecy"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_all_local_users is not changed
+      - nm_gathered_all_local_users.gathered is defined
+      - nm_gathered_all_local_users.gathered | type_debug == "list"
+      - nm_gathered_all_local_users.gathered | selectattr('login_id', 'equalto', 'ansible_local_user') | list | length == 1
+      - nm_gathered_all_local_users.gathered | selectattr('login_id', 'equalto', 'ansible_local_user_2') | list | length == 1
+      - nm_gathered_all_local_users.gathered | selectattr('user_password', 'defined') | list | length == 0
+      - nm_gathered_all_local_users.before is not defined
+      - nm_gathered_all_local_users.after is not defined
+      - nm_gathered_all_local_users.diff is not defined
+      - nm_gathered_all_local_users.proposed is not defined
+
+- name: "GATHERED: Filter by exact login ID"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - login_id: ansible_local_user
+  register: nm_gathered_exact_local_user
+
+- name: "GATHERED: Verify exact login-ID filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_exact_local_user is not changed
+      - nm_gathered_exact_local_user.gathered | length == 1
+      - nm_gathered_exact_local_user.gathered.0.login_id == "ansible_local_user"
+      - nm_gathered_exact_local_user.gathered.0.email == "ansibleuser@example.com"
+      - nm_gathered_exact_local_user.gathered.0.first_name == "Ansible first name"
+      - nm_gathered_exact_local_user.gathered.0.user_password is not defined
+
+- name: "GATHERED: Reuse gathered output as config in check mode"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: merged
+    config: "{{ nm_gathered_exact_local_user.gathered }}"
+  check_mode: true
+  register: cm_reuse_gathered_local_user
+
+- name: "GATHERED: Verify gathered output round-trips as config"
+  ansible.builtin.assert:
+    that:
+      - cm_reuse_gathered_local_user is not changed
+      - cm_reuse_gathered_local_user.proposed | length == 1
+      - cm_reuse_gathered_local_user.proposed.0.login_id == "ansible_local_user"
+      - cm_reuse_gathered_local_user.proposed.0.user_password is not defined
+
+- name: "GATHERED: Filter by multiple login IDs"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - login_id: ansible_local_user
+      - login_id: ansible_local_user_2
+  register: nm_gathered_or_local_users
+
+- name: "GATHERED: Verify separate login-ID filters use OR semantics"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_or_local_users is not changed
+      - nm_gathered_or_local_users.gathered | length == 2
+      - nm_gathered_or_local_users.gathered | map(attribute='login_id') | sort | list == ['ansible_local_user', 'ansible_local_user_2']
+
+- name: "GATHERED: Filter with different login-ID case"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - login_id: ANSIBLE_LOCAL_USER
+  register: nm_gathered_case_sensitive_local_user
+
+- name: "GATHERED: Verify login-ID filtering is case-sensitive"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_case_sensitive_local_user is not changed
+      - nm_gathered_case_sensitive_local_user.gathered == []
+
+- name: "GATHERED: Filter with no matching login ID"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - login_id: ansible-user-that-does-not-exist
+  register: nm_gathered_no_match_local_user
+
+- name: "GATHERED: Verify no-match filter"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_no_match_local_user is not changed
+      - nm_gathered_no_match_local_user.gathered == []
+
+- name: "GATHERED: Reject a non-login-ID filter"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - email: ansibleuser@example.com
+  register: nm_gathered_unsupported_filter
+  ignore_errors: true
+
+- name: "GATHERED: Verify unsupported-filter rejection"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_unsupported_filter is failed
+      - "'Only login_id can be used as a gathered-state filter' in nm_gathered_unsupported_filter.msg"
+      - "'email' in nm_gathered_unsupported_filter.msg"
+
+- name: "GATHERED: Reject an empty filter item"
+  cisco.nd.nd_local_user:
+    output_level: "{{ nd_info.output_level }}"
+    state: gathered
+    config:
+      - {}
+  register: nm_gathered_empty_filter
+  ignore_errors: true
+
+- name: "GATHERED: Verify empty-filter rejection"
+  ansible.builtin.assert:
+    that:
+      - nm_gathered_empty_filter is failed
+      - "'must contain at least one filtering criterion' in nm_gathered_empty_filter.msg"

--- a/tests/integration/targets/nd_local_user/tasks/main.yml
+++ b/tests/integration/targets/nd_local_user/tasks/main.yml
@@ -165,6 +165,9 @@
       - nm_merged_create_local_users.proposed.1.security_domains | length == 1
       - nm_merged_create_local_users.proposed.1.security_domains.0.name == "all"
 
+- name: Run nd_local_user gathered state tests
+  ansible.builtin.include_tasks: gathered.yml
+
 # MERGED STATE TESTS: UPDATE
 - name: Update all ansible_local_user_2's attributes except password (merge state - check mode)
   cisco.nd.nd_local_user: &update_second_local_user_merged_state

--- a/tests/integration/targets/nd_manage_fabric/tasks/fabric_ai_ebgp.yaml
+++ b/tests/integration/targets/nd_manage_fabric/tasks/fabric_ai_ebgp.yaml
@@ -36,7 +36,7 @@
     config:
       - "{{ {'fabric_name': ai_ebgp_test_fabric_merged} | combine(fabric_config_ai_ebgp) }}"
   register: merged_result_1
-  tags: [test_merged, test_merged_create]
+  tags: [test_merged, test_merged_create, test_gathered]
 
 - name: "TEST 1a: Verify fabric was created using merged state"
   assert:
@@ -45,7 +45,7 @@
       - merged_result_1 is not failed
     fail_msg: "AI eBGP VXLAN fabric creation with state merged failed"
     success_msg: "AI eBGP VXLAN fabric successfully created with state merged"
-  tags: [test_merged, test_merged_create]
+  tags: [test_merged, test_merged_create, test_gathered]
 
 - name: "TEST 1b: Create fabric using state merged (second run - idempotency test)"
   cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
@@ -54,7 +54,7 @@
     config:
       - "{{ {'fabric_name': ai_ebgp_test_fabric_merged} | combine(fabric_config_ai_ebgp) }}"
   register: merged_result_2
-  tags: [test_merged, test_merged_idempotent]
+  tags: [test_merged, test_merged_idempotent, test_gathered]
 
 - name: "TEST 1b: Verify merged state is idempotent"
   assert:
@@ -63,7 +63,7 @@
       - merged_result_2 is not failed
     fail_msg: "Merged state is not idempotent - should not change when run twice with same config"
     success_msg: "Merged state is idempotent - no changes on second run"
-  tags: [test_merged, test_merged_idempotent]
+  tags: [test_merged, test_merged_idempotent, test_gathered]
 
 - name: "TEST 1c: Update fabric using state merged (modify existing)"
   cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
@@ -147,7 +147,7 @@
           management_gateway: ""
           management_ipv4_prefix: 24
   register: merged_result_3
-  tags: [test_merged, test_merged_update]
+  tags: [test_merged, test_merged_update, test_gathered]
 
 - name: "TEST 1c: Verify fabric was updated using merged state"
   assert:
@@ -156,7 +156,195 @@
       - merged_result_3 is not failed
     fail_msg: "AI eBGP VXLAN fabric update with state merged failed"
     success_msg: "AI eBGP VXLAN fabric successfully updated with state merged"
-  tags: [test_merged, test_merged_update]
+  tags: [test_merged, test_merged_update, test_gathered]
+
+#############################################################################
+# TEST GATHERED: Read-only state and supported filtering
+#############################################################################
+- name: "GATHERED: Read all AI eBGP VXLAN fabrics"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+  register: ai_ebgp_gathered_all
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gather-all output is read-only"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_all is not changed
+      - ai_ebgp_gathered_all.gathered is defined
+      - ai_ebgp_gathered_all.gathered | type_debug == "list"
+      - ai_ebgp_test_fabric_merged in (ai_ebgp_gathered_all.gathered | map(attribute='fabric_name') | list)
+      - ai_ebgp_gathered_all.before is not defined
+      - ai_ebgp_gathered_all.after is not defined
+      - ai_ebgp_gathered_all.diff is not defined
+      - ai_ebgp_gathered_all.proposed is not defined
+  tags: [test_gathered]
+
+- name: "GATHERED: Read all fabrics with explicit empty config"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config: []
+  register: ai_ebgp_gathered_empty_config
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify explicit empty config matches omitted config"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_empty_config is not changed
+      - >-
+        ai_ebgp_gathered_empty_config.gathered | map(attribute='fabric_name') | sort | list
+        == ai_ebgp_gathered_all.gathered | map(attribute='fabric_name') | sort | list
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by exact fabric name"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ai_ebgp_test_fabric_merged }}"
+  register: ai_ebgp_gathered_exact
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify exact-name filter"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_exact is not changed
+      - ai_ebgp_gathered_exact.gathered | length == 1
+      - ai_ebgp_gathered_exact.gathered[0].fabric_name == ai_ebgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with all five supported properties"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ai_ebgp_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ai_ebgp_gathered_exact.gathered[0].license_tier }}"
+        security_domain: "{{ ai_ebgp_gathered_exact.gathered[0].security_domain }}"
+        alert_suspend: "{{ ai_ebgp_gathered_exact.gathered[0].alert_suspend }}"
+        telemetry_collection: "{{ ai_ebgp_gathered_exact.gathered[0].telemetry_collection }}"
+  register: ai_ebgp_gathered_all_fields
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify all supported properties use AND semantics"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_all_fields is not changed
+      - ai_ebgp_gathered_all_fields.gathered | length == 1
+      - ai_ebgp_gathered_all_fields.gathered[0].fabric_name == ai_ebgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Apply overlapping filters"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ai_ebgp_test_fabric_merged }}"
+      - fabric_name: "{{ ai_ebgp_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ai_ebgp_gathered_exact.gathered[0].license_tier }}"
+  register: ai_ebgp_gathered_overlapping
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify OR semantics and deduplication"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_overlapping is not changed
+      - ai_ebgp_gathered_overlapping.gathered | length == 1
+      - ai_ebgp_gathered_overlapping.gathered[0].fabric_name == ai_ebgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with more than three expressions"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ai_ebgp_test_fabric_merged }}"
+      - fabric_name: nonexistent_ai_ebgp_fallback_1
+      - fabric_name: nonexistent_ai_ebgp_fallback_2
+      - fabric_name: nonexistent_ai_ebgp_fallback_3
+  register: ai_ebgp_gathered_fallback
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify fallback preserves the matching OR item"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_fallback is not changed
+      - ai_ebgp_gathered_fallback.gathered | length == 1
+      - ai_ebgp_gathered_fallback.gathered[0].fabric_name == ai_ebgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by a non-existent fabric name"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: nonexistent_ai_ebgp_fabric_999
+  register: ai_ebgp_gathered_no_match
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify no-match filter returns an empty list"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_no_match is not changed
+      - ai_ebgp_gathered_no_match.gathered == []
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an empty filter item"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - {}
+  register: ai_ebgp_gathered_empty_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify empty filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_empty_filter is failed
+      - "'must contain at least one filtering criterion' in ai_ebgp_gathered_empty_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an unsupported location filter"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - location:
+          latitude: 0.0
+          longitude: 0.0
+  register: ai_ebgp_gathered_unsupported_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify unsupported filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_unsupported_filter is failed
+      - "'unsupported properties' in ai_ebgp_gathered_unsupported_filter.msg"
+      - "'location.latitude' in ai_ebgp_gathered_unsupported_filter.msg"
+      - "'location.longitude' in ai_ebgp_gathered_unsupported_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reuse exact gathered output as config in check mode"
+  cisco.nd.nd_manage_fabric_ai_ebgp_vxlan:
+    <<: *nd_info
+    state: merged
+    config: "{{ ai_ebgp_gathered_exact.gathered }}"
+  check_mode: true
+  register: ai_ebgp_gathered_round_trip
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gathered output round-trips without drift"
+  ansible.builtin.assert:
+    that:
+      - ai_ebgp_gathered_round_trip is not changed
+      - ai_ebgp_gathered_round_trip.proposed | length == 1
+      - ai_ebgp_gathered_round_trip.proposed[0].fabric_name == ai_ebgp_test_fabric_merged
+  tags: [test_gathered]
 
 #############################################################################
 # VALIDATION: Query ai_ebgp_test_fabric_merged and validate expected changes

--- a/tests/integration/targets/nd_manage_fabric/tasks/fabric_ai_ibgp.yaml
+++ b/tests/integration/targets/nd_manage_fabric/tasks/fabric_ai_ibgp.yaml
@@ -36,7 +36,7 @@
     config:
       - "{{ {'fabric_name': ai_ibgp_test_fabric_merged} | combine(fabric_config_ai_ibgp) }}"
   register: merged_result_1
-  tags: [test_merged, test_merged_create]
+  tags: [test_merged, test_merged_create, test_gathered]
 
 - name: "TEST 1a: Verify fabric was created using merged state"
   assert:
@@ -45,7 +45,7 @@
       - merged_result_1 is not failed
     fail_msg: "AI iBGP VXLAN fabric creation with state merged failed"
     success_msg: "AI iBGP VXLAN fabric successfully created with state merged"
-  tags: [test_merged, test_merged_create]
+  tags: [test_merged, test_merged_create, test_gathered]
 
 - name: "TEST 1b: Create fabric using state merged (second run - idempotency test)"
   cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
@@ -54,7 +54,7 @@
     config:
       - "{{ {'fabric_name': ai_ibgp_test_fabric_merged} | combine(fabric_config_ai_ibgp) }}"
   register: merged_result_2
-  tags: [test_merged, test_merged_idempotent]
+  tags: [test_merged, test_merged_idempotent, test_gathered]
 
 - name: "TEST 1b: Verify merged state is idempotent"
   assert:
@@ -63,7 +63,7 @@
       - merged_result_2 is not failed
     fail_msg: "Merged state is not idempotent - should not change when run twice with same config"
     success_msg: "Merged state is idempotent - no changes on second run"
-  tags: [test_merged, test_merged_idempotent]
+  tags: [test_merged, test_merged_idempotent, test_gathered]
 
 - name: "TEST 1c: Update fabric using state merged (modify existing)"
   cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
@@ -142,7 +142,7 @@
           management_gateway: ""
           management_ipv4_prefix: 24
   register: merged_result_3
-  tags: [test_merged, test_merged_update]
+  tags: [test_merged, test_merged_update, test_gathered]
 
 - name: "TEST 1c: Verify fabric was updated using merged state"
   assert:
@@ -151,7 +151,195 @@
       - merged_result_3 is not failed
     fail_msg: "AI iBGP VXLAN fabric update with state merged failed"
     success_msg: "AI iBGP VXLAN fabric successfully updated with state merged"
-  tags: [test_merged, test_merged_update]
+  tags: [test_merged, test_merged_update, test_gathered]
+
+#############################################################################
+# TEST GATHERED: Read-only state and supported filtering
+#############################################################################
+- name: "GATHERED: Read all AI iBGP VXLAN fabrics"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+  register: ai_ibgp_gathered_all
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gather-all output is read-only"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_all is not changed
+      - ai_ibgp_gathered_all.gathered is defined
+      - ai_ibgp_gathered_all.gathered | type_debug == "list"
+      - ai_ibgp_test_fabric_merged in (ai_ibgp_gathered_all.gathered | map(attribute='fabric_name') | list)
+      - ai_ibgp_gathered_all.before is not defined
+      - ai_ibgp_gathered_all.after is not defined
+      - ai_ibgp_gathered_all.diff is not defined
+      - ai_ibgp_gathered_all.proposed is not defined
+  tags: [test_gathered]
+
+- name: "GATHERED: Read all fabrics with explicit empty config"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config: []
+  register: ai_ibgp_gathered_empty_config
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify explicit empty config matches omitted config"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_empty_config is not changed
+      - >-
+        ai_ibgp_gathered_empty_config.gathered | map(attribute='fabric_name') | sort | list
+        == ai_ibgp_gathered_all.gathered | map(attribute='fabric_name') | sort | list
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by exact fabric name"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ai_ibgp_test_fabric_merged }}"
+  register: ai_ibgp_gathered_exact
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify exact-name filter"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_exact is not changed
+      - ai_ibgp_gathered_exact.gathered | length == 1
+      - ai_ibgp_gathered_exact.gathered[0].fabric_name == ai_ibgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with all five supported properties"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ai_ibgp_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ai_ibgp_gathered_exact.gathered[0].license_tier }}"
+        security_domain: "{{ ai_ibgp_gathered_exact.gathered[0].security_domain }}"
+        alert_suspend: "{{ ai_ibgp_gathered_exact.gathered[0].alert_suspend }}"
+        telemetry_collection: "{{ ai_ibgp_gathered_exact.gathered[0].telemetry_collection }}"
+  register: ai_ibgp_gathered_all_fields
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify all supported properties use AND semantics"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_all_fields is not changed
+      - ai_ibgp_gathered_all_fields.gathered | length == 1
+      - ai_ibgp_gathered_all_fields.gathered[0].fabric_name == ai_ibgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Apply overlapping filters"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ai_ibgp_test_fabric_merged }}"
+      - fabric_name: "{{ ai_ibgp_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ai_ibgp_gathered_exact.gathered[0].license_tier }}"
+  register: ai_ibgp_gathered_overlapping
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify OR semantics and deduplication"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_overlapping is not changed
+      - ai_ibgp_gathered_overlapping.gathered | length == 1
+      - ai_ibgp_gathered_overlapping.gathered[0].fabric_name == ai_ibgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with more than three expressions"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ai_ibgp_test_fabric_merged }}"
+      - fabric_name: nonexistent_ai_ibgp_fallback_1
+      - fabric_name: nonexistent_ai_ibgp_fallback_2
+      - fabric_name: nonexistent_ai_ibgp_fallback_3
+  register: ai_ibgp_gathered_fallback
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify fallback preserves the matching OR item"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_fallback is not changed
+      - ai_ibgp_gathered_fallback.gathered | length == 1
+      - ai_ibgp_gathered_fallback.gathered[0].fabric_name == ai_ibgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by a non-existent fabric name"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: nonexistent_ai_ibgp_fabric_999
+  register: ai_ibgp_gathered_no_match
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify no-match filter returns an empty list"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_no_match is not changed
+      - ai_ibgp_gathered_no_match.gathered == []
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an empty filter item"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - {}
+  register: ai_ibgp_gathered_empty_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify empty filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_empty_filter is failed
+      - "'must contain at least one filtering criterion' in ai_ibgp_gathered_empty_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an unsupported location filter"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - location:
+          latitude: 0.0
+          longitude: 0.0
+  register: ai_ibgp_gathered_unsupported_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify unsupported filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_unsupported_filter is failed
+      - "'unsupported properties' in ai_ibgp_gathered_unsupported_filter.msg"
+      - "'location.latitude' in ai_ibgp_gathered_unsupported_filter.msg"
+      - "'location.longitude' in ai_ibgp_gathered_unsupported_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reuse exact gathered output as config in check mode"
+  cisco.nd.nd_manage_fabric_ai_ibgp_vxlan:
+    <<: *nd_info
+    state: merged
+    config: "{{ ai_ibgp_gathered_exact.gathered }}"
+  check_mode: true
+  register: ai_ibgp_gathered_round_trip
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gathered output round-trips without drift"
+  ansible.builtin.assert:
+    that:
+      - ai_ibgp_gathered_round_trip is not changed
+      - ai_ibgp_gathered_round_trip.proposed | length == 1
+      - ai_ibgp_gathered_round_trip.proposed[0].fabric_name == ai_ibgp_test_fabric_merged
+  tags: [test_gathered]
 
 #############################################################################
 # VALIDATION: Query ai_ibgp_test_fabric_merged and validate expected changes

--- a/tests/integration/targets/nd_manage_fabric/tasks/fabric_ebgp.yaml
+++ b/tests/integration/targets/nd_manage_fabric/tasks/fabric_ebgp.yaml
@@ -37,7 +37,7 @@
     config:
       - "{{ {'fabric_name': ebgp_test_fabric_merged} | combine(fabric_config_ebgp) }}"
   register: ebgp_merged_result_1
-  tags: [test_merged, test_merged_create]
+  tags: [test_merged, test_merged_create, test_gathered]
 
 - name: "TEST 1a: Verify eBGP fabric was created using merged state"
   assert:
@@ -46,7 +46,7 @@
       - ebgp_merged_result_1 is not failed
     fail_msg: "eBGP fabric creation with state merged failed"
     success_msg: "eBGP fabric successfully created with state merged"
-  tags: [test_merged, test_merged_create]
+  tags: [test_merged, test_merged_create, test_gathered]
 
 - name: "TEST 1b: Create eBGP fabric using state merged (second run - idempotency test)"
   cisco.nd.nd_manage_fabric_ebgp_vxlan:
@@ -55,7 +55,7 @@
     config:
       - "{{ {'fabric_name': ebgp_test_fabric_merged} | combine(fabric_config_ebgp) }}"
   register: ebgp_merged_result_2
-  tags: [test_merged, test_merged_idempotent]
+  tags: [test_merged, test_merged_idempotent, test_gathered]
 
 - name: "TEST 1b: Verify merged state is idempotent"
   assert:
@@ -64,7 +64,7 @@
       - ebgp_merged_result_2 is not failed
     fail_msg: "Merged state is not idempotent - should not change when run twice with same config"
     success_msg: "Merged state is idempotent - no changes on second run"
-  tags: [test_merged, test_merged_idempotent]
+  tags: [test_merged, test_merged_idempotent, test_gathered]
 
 - name: "TEST 1c: Update eBGP fabric using state merged (modify existing)"
   cisco.nd.nd_manage_fabric_ebgp_vxlan:
@@ -149,7 +149,7 @@
           management_gateway: ""
           management_ipv4_prefix: 24
   register: ebgp_merged_result_3
-  tags: [test_merged, test_merged_update]
+  tags: [test_merged, test_merged_update, test_gathered]
 
 - name: "TEST 1c: Verify eBGP fabric was updated using merged state"
   assert:
@@ -158,7 +158,195 @@
       - ebgp_merged_result_3 is not failed
     fail_msg: "eBGP fabric update with state merged failed"
     success_msg: "eBGP fabric successfully updated with state merged"
-  tags: [test_merged, test_merged_update]
+  tags: [test_merged, test_merged_update, test_gathered]
+
+#############################################################################
+# TEST GATHERED: Read-only state and supported filtering
+#############################################################################
+- name: "GATHERED: Read all eBGP VXLAN fabrics"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+  register: ebgp_gathered_all
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gather-all output is read-only"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_all is not changed
+      - ebgp_gathered_all.gathered is defined
+      - ebgp_gathered_all.gathered | type_debug == "list"
+      - ebgp_test_fabric_merged in (ebgp_gathered_all.gathered | map(attribute='fabric_name') | list)
+      - ebgp_gathered_all.before is not defined
+      - ebgp_gathered_all.after is not defined
+      - ebgp_gathered_all.diff is not defined
+      - ebgp_gathered_all.proposed is not defined
+  tags: [test_gathered]
+
+- name: "GATHERED: Read all fabrics with explicit empty config"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config: []
+  register: ebgp_gathered_empty_config
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify explicit empty config matches omitted config"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_empty_config is not changed
+      - >-
+        ebgp_gathered_empty_config.gathered | map(attribute='fabric_name') | sort | list
+        == ebgp_gathered_all.gathered | map(attribute='fabric_name') | sort | list
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by exact fabric name"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ebgp_test_fabric_merged }}"
+  register: ebgp_gathered_exact
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify exact-name filter"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_exact is not changed
+      - ebgp_gathered_exact.gathered | length == 1
+      - ebgp_gathered_exact.gathered[0].fabric_name == ebgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with all five supported properties"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ebgp_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ebgp_gathered_exact.gathered[0].license_tier }}"
+        security_domain: "{{ ebgp_gathered_exact.gathered[0].security_domain }}"
+        alert_suspend: "{{ ebgp_gathered_exact.gathered[0].alert_suspend }}"
+        telemetry_collection: "{{ ebgp_gathered_exact.gathered[0].telemetry_collection }}"
+  register: ebgp_gathered_all_fields
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify all supported properties use AND semantics"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_all_fields is not changed
+      - ebgp_gathered_all_fields.gathered | length == 1
+      - ebgp_gathered_all_fields.gathered[0].fabric_name == ebgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Apply overlapping filters"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ebgp_test_fabric_merged }}"
+      - fabric_name: "{{ ebgp_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ebgp_gathered_exact.gathered[0].license_tier }}"
+  register: ebgp_gathered_overlapping
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify OR semantics and deduplication"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_overlapping is not changed
+      - ebgp_gathered_overlapping.gathered | length == 1
+      - ebgp_gathered_overlapping.gathered[0].fabric_name == ebgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with more than three expressions"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ebgp_test_fabric_merged }}"
+      - fabric_name: nonexistent_ebgp_fallback_1
+      - fabric_name: nonexistent_ebgp_fallback_2
+      - fabric_name: nonexistent_ebgp_fallback_3
+  register: ebgp_gathered_fallback
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify fallback preserves the matching OR item"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_fallback is not changed
+      - ebgp_gathered_fallback.gathered | length == 1
+      - ebgp_gathered_fallback.gathered[0].fabric_name == ebgp_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by a non-existent fabric name"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: nonexistent_ebgp_fabric_999
+  register: ebgp_gathered_no_match
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify no-match filter returns an empty list"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_no_match is not changed
+      - ebgp_gathered_no_match.gathered == []
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an empty filter item"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - {}
+  register: ebgp_gathered_empty_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify empty filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_empty_filter is failed
+      - "'must contain at least one filtering criterion' in ebgp_gathered_empty_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an unsupported location filter"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - location:
+          latitude: 0.0
+          longitude: 0.0
+  register: ebgp_gathered_unsupported_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify unsupported filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_unsupported_filter is failed
+      - "'unsupported properties' in ebgp_gathered_unsupported_filter.msg"
+      - "'location.latitude' in ebgp_gathered_unsupported_filter.msg"
+      - "'location.longitude' in ebgp_gathered_unsupported_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reuse exact gathered output as config in check mode"
+  cisco.nd.nd_manage_fabric_ebgp_vxlan:
+    <<: *nd_info
+    state: merged
+    config: "{{ ebgp_gathered_exact.gathered }}"
+  check_mode: true
+  register: ebgp_gathered_round_trip
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gathered output round-trips without drift"
+  ansible.builtin.assert:
+    that:
+      - ebgp_gathered_round_trip is not changed
+      - ebgp_gathered_round_trip.proposed | length == 1
+      - ebgp_gathered_round_trip.proposed[0].fabric_name == ebgp_test_fabric_merged
+  tags: [test_gathered]
 
 #############################################################################
 # VALIDATION: Query ebgp_test_fabric_merged and validate expected changes

--- a/tests/integration/targets/nd_manage_fabric/tasks/fabric_external.yaml
+++ b/tests/integration/targets/nd_manage_fabric/tasks/fabric_external.yaml
@@ -113,6 +113,195 @@
     success_msg: "Fabric successfully updated with state merged"
   tags: [test_merged, test_merged_update]
 
+
+#############################################################################
+# TEST GATHERED: Read-only state and supported filtering
+#############################################################################
+- name: "GATHERED: Read all External Connectivity fabrics"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: gathered
+  register: ext_gathered_all
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gather-all output is read-only"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_all is not changed
+      - ext_gathered_all.gathered is defined
+      - ext_gathered_all.gathered | type_debug == "list"
+      - ext_test_fabric_merged in (ext_gathered_all.gathered | map(attribute='fabric_name') | list)
+      - ext_gathered_all.before is not defined
+      - ext_gathered_all.after is not defined
+      - ext_gathered_all.diff is not defined
+      - ext_gathered_all.proposed is not defined
+  tags: [test_gathered]
+
+- name: "GATHERED: Read all fabrics with explicit empty config"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: gathered
+    config: []
+  register: ext_gathered_empty_config
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify explicit empty config matches omitted config"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_empty_config is not changed
+      - >-
+        ext_gathered_empty_config.gathered | map(attribute='fabric_name') | sort | list
+        == ext_gathered_all.gathered | map(attribute='fabric_name') | sort | list
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by exact fabric name"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ext_test_fabric_merged }}"
+  register: ext_gathered_exact
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify exact-name filter"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_exact is not changed
+      - ext_gathered_exact.gathered | length == 1
+      - ext_gathered_exact.gathered[0].fabric_name == ext_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with all five supported properties"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ext_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ext_gathered_exact.gathered[0].license_tier }}"
+        security_domain: "{{ ext_gathered_exact.gathered[0].security_domain }}"
+        alert_suspend: "{{ ext_gathered_exact.gathered[0].alert_suspend }}"
+        telemetry_collection: "{{ ext_gathered_exact.gathered[0].telemetry_collection }}"
+  register: ext_gathered_all_fields
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify all supported properties use AND semantics"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_all_fields is not changed
+      - ext_gathered_all_fields.gathered | length == 1
+      - ext_gathered_all_fields.gathered[0].fabric_name == ext_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Apply overlapping filters"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ext_test_fabric_merged }}"
+      - fabric_name: "{{ ext_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ext_gathered_exact.gathered[0].license_tier }}"
+  register: ext_gathered_overlapping
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify OR semantics and deduplication"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_overlapping is not changed
+      - ext_gathered_overlapping.gathered | length == 1
+      - ext_gathered_overlapping.gathered[0].fabric_name == ext_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with more than three expressions"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ext_test_fabric_merged }}"
+      - fabric_name: nonexistent_external_fallback_1
+      - fabric_name: nonexistent_external_fallback_2
+      - fabric_name: nonexistent_external_fallback_3
+  register: ext_gathered_fallback
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify fallback preserves the matching OR item"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_fallback is not changed
+      - ext_gathered_fallback.gathered | length == 1
+      - ext_gathered_fallback.gathered[0].fabric_name == ext_test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by a non-existent fabric name"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: nonexistent_external_fabric_999
+  register: ext_gathered_no_match
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify no-match filter returns an empty list"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_no_match is not changed
+      - ext_gathered_no_match.gathered == []
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an empty filter item"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: gathered
+    config:
+      - {}
+  register: ext_gathered_empty_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify empty filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_empty_filter is failed
+      - "'must contain at least one filtering criterion' in ext_gathered_empty_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an unsupported location filter"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: gathered
+    config:
+      - location:
+          latitude: 0.0
+          longitude: 0.0
+  register: ext_gathered_unsupported_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify unsupported filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_unsupported_filter is failed
+      - "'unsupported properties' in ext_gathered_unsupported_filter.msg"
+      - "'location.latitude' in ext_gathered_unsupported_filter.msg"
+      - "'location.longitude' in ext_gathered_unsupported_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reuse exact gathered output as config in check mode"
+  cisco.nd.nd_manage_fabric_external:
+    <<: *nd_info
+    state: merged
+    config: "{{ ext_gathered_exact.gathered }}"
+  check_mode: true
+  register: ext_gathered_round_trip
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gathered output round-trips without drift"
+  ansible.builtin.assert:
+    that:
+      - ext_gathered_round_trip is not changed
+      - ext_gathered_round_trip.proposed | length == 1
+      - ext_gathered_round_trip.proposed[0].fabric_name == ext_test_fabric_merged
+  tags: [test_gathered]
+
 #############################################################################
 # VALIDATION: Query ext_test_fabric_merged and validate expected changes
 #############################################################################

--- a/tests/integration/targets/nd_manage_fabric/tasks/fabric_ibgp.yaml
+++ b/tests/integration/targets/nd_manage_fabric/tasks/fabric_ibgp.yaml
@@ -36,7 +36,7 @@
     config:
       - "{{ {'fabric_name': test_fabric_merged} | combine(fabric_config_ibgp) }}"
   register: merged_result_1
-  tags: [test_merged, test_merged_create]
+  tags: [test_merged, test_merged_create, test_gathered]
 
 - name: "TEST 1a: Verify fabric was created using merged state"
   assert:
@@ -45,7 +45,7 @@
       - merged_result_1 is not failed
     fail_msg: "Fabric creation with state merged failed"
     success_msg: "Fabric successfully created with state merged"
-  tags: [test_merged, test_merged_create]
+  tags: [test_merged, test_merged_create, test_gathered]
 
 - name: "TEST 1b: Create fabric using state merged (second run - idempotency test)"
   cisco.nd.nd_manage_fabric_ibgp_vxlan:
@@ -54,7 +54,7 @@
     config:
       - "{{ {'fabric_name': test_fabric_merged} | combine(fabric_config_ibgp) }}"
   register: merged_result_2
-  tags: [test_merged, test_merged_idempotent]
+  tags: [test_merged, test_merged_idempotent, test_gathered]
 
 - name: "TEST 1b: Verify merged state is idempotent"
   assert:
@@ -63,7 +63,7 @@
       - merged_result_2 is not failed
     fail_msg: "Merged state is not idempotent - should not change when run twice with same config"
     success_msg: "Merged state is idempotent - no changes on second run"
-  tags: [test_merged, test_merged_idempotent]
+  tags: [test_merged, test_merged_idempotent, test_gathered]
 
 - name: "TEST 1c: Update fabric using state merged (modify existing)"
   cisco.nd.nd_manage_fabric_ibgp_vxlan:
@@ -142,7 +142,7 @@
           management_gateway: ""
           management_ipv4_prefix: 24
   register: merged_result_3
-  tags: [test_merged, test_merged_update]
+  tags: [test_merged, test_merged_update, test_gathered]
 
 - name: "TEST 1c: Verify fabric was updated using merged state"
   assert:
@@ -151,7 +151,195 @@
       - merged_result_3 is not failed
     fail_msg: "Fabric update with state merged failed"
     success_msg: "Fabric successfully updated with state merged"
-  tags: [test_merged, test_merged_update]
+  tags: [test_merged, test_merged_update, test_gathered]
+
+#############################################################################
+# TEST GATHERED: Read-only state and supported filtering
+#############################################################################
+- name: "GATHERED: Read all iBGP VXLAN fabrics"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+  register: ibgp_gathered_all
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gather-all output is read-only"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_all is not changed
+      - ibgp_gathered_all.gathered is defined
+      - ibgp_gathered_all.gathered | type_debug == "list"
+      - test_fabric_merged in (ibgp_gathered_all.gathered | map(attribute='fabric_name') | list)
+      - ibgp_gathered_all.before is not defined
+      - ibgp_gathered_all.after is not defined
+      - ibgp_gathered_all.diff is not defined
+      - ibgp_gathered_all.proposed is not defined
+  tags: [test_gathered]
+
+- name: "GATHERED: Read all fabrics with explicit empty config"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config: []
+  register: ibgp_gathered_empty_config
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify explicit empty config matches omitted config"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_empty_config is not changed
+      - >-
+        ibgp_gathered_empty_config.gathered | map(attribute='fabric_name') | sort | list
+        == ibgp_gathered_all.gathered | map(attribute='fabric_name') | sort | list
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by exact fabric name"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ test_fabric_merged }}"
+  register: ibgp_gathered_exact
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify exact-name filter"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_exact is not changed
+      - ibgp_gathered_exact.gathered | length == 1
+      - ibgp_gathered_exact.gathered[0].fabric_name == test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with all five supported properties"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ ibgp_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ibgp_gathered_exact.gathered[0].license_tier }}"
+        security_domain: "{{ ibgp_gathered_exact.gathered[0].security_domain }}"
+        alert_suspend: "{{ ibgp_gathered_exact.gathered[0].alert_suspend }}"
+        telemetry_collection: "{{ ibgp_gathered_exact.gathered[0].telemetry_collection }}"
+  register: ibgp_gathered_all_fields
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify all supported properties use AND semantics"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_all_fields is not changed
+      - ibgp_gathered_all_fields.gathered | length == 1
+      - ibgp_gathered_all_fields.gathered[0].fabric_name == test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Apply overlapping filters"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ test_fabric_merged }}"
+      - fabric_name: "{{ ibgp_gathered_exact.gathered[0].fabric_name }}"
+        license_tier: "{{ ibgp_gathered_exact.gathered[0].license_tier }}"
+  register: ibgp_gathered_overlapping
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify OR semantics and deduplication"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_overlapping is not changed
+      - ibgp_gathered_overlapping.gathered | length == 1
+      - ibgp_gathered_overlapping.gathered[0].fabric_name == test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter with more than three expressions"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: "{{ test_fabric_merged }}"
+      - fabric_name: nonexistent_ibgp_fallback_1
+      - fabric_name: nonexistent_ibgp_fallback_2
+      - fabric_name: nonexistent_ibgp_fallback_3
+  register: ibgp_gathered_fallback
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify fallback preserves the matching OR item"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_fallback is not changed
+      - ibgp_gathered_fallback.gathered | length == 1
+      - ibgp_gathered_fallback.gathered[0].fabric_name == test_fabric_merged
+  tags: [test_gathered]
+
+- name: "GATHERED: Filter by a non-existent fabric name"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - fabric_name: nonexistent_ibgp_fabric_999
+  register: ibgp_gathered_no_match
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify no-match filter returns an empty list"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_no_match is not changed
+      - ibgp_gathered_no_match.gathered == []
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an empty filter item"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - {}
+  register: ibgp_gathered_empty_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify empty filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_empty_filter is failed
+      - "'must contain at least one filtering criterion' in ibgp_gathered_empty_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reject an unsupported location filter"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: gathered
+    config:
+      - location:
+          latitude: 0.0
+          longitude: 0.0
+  register: ibgp_gathered_unsupported_filter
+  ignore_errors: true
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify unsupported filter rejection"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_unsupported_filter is failed
+      - "'unsupported properties' in ibgp_gathered_unsupported_filter.msg"
+      - "'location.latitude' in ibgp_gathered_unsupported_filter.msg"
+      - "'location.longitude' in ibgp_gathered_unsupported_filter.msg"
+  tags: [test_gathered]
+
+- name: "GATHERED: Reuse exact gathered output as config in check mode"
+  cisco.nd.nd_manage_fabric_ibgp_vxlan:
+    <<: *nd_info
+    state: merged
+    config: "{{ ibgp_gathered_exact.gathered }}"
+  check_mode: true
+  register: ibgp_gathered_round_trip
+  tags: [test_gathered]
+
+- name: "GATHERED: Verify gathered output round-trips without drift"
+  ansible.builtin.assert:
+    that:
+      - ibgp_gathered_round_trip is not changed
+      - ibgp_gathered_round_trip.proposed | length == 1
+      - ibgp_gathered_round_trip.proposed[0].fabric_name == test_fabric_merged
+  tags: [test_gathered]
 
 #############################################################################
 # VALIDATION: Query test_fabric_merged and validate expected changes

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
@@ -30,9 +30,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesRemove,
     ManageInterfacesListEndpointParams,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import (
-    LuceneQueryParams,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
@@ -30,6 +30,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesRemove,
     ManageInterfacesListEndpointParams,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 
@@ -228,6 +229,8 @@ def test_ep_manage_interfaces_00100():
     assert instance.class_name == "EpManageInterfacesListGet"
     assert instance.verb == HttpVerbEnum.GET
     assert isinstance(instance.endpoint_params, ManageInterfacesListEndpointParams)
+    assert isinstance(instance.lucene_params, LuceneQueryParams)
+    assert instance.lucene_params.is_empty()
 
 
 def test_ep_manage_interfaces_00110():
@@ -327,6 +330,56 @@ def test_ep_manage_interfaces_00140():
         "sort=ifName%3Aasc",
         "configOnly=true",
     }
+
+
+def test_ep_manage_interfaces_00150():
+    """Verify endpoint-specific and URL-encoded Lucene parameters compose."""
+    instance = EpManageInterfacesListGet()
+    instance.fabric_name = "fab1"
+    instance.switch_sn = "SN123"
+    instance.endpoint_params.cluster_name = "cluster-a"
+    instance.endpoint_params.network_name = "net1"
+    instance.endpoint_params.config_only = False
+    instance.lucene_params.filter = (
+        "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"
+    )
+    instance.lucene_params.max = 500
+    instance.lucene_params.offset = 0
+    instance.lucene_params.sort = "interfaceName:asc"
+    instance.lucene_params.fields = "interfaceName,configData"
+
+    path, query = instance.path.split("?", 1)
+
+    assert path == "/api/v1/manage/fabrics/fab1/switches/SN123/interfaces"
+    assert set(query.split("&")) == {
+        "clusterName=cluster-a",
+        "networkName=net1",
+        "configOnly=false",
+        "filter=interfaceType:loopback%20AND%20policyType:loopback%20AND%20interfaceName:loopback101",
+        "max=500",
+        "offset=0",
+        "sort=interfaceName%3Aasc",
+        "fields=interfaceName%2CconfigData",
+    }
+
+
+@pytest.mark.parametrize(
+    ("legacy_field", "legacy_value"),
+    [
+        ("filter", "interfaceType:loopback"),
+        ("offset", 0),
+    ],
+)
+def test_ep_manage_interfaces_00160(legacy_field, legacy_value):
+    """Verify callers cannot mix legacy and new Lucene parameter groups."""
+    instance = EpManageInterfacesListGet()
+    instance.fabric_name = "fab1"
+    instance.switch_sn = "SN123"
+    setattr(instance.endpoint_params, legacy_field, legacy_value)
+    instance.lucene_params.max = 500
+
+    with pytest.raises(ValueError, match="either.*endpoint_params.*or.*lucene_params"):
+        str(instance.path)
 
 
 # =============================================================================

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
@@ -30,7 +30,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesRemove,
     ManageInterfacesListEndpointParams,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import LuceneQueryParams
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import (
+    LuceneQueryParams,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
 
@@ -340,9 +342,7 @@ def test_ep_manage_interfaces_00150():
     instance.endpoint_params.cluster_name = "cluster-a"
     instance.endpoint_params.network_name = "net1"
     instance.endpoint_params.config_only = False
-    instance.lucene_params.filter = (
-        "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"
-    )
+    instance.lucene_params.filter = "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"
     instance.lucene_params.max = 500
     instance.lucene_params.offset = 0
     instance.lucene_params.sort = "interfaceName:asc"
@@ -812,7 +812,11 @@ def test_ep_manage_interfaces_00600():
     - EpManageInterfacesGet.path
     - EpManageInterfacesPut.path
     """
-    params = {"fabric_name": "fab1", "switch_sn": "SN123", "interface_name": "loopback0"}
+    params = {
+        "fabric_name": "fab1",
+        "switch_sn": "SN123",
+        "interface_name": "loopback0",
+    }
     expected_path = "/api/v1/manage/fabrics/fab1/switches/SN123/interfaces/loopback0"
 
     with does_not_raise():

--- a/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_fabric_context.json
@@ -200,5 +200,39 @@
             "local": false,
             "fabricStatus": "default"
         }
+    },
+    "test_fabric_context_00400a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists, local=true, fabricStatus=frozen (validate_for_read must NOT raise on freeze)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_a",
+            "local": true,
+            "fabricStatus": "frozen"
+        }
+    },
+   "test_fabric_context_00410a": {
+        "TEST_NOTES": ["Fabric summary: 404 not found (validate_for_read must raise on missing fabric)"],
+        "RETURN_CODE": 404,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/missing_fabric/summary",
+        "MESSAGE": "Not Found",
+        "DATA": {}
+    },
+    "test_fabric_context_00420a": {
+        "TEST_NOTES": ["Fabric summary: fabric exists, local=false (validate_for_read must raise on non-local)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "ownerCluster": "cluster_b",
+            "local": false,
+            "fabricStatus": "default"
+        }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_loopback_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_loopback_interface.json
@@ -546,6 +546,29 @@
         "DATA": {"status": "ok"}
     },
 
+    "test_loopback_interface_00860a": {
+        "TEST_NOTES": ["gathered on frozen fabric: fabric summary reports fabricStatus=frozen (validate_for_read must not raise)"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "name": "fabric_1",
+            "local": true,
+            "fabricStatus": "frozen"
+        }
+    },
+    "test_loopback_interface_00860b": {
+        "TEST_NOTES": ["gathered on frozen fabric: switches list returns no switches"],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": []
+        }
+    },
+
     "test_loopback_interface_00760a": {
         "TEST_NOTES": ["query_all multi-type: fabric summary"],
         "RETURN_CODE": 200,

--- a/tests/unit/module_utils/mock_ansible_module.py
+++ b/tests/unit/module_utils/mock_ansible_module.py
@@ -68,6 +68,7 @@ class MockAnsibleModule:
 
     def __init__(self) -> None:
         self.warnings: list[str] = []
+        self.no_log_values: set = set()
 
     @staticmethod
     def fail_json(msg, **kwargs) -> AnsibleFailJson:

--- a/tests/unit/module_utils/models/test_base_secrets.py
+++ b/tests/unit/module_utils/models/test_base_secrets.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Shreyas Srish (@shrsr) <ssrish@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the generic (base-model) secret handling: a single
+``json_schema_extra={"secret": True}`` tag drives both no_log value collection
+and output/diff stripping, while the value is kept in the controller payload.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, List, Optional
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+
+
+class _DemoModel(NDBaseModel):
+    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifier_strategy: ClassVar[str] = "single"
+    name: Optional[str] = None
+    password: Optional[str] = Field(default=None, json_schema_extra={"secret": True}, alias="pwd")
+
+
+class TestBaseSecretHandling:
+    def test_secret_field_keys(self):
+        assert _DemoModel.secret_field_keys(by_alias=False) == {"password"}
+        assert _DemoModel.secret_field_keys(by_alias=True) == {"pwd"}
+
+    def test_stripped_from_config_and_diff(self):
+        model = _DemoModel(name="u1", pwd="p@ss")
+        assert "password" not in model.to_config()
+        assert "pwd" not in model.to_diff_dict()
+
+    def test_kept_in_payload(self):
+        model = _DemoModel(name="u1", pwd="p@ss")
+        assert model.to_payload().get("pwd") == "p@ss"
+
+    def test_collect_secret_values_from_raw_config(self):
+        assert _DemoModel.collect_secret_values({"name": "u1", "password": "p@ss"}) == {"p@ss"}
+        assert _DemoModel.collect_secret_values({"name": "u1"}) == set()

--- a/tests/unit/module_utils/models/test_base_secrets.py
+++ b/tests/unit/module_utils/models/test_base_secrets.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 from typing import ClassVar, List, Optional
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 
 

--- a/tests/unit/module_utils/models/test_base_secrets.py
+++ b/tests/unit/module_utils/models/test_base_secrets.py
@@ -14,9 +14,7 @@ from __future__ import annotations
 
 from typing import ClassVar, List, Optional
 
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
-    Field,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 
 

--- a/tests/unit/module_utils/models/test_base_secrets.py
+++ b/tests/unit/module_utils/models/test_base_secrets.py
@@ -12,17 +12,17 @@ and output/diff stripping, while the value is kept in the controller payload.
 
 from __future__ import annotations
 
-from typing import ClassVar, List, Optional
+from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 
 
 class _DemoModel(NDBaseModel):
-    identifiers: ClassVar[Optional[List[str]]] = ["name"]
+    identifiers: ClassVar[list[str] | None] = ["name"]
     identifier_strategy: ClassVar[str] = "single"
-    name: Optional[str] = None
-    password: Optional[str] = Field(default=None, json_schema_extra={"secret": True}, alias="pwd")
+    name: str | None = None
+    password: str | None = Field(default=None, json_schema_extra={"secret": True}, alias="pwd")
 
 
 class TestBaseSecretHandling:

--- a/tests/unit/module_utils/models/test_ethernet_access_interface.py
+++ b/tests/unit/module_utils/models/test_ethernet_access_interface.py
@@ -371,7 +371,16 @@ def test_ethernet_access_interface_00235(value, should_raise):
         ("mtu", MtuEnum),
         ("storm_control_action", StormControlActionEnum),
     ],
-    ids=["speed", "duplex_mode", "fec", "bpdu_guard", "bpdu_filter", "link_type", "mtu", "storm_control_action"],
+    ids=[
+        "speed",
+        "duplex_mode",
+        "fec",
+        "bpdu_guard",
+        "bpdu_filter",
+        "link_type",
+        "mtu",
+        "storm_control_action",
+    ],
 )
 def test_ethernet_access_interface_00240(field, enum_cls):
     """
@@ -1340,7 +1349,13 @@ def test_ethernet_access_interface_01100():
     assert "switch_ip" in spec["config"]["options"]
     assert spec["config"]["type"] == "list"
     assert spec["config"]["elements"] == "dict"
-    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert spec["state"]["choices"] == [
+        "merged",
+        "replaced",
+        "overridden",
+        "deleted",
+        "gathered",
+    ]
     assert spec["state"]["default"] == "merged"
 
     # interface_type, mode, and network_os_type are hardcoded in the Pydantic model
@@ -1398,3 +1413,202 @@ def test_ethernet_access_interface_01120(field, enum_cls, key):
     else:
         expected = [e.value for e in enum_cls]
     assert policy_spec[field]["choices"] == expected
+
+
+# =============================================================================
+#
+# Gathered state and filtering tests
+#
+# =============================================================================
+
+
+def test_ethernet_access_interface_01200():
+    """
+    # Summary
+
+    Verify ``config`` is optional so ``state=gathered`` can run without input.
+
+    ## Test
+
+    - config required is False
+
+    ## Classes and Methods
+
+    - EthernetAccessInterfaceModel.get_argument_spec()
+    """
+    spec = EthernetAccessInterfaceModel.get_argument_spec()
+    assert spec["config"].get("required", False) is False
+
+
+def test_ethernet_access_interface_01210():
+    """
+    # Summary
+
+    Verify gathered filters may omit both identifiers (``switch_ip``, ``interface_names``).
+
+    ## Test
+
+    - switch_ip required is False
+    - interface_names required is False
+
+    ## Classes and Methods
+
+    - EthernetAccessInterfaceModel.get_argument_spec()
+    """
+    config_options = EthernetAccessInterfaceModel.get_argument_spec()["config"]["options"]
+    assert config_options["switch_ip"].get("required", False) is False
+    assert config_options["interface_names"].get("required", False) is False
+
+
+def test_ethernet_access_interface_01220():
+    """
+    # Summary
+
+    Verify ``supports_gathered_filtering`` is ``True`` on ``EthernetAccessInterfaceModel``
+    and ``False`` on the base ``NDBaseModel``.
+
+    ## Test
+
+    - NDBaseModel.supports_gathered_filtering is False
+    - EthernetAccessInterfaceModel.supports_gathered_filtering is True
+
+    ## Classes and Methods
+
+    - NDBaseModel.supports_gathered_filtering
+    - EthernetAccessInterfaceModel.supports_gathered_filtering
+    """
+    from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+
+    assert NDBaseModel.supports_gathered_filtering is False
+    assert EthernetAccessInterfaceModel.supports_gathered_filtering is True
+
+
+def test_ethernet_access_interface_01230():
+    """
+    # Summary
+
+    Verify ``gathered_filter_properties`` contains the expected 4 properties.
+
+    ## Test
+
+    - gathered_filter_properties tuple has exactly 4 entries
+    - Each entry matches the expected dot-path
+
+    ## Classes and Methods
+
+    - EthernetAccessInterfaceModel.gathered_filter_properties
+    """
+    assert EthernetAccessInterfaceModel.gathered_filter_properties == (
+        "switch_ip",
+        "interface_name",
+        "config_data.network_os.policy.admin_state",
+        "config_data.network_os.policy.access_vlan",
+    )
+
+
+def test_ethernet_access_interface_01240():
+    """
+    # Summary
+
+    Verify ``normalize_gathered_filter`` normalizes abbreviated interface names
+    to the canonical ``Ethernet`` prefix.
+
+    ## Test
+
+    - ``eth1/1`` normalizes to ``Ethernet1/1``
+    - ``e1/2`` normalizes to ``Ethernet1/2``
+    - ``ETHERNET1/3`` normalizes to ``Ethernet1/3``
+    - ``Ethernet1/4`` is idempotent
+
+    ## Classes and Methods
+
+    - EthernetAccessInterfaceModel.normalize_gathered_filter()
+    """
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({"interface_name": "eth1/1"}) == {"interface_name": "Ethernet1/1"}
+
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({"interface_name": "e1/2"}) == {"interface_name": "Ethernet1/2"}
+
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({"interface_name": "ETHERNET1/3"}) == {"interface_name": "Ethernet1/3"}
+
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({"interface_name": "Ethernet1/4"}) == {"interface_name": "Ethernet1/4"}
+
+
+def test_ethernet_access_interface_01250():
+    """
+    # Summary
+
+    Verify ``normalize_gathered_filter`` passes through filters without ``interface_name``
+    unchanged.
+
+    ## Test
+
+    - Filter with only switch_ip is returned unchanged
+    - Filter with only policy fields is returned unchanged
+    - Empty filter is returned unchanged
+
+    ## Classes and Methods
+
+    - EthernetAccessInterfaceModel.normalize_gathered_filter()
+    """
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({"switch_ip": "10.1.1.1"}) == {"switch_ip": "10.1.1.1"}
+
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({"config_data": {"network_os": {"policy": {"access_vlan": 100}}}}) == {
+        "config_data": {"network_os": {"policy": {"access_vlan": 100}}}
+    }
+
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({}) == {}
+
+
+def test_ethernet_access_interface_01260():
+    """
+    # Summary
+
+    Verify ``normalize_gathered_filter`` handles edge cases for ``interface_name``:
+    ``None``, empty string, and non-string values.
+
+    ## Test
+
+    - interface_name=None is passed through
+    - interface_name="" is passed through
+    - interface_name=123 is passed through
+
+    ## Classes and Methods
+
+    - EthernetAccessInterfaceModel.normalize_gathered_filter()
+    """
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({"interface_name": None}) == {"interface_name": None}
+
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({"interface_name": ""}) == {"interface_name": ""}
+
+    assert EthernetAccessInterfaceModel.normalize_gathered_filter({"interface_name": 123}) == {"interface_name": 123}
+
+
+def test_ethernet_access_interface_01270():
+    """
+    # Summary
+
+    Verify ``supports_gathered_server_filtering`` is ``True`` and ``gathered_lucene_spec``
+    has the correct base terms and field map on the access orchestrator.
+
+    ## Test
+
+    - supports_gathered_server_filtering is True
+    - gathered_lucene_spec.base_terms includes interfaceType:ethernet and policyType:accessHost
+    - gathered_lucene_spec.field_map maps interface_name to interfaceName
+
+    ## Classes and Methods
+
+    - EthernetAccessInterfaceOrchestrator.supports_gathered_server_filtering
+    - EthernetAccessInterfaceOrchestrator.gathered_lucene_spec
+    """
+    from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import (
+        EthernetAccessInterfaceOrchestrator,
+    )
+
+    assert EthernetAccessInterfaceOrchestrator.supports_gathered_server_filtering is True
+
+    spec = EthernetAccessInterfaceOrchestrator.gathered_lucene_spec
+    assert spec is not None
+    assert ("interfaceType", "ethernet") in spec.base_terms
+    assert ("policyType", "accessHost") in spec.base_terms
+    assert spec.field_map == {("interface_name",): "interfaceName"}

--- a/tests/unit/module_utils/models/test_ethernet_trunk_host_interface.py
+++ b/tests/unit/module_utils/models/test_ethernet_trunk_host_interface.py
@@ -1783,7 +1783,7 @@ def test_ethernet_trunk_host_interface_01100():
     assert "switch_ip" in spec["config"]["options"]
     assert spec["config"]["type"] == "list"
     assert spec["config"]["elements"] == "dict"
-    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted", "gathered"]
     assert spec["state"]["default"] == "merged"
     # interface_type, mode, and network_os_type are hardcoded in the Pydantic model
     # and intentionally absent from the user-facing argument spec.
@@ -1931,3 +1931,230 @@ def test_ethernet_trunk_host_interface_01140(kwargs, should_raise):
     else:
         with does_not_raise():
             EthernetTrunkHostPolicyModel(**kwargs)
+
+
+# =============================================================================
+#
+# Gathered state and filtering tests
+#
+# =============================================================================
+
+
+def test_ethernet_trunk_host_interface_01200():
+    """
+    # Summary
+
+    Verify state choices include ``gathered`` and default is ``merged``.
+
+    ## Test
+
+    - state choices: ["merged", "replaced", "overridden", "deleted", "gathered"]
+    - state default: "merged"
+
+    ## Classes and Methods
+
+    - EthernetTrunkHostInterfaceModel.get_argument_spec()
+    """
+    spec = EthernetTrunkHostInterfaceModel.get_argument_spec()
+    state_spec = spec["state"]
+    assert state_spec["choices"] == [
+        "merged",
+        "replaced",
+        "overridden",
+        "deleted",
+        "gathered",
+    ]
+    assert state_spec["default"] == "merged"
+
+
+def test_ethernet_trunk_host_interface_01210():
+    """
+    # Summary
+
+    Verify ``config`` is optional so ``state=gathered`` can run without input.
+
+    ## Test
+
+    - config required is False
+
+    ## Classes and Methods
+
+    - EthernetTrunkHostInterfaceModel.get_argument_spec()
+    """
+    spec = EthernetTrunkHostInterfaceModel.get_argument_spec()
+    assert spec["config"].get("required", False) is False
+
+
+def test_ethernet_trunk_host_interface_01220():
+    """
+    # Summary
+
+    Verify gathered filters may omit both identifiers (``switch_ip``, ``interface_names``).
+
+    ## Test
+
+    - switch_ip required is False
+    - interface_names required is False
+
+    ## Classes and Methods
+
+    - EthernetTrunkHostInterfaceModel.get_argument_spec()
+    """
+    config_options = EthernetTrunkHostInterfaceModel.get_argument_spec()["config"]["options"]
+    assert config_options["switch_ip"].get("required", False) is False
+    assert config_options["interface_names"].get("required", False) is False
+
+
+def test_ethernet_trunk_host_interface_01230():
+    """
+    # Summary
+
+    Verify ``supports_gathered_filtering`` is ``True`` on ``EthernetTrunkHostInterfaceModel``
+    and ``False`` on the base ``NDBaseModel``.
+
+    ## Test
+
+    - NDBaseModel.supports_gathered_filtering is False
+    - EthernetTrunkHostInterfaceModel.supports_gathered_filtering is True
+
+    ## Classes and Methods
+
+    - NDBaseModel.supports_gathered_filtering
+    - EthernetTrunkHostInterfaceModel.supports_gathered_filtering
+    """
+    from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+
+    assert NDBaseModel.supports_gathered_filtering is False
+    assert EthernetTrunkHostInterfaceModel.supports_gathered_filtering is True
+
+
+def test_ethernet_trunk_host_interface_01240():
+    """
+    # Summary
+
+    Verify ``gathered_filter_properties`` contains the expected 5 properties.
+
+    ## Test
+
+    - gathered_filter_properties tuple has exactly 5 entries
+    - Each entry matches the expected dot-path
+
+    ## Classes and Methods
+
+    - EthernetTrunkHostInterfaceModel.gathered_filter_properties
+    """
+    assert EthernetTrunkHostInterfaceModel.gathered_filter_properties == (
+        "switch_ip",
+        "interface_name",
+        "config_data.network_os.policy.admin_state",
+        "config_data.network_os.policy.allowed_vlans",
+        "config_data.network_os.policy.native_vlan",
+    )
+
+
+def test_ethernet_trunk_host_interface_01250():
+    """
+    # Summary
+
+    Verify ``normalize_gathered_filter`` normalizes abbreviated interface names
+    to the canonical ``Ethernet`` prefix.
+
+    ## Test
+
+    - ``eth1/1`` normalizes to ``Ethernet1/1``
+    - ``e1/2`` normalizes to ``Ethernet1/2``
+    - ``ETHERNET1/3`` normalizes to ``Ethernet1/3``
+    - ``Ethernet1/4`` is idempotent
+
+    ## Classes and Methods
+
+    - EthernetTrunkHostInterfaceModel.normalize_gathered_filter()
+    """
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({"interface_name": "eth1/1"}) == {"interface_name": "Ethernet1/1"}
+
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({"interface_name": "e1/2"}) == {"interface_name": "Ethernet1/2"}
+
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({"interface_name": "ETHERNET1/3"}) == {"interface_name": "Ethernet1/3"}
+
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({"interface_name": "Ethernet1/4"}) == {"interface_name": "Ethernet1/4"}
+
+
+def test_ethernet_trunk_host_interface_01260():
+    """
+    # Summary
+
+    Verify ``normalize_gathered_filter`` passes through filters without ``interface_name``
+    unchanged.
+
+    ## Test
+
+    - Filter with only switch_ip is returned unchanged
+    - Filter with only policy fields is returned unchanged
+    - Empty filter is returned unchanged
+
+    ## Classes and Methods
+
+    - EthernetTrunkHostInterfaceModel.normalize_gathered_filter()
+    """
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({"switch_ip": "10.1.1.1"}) == {"switch_ip": "10.1.1.1"}
+
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({"config_data": {"network_os": {"policy": {"admin_state": True}}}}) == {
+        "config_data": {"network_os": {"policy": {"admin_state": True}}}
+    }
+
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({}) == {}
+
+
+def test_ethernet_trunk_host_interface_01270():
+    """
+    # Summary
+
+    Verify ``normalize_gathered_filter`` handles edge cases for ``interface_name``:
+    ``None``, empty string, and non-string values.
+
+    ## Test
+
+    - interface_name=None is passed through
+    - interface_name="" is passed through
+    - interface_name=123 is passed through
+
+    ## Classes and Methods
+
+    - EthernetTrunkHostInterfaceModel.normalize_gathered_filter()
+    """
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({"interface_name": None}) == {"interface_name": None}
+
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({"interface_name": ""}) == {"interface_name": ""}
+
+    assert EthernetTrunkHostInterfaceModel.normalize_gathered_filter({"interface_name": 123}) == {"interface_name": 123}
+
+
+def test_ethernet_trunk_host_interface_01280():
+    """
+    # Summary
+
+    Verify ``supports_gathered_server_filtering`` is ``True`` and ``gathered_lucene_spec``
+    has the correct base terms and field map on the trunk host orchestrator.
+
+    ## Test
+
+    - supports_gathered_server_filtering is True
+    - gathered_lucene_spec.base_terms includes interfaceType:ethernet and policyType:trunkHost
+    - gathered_lucene_spec.field_map maps interface_name to interfaceName
+
+    ## Classes and Methods
+
+    - EthernetTrunkHostInterfaceOrchestrator.supports_gathered_server_filtering
+    - EthernetTrunkHostInterfaceOrchestrator.gathered_lucene_spec
+    """
+    from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import (
+        EthernetTrunkHostInterfaceOrchestrator,
+    )
+
+    assert EthernetTrunkHostInterfaceOrchestrator.supports_gathered_server_filtering is True
+
+    spec = EthernetTrunkHostInterfaceOrchestrator.gathered_lucene_spec
+    assert spec is not None
+    assert ("interfaceType", "ethernet") in spec.base_terms
+    assert ("policyType", "trunkHost") in spec.base_terms
+    assert spec.field_map == {("interface_name",): "interfaceName"}

--- a/tests/unit/module_utils/models/test_fabric_update_group.py
+++ b/tests/unit/module_utils/models/test_fabric_update_group.py
@@ -33,9 +33,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.fabric_update_grou
     InstallImageDataModel,
     UpdateReportCheckModel,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.fabric_update_group import (
-    FabricUpdateGroupOrchestrator,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.fabric_update_group import FabricUpdateGroupOrchestrator
 
 
 @contextmanager

--- a/tests/unit/module_utils/models/test_fabric_update_group.py
+++ b/tests/unit/module_utils/models/test_fabric_update_group.py
@@ -13,6 +13,7 @@ Tests:
 - to_payload / from_response round-trip
 - Nested InstallImageDataModel and UpdateReportCheckModel
 - get_argument_spec shape
+- Gathered state filtering
 """
 
 # pylint: disable=disallowed-name,protected-access,redefined-outer-name,too-many-lines,line-too-long,invalid-name
@@ -20,12 +21,20 @@ Tests:
 from __future__ import annotations
 
 from contextlib import contextmanager
+from copy import deepcopy
 
 import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    filter_gathered_response,
+    validate_gathered_filters,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.fabric_update_group.fabric_update_group import (
     FabricUpdateGroupModel,
     InstallImageDataModel,
     UpdateReportCheckModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.fabric_update_group import (
+    FabricUpdateGroupOrchestrator,
 )
 
 
@@ -612,8 +621,10 @@ def test_fabric_update_group_00600() -> None:
 
     - `fabric_name`, `state`, `config`, `auto_assign` are top-level keys
     - `state` choices are merged/replaced/overridden/deleted (no `query` - the ND collection has no
-      `query` state; `gathered` is the planned read mechanism)
-    - `config.options.update_group_name` is required
+      `query` state;)
+    - `state` choices include `gathered`
+    - `config` is optional (not required) so state=gathered can run without input
+    - `config.options.update_group_name` is not required (optional filter for gathered)
     - `install_image_data` and `update_report_checks` are nested dicts/lists
 
     ## Classes and Methods
@@ -624,14 +635,26 @@ def test_fabric_update_group_00600() -> None:
 
     assert set(spec.keys()) == {"fabric_name", "config", "state", "auto_assign"}
     assert spec["fabric_name"]["required"] is True
-    assert spec["state"]["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert spec["state"]["choices"] == [
+        "merged",
+        "replaced",
+        "overridden",
+        "deleted",
+        "gathered",
+    ]
     assert spec["config"]["type"] == "list"
     assert spec["config"]["elements"] == "dict"
+    assert spec["config"].get("required", False) is False
 
     options = spec["config"]["options"]
-    assert options["update_group_name"]["required"] is True
+    assert options["update_group_name"]["required"] is False
     assert options["execution"]["choices"] == ["parallel", "serial"]
-    assert options["analysis"]["choices"] == ["snapshot", "noAnalysis", "fullAnalysis", "usePreExistingAnalysis"]
+    assert options["analysis"]["choices"] == [
+        "snapshot",
+        "noAnalysis",
+        "fullAnalysis",
+        "usePreExistingAnalysis",
+    ]
     assert options["install_image_data"]["type"] == "dict"
     assert "nos_image_name" in options["install_image_data"]["options"]
     assert options["update_report_checks"]["type"] == "list"
@@ -839,4 +862,346 @@ def test_fabric_update_group_00830() -> None:
     options = FabricUpdateGroupModel.get_argument_spec()["config"]["options"]
 
     assert options["force_created"]["type"] == "bool"
-    assert options["force_created"]["default"] is False
+    assert options["force_created"].get("default") is None
+
+
+# =============================================================================
+# Test: Gathered State Filtering
+# =============================================================================
+
+
+def test_fabric_update_group_00900() -> None:
+    """
+    # Summary
+
+    Verify `FabricUpdateGroupModel` opts into gathered filtering and
+    `FabricUpdateGroupOrchestrator` does NOT opt into server-side (Lucene) filtering.
+
+    The updateGroups endpoint does not support Lucene query parameters,
+    so all filtering is local (post-query).
+
+    ## Test
+
+    - `supports_gathered_filtering` is True on the model
+    - `gathered_filter_properties` contains the expected 6 properties
+    - `supports_gathered_server_filtering` is False on the orchestrator
+
+    ## Classes and Methods
+
+    - FabricUpdateGroupModel (class vars)
+    - FabricUpdateGroupOrchestrator (class vars)
+    """
+    assert FabricUpdateGroupModel.supports_gathered_filtering is True
+    assert FabricUpdateGroupModel.gathered_filter_properties == (
+        "update_group_name",
+        "execution",
+        "contingency",
+        "analysis",
+        "is_maintenance",
+        "is_disruptive_update",
+    )
+    assert FabricUpdateGroupOrchestrator.supports_gathered_server_filtering is False
+
+
+def test_fabric_update_group_00910() -> None:
+    """
+    # Summary
+
+    Verify gathered filter matches by `update_group_name` (primary identifier).
+
+    ## Test
+
+    - Filter with matching name returns 1 result
+    - Filter with non-matching name returns 0 results
+
+    ## Classes and Methods
+
+    - filter_gathered_response()
+    - FabricUpdateGroupModel.matches_gathered_filter()
+    """
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"update_group_name": "leaf_group"}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 1
+    assert result[0].update_group_name == "leaf_group"
+
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"update_group_name": "nonexistent_group"}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 0
+
+
+def test_fabric_update_group_00920() -> None:
+    """
+    # Summary
+
+    Verify gathered filter matches by `execution` enum value.
+
+    ## Test
+
+    - Filter `execution: serial` matches the sample (which has serial)
+    - Filter `execution: parallel` does not match
+
+    ## Classes and Methods
+
+    - filter_gathered_response()
+    """
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"execution": "serial"}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 1
+
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"execution": "parallel"}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 0
+
+
+def test_fabric_update_group_00930() -> None:
+    """
+    # Summary
+
+    Verify gathered filter matches by boolean properties.
+
+    Boolean `False` is a meaningful filter criterion (not treated as absent).
+    This confirms the framework correctly distinguishes `False` from `None`.
+
+    ## Test
+
+    - Filter `is_maintenance: true` matches (sample has True)
+    - Filter `is_maintenance: false` does not match
+    - Filter `is_disruptive_update: true` matches (sample has True)
+
+    ## Classes and Methods
+
+    - filter_gathered_response()
+    """
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"is_maintenance": True}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 1
+
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"is_maintenance": False}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 0
+
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"is_disruptive_update": True}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 1
+
+
+def test_fabric_update_group_00940() -> None:
+    """
+    # Summary
+
+    Verify AND semantics within a single gathered filter item.
+
+    When a user supplies multiple criteria in one config item, ALL must match
+    the candidate for it to be included in the result.
+
+    ## Test
+
+    - `execution: serial` AND `contingency: continue` → matches (both true in sample)
+    - `execution: serial` AND `contingency: pause` → no match (contingency mismatch)
+
+    ## Classes and Methods
+
+    - filter_gathered_response()
+    """
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"execution": "serial", "contingency": "continue"}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 1
+
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"execution": "serial", "contingency": "pause"}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 0
+
+
+def test_fabric_update_group_00950() -> None:
+    """
+    # Summary
+
+    Verify OR semantics across multiple gathered filter items.
+
+    When a user supplies multiple items in the config list, a candidate matches
+    if ANY item matches (union). This lets users express "show me groups that are
+    serial OR groups named X" in a single task.
+
+    ## Test
+
+    - Two filter items: one doesn't match (name), one does (execution) → 1 result
+    - Two filter items: neither matches → 0 results
+
+    ## Classes and Methods
+
+    - filter_gathered_response()
+    """
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[
+            {"update_group_name": "nonexistent"},
+            {"execution": "serial"},
+        ],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 1
+
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[
+            {"update_group_name": "nonexistent"},
+            {"execution": "parallel"},
+        ],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 0
+
+
+def test_fabric_update_group_00960() -> None:
+    """
+    # Summary
+
+    Verify `report_selection` and `reports` enum-valued gathered filters.
+
+    ## Test
+
+    - Filter `report_selection: advanced` matches (sample has advanced)
+    - Filter `reports: usePreExistingReports` matches
+    - Filter `report_selection: noReport` does not match
+
+    ## Classes and Methods
+
+    - filter_gathered_response()
+    """
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"report_selection": "advanced"}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 1
+
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"reports": "usePreExistingReports"}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 1
+
+    result = filter_gathered_response(
+        response_data=[deepcopy(SAMPLE_API_RESPONSE)],
+        filters=[{"report_selection": "noReport"}],
+        model_class=FabricUpdateGroupModel,
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+    )
+    assert len(result) == 0
+
+
+@pytest.mark.parametrize(
+    "filter_item",
+    [
+        {"update_group_switches": ["192.168.7.11"]},
+        {"force_created": True},
+        {"install_image_data": {"nos_image_name": "nxos.9.3.13.bin"}},
+    ],
+    ids=["update_group_switches", "force_created", "install_image_data_nested"],
+)
+def test_fabric_update_group_00970(filter_item) -> None:
+    """
+    # Summary
+
+    Verify unsupported gathered filter properties are rejected with a clear error.
+
+    Properties excluded from `gathered_filter_properties` must not silently pass
+    validation. This guards against customers accidentally filtering on fields
+    that cannot work (module-only params, nested objects, list-valued fields).
+
+    ## Test
+
+    - `update_group_switches` (list-valued, no meaningful equality match)
+    - `force_created` (module-only operational flag, never returned by API)
+    - `install_image_data.nos_image_name` (nested property, not supported)
+
+    ## Classes and Methods
+
+    - validate_gathered_filters()
+    """
+    with pytest.raises(ValueError, match="unsupported properties"):
+        validate_gathered_filters(
+            filters=[filter_item],
+            normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+            supported_properties=FabricUpdateGroupModel.gathered_filter_properties,
+        )
+
+
+def test_fabric_update_group_00980() -> None:
+    """
+    # Summary
+
+    Verify Ansible-injected None values are not treated as filter criteria.
+
+    Ansible pads all omitted suboptions with None after argument validation.
+    These Nones must not trigger "unsupported property" errors or act as
+    filter criteria. Only explicitly supplied non-None values count.
+
+    ## Test
+
+    - Filter item with one active property and several None-padded properties
+      passes validation without error
+
+    ## Classes and Methods
+
+    - validate_gathered_filters()
+    """
+    filter_item = {
+        "update_group_name": "leaf_group",
+        "execution": None,
+        "contingency": None,
+        "analysis": None,
+        "is_maintenance": None,
+        "is_disruptive_update": None,
+        "update_group_switches": None,
+        "force_created": None,
+        "install_image_data": None,
+    }
+
+    # Should not raise — None values are ignored by property validation
+    validate_gathered_filters(
+        filters=[filter_item],
+        normalize_filter=FabricUpdateGroupModel.normalize_gathered_filter,
+        supported_properties=FabricUpdateGroupModel.gathered_filter_properties,
+    )

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -1,0 +1,108 @@
+# Copyright: (c) 2026, Cisco and/or its affiliates.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from copy import deepcopy
+
+import pytest
+
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
+
+
+API_USER = {
+    "loginID": "user1",
+    "email": "user1@example.com",
+    "passwordPolicy": {
+        "reuseLimitation": 0,
+        "timeIntervalLimitation": 0,
+    },
+    "rbac": {
+        "domains": {
+            "all": {
+                "roles": ["observer", "support-engineer"],
+            }
+        }
+    },
+    "xLaunch": False,
+}
+
+
+def test_local_user_opts_in_to_gathered_filtering():
+    assert LocalUserModel.supports_gathered_filtering is True
+
+
+def test_local_user_does_not_opt_in_to_lucene_filtering():
+    assert LocalUserOrchestrator.supports_gathered_lucene_filtering is False
+
+
+def test_argument_spec_allows_gathered_login_id_filter():
+    spec = LocalUserModel.get_argument_spec()
+
+    assert spec["config"]["required"] is False
+    assert spec["config"]["options"]["login_id"].get("required", False) is False
+    assert "gathered" in spec["state"]["choices"]
+
+
+def test_password_is_excluded_from_config_but_included_in_payload():
+    model = LocalUserModel.from_config(
+        {
+            "login_id": "user1",
+            "user_password": "Password1!",
+        }
+    )
+
+    assert "user_password" not in model.to_config()
+    assert model.to_payload()["password"] == "Password1!"
+
+
+@pytest.mark.parametrize(
+    "filter_item",
+    [
+        {"email": "user1@example.com"},
+        {"user_password": "Password1!"},
+        {"reuse_limitation": 0},
+        {"remote_user_authorization": False},
+        {"security_domains": [{"name": "all"}]},
+    ],
+)
+def test_non_login_id_gathered_filters_are_rejected(filter_item):
+    with pytest.raises(ValueError, match="Only login_id can be used"):
+        LocalUserModel.normalize_gathered_filter(filter_item)
+
+
+def test_ansible_injected_null_option_is_not_treated_as_a_filter():
+    filter_item = {
+        "login_id": "user1",
+        "user_password": None,
+    }
+
+    assert LocalUserModel.normalize_gathered_filter(filter_item) == filter_item
+
+
+def test_api_deserialization_does_not_mutate_response():
+    response = deepcopy(API_USER)
+    original = deepcopy(response)
+
+    LocalUserModel.from_response(response)
+
+    assert response == original
+
+
+@pytest.mark.parametrize(
+    ("login_id", "expected"),
+    [
+        ("user1", 1),
+        ("missing-user", 0),
+    ],
+)
+def test_login_id_gathered_filter(login_id, expected):
+    result = filter_gathered_response(
+        response_data=[deepcopy(API_USER)],
+        filters=[{"login_id": login_id}],
+        model_class=LocalUserModel,
+        normalize_filter=LocalUserModel.normalize_gathered_filter,
+    )
+
+    assert len(result) == expected

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -6,10 +6,16 @@ from copy import deepcopy
 
 import pytest
 
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response, validate_gathered_filters
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
-
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    filter_gathered_response,
+    validate_gathered_filters,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
+    LocalUserModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import (
+    LocalUserOrchestrator,
+)
 
 API_USER = {
     "loginID": "user1",

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -10,12 +10,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     filter_gathered_response,
     validate_gathered_filters,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import (
-    LocalUserModel,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import (
-    LocalUserOrchestrator,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
 
 API_USER = {
     "loginID": "user1",

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -40,7 +40,7 @@ def test_local_user_opts_in_to_gathered_filtering():
 
 
 def test_local_user_does_not_opt_in_to_lucene_filtering():
-    assert LocalUserOrchestrator.supports_gathered_lucene_filtering is False
+    assert LocalUserOrchestrator.supports_gathered_server_filtering is False
 
 
 def test_argument_spec_allows_gathered_login_id_filter():

--- a/tests/unit/module_utils/models/test_local_user.py
+++ b/tests/unit/module_utils/models/test_local_user.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 import pytest
 
-from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import filter_gathered_response, validate_gathered_filters
 from ansible_collections.cisco.nd.plugins.module_utils.models.local_user.local_user import LocalUserModel
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.local_user import LocalUserOrchestrator
 
@@ -60,16 +60,19 @@ def test_password_is_excluded_from_config_but_included_in_payload():
 @pytest.mark.parametrize(
     "filter_item",
     [
-        {"email": "user1@example.com"},
         {"user_password": "Password1!"},
         {"reuse_limitation": 0},
         {"remote_user_authorization": False},
         {"security_domains": [{"name": "all"}]},
     ],
 )
-def test_non_login_id_gathered_filters_are_rejected(filter_item):
-    with pytest.raises(ValueError, match="Only login_id can be used"):
-        LocalUserModel.normalize_gathered_filter(filter_item)
+def test_unsupported_gathered_filters_are_rejected(filter_item):
+    with pytest.raises(ValueError, match="unsupported properties"):
+        validate_gathered_filters(
+            filters=[filter_item],
+            normalize_filter=LocalUserModel.normalize_gathered_filter,
+            supported_properties=LocalUserModel.gathered_filter_properties,
+        )
 
 
 def test_ansible_injected_null_option_is_not_treated_as_a_filter():
@@ -78,7 +81,12 @@ def test_ansible_injected_null_option_is_not_treated_as_a_filter():
         "user_password": None,
     }
 
-    assert LocalUserModel.normalize_gathered_filter(filter_item) == filter_item
+    # Null values are ignored by property validation — no error raised
+    validate_gathered_filters(
+        filters=[filter_item],
+        normalize_filter=LocalUserModel.normalize_gathered_filter,
+        supported_properties=LocalUserModel.gathered_filter_properties,
+    )
 
 
 def test_api_deserialization_does_not_mutate_response():

--- a/tests/unit/module_utils/models/test_loopback_interface.py
+++ b/tests/unit/module_utils/models/test_loopback_interface.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from typing import Any
 
 import pytest  # pylint: disable=unused-import
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import (
     Csr1kvLoopbackPolicyModel,
     CsrLoopbackPolicyModel,
@@ -1679,7 +1680,7 @@ def test_loopback_interface_00720():
 
     ## Test
 
-    - state choices: ["merged", "replaced", "overridden", "deleted"]
+    - state choices: ["merged", "replaced", "overridden", "deleted", "gathered"]
     - state default: "merged"
 
     ## Classes and Methods
@@ -1688,7 +1689,7 @@ def test_loopback_interface_00720():
     """
     spec = LoopbackInterfaceModel.get_argument_spec()
     state_spec = spec["state"]
-    assert state_spec["choices"] == ["merged", "replaced", "overridden", "deleted"]
+    assert state_spec["choices"] == ["merged", "replaced", "overridden", "deleted", "gathered"]
     assert state_spec["default"] == "merged"
 
 
@@ -2586,6 +2587,7 @@ def test_xe_from_response_tolerates_injected_policy_key() -> None:
     assert isinstance(instance.config_data.network_os.policy, XeLoopbackPolicyModel)
     with pytest.raises(ValidationError):
         result = XeLoopbackPolicyModel(policyType="iosXeLoopback", ndInjectedKey="x")  # pylint: disable=unused-variable
+    assert "policy_type" not in policy_options
 
 
 def test_loopback_interface_00740():
@@ -2777,3 +2779,26 @@ def test_reverse_diff_defaults_apply_through_xe_interface_union() -> None:
         }
     )
     assert existing.get_diff(proposed, exclude_unset=False) is True
+
+
+def test_loopback_interface_00740():
+    """
+    Verify config is optional so state=gathered can run without input.
+    """
+    spec = LoopbackInterfaceModel.get_argument_spec()
+
+    assert spec["config"].get("required", False) is False
+
+
+def test_loopback_interface_00750():
+    """Verify gathered filters may omit either loopback identifier."""
+    config_options = LoopbackInterfaceModel.get_argument_spec()["config"]["options"]
+
+    assert config_options["switch_ip"].get("required", False) is False
+    assert config_options["interface_name"].get("required", False) is False
+
+
+def test_loopback_interface_00760():
+    """Verify only loopback opts into generic gathered filtering."""
+    assert NDBaseModel.supports_gathered_filtering is False
+    assert LoopbackInterfaceModel.supports_gathered_filtering is True

--- a/tests/unit/module_utils/models/test_loopback_interface.py
+++ b/tests/unit/module_utils/models/test_loopback_interface.py
@@ -2593,7 +2593,6 @@ def test_xe_from_response_tolerates_injected_policy_key() -> None:
     assert isinstance(instance.config_data.network_os.policy, XeLoopbackPolicyModel)
     with pytest.raises(ValidationError):
         result = XeLoopbackPolicyModel(policyType="iosXeLoopback", ndInjectedKey="x")  # pylint: disable=unused-variable
-    assert "policy_type" not in policy_options
 
 
 def test_loopback_interface_00740():

--- a/tests/unit/module_utils/models/test_loopback_interface.py
+++ b/tests/unit/module_utils/models/test_loopback_interface.py
@@ -1689,7 +1689,13 @@ def test_loopback_interface_00720():
     """
     spec = LoopbackInterfaceModel.get_argument_spec()
     state_spec = spec["state"]
-    assert state_spec["choices"] == ["merged", "replaced", "overridden", "deleted", "gathered"]
+    assert state_spec["choices"] == [
+        "merged",
+        "replaced",
+        "overridden",
+        "deleted",
+        "gathered",
+    ]
     assert state_spec["default"] == "merged"
 
 

--- a/tests/unit/module_utils/models/test_manage_fabric_base.py
+++ b/tests/unit/module_utils/models/test_manage_fabric_base.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026,  Deeksha Pandey (@deekpand)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for shared manage-fabric model behavior."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ai_ebgp_vxlan import (
+    FabricAiEbgpVxlanModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ai_ibgp_vxlan import (
+    FabricAiIbgpVxlanModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ebgp_vxlan import (
+    FabricEbgpModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_external import (
+    FabricExternalConnectivityModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ibgp_vxlan import (
+    FabricIbgpModel,
+)
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [
+        FabricExternalConnectivityModel,
+        FabricEbgpModel,
+        FabricIbgpModel,
+        FabricAiEbgpVxlanModel,
+        FabricAiIbgpVxlanModel,
+    ],
+    ids=[
+        "external",
+        "ebgp",
+        "ibgp",
+        "ai_ebgp",
+        "ai_ibgp",
+    ],
+)
+def test_mutating_fabric_states_require_config(model_class) -> None:
+    """Verify every fabric model requires config only for mutating states."""
+    assert model_class.get_required_if() == [
+        ("state", "merged", ["config"]),
+        ("state", "replaced", ["config"]),
+        ("state", "overridden", ["config"]),
+        ("state", "deleted", ["config"]),
+    ]

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, annotations, division, print_function
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import inspect
+from types import SimpleNamespace
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
@@ -1186,6 +1187,254 @@ def test_loopback_interface_00750() -> None:
     assert result[0]["interfaceName"] == "loopback10"
     assert result[0]["switchIp"] == "192.168.12.151"
 
+@pytest.mark.parametrize(
+    ("filters", "expected"),
+    [
+        (
+            [],
+            {
+                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
+                "192.0.2.11": ("SERIAL-B", {"interfaceType:loopback AND policyType:loopback"}),
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.10"}],
+            {"192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"})},
+        ),
+        (
+            [{"interface_name": "Loopback101"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.10", "interface_name": "loopback101"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                )
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}],
+            {},
+        ),
+        (
+            [{"switch_ip": "192.0.2.10"}, {"interface_name": "loopback101"}],
+            {
+                # The broad switch filter supersedes the narrower name query.
+                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+            },
+        ),
+        (
+            [{"config_data": {"network_os": {"policy": {"description": "local-only"}}}}],
+            {
+                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
+                "192.0.2.11": ("SERIAL-B", {"interfaceType:loopback AND policyType:loopback"}),
+            },
+        ),
+    ],
+)
+def test_loopback_interface_00760(filters, expected) -> None:
+    """Verify gathered query planning routes switches and builds safe Lucene expressions."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
+        switch_map={
+            "192.0.2.10": "SERIAL-A",
+            "192.0.2.11": "SERIAL-B",
+        }
+    )
+
+    assert instance._build_gathered_query_plan(filters) == expected
+
+
+def test_loopback_interface_00770(monkeypatch) -> None:
+    """Verify an exact gathered filter uses the list endpoint with encoded Lucene parameters."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+    requested_paths = []
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return {
+            "interfaces": [
+                {
+                    "interfaceName": "loopback101",
+                    "interfaceType": "loopback",
+                    "configData": {
+                        "networkOS": {
+                            "policy": {
+                                "policyType": "loopback",
+                            }
+                        }
+                    }
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        }
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    assert instance.query_all(
+        gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}]
+    ) == [
+        {
+            "switchIp": "192.0.2.10",
+            "interfaceName": "loopback101",
+            "interfaceType": "loopback",
+            "configData": {
+                "networkOS": {
+                    "policy": {
+                        "policyType": "loopback",
+                    }
+                }
+            },
+        }
+    ]
+    path, query = requested_paths[0].split("?", 1)
+    assert path == "/api/v1/manage/fabrics/fabric_1/switches/SERIAL-A/interfaces"
+    assert set(query.split("&")) == {
+        "configOnly=false",
+        "filter=interfaceType:loopback%20AND%20policyType:loopback%20AND%20interfaceName:loopback101",
+        "max=500",
+        "offset=0",
+    }
+
+
+def test_loopback_interface_00780(monkeypatch) -> None:
+    """Verify Lucene candidates outside this module's policy scope are still excluded locally."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+    monkeypatch.setattr(
+        LoopbackInterfaceOrchestrator,
+        "_request",
+        lambda self, path, verb, **kwargs: {
+            "interfaces": [
+                {
+                    "interfaceName": "loopback0",
+                    "interfaceType": "loopback",
+                    "configData": {"networkOS": {"policy": {"policyType": "underlayLoopback"}}},
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        },
+    )
+
+    assert instance.query_all(gathered_filters=[{"interface_name": "loopback0"}]) == []
+
+
+def test_loopback_interface_00795(monkeypatch) -> None:
+    """Verify responses from separate OR expressions are unioned and deduplicated."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    duplicate = {
+        "interfaceName": "loopback101",
+        "interfaceType": "loopback",
+        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+    }
+    requested_paths = []
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+    monkeypatch.setattr(
+        LoopbackInterfaceOrchestrator,
+        "_build_gathered_query_plan",
+        lambda self, filters: {
+            "192.0.2.10": ("SERIAL-A", {"expression-one", "expression-two"}),
+        },
+    )
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return {"interfaces": [duplicate], "meta": {"counts": {"remaining": 0}}}
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    result = instance.query_all(gathered_filters=[{"interface_name": "loopback101"}])
+
+    assert len(requested_paths) == 2
+    assert result == [{"switchIp": "192.0.2.10", **duplicate}]
+
+
+def test_loopback_interface_00810(monkeypatch) -> None:
+    """Verify Lucene list pagination advances offsets and collects all pages."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    requested_paths = []
+    pages = iter(
+        [
+            {
+                "interfaces": [
+                    {
+                        "interfaceName": "loopback101",
+                        "interfaceType": "loopback",
+                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+                    }
+                ],
+                "meta": {"counts": {"remaining": "1"}},
+            },
+            {
+                "interfaces": [
+                    {
+                        "interfaceName": "loopback102",
+                        "interfaceType": "loopback",
+                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+                    }
+                ],
+                "meta": {"counts": {"remaining": 0}},
+            },
+        ]
+    )
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return next(pages)
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    result = instance._query_interfaces_with_lucene("SERIAL-A", "interfaceType:loopback")
+
+    assert [item["interfaceName"] for item in result] == ["loopback101", "loopback102"]
+    assert "offset=0" in requested_paths[0]
+    assert "offset=1" in requested_paths[1]
 
 def test_loopback_interface_00760() -> None:
     """

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -1355,7 +1355,7 @@ def test_loopback_interface_00800() -> None:
             },
         ),
         (
-            [{"interface_name": "Loopback101"}],
+            [{"interface_name": "loopback101"}],
             {
                 "192.0.2.10": (
                     "SERIAL-A",
@@ -1375,10 +1375,6 @@ def test_loopback_interface_00800() -> None:
                     {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
                 )
             },
-        ),
-        (
-            [{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}],
-            {},
         ),
         (
             [{"switch_ip": "192.0.2.10"}, {"interface_name": "loopback101"}],
@@ -1418,13 +1414,34 @@ def test_loopback_interface_00810(filters, expected) -> None:
     rest_send = _build_rest_send(ResponseGenerator(responses()))
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
     instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
+        fabric_name="test_fabric",
         switch_map={
             "192.0.2.10": "SERIAL-A",
             "192.0.2.11": "SERIAL-B",
-        }
+        },
     )
 
     assert instance._build_gathered_query_plan(filters) == expected
+
+
+def test_loopback_interface_00815() -> None:
+    """Verify unknown switch_ip in a gathered filter raises ValueError."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
+        fabric_name="test_fabric",
+        switch_map={
+            "192.0.2.10": "SERIAL-A",
+            "192.0.2.11": "SERIAL-B",
+        },
+    )
+
+    with pytest.raises(ValueError, match="does not exist in fabric"):
+        instance._build_gathered_query_plan([{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}])
 
 
 def test_loopback_interface_00820(monkeypatch) -> None:
@@ -1435,7 +1452,7 @@ def test_loopback_interface_00820(monkeypatch) -> None:
 
     rest_send = _build_rest_send(ResponseGenerator(responses()))
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+    instance._fabric_context = SimpleNamespace(fabric_name="test_fabric", switch_map={"192.0.2.10": "SERIAL-A"})
     requested_paths = []
 
     monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
@@ -1461,7 +1478,7 @@ def test_loopback_interface_00820(monkeypatch) -> None:
 
     monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
 
-    assert instance.query_all(gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}]) == [
+    assert instance.query_all(gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "loopback101"}]) == [
         {
             "switchIp": "192.0.2.10",
             "interfaceName": "loopback101",
@@ -1493,7 +1510,7 @@ def test_loopback_interface_00830(monkeypatch) -> None:
 
     rest_send = _build_rest_send(ResponseGenerator(responses()))
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+    instance._fabric_context = SimpleNamespace(fabric_name="test_fabric", switch_map={"192.0.2.10": "SERIAL-A"})
 
     monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
     monkeypatch.setattr(

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -1626,3 +1626,77 @@ def test_loopback_interface_00850(monkeypatch) -> None:
     assert [item["interfaceName"] for item in result] == ["loopback101", "loopback102"]
     assert "offset=0" in requested_paths[0]
     assert "offset=1" in requested_paths[1]
+
+
+# =============================================================================
+# Test: read-only vs mutation pre-flight (deployment freeze)
+# =============================================================================
+
+
+def test_loopback_interface_00860() -> None:
+    """
+    # Summary
+
+    Verify `query_all` succeeds for `state: gathered` when the fabric is in deployment freeze mode.
+
+    ## Test
+
+    - Fabric summary returns `fabricStatus: frozen`
+    - state is `gathered`, so `validate_prerequisites` selects `validate_for_read`, which does not
+      check deployment freeze
+    - Switches list returns no switches, so `query_all` returns []
+
+    ## Classes and Methods
+
+    - LoopbackInterfaceOrchestrator.query_all()
+    - NDBaseInterfaceOrchestrator.validate_prerequisites()
+    - FabricContext.validate_for_read()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_loopback_interface(f"{method_name}a")
+        yield responses_loopback_interface(f"{method_name}b")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, state="gathered", config=[])
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+
+    with does_not_raise():
+        result = instance.query_all(gathered_filters=[])
+
+    assert result == []
+
+
+def test_loopback_interface_00870() -> None:
+    """
+    # Summary
+
+    Verify `query_all` still raises for `state: deleted` when the fabric is in deployment freeze mode.
+
+    ## Test
+
+    - Fabric summary returns `fabricStatus: frozen`
+    - state is `deleted`, which mutates configuration, so `validate_for_mutation` applies
+    - `query_all` raises `RuntimeError` with `Query all failed.*deployment freeze`
+
+    `NDStateMachine.manage_state` does not route `deleted` through `preflight`, so `query_all` is the
+    only deployment-freeze guard for that state.
+
+    ## Classes and Methods
+
+    - LoopbackInterfaceOrchestrator.query_all()
+    - NDBaseInterfaceOrchestrator.validate_prerequisites()
+    - FabricContext.validate_for_mutation()
+    """
+
+    def responses():
+        yield responses_loopback_interface("test_loopback_interface_00730a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses, state="deleted", config=[{"switch_ip": "192.168.12.151"}])
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+
+    match = r"Query all failed.*deployment freeze"
+    with pytest.raises(RuntimeError, match=match):
+        instance.query_all()

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -35,25 +35,13 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopbac
     NexusLoopbackNetworkOSModel,
     NexusLoopbackPolicyModel,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import (
-    LoopbackInterfaceOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
-    ResponseHandler,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
-    does_not_raise,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import (
-    load_fixture,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
-    MockAnsibleModule,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import (
-    ResponseGenerator,
-)
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
 
@@ -1442,6 +1430,32 @@ def test_loopback_interface_00815() -> None:
 
     with pytest.raises(ValueError, match="does not exist in fabric"):
         instance._build_gathered_query_plan([{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}])
+
+
+def test_loopback_interface_00817() -> None:
+    """Verify total request budget collapses fabric-wide expressions on large fabrics."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    large_switch_map = {f"192.0.2.{i}": f"SERIAL-{i}" for i in range(150)}
+    instance._fabric_context = SimpleNamespace(
+        fabric_name="large_fabric",
+        switch_map=large_switch_map,
+    )
+
+    filters = [
+        {"interface_name": "loopback100"},
+        {"interface_name": "loopback101"},
+        {"interface_name": "loopback102"},
+    ]
+    plan = instance._build_gathered_query_plan(filters)
+
+    base = "interfaceType:loopback AND policyType:loopback"
+    for switch_ip in large_switch_map:
+        assert plan[switch_ip][1] == {base}
 
 
 def test_loopback_interface_00820(monkeypatch) -> None:

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -35,13 +35,25 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopbac
     NexusLoopbackNetworkOSModel,
     NexusLoopbackPolicyModel,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import (
+    LoopbackInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
-from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import load_fixture
-from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
-from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
+    does_not_raise,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.fixtures.load_fixture import (
+    load_fixture,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
+    MockAnsibleModule,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import (
+    ResponseGenerator,
+)
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
 
@@ -83,7 +95,11 @@ def _build_rest_send(
     return rest_send
 
 
-def _build_loopback_model(switch_ip: str = "192.168.12.151", interface_name: str = "loopback10", include_config: bool = True) -> LoopbackInterfaceModel:
+def _build_loopback_model(
+    switch_ip: str = "192.168.12.151",
+    interface_name: str = "loopback10",
+    include_config: bool = True,
+) -> LoopbackInterfaceModel:
     """Build a minimal `LoopbackInterfaceModel` instance for tests."""
     kwargs: dict = {"switch_ip": switch_ip, "interface_name": interface_name}
     if include_config:
@@ -877,8 +893,16 @@ def test_loopback_interface_00500() -> None:
     rest_send = _build_rest_send(gen_responses)
     instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
     models = [
-        _build_loopback_model(switch_ip="192.168.12.151", interface_name="loopback10", include_config=False),
-        _build_loopback_model(switch_ip="192.168.12.152", interface_name="loopback20", include_config=False),
+        _build_loopback_model(
+            switch_ip="192.168.12.151",
+            interface_name="loopback10",
+            include_config=False,
+        ),
+        _build_loopback_model(
+            switch_ip="192.168.12.152",
+            interface_name="loopback20",
+            include_config=False,
+        ),
     ]
 
     with does_not_raise():
@@ -1187,254 +1211,6 @@ def test_loopback_interface_00750() -> None:
     assert result[0]["interfaceName"] == "loopback10"
     assert result[0]["switchIp"] == "192.168.12.151"
 
-@pytest.mark.parametrize(
-    ("filters", "expected"),
-    [
-        (
-            [],
-            {
-                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
-                "192.0.2.11": ("SERIAL-B", {"interfaceType:loopback AND policyType:loopback"}),
-            },
-        ),
-        (
-            [{"switch_ip": "192.0.2.10"}],
-            {"192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"})},
-        ),
-        (
-            [{"interface_name": "Loopback101"}],
-            {
-                "192.0.2.10": (
-                    "SERIAL-A",
-                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
-                ),
-                "192.0.2.11": (
-                    "SERIAL-B",
-                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
-                ),
-            },
-        ),
-        (
-            [{"switch_ip": "192.0.2.10", "interface_name": "loopback101"}],
-            {
-                "192.0.2.10": (
-                    "SERIAL-A",
-                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
-                )
-            },
-        ),
-        (
-            [{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}],
-            {},
-        ),
-        (
-            [{"switch_ip": "192.0.2.10"}, {"interface_name": "loopback101"}],
-            {
-                # The broad switch filter supersedes the narrower name query.
-                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
-                "192.0.2.11": (
-                    "SERIAL-B",
-                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
-                ),
-            },
-        ),
-        (
-            [{"config_data": {"network_os": {"policy": {"description": "local-only"}}}}],
-            {
-                "192.0.2.10": ("SERIAL-A", {"interfaceType:loopback AND policyType:loopback"}),
-                "192.0.2.11": ("SERIAL-B", {"interfaceType:loopback AND policyType:loopback"}),
-            },
-        ),
-    ],
-)
-def test_loopback_interface_00760(filters, expected) -> None:
-    """Verify gathered query planning routes switches and builds safe Lucene expressions."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
-        switch_map={
-            "192.0.2.10": "SERIAL-A",
-            "192.0.2.11": "SERIAL-B",
-        }
-    )
-
-    assert instance._build_gathered_query_plan(filters) == expected
-
-
-def test_loopback_interface_00770(monkeypatch) -> None:
-    """Verify an exact gathered filter uses the list endpoint with encoded Lucene parameters."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
-    requested_paths = []
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
-
-    def fake_request(self, path, verb, **kwargs):
-        requested_paths.append(path)
-        return {
-            "interfaces": [
-                {
-                    "interfaceName": "loopback101",
-                    "interfaceType": "loopback",
-                    "configData": {
-                        "networkOS": {
-                            "policy": {
-                                "policyType": "loopback",
-                            }
-                        }
-                    }
-                }
-            ],
-            "meta": {"counts": {"remaining": 0}},
-        }
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
-
-    assert instance.query_all(
-        gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}]
-    ) == [
-        {
-            "switchIp": "192.0.2.10",
-            "interfaceName": "loopback101",
-            "interfaceType": "loopback",
-            "configData": {
-                "networkOS": {
-                    "policy": {
-                        "policyType": "loopback",
-                    }
-                }
-            },
-        }
-    ]
-    path, query = requested_paths[0].split("?", 1)
-    assert path == "/api/v1/manage/fabrics/fabric_1/switches/SERIAL-A/interfaces"
-    assert set(query.split("&")) == {
-        "configOnly=false",
-        "filter=interfaceType:loopback%20AND%20policyType:loopback%20AND%20interfaceName:loopback101",
-        "max=500",
-        "offset=0",
-    }
-
-
-def test_loopback_interface_00780(monkeypatch) -> None:
-    """Verify Lucene candidates outside this module's policy scope are still excluded locally."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
-    monkeypatch.setattr(
-        LoopbackInterfaceOrchestrator,
-        "_request",
-        lambda self, path, verb, **kwargs: {
-            "interfaces": [
-                {
-                    "interfaceName": "loopback0",
-                    "interfaceType": "loopback",
-                    "configData": {"networkOS": {"policy": {"policyType": "underlayLoopback"}}},
-                }
-            ],
-            "meta": {"counts": {"remaining": 0}},
-        },
-    )
-
-    assert instance.query_all(gathered_filters=[{"interface_name": "loopback0"}]) == []
-
-
-def test_loopback_interface_00795(monkeypatch) -> None:
-    """Verify responses from separate OR expressions are unioned and deduplicated."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    duplicate = {
-        "interfaceName": "loopback101",
-        "interfaceType": "loopback",
-        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
-    }
-    requested_paths = []
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
-    monkeypatch.setattr(
-        LoopbackInterfaceOrchestrator,
-        "_build_gathered_query_plan",
-        lambda self, filters: {
-            "192.0.2.10": ("SERIAL-A", {"expression-one", "expression-two"}),
-        },
-    )
-
-    def fake_request(self, path, verb, **kwargs):
-        requested_paths.append(path)
-        return {"interfaces": [duplicate], "meta": {"counts": {"remaining": 0}}}
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
-
-    result = instance.query_all(gathered_filters=[{"interface_name": "loopback101"}])
-
-    assert len(requested_paths) == 2
-    assert result == [{"switchIp": "192.0.2.10", **duplicate}]
-
-
-def test_loopback_interface_00810(monkeypatch) -> None:
-    """Verify Lucene list pagination advances offsets and collects all pages."""
-
-    def responses():
-        yield {}
-
-    rest_send = _build_rest_send(ResponseGenerator(responses()))
-    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
-    requested_paths = []
-    pages = iter(
-        [
-            {
-                "interfaces": [
-                    {
-                        "interfaceName": "loopback101",
-                        "interfaceType": "loopback",
-                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
-                    }
-                ],
-                "meta": {"counts": {"remaining": "1"}},
-            },
-            {
-                "interfaces": [
-                    {
-                        "interfaceName": "loopback102",
-                        "interfaceType": "loopback",
-                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
-                    }
-                ],
-                "meta": {"counts": {"remaining": 0}},
-            },
-        ]
-    )
-
-    def fake_request(self, path, verb, **kwargs):
-        requested_paths.append(path)
-        return next(pages)
-
-    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
-
-    result = instance._query_interfaces_with_lucene("SERIAL-A", "interfaceType:loopback")
-
-    assert [item["interfaceName"] for item in result] == ["loopback101", "loopback102"]
-    assert "offset=0" in requested_paths[0]
-    assert "offset=1" in requested_paths[1]
 
 def test_loopback_interface_00760() -> None:
     """
@@ -1551,3 +1327,271 @@ def test_loopback_interface_00800() -> None:
         instance.create(model)
 
     assert instance._pending_deploys == [("loopback10", "FDO12345ABC")]
+
+
+@pytest.mark.parametrize(
+    ("filters", "expected"),
+    [
+        (
+            [],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.10"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                )
+            },
+        ),
+        (
+            [{"interface_name": "Loopback101"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.10", "interface_name": "loopback101"}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                )
+            },
+        ),
+        (
+            [{"switch_ip": "192.0.2.99", "interface_name": "loopback101"}],
+            {},
+        ),
+        (
+            [{"switch_ip": "192.0.2.10"}, {"interface_name": "loopback101"}],
+            {
+                # The broad switch filter supersedes the narrower name query.
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"},
+                ),
+            },
+        ),
+        (
+            [{"config_data": {"network_os": {"policy": {"description": "local-only"}}}}],
+            {
+                "192.0.2.10": (
+                    "SERIAL-A",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+                "192.0.2.11": (
+                    "SERIAL-B",
+                    {"interfaceType:loopback AND policyType:loopback"},
+                ),
+            },
+        ),
+    ],
+)
+def test_loopback_interface_00810(filters, expected) -> None:
+    """Verify gathered query planning routes switches and builds safe Lucene expressions."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(  # pylint: disable=protected-access
+        switch_map={
+            "192.0.2.10": "SERIAL-A",
+            "192.0.2.11": "SERIAL-B",
+        }
+    )
+
+    assert instance._build_gathered_query_plan(filters) == expected
+
+
+def test_loopback_interface_00820(monkeypatch) -> None:
+    """Verify an exact gathered filter uses the list endpoint with encoded Lucene parameters."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+    requested_paths = []
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return {
+            "interfaces": [
+                {
+                    "interfaceName": "loopback101",
+                    "interfaceType": "loopback",
+                    "configData": {
+                        "networkOS": {
+                            "policy": {
+                                "policyType": "loopback",
+                            }
+                        }
+                    },
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        }
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    assert instance.query_all(gathered_filters=[{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}]) == [
+        {
+            "switchIp": "192.0.2.10",
+            "interfaceName": "loopback101",
+            "interfaceType": "loopback",
+            "configData": {
+                "networkOS": {
+                    "policy": {
+                        "policyType": "loopback",
+                    }
+                }
+            },
+        }
+    ]
+    path, query = requested_paths[0].split("?", 1)
+    assert path == "/api/v1/manage/fabrics/fabric_1/switches/SERIAL-A/interfaces"
+    assert set(query.split("&")) == {
+        "configOnly=false",
+        "filter=interfaceType:loopback%20AND%20policyType:loopback%20AND%20interfaceName:loopback101",
+        "max=500",
+        "offset=0",
+    }
+
+
+def test_loopback_interface_00830(monkeypatch) -> None:
+    """Verify Lucene candidates outside this module's policy scope are still excluded locally."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    instance._fabric_context = SimpleNamespace(switch_map={"192.0.2.10": "SERIAL-A"})
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+    monkeypatch.setattr(
+        LoopbackInterfaceOrchestrator,
+        "_request",
+        lambda self, path, verb, **kwargs: {
+            "interfaces": [
+                {
+                    "interfaceName": "loopback0",
+                    "interfaceType": "loopback",
+                    "configData": {"networkOS": {"policy": {"policyType": "underlayLoopback"}}},
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        },
+    )
+
+    assert instance.query_all(gathered_filters=[{"interface_name": "loopback0"}]) == []
+
+
+def test_loopback_interface_00840(monkeypatch) -> None:
+    """Verify responses from separate OR expressions are unioned and deduplicated."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    duplicate = {
+        "interfaceName": "loopback101",
+        "interfaceType": "loopback",
+        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+    }
+    requested_paths = []
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "validate_prerequisites", lambda self: None)
+    monkeypatch.setattr(
+        LoopbackInterfaceOrchestrator,
+        "_build_gathered_query_plan",
+        lambda self, filters: {
+            "192.0.2.10": ("SERIAL-A", {"expression-one", "expression-two"}),
+        },
+    )
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return {"interfaces": [duplicate], "meta": {"counts": {"remaining": 0}}}
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    result = instance.query_all(gathered_filters=[{"interface_name": "loopback101"}])
+
+    assert len(requested_paths) == 2
+    assert result == [{"switchIp": "192.0.2.10", **duplicate}]
+
+
+def test_loopback_interface_00850(monkeypatch) -> None:
+    """Verify Lucene list pagination advances offsets and collects all pages."""
+
+    def responses():
+        yield {}
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()))
+    instance = LoopbackInterfaceOrchestrator(rest_send=rest_send)
+    requested_paths = []
+    pages = iter(
+        [
+            {
+                "interfaces": [
+                    {
+                        "interfaceName": "loopback101",
+                        "interfaceType": "loopback",
+                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+                    }
+                ],
+                "meta": {"counts": {"remaining": "1"}},
+            },
+            {
+                "interfaces": [
+                    {
+                        "interfaceName": "loopback102",
+                        "interfaceType": "loopback",
+                        "configData": {"networkOS": {"policy": {"policyType": "loopback"}}},
+                    }
+                ],
+                "meta": {"counts": {"remaining": 0}},
+            },
+        ]
+    )
+
+    def fake_request(self, path, verb, **kwargs):
+        requested_paths.append(path)
+        return next(pages)
+
+    monkeypatch.setattr(LoopbackInterfaceOrchestrator, "_request", fake_request)
+
+    result = instance._query_interfaces_with_lucene("SERIAL-A", "interfaceType:loopback")
+
+    assert [item["interfaceName"] for item in result] == ["loopback101", "loopback102"]
+    assert "offset=0" in requested_paths[0]
+    assert "offset=1" in requested_paths[1]

--- a/tests/unit/module_utils/orchestrators/test_manage_fabric_ai_vxlan.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_fabric_ai_vxlan.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type
 
+from urllib.parse import unquote
+
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ai_ebgp_vxlan import (
     ManageAiEbgpVxlanFabricOrchestrator,
@@ -69,3 +71,150 @@ def test_manage_fabric_ai_vxlan_00020(monkeypatch) -> None:
 
     assert captured["kwargs"]["not_found_ok"] is True
     assert result == [{"name": "ai1", "management": {"type": "aimlVxlanIbgp"}}]
+
+
+def test_manage_fabric_ai_vxlan_00030(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify AI eBGP gathered filters use the exact endpoint for fabric_name-only
+    filters and Lucene for other properties. Preserves OR semantics, rejects
+    other fabric types, and deduplicates overlapping API results.
+    """
+    instance = ManageAiEbgpVxlanFabricOrchestrator(rest_send=RestSend({"check_mode": False, "state": "gathered"}))
+    requested_paths = []
+    expected_fabric = {"name": "ai1", "management": {"type": "aimlVxlanEbgp"}}
+
+    def fake_request(*args, **kwargs):
+        requested_paths.append(unquote(kwargs["path"]))
+        # Exact endpoint returns a single fabric dict; list endpoint returns {"fabrics": [...]}
+        if "/fabrics/ai1" in kwargs["path"]:
+            return expected_fabric
+        return {
+            "fabrics": [
+                expected_fabric,
+                {"name": "standard1", "management": {"type": "vxlanEbgp"}},
+            ]
+        }
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all(
+        gathered_filters=[
+            {"fabric_name": "ai1"},
+            {"license_tier": "premier"},
+        ]
+    )
+
+    assert requested_paths == [
+        "/api/v1/manage/fabrics/ai1",
+        "/api/v1/manage/fabrics?filter=type:aimlVxlanEbgp AND licenseTier:premier&max=500&offset=0",
+    ]
+    assert result == [expected_fabric]
+
+
+def test_manage_fabric_ai_vxlan_00040(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify AI eBGP gathered filtering falls back to a type-only paginated
+    query when the Lucene expression limit is exceeded.
+    """
+    instance = ManageAiEbgpVxlanFabricOrchestrator(rest_send=RestSend({"check_mode": False, "state": "gathered"}))
+    requested_paths = []
+    expected_fabric = {"name": "ai1", "management": {"type": "aimlVxlanEbgp"}}
+
+    def fake_request(*args, **kwargs):
+        requested_paths.append(unquote(kwargs["path"]))
+        return {
+            "fabrics": [expected_fabric],
+        }
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all(
+        gathered_filters=[
+            {"license_tier": "premier"},
+            {"license_tier": "advantage"},
+            {"license_tier": "essentials"},
+            {"license_tier": "addon"},
+        ]
+    )
+
+    # Should fall back to type-only query, not an unfiltered query
+    assert len(requested_paths) == 1
+    assert "type:aimlVxlanEbgp" in requested_paths[0]
+    assert result == [expected_fabric]
+
+
+def test_manage_fabric_ai_vxlan_00050(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify AI iBGP gathered filters use the exact endpoint for fabric_name-only
+    filters and Lucene for other properties. Preserves OR semantics, rejects
+    other fabric types, and deduplicates overlapping API results.
+    """
+    instance = ManageAiIbgpVxlanFabricOrchestrator(rest_send=RestSend({"check_mode": False, "state": "gathered"}))
+    requested_paths = []
+    expected_fabric = {"name": "ai1", "management": {"type": "aimlVxlanIbgp"}}
+
+    def fake_request(*args, **kwargs):
+        requested_paths.append(unquote(kwargs["path"]))
+        if "/fabrics/ai1" in kwargs["path"]:
+            return expected_fabric
+        return {
+            "fabrics": [
+                expected_fabric,
+                {"name": "standard1", "management": {"type": "vxlanIbgp"}},
+            ]
+        }
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all(
+        gathered_filters=[
+            {"fabric_name": "ai1"},
+            {"license_tier": "premier"},
+        ]
+    )
+
+    assert requested_paths == [
+        "/api/v1/manage/fabrics/ai1",
+        "/api/v1/manage/fabrics?filter=type:aimlVxlanIbgp AND licenseTier:premier&max=500&offset=0",
+    ]
+    assert result == [expected_fabric]
+
+
+def test_manage_fabric_ai_vxlan_00060(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify AI iBGP gathered filtering falls back to a type-only paginated
+    query when the Lucene expression limit is exceeded.
+    """
+    instance = ManageAiIbgpVxlanFabricOrchestrator(rest_send=RestSend({"check_mode": False, "state": "gathered"}))
+    requested_paths = []
+    expected_fabric = {"name": "ai1", "management": {"type": "aimlVxlanIbgp"}}
+
+    def fake_request(*args, **kwargs):
+        requested_paths.append(unquote(kwargs["path"]))
+        return {
+            "fabrics": [expected_fabric],
+        }
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all(
+        gathered_filters=[
+            {"license_tier": "premier"},
+            {"license_tier": "advantage"},
+            {"license_tier": "essentials"},
+            {"license_tier": "addon"},
+        ]
+    )
+
+    # Should fall back to type-only query, not an unfiltered query
+    assert len(requested_paths) == 1
+    assert "type:aimlVxlanIbgp" in requested_paths[0]
+    assert result == [expected_fabric]

--- a/tests/unit/module_utils/orchestrators/test_manage_fabric_gathered.py
+++ b/tests/unit/module_utils/orchestrators/test_manage_fabric_gathered.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Deeksha Pandey (@deekpand)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for gathered queries shared by the manage-fabric family."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+from urllib.parse import unquote
+
+import pytest
+
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ai_ebgp_vxlan import (
+    ManageAiEbgpVxlanFabricOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ai_ibgp_vxlan import (
+    ManageAiIbgpVxlanFabricOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ebgp_vxlan import (
+    ManageEbgpFabricOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_external import (
+    ManageExternalFabricOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ibgp_vxlan import (
+    ManageIbgpFabricOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+
+
+@pytest.mark.parametrize(
+    ("orchestrator_class", "fabric_type"),
+    [
+        (ManageExternalFabricOrchestrator, "externalConnectivity"),
+        (ManageEbgpFabricOrchestrator, "vxlanEbgp"),
+        (ManageIbgpFabricOrchestrator, "vxlanIbgp"),
+        (ManageAiEbgpVxlanFabricOrchestrator, "aimlVxlanEbgp"),
+        (ManageAiIbgpVxlanFabricOrchestrator, "aimlVxlanIbgp"),
+    ],
+    ids=[
+        "external",
+        "ebgp",
+        "ibgp",
+        "ai_ebgp",
+        "ai_ibgp",
+    ],
+)
+def test_empty_gathered_filters_use_type_only_lucene_query(
+    monkeypatch,
+    orchestrator_class,
+    fabric_type,
+) -> None:
+    """Verify an explicit empty filter list narrows the request by fabric type."""
+    instance = orchestrator_class(
+        rest_send=RestSend(
+            {
+                "check_mode": False,
+                "state": "gathered",
+            }
+        )
+    )
+    requested_paths = []
+    expected_fabric = {
+        "name": "matching-fabric",
+        "management": {"type": fabric_type},
+    }
+
+    def fake_request(*args, **kwargs):
+        requested_paths.append(unquote(kwargs["path"]))
+        return {
+            "fabrics": [
+                expected_fabric,
+                {
+                    "name": "wrong-type-fabric",
+                    "management": {"type": "wrongType"},
+                },
+            ]
+        }
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all(gathered_filters=[])
+
+    assert requested_paths == [
+        f"/api/v1/manage/fabrics?filter=type:{fabric_type}&max=500&offset=0",
+    ]
+    assert result == [expected_fabric]
+
+
+@pytest.mark.parametrize(
+    ("orchestrator_class", "fabric_type"),
+    [
+        (ManageEbgpFabricOrchestrator, "vxlanEbgp"),
+        (ManageIbgpFabricOrchestrator, "vxlanIbgp"),
+    ],
+    ids=["ebgp", "ibgp"],
+)
+def test_pagination_collects_multiple_pages(
+    monkeypatch,
+    orchestrator_class,
+    fabric_type,
+) -> None:
+    """Verify _fetch_fabrics_paginated fetches until a short page signals the end."""
+    instance = orchestrator_class(rest_send=RestSend({"check_mode": False, "state": "gathered"}))
+    page_size = 500
+    call_count = 0
+
+    def fake_request(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {"fabrics": [{"name": f"fabric-{i}", "management": {"type": fabric_type}} for i in range(page_size)]}
+        return {
+            "fabrics": [
+                {"name": "fabric-last", "management": {"type": fabric_type}},
+            ]
+        }
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance._fetch_fabrics_paginated(f"type:{fabric_type}")
+
+    assert call_count == 2
+    assert len(result) == page_size + 1
+    assert result[-1]["name"] == "fabric-last"
+
+
+@pytest.mark.parametrize(
+    ("orchestrator_class", "fabric_type"),
+    [
+        (ManageEbgpFabricOrchestrator, "vxlanEbgp"),
+        (ManageIbgpFabricOrchestrator, "vxlanIbgp"),
+        (ManageExternalFabricOrchestrator, "externalConnectivity"),
+        (ManageAiEbgpVxlanFabricOrchestrator, "aimlVxlanEbgp"),
+        (ManageAiIbgpVxlanFabricOrchestrator, "aimlVxlanIbgp"),
+    ],
+    ids=["ebgp", "ibgp", "external", "ai_ebgp", "ai_ibgp"],
+)
+def test_fabric_name_only_uses_exact_endpoint(
+    monkeypatch,
+    orchestrator_class,
+    fabric_type,
+) -> None:
+    """Verify fabric_name-only filters use GET /fabrics/{name} instead of Lucene."""
+    instance = orchestrator_class(rest_send=RestSend({"check_mode": False, "state": "gathered"}))
+    requested_paths = []
+    expected_fabric = {"name": "my-fabric", "management": {"type": fabric_type}}
+
+    def fake_request(*args, **kwargs):
+        requested_paths.append(unquote(kwargs["path"]))
+        if "/fabrics/my-fabric" in kwargs["path"]:
+            return expected_fabric
+        return {"fabrics": []}
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all(gathered_filters=[{"fabric_name": "my-fabric"}])
+
+    assert len(requested_paths) == 1
+    assert "/fabrics/my-fabric" in requested_paths[0]
+    assert "filter=" not in requested_paths[0]
+    assert result == [expected_fabric]
+
+
+@pytest.mark.parametrize(
+    ("orchestrator_class", "fabric_type"),
+    [
+        (ManageEbgpFabricOrchestrator, "vxlanEbgp"),
+        (ManageExternalFabricOrchestrator, "externalConnectivity"),
+    ],
+    ids=["ebgp", "external"],
+)
+def test_nonexistent_fabric_name_returns_empty(
+    monkeypatch,
+    orchestrator_class,
+    fabric_type,
+) -> None:
+    """Verify a non-existent fabric_name returns empty without error."""
+    instance = orchestrator_class(rest_send=RestSend({"check_mode": False, "state": "gathered"}))
+
+    def fake_request(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all(gathered_filters=[{"fabric_name": "does-not-exist"}])
+
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    ("orchestrator_class", "fabric_type"),
+    [
+        (ManageEbgpFabricOrchestrator, "vxlanEbgp"),
+        (ManageIbgpFabricOrchestrator, "vxlanIbgp"),
+    ],
+    ids=["ebgp", "ibgp"],
+)
+def test_exact_endpoint_rejects_wrong_fabric_type(
+    monkeypatch,
+    orchestrator_class,
+    fabric_type,
+) -> None:
+    """Verify _query_one_by_name filters out fabrics of the wrong type."""
+    instance = orchestrator_class(rest_send=RestSend({"check_mode": False, "state": "gathered"}))
+
+    def fake_request(*args, **kwargs):
+        return {"name": "some-fabric", "management": {"type": "wrongType"}}
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all(gathered_filters=[{"fabric_name": "some-fabric"}])
+
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    ("orchestrator_class", "fabric_type"),
+    [
+        (ManageEbgpFabricOrchestrator, "vxlanEbgp"),
+    ],
+    ids=["ebgp"],
+)
+def test_mixed_exact_and_lucene_filters(
+    monkeypatch,
+    orchestrator_class,
+    fabric_type,
+) -> None:
+    """Verify OR filters with fabric_name-only and property filters use both paths."""
+    instance = orchestrator_class(rest_send=RestSend({"check_mode": False, "state": "gathered"}))
+    requested_paths = []
+    exact_fabric = {"name": "exact-hit", "management": {"type": fabric_type}}
+    lucene_fabric = {"name": "lucene-hit", "management": {"type": fabric_type}}
+
+    def fake_request(*args, **kwargs):
+        path = unquote(kwargs["path"])
+        requested_paths.append(path)
+        if "/fabrics/exact-hit" in path:
+            return exact_fabric
+        return {"fabrics": [lucene_fabric]}
+
+    monkeypatch.setattr(instance, "_request", fake_request)
+
+    result = instance.query_all(
+        gathered_filters=[
+            {"fabric_name": "exact-hit"},
+            {"license_tier": "premier"},
+        ]
+    )
+
+    assert len(requested_paths) == 2
+    assert "/fabrics/exact-hit" in requested_paths[0]
+    assert "filter=" in requested_paths[1]
+    assert len(result) == 2
+    assert exact_fabric in result
+    assert lucene_fabric in result

--- a/tests/unit/module_utils/test_fabric_context.py
+++ b/tests/unit/module_utils/test_fabric_context.py
@@ -597,3 +597,98 @@ def test_fabric_context_00330() -> None:
     match = r"Fabric 'fabric_1' is owned by a different controller"
     with pytest.raises(RuntimeError, match=match):
         instance.validate_for_mutation()
+
+
+# =============================================================================
+# Test: validate_for_read
+# =============================================================================
+
+
+def test_fabric_context_00400() -> None:
+    """
+    # Summary
+
+    Verify `validate_for_read` does not raise when the fabric is in deployment freeze mode.
+
+    ## Test
+
+    - GET (summary) returns 200 with `local: true` and `fabricStatus: frozen`
+    - `validate_for_read` is a no-op: deployment freeze blocks configuration changes reaching the
+      switches, and does not prevent reading existing configuration
+
+    ## Classes and Methods
+
+    - FabricContext.validate_for_read
+    - FabricContext.fabric_is_deployment_frozen
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_fabric_context(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    instance = FabricContext(rest_send=rest_send, fabric_name="fabric_1")
+    with does_not_raise():
+        instance.validate_for_read()
+
+
+def test_fabric_context_00410() -> None:
+    """
+    # Summary
+
+    Verify `validate_for_read` raises `RuntimeError` when the fabric does not exist.
+
+    ## Test
+
+    - GET (summary) returns 404
+    - `validate_for_read` raises with a message that mentions the fabric name
+
+    ## Classes and Methods
+
+    - FabricContext.validate_for_read
+    - FabricContext.fabric_exists
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_fabric_context(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    instance = FabricContext(rest_send=rest_send, fabric_name="missing_fabric")
+    match = r"Fabric 'missing_fabric' not found"
+    with pytest.raises(RuntimeError, match=match):
+        instance.validate_for_read()
+
+
+def test_fabric_context_00420() -> None:
+    """
+    # Summary
+
+    Verify `validate_for_read` raises `RuntimeError` when the fabric is owned by a different controller.
+
+    ## Test
+
+    - GET (summary) returns 200 with `local: false`
+    - `validate_for_read` raises with a message that mentions a different controller and the fabric name
+
+    ## Classes and Methods
+
+    - FabricContext.validate_for_read
+    - FabricContext.fabric_is_local
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_fabric_context(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+
+    instance = FabricContext(rest_send=rest_send, fabric_name="fabric_1")
+    match = r"Fabric 'fabric_1' is owned by a different controller"
+    with pytest.raises(RuntimeError, match=match):
+        instance.validate_for_read()

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Deeksha Pandey (deekpand-cisco)  deekpand@cisco.com
+# Copyright: (c) 2026, Deeksha Pandey (@deekpand) <deekpand@cisco.com>
 
 
 """Unit tests for generic gathered-state local and Lucene filtering."""
@@ -14,6 +14,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     build_lucene_expressions,
     filter_gathered_response,
     format_lucene_value,
+    validate_gathered_filters,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import (
     LoopbackInterfaceModel,
@@ -74,7 +75,7 @@ def test_lucene_supported_fields_are_combined_with_and():
     assert build_lucene_expressions(
         [{"interface_name": "loopback101"}],
         _lucene_spec(),
-    ) == ["interfaceType:loopback AND policyType:loopback AND " "interfaceName:loopback101"]
+    ) == ["interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101"]
 
 
 def test_lucene_multiple_items_remain_separate_expressions():
@@ -186,3 +187,40 @@ def test_nonmatching_filter_returns_empty_list():
 def test_empty_filter_item_is_rejected(filter_item):
     with pytest.raises(ValueError, match="at least one filtering criterion"):
         _filter([_response()], [filter_item])
+
+
+def test_validate_rejects_non_dict_filters_item():
+    with pytest.raises(ValueError, match="must be a dictionary.*index 0"):
+        validate_gathered_filters(
+            filters=["not_a_dict"],
+            normalize_filter=None,
+            supported_properties=("switch_ip",),
+        )
+
+
+def test_validate_rejects_unsupported_properties():
+    with pytest.raises(ValueError, match="unsupported properties.*'extra_field'"):
+        validate_gathered_filters(
+            filters=[{"extra_field": "value"}],
+            normalize_filter=None,
+            supported_properties=("switch_ip", "interface_name"),
+        )
+
+
+def test_validate_rejects_nested_unsupported_property():
+    with pytest.raises(ValueError, match="unsupported properties.*'config_data.network_os.policy.extra_config'"):
+        validate_gathered_filters(
+            filters=[{"config_data": {"network_os": {"policy": {"extra_config": "value"}}}}],
+            normalize_filter=None,
+            supported_properties=LoopbackInterfaceModel.gathered_filter_properties,
+        )
+
+
+def test_validate_skips_property_check_when_supported_properties_empty():
+    # Backward compatibility: empty tuple means no property restriction
+    # Should only fail on active-value check if filter is empty, not on property check
+    validate_gathered_filters(
+        filters=[{"any_fields": "any_value"}],
+        normalize_filter=None,
+        supported_properties=(),
+    )

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2026, Cisco and/or its affiliates.
+# Copyright: (c) 2026, Deeksha Pandey (deekpand-cisco)  deekpand@cisco.com
 
-# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 """Unit tests for generic gathered-state local and Lucene filtering."""
 
@@ -16,7 +15,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     filter_gathered_response,
     format_lucene_value,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import (
+    LoopbackInterfaceModel,
+)
 
 
 def _response(
@@ -66,21 +67,14 @@ def _lucene_spec() -> GatheredLuceneSpec:
 
 
 def test_lucene_without_filters_returns_base_expression():
-    assert build_lucene_expressions([], _lucene_spec()) == [
-        "interfaceType:loopback AND policyType:loopback"
-    ]
+    assert build_lucene_expressions([], _lucene_spec()) == ["interfaceType:loopback AND policyType:loopback"]
 
 
 def test_lucene_supported_fields_are_combined_with_and():
     assert build_lucene_expressions(
         [{"interface_name": "loopback101"}],
         _lucene_spec(),
-    ) == [
-        (
-            "interfaceType:loopback AND policyType:loopback AND "
-            "interfaceName:loopback101"
-        )
-    ]
+    ) == ["interfaceType:loopback AND policyType:loopback AND " "interfaceName:loopback101"]
 
 
 def test_lucene_multiple_items_remain_separate_expressions():
@@ -154,7 +148,11 @@ def test_ansible_injected_null_values_do_not_become_criteria():
 
 
 def test_multiple_filter_items_use_or_semantics():
-    responses = [_response(), _response(interface_name="loopback102"), _response(interface_name="loopback103")]
+    responses = [
+        _response(),
+        _response(interface_name="loopback102"),
+        _response(interface_name="loopback103"),
+    ]
 
     result = _filter(
         responses,
@@ -165,7 +163,10 @@ def test_multiple_filter_items_use_or_semantics():
 
 
 def test_nested_false_value_is_an_active_filter():
-    responses = [_response(admin_state=False), _response(interface_name="loopback102", admin_state=True)]
+    responses = [
+        _response(admin_state=False),
+        _response(interface_name="loopback102", admin_state=True),
+    ]
     filters = [{"config_data": {"network_os": {"policy": {"admin_state": False}}}}]
 
     assert _filter(responses, filters) == [responses[0]]

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -16,9 +16,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
     format_lucene_value,
     validate_gathered_filters,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import (
-    LoopbackInterfaceModel,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
 
 
 def _response(

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -47,6 +47,7 @@ def _response(
 
 
 def _filter(responses, filters):
+    """Apply gathered filters and return matched models."""
     return filter_gathered_response(
         response_data=responses,
         filters=filters,
@@ -118,8 +119,10 @@ def test_format_lucene_value(value, expected):
 
 def test_no_filters_returns_all_responses():
     responses = [_response(), _response(interface_name="loopback102")]
-
-    assert _filter(responses, []) == responses
+    result = _filter(responses, [])
+    assert len(result) == 2
+    assert result[0].interface_name == "loopback101"
+    assert result[1].interface_name == "loopback102"
 
 
 def test_one_filter_item_uses_and_semantics_and_normalizes_name():
@@ -134,7 +137,9 @@ def test_one_filter_item_uses_and_semantics_and_normalizes_name():
         [{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}],
     )
 
-    assert result == [responses[0]]
+    assert len(result) == 1
+    assert result[0].switch_ip == "192.0.2.10"
+    assert result[0].interface_name == "loopback101"
 
 
 def test_ansible_injected_null_values_do_not_become_criteria():
@@ -145,7 +150,8 @@ def test_ansible_injected_null_values_do_not_become_criteria():
         [{"switch_ip": None, "interface_name": "Loopback101"}],
     )
 
-    assert result == [responses[0]]
+    assert len(result) == 1
+    assert result[0].interface_name == "loopback101"
 
 
 def test_multiple_filter_items_use_or_semantics():
@@ -160,7 +166,9 @@ def test_multiple_filter_items_use_or_semantics():
         [{"interface_name": "loopback101"}, {"interface_name": "loopback102"}],
     )
 
-    assert result == responses[:2]
+    assert len(result) == 2
+    assert result[0].interface_name == "loopback101"
+    assert result[1].interface_name == "loopback102"
 
 
 def test_nested_false_value_is_an_active_filter():
@@ -170,17 +178,23 @@ def test_nested_false_value_is_an_active_filter():
     ]
     filters = [{"config_data": {"network_os": {"policy": {"admin_state": False}}}}]
 
-    assert _filter(responses, filters) == [responses[0]]
+    result = _filter(responses, filters)
+    assert len(result) == 1
+    assert result[0].interface_name == "loopback101"
+    assert result[0].config_data.network_os.policy.admin_state is False
 
 
 def test_duplicate_identifiers_are_returned_once():
     response = _response()
 
-    assert _filter([response, dict(response)], [{"interface_name": "loopback101"}]) == [response]
+    result = _filter([response, dict(response)], [{"interface_name": "loopback101"}])
+    assert len(result) == 1
+    assert result[0].interface_name == "loopback101"
 
 
 def test_nonmatching_filter_returns_empty_list():
-    assert _filter([_response()], [{"interface_name": "loopback999"}]) == []
+    result = _filter([_response()], [{"interface_name": "loopback999"}])
+    assert result == []
 
 
 @pytest.mark.parametrize("filter_item", [{}, {"switch_ip": None}, {"interface_name": ""}])

--- a/tests/unit/module_utils/test_gathered_filter.py
+++ b/tests/unit/module_utils/test_gathered_filter.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Cisco and/or its affiliates.
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for generic gathered-state local and Lucene filtering."""
+
+from __future__ import annotations
+
+import pytest
+
+from ansible_collections.cisco.nd.plugins.module_utils.gathered_filter import (
+    GatheredLuceneSpec,
+    build_lucene_expressions,
+    filter_gathered_response,
+    format_lucene_value,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
+
+
+def _response(
+    switch_ip: str = "192.0.2.10",
+    interface_name: str = "loopback101",
+    admin_state: bool = True,
+    description: str = "primary loopback",
+) -> dict:
+    return {
+        "switchIp": switch_ip,
+        "interfaceName": interface_name,
+        "interfaceType": "loopback",
+        "configData": {
+            "mode": "managed",
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "adminState": admin_state,
+                    "ip": "10.101.0.1/32",
+                    "description": description,
+                    "policyType": "loopback",
+                },
+            },
+        },
+    }
+
+
+def _filter(responses, filters):
+    return filter_gathered_response(
+        response_data=responses,
+        filters=filters,
+        model_class=LoopbackInterfaceModel,
+        normalize_filter=LoopbackInterfaceModel.normalize_gathered_filter,
+    )
+
+
+def _lucene_spec() -> GatheredLuceneSpec:
+    return GatheredLuceneSpec(
+        base_terms=(
+            ("interfaceType", "loopback"),
+            ("policyType", "loopback"),
+        ),
+        field_map={
+            ("interface_name",): "interfaceName",
+        },
+    )
+
+
+def test_lucene_without_filters_returns_base_expression():
+    assert build_lucene_expressions([], _lucene_spec()) == [
+        "interfaceType:loopback AND policyType:loopback"
+    ]
+
+
+def test_lucene_supported_fields_are_combined_with_and():
+    assert build_lucene_expressions(
+        [{"interface_name": "loopback101"}],
+        _lucene_spec(),
+    ) == [
+        (
+            "interfaceType:loopback AND policyType:loopback AND "
+            "interfaceName:loopback101"
+        )
+    ]
+
+
+def test_lucene_multiple_items_remain_separate_expressions():
+    assert build_lucene_expressions(
+        [
+            {"interface_name": "loopback101"},
+            {"interface_name": "loopback102"},
+        ],
+        _lucene_spec(),
+    ) == [
+        "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback101",
+        "interfaceType:loopback AND policyType:loopback AND interfaceName:loopback102",
+    ]
+
+
+def test_lucene_unmapped_fields_fall_back_to_base_and_deduplicate():
+    assert build_lucene_expressions(
+        [
+            {"config_data": {"network_os": {"policy": {"description": "first"}}}},
+            {"config_data": {"network_os": {"policy": {"description": "second"}}}},
+        ],
+        _lucene_spec(),
+    ) == ["interfaceType:loopback AND policyType:loopback"]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, "true"),
+        (False, "false"),
+        (0, "0"),
+        ("loopback101", "loopback101"),
+        ("nx-os", '"nx-os"'),
+        ('contains "quotes"', '"contains \\"quotes\\""'),
+    ],
+)
+def test_format_lucene_value(value, expected):
+    assert format_lucene_value(value) == expected
+
+
+def test_no_filters_returns_all_responses():
+    responses = [_response(), _response(interface_name="loopback102")]
+
+    assert _filter(responses, []) == responses
+
+
+def test_one_filter_item_uses_and_semantics_and_normalizes_name():
+    responses = [
+        _response(),
+        _response(switch_ip="192.0.2.11"),
+        _response(interface_name="loopback102"),
+    ]
+
+    result = _filter(
+        responses,
+        [{"switch_ip": "192.0.2.10", "interface_name": "Loopback101"}],
+    )
+
+    assert result == [responses[0]]
+
+
+def test_ansible_injected_null_values_do_not_become_criteria():
+    responses = [_response(), _response(interface_name="loopback102")]
+
+    result = _filter(
+        responses,
+        [{"switch_ip": None, "interface_name": "Loopback101"}],
+    )
+
+    assert result == [responses[0]]
+
+
+def test_multiple_filter_items_use_or_semantics():
+    responses = [_response(), _response(interface_name="loopback102"), _response(interface_name="loopback103")]
+
+    result = _filter(
+        responses,
+        [{"interface_name": "loopback101"}, {"interface_name": "loopback102"}],
+    )
+
+    assert result == responses[:2]
+
+
+def test_nested_false_value_is_an_active_filter():
+    responses = [_response(admin_state=False), _response(interface_name="loopback102", admin_state=True)]
+    filters = [{"config_data": {"network_os": {"policy": {"admin_state": False}}}}]
+
+    assert _filter(responses, filters) == [responses[0]]
+
+
+def test_duplicate_identifiers_are_returned_once():
+    response = _response()
+
+    assert _filter([response, dict(response)], [{"interface_name": "loopback101"}]) == [response]
+
+
+def test_nonmatching_filter_returns_empty_list():
+    assert _filter([_response()], [{"interface_name": "loopback999"}]) == []
+
+
+@pytest.mark.parametrize("filter_item", [{}, {"switch_ip": None}, {"interface_name": ""}])
+def test_empty_filter_item_is_rejected(filter_item):
+    with pytest.raises(ValueError, match="at least one filtering criterion"):
+        _filter([_response()], [filter_item])

--- a/tests/unit/module_utils/test_nd_output.py
+++ b/tests/unit/module_utils/test_nd_output.py
@@ -215,6 +215,92 @@ class TestNDOutputFormat:
         assert output.format()["changed"] is True
 
 
+class TestNDOutputGatheredState:
+    """Tests for the read-only gathered state output convention."""
+
+    def test_gathered_uses_gathered_key(self):
+        """state='gathered' surfaces fetched objects under a 'gathered' key."""
+        output = NDOutput("normal", state="gathered")
+        output._after = [{"name": "link1"}]
+        result = output.format()
+        assert result["gathered"] == [{"name": "link1"}]
+
+    def test_gathered_omits_change_oriented_keys(self):
+        """state='gathered' omits before/after/diff/proposed."""
+        output = NDOutput("info", state="gathered")
+        result = output.format()
+        for key in ("after", "before", "diff", "proposed"):
+            assert key not in result
+
+    def test_gathered_is_not_changed(self):
+        """gathered is read-only, so changed is always False."""
+        output = NDOutput("normal", state="gathered")
+        result = output.format()
+        assert result["changed"] is False
+
+    def test_gathered_debug_includes_logs(self):
+        """Debug output_level still surfaces logs under gathered."""
+        output = NDOutput("debug", state="gathered")
+        output.assign(logs=["l1"])
+        result = output.format()
+        assert result["logs"] == ["l1"]
+
+    def test_non_gathered_state_keeps_classic_shape(self):
+        """Non-gathered states retain the before/after/diff shape and no gathered key."""
+        output = NDOutput("normal", state="merged")
+        result = output.format()
+        assert "gathered" not in result
+        assert "after" in result and "before" in result and "diff" in result
+
+    def test_gathered_prunes_to_argument_spec(self):
+        """gathered_spec drops response-only keys so output round-trips as config."""
+        output = NDOutput("normal", state="gathered")
+        output._after = [{"src_switch_name": "leaf1", "link_id": "UUID-123"}]
+        output.assign(gathered_spec={"src_switch_name": {"type": "str"}})
+        result = output.format()
+        assert result["gathered"] == [{"src_switch_name": "leaf1"}]
+
+    def test_gathered_prunes_nested_but_keeps_free_form(self):
+        """Pruning recurses into modeled dicts but leaves free-form dicts intact."""
+        output = NDOutput("normal", state="gathered")
+        output._after = [
+            {
+                "src_switch_name": "leaf1",
+                "config_data": {
+                    "policy_type": "numbered",
+                    "template_inputs": {"anyKey": 1},
+                    "server_only": "drop-me",
+                },
+            }
+        ]
+        output.assign(
+            gathered_spec={
+                "src_switch_name": {"type": "str"},
+                "config_data": {
+                    "type": "dict",
+                    "options": {
+                        "policy_type": {"type": "str"},
+                        "template_inputs": {"type": "dict"},
+                    },
+                },
+            }
+        )
+        result = output.format()
+        assert result["gathered"] == [
+            {
+                "src_switch_name": "leaf1",
+                "config_data": {"policy_type": "numbered", "template_inputs": {"anyKey": 1}},
+            }
+        ]
+
+    def test_gathered_without_spec_is_unpruned(self):
+        """No gathered_spec means no pruning (backward compatible)."""
+        output = NDOutput("normal", state="gathered")
+        output._after = [{"src_switch_name": "leaf1", "link_id": "UUID-123"}]
+        result = output.format()
+        assert result["gathered"] == [{"src_switch_name": "leaf1", "link_id": "UUID-123"}]
+
+
 # =============================================================================
 # Test: NDOutput.assign
 # =============================================================================

--- a/tests/unit/module_utils/test_nd_output.py
+++ b/tests/unit/module_utils/test_nd_output.py
@@ -17,7 +17,10 @@ from __future__ import absolute_import, annotations, division, print_function
 
 __metaclass__ = type  # pylint: disable=invalid-name
 
-from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum, OperationType
+from ansible_collections.cisco.nd.plugins.module_utils.enums import (
+    HttpVerbEnum,
+    OperationType,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
@@ -198,13 +201,25 @@ class TestNDOutputFormat:
         from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import (
             EthernetTrunkHostInterfaceModel,
         )
-        from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+        from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+            NDConfigCollection,
+        )
 
         def response(policy):
-            return {"switchIp": "192.0.2.10", "interfaceName": "Ethernet1/1", "configData": {"networkOS": {"policy": policy}}}
+            return {
+                "switchIp": "192.0.2.10",
+                "interfaceName": "Ethernet1/1",
+                "configData": {"networkOS": {"policy": policy}},
+            }
 
         before_item = EthernetTrunkHostInterfaceModel.from_response(
-            response({"policyType": "trunkHost", "stormControlBroadcastLevel": 50.0, "stormControlBroadcastLevelPps": 12345})
+            response(
+                {
+                    "policyType": "trunkHost",
+                    "stormControlBroadcastLevel": 50.0,
+                    "stormControlBroadcastLevelPps": 12345,
+                }
+            )
         )
         after_item = EthernetTrunkHostInterfaceModel.from_response(response({"policyType": "trunkHost", "stormControlBroadcastLevelPps": 12345}))
         before = NDConfigCollection(model_class=EthernetTrunkHostInterfaceModel, items=[before_item])
@@ -289,7 +304,10 @@ class TestNDOutputGatheredState:
         assert result["gathered"] == [
             {
                 "src_switch_name": "leaf1",
-                "config_data": {"policy_type": "numbered", "template_inputs": {"anyKey": 1}},
+                "config_data": {
+                    "policy_type": "numbered",
+                    "template_inputs": {"anyKey": 1},
+                },
             }
         ]
 
@@ -462,7 +480,13 @@ class TestFormatWithVerbosityLevel3:
         output = NDOutput("normal")
         results = _make_results_write_and_query()
         result = output.format_with_verbosity(3, results)
-        for key in ("api_response", "api_result", "api_diff", "api_metadata", "api_payload"):
+        for key in (
+            "api_response",
+            "api_result",
+            "api_diff",
+            "api_metadata",
+            "api_payload",
+        ):
             assert len(result[key]) == 2, f"{key} should have 2 entries"
 
     def test_verbosity_3_payload_contains_correct_data(self):

--- a/tests/unit/module_utils/test_nd_output.py
+++ b/tests/unit/module_utils/test_nd_output.py
@@ -240,12 +240,14 @@ class TestNDOutputGatheredState:
         result = output.format()
         assert result["gathered"] == [{"name": "link1"}]
 
-    def test_gathered_omits_change_oriented_keys(self):
-        """state='gathered' omits before/after/diff/proposed."""
+    def test_gathered_includes_empty_change_oriented_keys(self):
+        """state='gathered' includes before/after/diff as empty lists."""
         output = NDOutput("info", state="gathered")
         result = output.format()
-        for key in ("after", "before", "diff", "proposed"):
-            assert key not in result
+        assert result["before"] == []
+        assert result["after"] == []
+        assert result["diff"] == []
+        assert result["proposed"] == []
 
     def test_gathered_is_not_changed(self):
         """gathered is read-only, so changed is always False."""

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -35,32 +35,16 @@ __metaclass__ = type  # pylint: disable=invalid-name
 
 import pytest
 import ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine as state_machine_module
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
-    NDStateMachineError,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
-    NDStateMachine,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import (
-    LoopbackInterfaceOrchestrator,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
-    ResponseType,
-)
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
-    ResponseHandler,
-)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
-    does_not_raise,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
-    MockAnsibleModule,
-)
-from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import (
-    ResponseGenerator,
-)
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
 

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -659,7 +659,8 @@ class _FakeOrchestratorBase:
 
     supports_bulk_create = False
     supports_bulk_delete = False
-    supports_gathered_lucene_filtering = False
+    supports_gathered_server_filtering = False
+    gathered_transform = None
 
     def __init__(self, model_class, response_data):
         self.model_class = model_class
@@ -711,7 +712,7 @@ def _build_gathered_state_machine(monkeypatch, model_class, state, config, serve
         {"name": "other", "value": 20},
     ]
     orchestrator = _FakeOrchestratorBase(model_class, response_data)
-    orchestrator.supports_gathered_lucene_filtering = server_filtering
+    orchestrator.supports_gathered_server_filtering = server_filtering
     machine = NDStateMachine(
         module=_FakeModule(state=state, config=config),
         model_orchestrator=orchestrator,

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -28,6 +28,9 @@ the seam the per-method capability tests in `test_base_interface.py` cannot: the
 
 from __future__ import absolute_import, annotations, division, print_function
 
+from copy import deepcopy
+from typing import ClassVar, Literal
+
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import pytest
@@ -41,6 +44,8 @@ from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import do
 from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
 from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
 from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
+import ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine as state_machine_module
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 
 
 class _SpyLoopbackOrchestrator(LoopbackInterfaceOrchestrator):
@@ -594,3 +599,207 @@ def test_nd_state_machine_00210() -> None:
     assert "update" in names
     assert "delete" not in names
     assert "delete_bulk" not in names
+
+
+class _FilterModel(NDBaseModel):
+    """Small opted-in model used to exercise state-machine routing."""
+
+    identifiers: ClassVar[list[str] | None] = ["name"]
+    identifier_strategy: ClassVar[Literal["single"]] = "single"
+    supports_gathered_filtering: ClassVar[bool] = True
+
+    name: str
+    value: int | None = None
+
+    @classmethod
+    def get_argument_spec(cls) -> dict:
+        return {
+            "config": {
+                "type": "list",
+                "elements": "dict",
+                "options": {
+                    "name": {"type": "str"},
+                    "value": {"type": "int"},
+                },
+            }
+        }
+
+
+class _LegacyModel(_FilterModel):
+    """Model that deliberately keeps the pre-filtering state-machine path."""
+
+    supports_gathered_filtering: ClassVar[bool] = False
+
+
+class _FakeOrchestratorBase:
+    """Minimal orchestrator accepted through the instance-injection path."""
+
+    supports_bulk_create = False
+    supports_bulk_delete = False
+    supports_gathered_lucene_filtering = False
+
+    def __init__(self, model_class, response_data):
+        self.model_class = model_class
+        self.response_data = response_data
+        self.prepare_calls = []
+        self.query_calls = []
+        self.results = None
+
+    def query_all(self, **kwargs):
+        self.query_calls.append(deepcopy(kwargs))
+        return deepcopy(self.response_data)
+
+    def prepare_config_data(self, raw_config):
+        self.prepare_calls.append(deepcopy(raw_config))
+        return raw_config
+
+
+class _FakeRestSend:
+    """REST holder; no request is made by these state-machine tests."""
+
+    def __init__(self, params):
+        self.params = params
+        self.sender = None
+        self.response_handler = None
+
+
+class _FakeSender:
+    ansible_module = None
+
+
+class _FakeModule:
+    def __init__(self, state, config):
+        self.params = {
+            "state": state,
+            "config": config,
+            "output_level": "normal",
+        }
+        self.check_mode = False
+        self.no_log_values = set()
+
+
+def _build_state_machine(monkeypatch, model_class, state, config, server_filtering=False):
+    monkeypatch.setattr(state_machine_module, "NDBaseOrchestrator", _FakeOrchestratorBase)
+    monkeypatch.setattr(state_machine_module, "RestSend", _FakeRestSend)
+    monkeypatch.setattr(state_machine_module, "Sender", _FakeSender)
+
+    response_data = [
+        {"name": "wanted", "value": 10},
+        {"name": "other", "value": 20},
+    ]
+    orchestrator = _FakeOrchestratorBase(model_class, response_data)
+    orchestrator.supports_gathered_lucene_filtering = server_filtering
+    machine = NDStateMachine(
+        module=_FakeModule(state=state, config=config),
+        model_orchestrator=orchestrator,
+    )
+    return machine, orchestrator
+
+
+def test_gathered_filtering_filters_existing_and_keeps_filters_out_of_proposed(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state="gathered",
+        config=[{"name": "wanted"}],
+    )
+
+    assert machine.before.to_ansible_config() == [{"name": "wanted", "value": 10}]
+    assert machine.proposed.to_ansible_config() == []
+    assert orchestrator.prepare_calls == [[]]
+    assert orchestrator.query_calls == [{}]
+    assert machine.output.format()["gathered"] == [{"name": "wanted", "value": 10}]
+
+
+def test_opted_in_model_preserves_write_state_config_flow(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state="merged",
+        config=[{"name": "wanted", "value": 10}],
+    )
+
+    assert machine.before.to_ansible_config() == [
+        {"name": "wanted", "value": 10},
+        {"name": "other", "value": 20},
+    ]
+    assert machine.proposed.to_ansible_config() == [{"name": "wanted", "value": 10}]
+    assert orchestrator.prepare_calls == [[{"name": "wanted", "value": 10}]]
+    assert orchestrator.query_calls == [{}]
+
+
+def test_model_without_opt_in_preserves_legacy_gathered_flow(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_LegacyModel,
+        state="gathered",
+        config=[{"name": "wanted"}],
+    )
+
+    assert machine.before.to_ansible_config() == [
+        {"name": "wanted", "value": 10},
+        {"name": "other", "value": 20},
+    ]
+    assert machine.proposed.to_ansible_config() == [{"name": "wanted"}]
+    assert orchestrator.prepare_calls == [[{"name": "wanted"}]]
+    assert orchestrator.query_calls == [{}]
+
+
+def test_gathered_filters_are_forwarded_when_model_and_orchestrator_opt_in(monkeypatch):
+    config = [{"name": "wanted"}]
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state="gathered",
+        config=config,
+        server_filtering=True,
+    )
+
+    assert orchestrator.query_calls == [{"gathered_filters": config}]
+    # Server-side filtering remains candidate reduction; local matching is
+    # still authoritative and keeps criteria out of proposed configuration.
+    assert machine.before.to_ansible_config() == [{"name": "wanted", "value": 10}]
+    assert machine.proposed.to_ansible_config() == []
+
+
+def test_empty_gathered_config_is_forwarded_explicitly(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state="gathered",
+        config=[],
+        server_filtering=True,
+    )
+
+    assert orchestrator.query_calls == [{"gathered_filters": []}]
+    assert machine.before.to_ansible_config() == [
+        {"name": "wanted", "value": 10},
+        {"name": "other", "value": 20},
+    ]
+
+
+@pytest.mark.parametrize("state", ["merged", "replaced", "overridden", "deleted"])
+def test_write_states_never_receive_gathered_filters(monkeypatch, state):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_FilterModel,
+        state=state,
+        config=[{"name": "wanted", "value": 10}],
+        server_filtering=True,
+    )
+
+    assert machine.state == state
+    assert orchestrator.query_calls == [{}]
+
+
+def test_legacy_model_does_not_forward_filters_even_when_orchestrator_opts_in(monkeypatch):
+    machine, orchestrator = _build_state_machine(
+        monkeypatch,
+        model_class=_LegacyModel,
+        state="gathered",
+        config=[{"name": "wanted"}],
+        server_filtering=True,
+    )
+
+    assert machine.state == "gathered"
+    assert orchestrator.query_calls == [{}]

--- a/tests/unit/module_utils/test_nd_state_machine.py
+++ b/tests/unit/module_utils/test_nd_state_machine.py
@@ -34,18 +34,34 @@ from typing import ClassVar, Literal
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import pytest
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
-from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
-from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
-from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
-from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import MockAnsibleModule
-from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import ResponseGenerator
-from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 import ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine as state_machine_module
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import (
+    LoopbackInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import (
+    does_not_raise,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
+    MockAnsibleModule,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.response_generator import (
+    ResponseGenerator,
+)
+from ansible_collections.cisco.nd.tests.unit.module_utils.sender_file import Sender
 
 
 class _SpyLoopbackOrchestrator(LoopbackInterfaceOrchestrator):
@@ -108,6 +124,7 @@ def _build_module(state: str, check_mode: bool, config: list[dict]) -> MockAnsib
     """Build a `MockAnsibleModule` with the params `NDStateMachine` reads."""
     module = MockAnsibleModule()
     module.check_mode = check_mode
+    module.no_log_values = set()
     module.params = {
         "state": state,
         "config": config,
@@ -255,7 +272,13 @@ class _ExistingLoopbackSpy(_SpyLoopbackOrchestrator):
     """Spy whose inventory already contains loopback10, so a re-submitted policy-less item is not a create."""
 
     def query_all(self, model_instance=None, **kwargs) -> ResponseType:
-        return [{"switchIp": "192.168.12.151", "interfaceName": "loopback10", "interfaceType": "loopback"}]
+        return [
+            {
+                "switchIp": "192.168.12.151",
+                "interfaceName": "loopback10",
+                "interfaceType": "loopback",
+            }
+        ]
 
 
 def test_nd_state_machine_00140() -> None:
@@ -678,7 +701,7 @@ class _FakeModule:
         self.no_log_values = set()
 
 
-def _build_state_machine(monkeypatch, model_class, state, config, server_filtering=False):
+def _build_gathered_state_machine(monkeypatch, model_class, state, config, server_filtering=False):
     monkeypatch.setattr(state_machine_module, "NDBaseOrchestrator", _FakeOrchestratorBase)
     monkeypatch.setattr(state_machine_module, "RestSend", _FakeRestSend)
     monkeypatch.setattr(state_machine_module, "Sender", _FakeSender)
@@ -696,8 +719,24 @@ def _build_state_machine(monkeypatch, model_class, state, config, server_filteri
     return machine, orchestrator
 
 
-def test_gathered_filtering_filters_existing_and_keeps_filters_out_of_proposed(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00200(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify gathered filtering removes non-matching items from `before` and keeps filter criteria out of `proposed`.
+
+    ## Test
+
+    - `state: gathered`, opted-in `_FilterModel`, config filters for `name: wanted`
+    - `before` contains only the matching item; `proposed` is empty (filters are not desired state)
+    - `gathered` output matches the filtered `before`
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    - NDConfigCollection.from_api_response()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state="gathered",
@@ -711,8 +750,23 @@ def test_gathered_filtering_filters_existing_and_keeps_filters_out_of_proposed(m
     assert machine.output.format()["gathered"] == [{"name": "wanted", "value": 10}]
 
 
-def test_opted_in_model_preserves_write_state_config_flow(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00210(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify an opted-in model preserves the normal write-state config flow under `merged`.
+
+    ## Test
+
+    - `state: merged`, opted-in `_FilterModel`, config has `name: wanted, value: 10`
+    - `before` contains the full inventory (no filtering for write states)
+    - `proposed` contains the user config; `prepare_config_data` receives it unmodified
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state="merged",
@@ -728,8 +782,23 @@ def test_opted_in_model_preserves_write_state_config_flow(monkeypatch):
     assert orchestrator.query_calls == [{}]
 
 
-def test_model_without_opt_in_preserves_legacy_gathered_flow(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00220(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify a model without gathered filtering opt-in preserves the legacy gathered flow.
+
+    ## Test
+
+    - `state: gathered`, `_LegacyModel` (opt-in disabled), config has `name: wanted`
+    - `before` contains the full inventory (no filtering applied)
+    - `proposed` contains the user config as-is (legacy behavior)
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_LegacyModel,
         state="gathered",
@@ -745,9 +814,24 @@ def test_model_without_opt_in_preserves_legacy_gathered_flow(monkeypatch):
     assert orchestrator.query_calls == [{}]
 
 
-def test_gathered_filters_are_forwarded_when_model_and_orchestrator_opt_in(monkeypatch):
+def test_nd_state_machine_00230(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify gathered filters are forwarded to `query_all` when both model and orchestrator opt in.
+
+    ## Test
+
+    - `state: gathered`, opted-in `_FilterModel`, server filtering enabled
+    - `query_all` receives `gathered_filters` with the user config
+    - Local filtering still applies; `before` contains only the match; `proposed` is empty
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
     config = [{"name": "wanted"}]
-    machine, orchestrator = _build_state_machine(
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state="gathered",
@@ -762,8 +846,23 @@ def test_gathered_filters_are_forwarded_when_model_and_orchestrator_opt_in(monke
     assert machine.proposed.to_ansible_config() == []
 
 
-def test_empty_gathered_config_is_forwarded_explicitly(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00240(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify an empty gathered config is forwarded explicitly as an empty list.
+
+    ## Test
+
+    - `state: gathered`, opted-in `_FilterModel`, empty config, server filtering enabled
+    - `query_all` receives `gathered_filters: []` (not omitted)
+    - `before` contains the full inventory (no filter criteria to apply)
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state="gathered",
@@ -779,8 +878,22 @@ def test_empty_gathered_config_is_forwarded_explicitly(monkeypatch):
 
 
 @pytest.mark.parametrize("state", ["merged", "replaced", "overridden", "deleted"])
-def test_write_states_never_receive_gathered_filters(monkeypatch, state):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00250(monkeypatch, state) -> None:
+    """
+    # Summary
+
+    Verify write states never receive `gathered_filters` even when server filtering is enabled.
+
+    ## Test
+
+    - Parametrized over `merged`, `replaced`, `overridden`, `deleted`
+    - Server filtering enabled, but `query_all` receives no `gathered_filters`
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_FilterModel,
         state=state,
@@ -792,8 +905,22 @@ def test_write_states_never_receive_gathered_filters(monkeypatch, state):
     assert orchestrator.query_calls == [{}]
 
 
-def test_legacy_model_does_not_forward_filters_even_when_orchestrator_opts_in(monkeypatch):
-    machine, orchestrator = _build_state_machine(
+def test_nd_state_machine_00260(monkeypatch) -> None:
+    """
+    # Summary
+
+    Verify a legacy model does not forward gathered filters even when the orchestrator opts in.
+
+    ## Test
+
+    - `state: gathered`, `_LegacyModel` (opt-in disabled), server filtering enabled
+    - `query_all` receives no `gathered_filters` (model gate prevents forwarding)
+
+    ## Classes and Methods
+
+    - NDStateMachine.__init__()
+    """
+    machine, orchestrator = _build_gathered_state_machine(
         monkeypatch,
         model_class=_LegacyModel,
         state="gathered",

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -304,7 +304,10 @@ class TestPruneToSpec:
     def test_keeps_scalar_and_scalar_list_verbatim(self):
         """Scalars and lists of scalars pass through unchanged."""
         data = {"name": "leaf1", "interface_names": ["Eth1/1", "Eth1/2"]}
-        spec = {"name": {"type": "str"}, "interface_names": {"type": "list", "elements": "str"}}
+        spec = {
+            "name": {"type": "str"},
+            "interface_names": {"type": "list", "elements": "str"},
+        }
         assert prune_to_spec(data, spec) == data
 
     def test_recurses_into_modeled_dict(self):
@@ -316,7 +319,13 @@ class TestPruneToSpec:
     def test_recurses_into_list_of_modeled_dicts(self):
         """A list of dicts with options is pruned element by element."""
         data = {"links": [{"name": "a", "extra": 1}, {"name": "b", "extra": 2}]}
-        spec = {"links": {"type": "list", "elements": "dict", "options": {"name": {"type": "str"}}}}
+        spec = {
+            "links": {
+                "type": "list",
+                "elements": "dict",
+                "options": {"name": {"type": "str"}},
+            }
+        }
         assert prune_to_spec(data, spec) == {"links": [{"name": "a"}, {"name": "b"}]}
 
     def test_free_form_dict_left_untouched(self):
@@ -334,7 +343,12 @@ class TestPruneToSpec:
                 "options": {
                     "network_os": {
                         "type": "dict",
-                        "options": {"policy": {"type": "dict", "options": {"mtu": {"type": "str"}}}},
+                        "options": {
+                            "policy": {
+                                "type": "dict",
+                                "options": {"mtu": {"type": "str"}},
+                            }
+                        },
                     }
                 },
             }
@@ -353,7 +367,10 @@ class TestPruneToSpec:
         spec = {
             "config_data": {
                 "type": "dict",
-                "options": {"policy_type": {"type": "str"}, "password": {"type": "str", "no_log": True}},
+                "options": {
+                    "policy_type": {"type": "str"},
+                    "password": {"type": "str", "no_log": True},
+                },
             }
         }
         assert prune_to_spec(data, spec) == {"config_data": {"policy_type": "numbered"}}

--- a/tests/unit/module_utils/test_utils.py
+++ b/tests/unit/module_utils/test_utils.py
@@ -1,23 +1,26 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2026, Allen Robel (@allenrobel)
+# Copyright: (c) 2026, Shreyas Srish (@shrsr) <ssrish@cisco.com>
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 """
-Unit tests for the pure diff helpers in `plugins/module_utils/utils.py`.
+Unit tests for the pure diff helpers and prune_to_spec in `plugins/module_utils/utils.py`.
 
-Covers `issubset` (the one-way forward comparison used by `NDBaseModel.get_diff`) and `has_removals`
+Covers `issubset` (the one-way forward comparison used by `NDBaseModel.get_diff`), `has_removals`
 (the reverse pass added for issue #410: detect fields present on the existing/device side that are
 absent from the proposed side, so `replaced`/`overridden` states can classify removal-only changes
-as a difference).
+as a difference), and `prune_to_spec` (trims gathered output to an argument spec's declared options).
 """
 
 # pylint: disable=line-too-long
 
-from __future__ import annotations
+from __future__ import absolute_import, annotations, division, print_function
 
-from ansible_collections.cisco.nd.plugins.module_utils.utils import has_removals, issubset
+__metaclass__ = type  # pylint: disable=invalid-name
+
+from ansible_collections.cisco.nd.plugins.module_utils.utils import has_removals, issubset, prune_to_spec
 
 # --- issubset (001XX) ---
 
@@ -287,3 +290,81 @@ def test_utils_00280() -> None:
     - utils.has_removals()
     """
     assert has_removals({"a": 1}, "not-a-dict") is False
+
+
+class TestPruneToSpec:
+    """Tests for prune_to_spec, which trims data to an argument spec's options."""
+
+    def test_drops_keys_not_in_spec(self):
+        """Keys absent from the spec (e.g. response-only fields) are removed."""
+        data = {"name": "leaf1", "link_id": "UUID-123"}
+        spec = {"name": {"type": "str"}}
+        assert prune_to_spec(data, spec) == {"name": "leaf1"}
+
+    def test_keeps_scalar_and_scalar_list_verbatim(self):
+        """Scalars and lists of scalars pass through unchanged."""
+        data = {"name": "leaf1", "interface_names": ["Eth1/1", "Eth1/2"]}
+        spec = {"name": {"type": "str"}, "interface_names": {"type": "list", "elements": "str"}}
+        assert prune_to_spec(data, spec) == data
+
+    def test_recurses_into_modeled_dict(self):
+        """A dict suboption with options is pruned recursively."""
+        data = {"config_data": {"policy_type": "numbered", "server_only": "x"}}
+        spec = {"config_data": {"type": "dict", "options": {"policy_type": {"type": "str"}}}}
+        assert prune_to_spec(data, spec) == {"config_data": {"policy_type": "numbered"}}
+
+    def test_recurses_into_list_of_modeled_dicts(self):
+        """A list of dicts with options is pruned element by element."""
+        data = {"links": [{"name": "a", "extra": 1}, {"name": "b", "extra": 2}]}
+        spec = {"links": {"type": "list", "elements": "dict", "options": {"name": {"type": "str"}}}}
+        assert prune_to_spec(data, spec) == {"links": [{"name": "a"}, {"name": "b"}]}
+
+    def test_free_form_dict_left_untouched(self):
+        """A dict suboption without options is free-form and preserved verbatim."""
+        data = {"template_inputs": {"anyKey": 1, "nested": {"deep": True}}}
+        spec = {"template_inputs": {"type": "dict"}}
+        assert prune_to_spec(data, spec) == data
+
+    def test_deeply_nested_recursion(self):
+        """Recursion follows options through several levels."""
+        data = {"config_data": {"network_os": {"policy": {"mtu": "9216", "server_only": "x"}}}}
+        spec = {
+            "config_data": {
+                "type": "dict",
+                "options": {
+                    "network_os": {
+                        "type": "dict",
+                        "options": {"policy": {"type": "dict", "options": {"mtu": {"type": "str"}}}},
+                    }
+                },
+            }
+        }
+        assert prune_to_spec(data, spec) == {"config_data": {"network_os": {"policy": {"mtu": "9216"}}}}
+
+    def test_drops_no_log_keys(self):
+        """no_log suboptions are dropped so gathered never surfaces a secret."""
+        data = {"name": "leaf1", "password": "hunter2"}
+        spec = {"name": {"type": "str"}, "password": {"type": "str", "no_log": True}}
+        assert prune_to_spec(data, spec) == {"name": "leaf1"}
+
+    def test_drops_nested_no_log_keys(self):
+        """no_log suboptions nested inside a modeled dict are also dropped."""
+        data = {"config_data": {"policy_type": "numbered", "password": "hunter2"}}
+        spec = {
+            "config_data": {
+                "type": "dict",
+                "options": {"policy_type": {"type": "str"}, "password": {"type": "str", "no_log": True}},
+            }
+        }
+        assert prune_to_spec(data, spec) == {"config_data": {"policy_type": "numbered"}}
+
+    def test_non_dict_data_returned_as_is(self):
+        """Non-dict input is returned unchanged."""
+        assert prune_to_spec("leaf1", {"name": {"type": "str"}}) == "leaf1"
+
+    def test_mismatched_type_values_kept(self):
+        """If data shape does not match the spec's declared type, value is kept as-is."""
+        # spec says dict, but data has a scalar -> keep verbatim rather than crash
+        data = {"config_data": "unexpected"}
+        spec = {"config_data": {"type": "dict", "options": {"policy_type": {"type": "str"}}}}
+        assert prune_to_spec(data, spec) == {"config_data": "unexpected"}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->

Related to https://github.com/CiscoDevNet/ansible-nd/issues/340.

This PR builds on the foundational framework established in
https://github.com/CiscoDevNet/ansible-nd/pull/312
including the state machine, base model infrastructure, orchestrator pattern,
and secrets handling.

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Enable `state: gathered` with server-side and local filtering for all five fabric modules:
- `nd_manage_fabric_ebgp_vxlan`
- `nd_manage_fabric_ibgp_vxlan`
- `nd_manage_fabric_external`
- `nd_manage_fabric_ai_ebgp_vxlan`
- `nd_manage_fabric_ai_ibgp_vxlan`

### Stacked PR

> **This PR is stacked on two prior PRs and should be reviewed/merged in order:**
>
> 1. `feature/pr312-gathered-module-filtering` — gathered framework + loopback/local_user support
> 2. `feature/gathered-ethernet-fabric-update-group` — ethernet access/trunk-host + fabric update group
> 3. **`feature/fabric-family-gathered` (this PR)** — all five fabric modules

### Orchestrators (5 files)
- Add `_fetch_fabrics_paginated()` with bounded pagination and `meta.counts.remaining` support (aligned with `base_interface._query_interfaces_with_lucene`)
- Add `_query_one_by_name()` for exact-name lookups via `GET /fabrics/{name}`, bypassing Lucene quoting issues with hyphens and special characters
- Fallback (>3 expressions or quoted values) uses type-only paginated query instead of unfiltered scan
- `_query_all_for_gathered()` splits filters: `fabric_name`-only → exact endpoint, compound → Lucene

### Module runners (5 files)
- Reject `config_actions.save`/`deploy` with `state=gathered` (fail-fast, aligned with `nd_manage_vpc_pair`)
- Update `config_actions` docstring to reflect rejection behavior

### Model
- Add `gathered_filter_properties` and `supports_gathered_filtering` to fabric base model

## Test Notes
<!--- Please provide notes or description of testing -->

### Unit Tests
- 4119 unit tests passing (0 failures)
- 17 new tests in `test_manage_fabric_gathered.py` — pagination, exact-name, wrong-type rejection, mixed filters, non-existent name, parametrized across all 5 fabric types

### Integration Tests
- Gathered test blocks added to all 5 fabric integration task files (fabric_ebgp, fabric_ibgp, fabric_external, fabric_ai_ebgp, fabric_ai_ibgp)

## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->
4.2.1.10

## Related ND API Resource Category
<!-- Please select ND API resource category, please specify -->
* [ ] analyze
* [ ] infa
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers