### PR TITLE
nd_interface_*: default config_actions.deploy to false

### DIFF
--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -52,7 +52,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
     - Via `remove_pending` if the bulk remove API request fails.
     """
 
-    deploy: bool = True
+    deploy: bool = False
 
     # Subclasses opt in to capability preflight by setting BOTH ClassVars (e.g. loopback sets
     # `interface_type = "loopback"` and `interface_mode = "managed"`). Leaving `interface_type` as ""

--- a/plugins/modules/nd_interface_ethernet_trunk_host.py
+++ b/plugins/modules/nd_interface_ethernet_trunk_host.py
@@ -286,8 +286,9 @@ options:
           execution via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
-        default: true
+        default: false
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -339,6 +340,8 @@ EXAMPLES = r"""
               cdp: true
               description: Trunk Host Interface
               speed: auto
+    config_actions:
+      deploy: true
     state: merged
   register: result
 
@@ -370,6 +373,8 @@ EXAMPLES = r"""
               allowed_vlans: all
               native_vlan: 200
               description: Server trunk ports switch 2
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Configure VLAN mapping on a trunkHost interface
@@ -392,6 +397,8 @@ EXAMPLES = r"""
                 - customer_vlan_id: ["30-40"]
                   dot1q_tunnel: true
                   provider_vlan_id: 200
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Replace the configuration of specific trunkHost interfaces
@@ -408,6 +415,8 @@ EXAMPLES = r"""
               allowed_vlans: "300-400"
               native_vlan: 300
               description: Reprovisioned trunk port
+    config_actions:
+      deploy: true
     state: replaced
 
 # state=overridden is fabric-wide: every trunkHost interface in the fabric that is NOT listed
@@ -428,6 +437,8 @@ EXAMPLES = r"""
               allowed_vlans: "100-200"
               native_vlan: 1
               description: Trunk ports to keep; all other trunkHost interfaces reset
+    config_actions:
+      deploy: true
     state: overridden
 
 - name: Delete trunkHost interface configurations
@@ -438,6 +449,8 @@ EXAMPLES = r"""
         interface_names:
           - Ethernet1/1
           - Ethernet1/2
+    config_actions:
+      deploy: true
     state: deleted
 
 - name: Create trunkHost interfaces without deploying (for batching)
@@ -699,7 +712,7 @@ def main() -> None:
         config_actions={
             "type": "dict",
             "options": {
-                "deploy": {"type": "bool", "default": True},
+                "deploy": {"type": "bool", "default": False},
             },
         },
     )
@@ -737,7 +750,7 @@ def main() -> None:
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
         config_actions = module.params.get("config_actions") or {}
-        deploy = config_actions.get("deploy", True)
+        deploy = config_actions.get("deploy", False)
         nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -223,8 +223,9 @@ options:
           execution via the C(interfaceActions/deploy) API. Only the port-channels modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
-        default: true
+        default: false
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -267,6 +268,8 @@ EXAMPLES = r"""
               port_channel_mode: active
               lacp_rate: fast
               description: Server bundle
+    config_actions:
+      deploy: true
     state: merged
   register: result
 
@@ -283,6 +286,8 @@ EXAMPLES = r"""
                 - Ethernet1/1
                 - Ethernet1/2
                 - Ethernet1/3
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Delete a port-channel
@@ -291,6 +296,8 @@ EXAMPLES = r"""
     config:
       - switch_ip: 192.168.1.1
         interface_name: port-channel501
+    config_actions:
+      deploy: true
     state: deleted
 
 - name: Stage port-channel changes without deploying
@@ -328,6 +335,8 @@ EXAMPLES = r"""
               ports:
                 - Ethernet1/1
               port_channel_mode: active
+    config_actions:
+      deploy: true
     state: replaced
 
 # WARNING: state=overridden is FABRIC-WIDE. Every accessPoHost port-channel on
@@ -349,6 +358,8 @@ EXAMPLES = r"""
                 - Ethernet1/1
                 - Ethernet1/2
               port_channel_mode: active
+    config_actions:
+      deploy: true
     state: overridden
 """
 
@@ -475,7 +486,7 @@ def main():
         config_actions={
             "type": "dict",
             "options": {
-                "deploy": {"type": "bool", "default": True},
+                "deploy": {"type": "bool", "default": False},
             },
         },
     )
@@ -498,7 +509,7 @@ def main():
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
         config_actions = module.params.get("config_actions") or {}
-        deploy = config_actions.get("deploy", True)
+        deploy = config_actions.get("deploy", False)
         nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(

--- a/plugins/modules/nd_interface_port_channel_trunk_host.py
+++ b/plugins/modules/nd_interface_port_channel_trunk_host.py
@@ -297,8 +297,9 @@ options:
           execution via the C(interfaceActions/deploy) API. Only the port-channels modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
-        default: true
+        default: false
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -342,6 +343,8 @@ EXAMPLES = r"""
               port_channel_mode: active
               lacp_rate: fast
               description: Server trunk bundle
+    config_actions:
+      deploy: true
     state: merged
   register: result
 
@@ -359,6 +362,8 @@ EXAMPLES = r"""
                 - Ethernet1/1
                 - Ethernet1/2
                 - Ethernet1/3
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Configure VLAN mapping with selective dot1q-tunnel
@@ -375,6 +380,8 @@ EXAMPLES = r"""
                 - customer_vlan_id: ["100"]
                   provider_vlan_id: 200
                   dot1q_tunnel: true
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Replace a port-channel configuration
@@ -392,6 +399,8 @@ EXAMPLES = r"""
                 - Ethernet1/1
               port_channel_mode: active
               description: Replaced port-channel configuration
+    config_actions:
+      deploy: true
     state: replaced
 
 - name: Override all port-channels in the fabric to match this configuration
@@ -409,6 +418,8 @@ EXAMPLES = r"""
                 - Ethernet1/1
                 - Ethernet1/2
               port_channel_mode: active
+    config_actions:
+      deploy: true
     state: overridden
 
 - name: Delete a port-channel
@@ -417,6 +428,8 @@ EXAMPLES = r"""
     config:
       - switch_ip: 192.168.1.1
         interface_name: port-channel501
+    config_actions:
+      deploy: true
     state: deleted
 
 - name: Stage port-channel changes without deploying
@@ -562,7 +575,7 @@ def main():
         config_actions={
             "type": "dict",
             "options": {
-                "deploy": {"type": "bool", "default": True},
+                "deploy": {"type": "bool", "default": False},
             },
         },
     )
@@ -585,7 +598,7 @@ def main():
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
         config_actions = module.params.get("config_actions") or {}
-        deploy = config_actions.get("deploy", True)
+        deploy = config_actions.get("deploy", False)
         nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -154,8 +154,9 @@ options:
           execution via the C(interfaceActions/deploy) API. Only the subinterfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
-        default: true
+        default: false
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -210,6 +211,8 @@ EXAMPLES = r"""
               pim_sparse: true
               pim_dr_priority: 1
               netflow: false
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Create multiple subinterfaces on different parents in one task
@@ -234,6 +237,8 @@ EXAMPLES = r"""
               vlan_id: 20
               ip: 10.10.20.1
               prefix: 24
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Replace the configuration of a specific subinterface
@@ -250,6 +255,8 @@ EXAMPLES = r"""
               ip: 10.20.30.40
               prefix: 24
               description: Reprovisioned subinterface Ethernet1/3.2
+    config_actions:
+      deploy: true
     state: replaced
 
 # state=overridden is fabric-wide: every managed subinterface in the fabric that is managed by this module and is
@@ -268,6 +275,8 @@ EXAMPLES = r"""
               ip: 10.10.10.1
               prefix: 24
               description: Subinterface to keep; all other managed subinterfaces deleted
+    config_actions:
+      deploy: true
     state: overridden
 
 - name: Delete a subinterface
@@ -276,6 +285,8 @@ EXAMPLES = r"""
     config:
       - switch_ip: 192.168.1.1
         interface_name: Ethernet1/3.2
+    config_actions:
+      deploy: true
     state: deleted
 
 - name: Stage changes without deploying
@@ -412,7 +423,7 @@ def main():
         config_actions={
             "type": "dict",
             "options": {
-                "deploy": {"type": "bool", "default": True},
+                "deploy": {"type": "bool", "default": False},
             },
         },
     )
@@ -440,7 +451,7 @@ def main():
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
         config_actions = module.params.get("config_actions") or {}
-        deploy = config_actions.get("deploy", True)
+        deploy = config_actions.get("deploy", False)
         nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(

--- a/plugins/modules/nd_interface_subinterface_unmanaged.py
+++ b/plugins/modules/nd_interface_subinterface_unmanaged.py
@@ -62,8 +62,9 @@ options:
           execution via the C(interfaceActions/deploy) API. Only the subinterfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
-        default: true
+        default: false
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -103,6 +104,8 @@ EXAMPLES = r"""
     config:
       - switch_ip: 192.168.1.1
         interface_name: Ethernet1/3.20
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Create multiple unmanaged subinterfaces on different parents in one task
@@ -113,6 +116,8 @@ EXAMPLES = r"""
         interface_name: Ethernet1/3.20
       - switch_ip: 192.168.1.1
         interface_name: Port-channel10.20
+    config_actions:
+      deploy: true
     state: merged
 
 # Note: For unmanaged subinterfaces, replaced is effectively a no-op on existing
@@ -124,6 +129,8 @@ EXAMPLES = r"""
     config:
       - switch_ip: 192.168.1.1
         interface_name: Ethernet1/3.20
+    config_actions:
+      deploy: true
     state: replaced
 
 - name: Override fabric-wide - delete any unmanaged subinterfaces not listed here
@@ -132,6 +139,8 @@ EXAMPLES = r"""
     config:
       - switch_ip: 192.168.1.1
         interface_name: Ethernet1/3.20
+    config_actions:
+      deploy: true
     state: overridden
 
 - name: Delete an unmanaged subinterface
@@ -140,6 +149,8 @@ EXAMPLES = r"""
     config:
       - switch_ip: 192.168.1.1
         interface_name: Ethernet1/3.20
+    config_actions:
+      deploy: true
     state: deleted
 
 - name: Stage an unmanaged subinterface without deploying
@@ -243,7 +254,7 @@ def main():
         config_actions={
             "type": "dict",
             "options": {
-                "deploy": {"type": "bool", "default": True},
+                "deploy": {"type": "bool", "default": False},
             },
         },
     )
@@ -271,7 +282,7 @@ def main():
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
         config_actions = module.params.get("config_actions") or {}
-        deploy = config_actions.get("deploy", True)
+        deploy = config_actions.get("deploy", False)
         nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -224,8 +224,9 @@ options:
           execution via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
-        default: true
+        default: false
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -282,6 +283,8 @@ EXAMPLES = r"""
               ip: 10.99.101.1
               prefix: 24
               description: Tenant SVI 335
+    config_actions:
+      deploy: true
     state: merged
   register: result
 
@@ -305,6 +308,8 @@ EXAMPLES = r"""
               admin_state: true
               ip: 10.99.99.2
               prefix: 24
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Replace the configuration of specific SVIs
@@ -320,6 +325,8 @@ EXAMPLES = r"""
               ip: 10.99.99.10
               prefix: 24
               description: Reprovisioned tenant SVI 333
+    config_actions:
+      deploy: true
     state: replaced
 
 # state=overridden is fabric-wide: every SVI in the fabric that is managed by this module and is NOT
@@ -337,6 +344,8 @@ EXAMPLES = r"""
               ip: 10.99.99.1
               prefix: 24
               description: SVI to keep; all other SVIs deleted
+    config_actions:
+      deploy: true
     state: overridden
 
 - name: Delete SVI interfaces
@@ -347,6 +356,8 @@ EXAMPLES = r"""
         interface_name: vlan333
       - switch_ip: 192.168.1.1
         interface_name: vlan334
+    config_actions:
+      deploy: true
     state: deleted
 
 - name: Stage SVI changes without deploying (for batching)
@@ -385,6 +396,8 @@ EXAMPLES = r"""
               hsrp_priority: 110
               preempt: true
               mac: "0000.0c07.ac05"
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Create an SVI with HSRP configured via extra_config (raw CLI)
@@ -405,6 +418,8 @@ EXAMPLES = r"""
                   priority 110
                   authentication md5 key-chain hsrp-keys
                   track 1 decrement 20
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Create an SVI with DHCP relay servers
@@ -424,6 +439,8 @@ EXAMPLES = r"""
               vrf_dhcp1: shared_services
               dhcp_server_address2: 10.10.10.11
               vrf_dhcp2: shared_services
+    config_actions:
+      deploy: true
     state: merged
 """
 
@@ -539,7 +556,7 @@ def main():
         config_actions={
             "type": "dict",
             "options": {
-                "deploy": {"type": "bool", "default": True},
+                "deploy": {"type": "bool", "default": False},
             },
         },
     )
@@ -571,7 +588,7 @@ def main():
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
         config_actions = module.params.get("config_actions") or {}
-        deploy = config_actions.get("deploy", True)
+        deploy = config_actions.get("deploy", False)
         nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -282,8 +282,9 @@ options:
           execution via the C(interfaceActions/deploy) API. Only the vPC interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
-        default: true
+        default: false
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -333,6 +334,8 @@ EXAMPLES = r"""
               lacp_rate: fast
               peer1_port_channel_description: Server-A on peer1
               peer2_port_channel_description: Server-A on peer2
+    config_actions:
+      deploy: true
     state: merged
   register: result
 
@@ -348,6 +351,8 @@ EXAMPLES = r"""
               peer1_member_ports:
                 - Ethernet1/1
                 - Ethernet1/2
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Replace the configuration of a specific vPC interface
@@ -370,6 +375,8 @@ EXAMPLES = r"""
               port_channel_mode: active
               peer1_port_channel_description: Reprovisioned Server-A on peer1
               peer2_port_channel_description: Reprovisioned Server-A on peer2
+    config_actions:
+      deploy: true
     state: replaced
 
 # state=overridden is fabric-wide: every vPC interface in the fabric that is managed by this module and is NOT
@@ -392,6 +399,8 @@ EXAMPLES = r"""
               peer2_member_ports:
                 - Ethernet1/1
               port_channel_mode: active
+    config_actions:
+      deploy: true
     state: overridden
 
 - name: Delete a vPC interface
@@ -400,6 +409,8 @@ EXAMPLES = r"""
     config:
       - switch_ip: 192.168.1.1
         interface_name: vpc100
+    config_actions:
+      deploy: true
     state: deleted
 
 - name: Stage vPC interface changes without deploying
@@ -549,7 +560,7 @@ def main():
         config_actions={
             "type": "dict",
             "options": {
-                "deploy": {"type": "bool", "default": True},
+                "deploy": {"type": "bool", "default": False},
             },
         },
     )
@@ -572,7 +583,7 @@ def main():
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
         config_actions = module.params.get("config_actions") or {}
-        deploy = config_actions.get("deploy", True)
+        deploy = config_actions.get("deploy", False)
         nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(

--- a/plugins/modules/nd_interface_vpc_trunk_host.py
+++ b/plugins/modules/nd_interface_vpc_trunk_host.py
@@ -325,8 +325,9 @@ options:
           execution via the C(interfaceActions/deploy) API. Only the vPC interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
+        - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
-        default: true
+        default: false
   state:
     description:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
@@ -377,6 +378,8 @@ EXAMPLES = r"""
               lacp_rate: fast
               peer1_port_channel_description: Server-A on peer1
               peer2_port_channel_description: Server-A on peer2
+    config_actions:
+      deploy: true
     state: merged
   register: result
 
@@ -391,6 +394,8 @@ EXAMPLES = r"""
             policy:
               allowed_vlans: all
               native_vlan: 1
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Enable VLAN mapping with two entries
@@ -413,6 +418,8 @@ EXAMPLES = r"""
                   customer_inner_vlan_id: 510
                   provider_vlan_id: 1010
                   dot1q_tunnel: true
+    config_actions:
+      deploy: true
     state: merged
 
 - name: Replace a vPC trunk-host policy (un-set fields revert to ND defaults)
@@ -434,6 +441,8 @@ EXAMPLES = r"""
               peer2_member_ports:
                 - Ethernet1/1
               port_channel_mode: active
+    config_actions:
+      deploy: true
     state: replaced
 
 - name: Override the fabric vPC trunk-host inventory to a single managed vPC
@@ -455,6 +464,8 @@ EXAMPLES = r"""
               peer2_member_ports:
                 - Ethernet1/1
               port_channel_mode: active
+    config_actions:
+      deploy: true
     state: overridden
 
 - name: Delete a vPC interface (cascades to both peers)
@@ -463,6 +474,8 @@ EXAMPLES = r"""
     config:
       - switch_ip: 192.168.1.1
         interface_name: vpc500
+    config_actions:
+      deploy: true
     state: deleted
 
 - name: Stage vPC interface changes without deploying
@@ -615,7 +628,7 @@ def main():
         config_actions={
             "type": "dict",
             "options": {
-                "deploy": {"type": "bool", "default": True},
+                "deploy": {"type": "bool", "default": False},
             },
         },
     )
@@ -638,7 +651,7 @@ def main():
         if not isinstance(nd_state_machine.model_orchestrator, NDBaseInterfaceOrchestrator):
             raise AssertionError(f"Expected NDBaseInterfaceOrchestrator, got {type(nd_state_machine.model_orchestrator)}")
         config_actions = module.params.get("config_actions") or {}
-        deploy = config_actions.get("deploy", True)
+        deploy = config_actions.get("deploy", False)
         nd_state_machine.model_orchestrator.deploy = deploy
 
         module_log.debug(

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -119,7 +119,7 @@ def test_base_interface_00010() -> None:
     ## Test
 
     - `_pending_deploys` and `_pending_removes` start empty
-    - `deploy` defaults to True
+    - `deploy` defaults to False
     - `_fabric_context` is None before first access
 
     ## Classes and Methods
@@ -139,7 +139,7 @@ def test_base_interface_00010() -> None:
 
     assert instance._pending_deploys == []
     assert instance._pending_removes == []
-    assert instance.deploy is True
+    assert instance.deploy is False
     assert instance._fabric_context is None
 
 
@@ -605,6 +605,7 @@ def test_base_interface_00620() -> None:
 
     ## Test
 
+    - `deploy` is enabled (it defaults to False)
     - Two pairs are queued
     - POST is issued to `/api/v1/manage/fabrics/fabric_1/interfaceActions/deploy`
     - Request body is `{"interfaces": [{"interfaceName": ..., "switchId": ...}, ...]}` in queue order
@@ -623,6 +624,7 @@ def test_base_interface_00620() -> None:
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
     instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance.deploy = True
     instance._queue_deploy("loopback10", "FDO12345ABC")
     instance._queue_deploy("loopback20", "FDO12345ABD")
 
@@ -649,6 +651,7 @@ def test_base_interface_00630() -> None:
 
     ## Test
 
+    - `deploy` is enabled (it defaults to False)
     - One pair queued
     - POST returns 500
     - `RuntimeError` matches `Bulk deploy failed`
@@ -666,6 +669,7 @@ def test_base_interface_00630() -> None:
     gen_responses = ResponseGenerator(responses())
     rest_send = _build_rest_send(gen_responses)
     instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance.deploy = True
     instance._queue_deploy("loopback10", "FDO12345ABC")
 
     match = r"Bulk deploy failed"

--- a/tests/unit/module_utils/orchestrators/test_loopback_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_loopback_interface.py
@@ -109,7 +109,7 @@ def test_loopback_interface_00010() -> None:
     - `model_class` is `LoopbackInterfaceModel`
     - `supports_bulk_create` and `supports_bulk_delete` are True
     - `_pending_deploys` and `_pending_removes` start empty
-    - `deploy` defaults to True
+    - `deploy` defaults to False
 
     ## Classes and Methods
 
@@ -130,7 +130,7 @@ def test_loopback_interface_00010() -> None:
     assert instance.supports_bulk_delete is True
     assert instance._pending_deploys == []
     assert instance._pending_removes == []
-    assert instance.deploy is True
+    assert instance.deploy is False
 
 
 def test_loopback_interface_00020() -> None:

--- a/tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_subinterface_managed_interface.py
@@ -484,7 +484,7 @@ def test_subinterface_managed_orchestrator_00820() -> None:
 
     ## Test
 
-    - Queue one interface manually
+    - Enable `deploy` (it defaults to False) and queue one interface manually
     - Call deploy_pending
     - Queue is empty after success
 
@@ -498,6 +498,7 @@ def test_subinterface_managed_orchestrator_00820() -> None:
 
     gen_responses = ResponseGenerator(responses())
     orchestrator = _build_orchestrator(gen_responses)
+    orchestrator.deploy = True
     orchestrator._queue_deploy("Ethernet1/3.2", "FDO11111AAA")
 
     with does_not_raise():

--- a/tests/unit/module_utils/orchestrators/test_svi_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_svi_interface.py
@@ -446,7 +446,7 @@ def test_svi_orchestrator_00820() -> None:
 
     ## Test
 
-    - Queue one interface manually
+    - Enable `deploy` (it defaults to False) and queue one interface manually
     - Call deploy_pending
     - Queue is empty after success
 
@@ -460,6 +460,7 @@ def test_svi_orchestrator_00820() -> None:
 
     gen_responses = ResponseGenerator(responses())
     orchestrator = _build_orchestrator(gen_responses)
+    orchestrator.deploy = True
     orchestrator._queue_deploy("vlan333", "FDO11111AAA")
 
     with does_not_raise():

--- a/tests/unit/modules/test_nd_interface_deploy_default.py
+++ b/tests/unit/modules/test_nd_interface_deploy_default.py
@@ -1,0 +1,87 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests verifying the `config_actions.deploy` default is `False` across the `nd_interface_*` modules.
+
+Deployment is opt-in: each module must document `default: false` and build an `argument_spec` whose `config_actions.deploy` default is
+`False`, so that changes are staged on the controller and only pushed to switches when the user sets `config_actions.deploy: true`.
+"""
+
+# pylint: disable=invalid-name
+# pylint: disable=line-too-long
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+import yaml
+
+INTERFACE_MODULES = (
+    "nd_interface_ethernet_trunk_host",
+    "nd_interface_port_channel_access",
+    "nd_interface_port_channel_trunk_host",
+    "nd_interface_subinterface_managed",
+    "nd_interface_subinterface_unmanaged",
+    "nd_interface_svi",
+    "nd_interface_vpc_access",
+    "nd_interface_vpc_trunk_host",
+)
+
+
+class _ArgumentSpecCaptured(Exception):
+    """
+    # Summary
+
+    Raised by the `AnsibleModule` stand-in to abort `main()` immediately after the `argument_spec` has been built, carrying the spec.
+
+    ## Raises
+
+    None
+    """
+
+
+def _capture_argument_spec(**kwargs: Any) -> None:
+    """
+    # Summary
+
+    Stand in for `AnsibleModule` inside a module's `main()`: raise `_ArgumentSpecCaptured` with the `argument_spec` keyword argument.
+
+    ## Raises
+
+    ### _ArgumentSpecCaptured
+
+    - Always, carrying `kwargs["argument_spec"]`
+    """
+    raise _ArgumentSpecCaptured(kwargs["argument_spec"])
+
+
+@pytest.mark.parametrize("module_name", INTERFACE_MODULES)
+def test_nd_interface_deploy_default_00000(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
+    """
+    # Summary
+
+    Verify `config_actions.deploy` defaults to `False` in both the DOCUMENTATION and the runtime `argument_spec` of each interface module.
+
+    ## Test
+
+    - DOCUMENTATION declares `options.config_actions.suboptions.deploy.default` as `false`
+    - `main()` builds an `argument_spec` whose `config_actions.options.deploy.default` is `False`
+
+    ## Classes and Methods
+
+    - nd_interface_*.main()
+    """
+    module = importlib.import_module(f"ansible_collections.cisco.nd.plugins.modules.{module_name}")
+
+    documentation = yaml.safe_load(module.DOCUMENTATION)
+    assert documentation["options"]["config_actions"]["suboptions"]["deploy"]["default"] is False
+
+    monkeypatch.setattr(module, "AnsibleModule", _capture_argument_spec)
+    with pytest.raises(_ArgumentSpecCaptured) as exc_info:
+        module.main()
+    argument_spec = exc_info.value.args[0]
+    assert argument_spec["config_actions"]["options"]["deploy"]["default"] is False


### PR DESCRIPTION
## Related Issue(s)

Closes #521

Follow-up to the review feedback on #366 and #367 ("We need to default this to false. We need this for NaC and it aligns better with controller behavior."). Applies the same default across the rest of the interface module family so the family stays consistent. Same pattern as #504 for the policy modules.

## Proposed Changes

- `config_actions_spec()` (shared fragment in `nd_argument_specs.py`) now defaults `deploy` to `False`. This is the same standalone commit carried by #366 and #367, so whichever merges last rebases cleanly.
- `NDBaseInterfaceOrchestrator.deploy` defaults to `False` (mirrors what #504 did for `PolicyGroupOrchestrator`). Modules always set it explicitly from `config_actions.deploy`, so this is a safety default only.
- The eight `nd_interface_*` modules that still declare `config_actions` inline default `deploy` to `False` in DOCUMENTATION, `argument_spec`, and the runtime fallback:
  `ethernet_trunk_host`, `port_channel_access`, `port_channel_trunk_host`, `subinterface_managed`, `subinterface_unmanaged`, `svi`, `vpc_access`, `vpc_trunk_host`.
  Each gains the doc line "Deployment is opt-in. Set `config_actions.deploy=true` explicitly to push changes to switches."
- EXAMPLES that push config now set `config_actions.deploy: true` explicitly.
- New parametrized unit test `tests/unit/modules/test_nd_interface_deploy_default.py` asserts DOCUMENTATION and `argument_spec` agree on the `False` default for all eight modules.
- Orchestrator unit tests that exercise `deploy_pending` now opt in explicitly.

`nd_interface_loopback` and `nd_interface_ethernet_access` are intentionally **not** touched here: they move to the shared fragment (and pick up the `False` default) in #366 and #367. Merge order between this PR and those two does not matter.

## Test Notes

- Full unit suite passes in `nd-dev`: `4020 passed`
- `ansible-test sanity --test validate-modules` passes on all eight modules (cross-checks DOCUMENTATION defaults against `argument_spec`)
- `ansible-lint`, `black`, `isort`, `pylint` clean on changed files; `mypy` unchanged from develop baseline
- Integration targets not re-run: none of the `nd_interface_*` targets assert on deploy-by-default (they only exercise the explicit `deploy: false` path), so behavior under test is unchanged. Adding an explicit `config_actions.deploy: true` deploy-path task per target is a reasonable lab-verified follow-up.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7fNh2q6RyHbb37T67hkN6
