### PR TITLE
ND Interface Aggregator

### DIFF
--- a/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
+++ b/plugins/module_utils/endpoints/v1/manage/manage_interfaces.py
@@ -13,6 +13,8 @@ in the ND Manage API.
   (GET /api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/interfaces/{interface_name})
 - `EpManageInterfacesListGet` - List all interfaces on a switch
   (GET /api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/interfaces)
+- `EpManageInterfacesSummaryGet` - List interface summary records for a fabric
+  (GET /api/v1/manage/fabrics/{fabric_name}/interfacesSummary)
 - `EpManageInterfacesPost` - Create interfaces on a switch
   (POST /api/v1/manage/fabrics/{fabric_name}/switches/{switch_sn}/interfaces)
 - `EpManageInterfacesPut` - Update a specific interface
@@ -42,6 +44,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.mixins import (
     MaxMixin,
     NetworkNameMixin,
     OffsetMixin,
+    SwitchIdMixin,
     SwitchSerialNumberMixin,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.query_params import EndpointQueryParams
@@ -60,6 +63,12 @@ class ManageInterfacesListEndpointParams(ClusterNameMixin, FilterMixin, MaxMixin
 
     sort: str | None = Field(default=None, min_length=1, description="Sort field and direction")
     config_only: bool | None = Field(default=None, description="Return config-only interface data")
+
+
+class ManageInterfacesSummaryEndpointParams(ClusterNameMixin, FilterMixin, MaxMixin, OffsetMixin, SwitchIdMixin, EndpointQueryParams):
+    """Endpoint-specific query parameters for fabric interface summaries."""
+
+    sort: str | None = Field(default=None, min_length=1, description="Sort field and direction")
 
 
 class _EpManageInterfacesBase(FabricNameMixin, SwitchSerialNumberMixin, InterfaceNameMixin, NDEndpointBaseModel):
@@ -208,6 +217,36 @@ class EpManageInterfacesListGet(_EpManageInterfacesBase):
 
         None
         """
+        return HttpVerbEnum.GET
+
+
+class EpManageInterfacesSummaryGet(FabricNameMixin, NDEndpointBaseModel):
+    """List interface summary records for a fabric."""
+
+    class_name: Literal["EpManageInterfacesSummaryGet"] = Field(
+        default="EpManageInterfacesSummaryGet",
+        frozen=True,
+        description="Class name for backward compatibility",
+    )
+    endpoint_params: ManageInterfacesSummaryEndpointParams = Field(
+        default_factory=ManageInterfacesSummaryEndpointParams,
+        description="Endpoint-specific query parameters",
+    )
+
+    @property
+    def path(self) -> str:
+        """Build the fabric interface-summary endpoint path."""
+        if self.fabric_name is None:
+            raise ValueError(f"{type(self).__name__}.path: fabric_name must be set before accessing path.")
+        path = BasePath.path("fabrics", quote(self.fabric_name, safe=""), "interfacesSummary")
+        query_string = self.endpoint_params.to_query_string()
+        if query_string:
+            return f"{path}?{query_string}"
+        return path
+
+    @property
+    def verb(self) -> HttpVerbEnum:
+        """Return ``HttpVerbEnum.GET``."""
         return HttpVerbEnum.GET
 
 

--- a/plugins/module_utils/fabric_context.py
+++ b/plugins/module_utils/fabric_context.py
@@ -14,6 +14,8 @@ the `local` and `fabricStatus` fields used by the pre-flight checks.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import EpManageFabricsSummaryGet
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_switches import EpManageSwitchesListGet
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
@@ -57,6 +59,7 @@ class FabricContext:
         self._fabric_summary = _NOT_FETCHED
         self._switch_map: dict[str, str] | None = None
         self._switch_map_by_id: dict[str, str] | None = None
+        self._switch_records_by_id: dict[str, dict] | None = None
 
     def _query_get(self, path: str) -> dict:
         """
@@ -172,7 +175,7 @@ class FabricContext:
         """
         # Summary
 
-        Drop all cached state so the next access to `fabric_summary`, `switch_map`, or `switch_map_by_id` re-fetches from the API.
+        Drop all cached state so the next access to `fabric_summary`, switch lookup, or switch status re-fetches from the API.
         Useful after a mutation that should be reflected on subsequent reads.
 
         ## Raises
@@ -182,6 +185,7 @@ class FabricContext:
         self._fabric_summary = _NOT_FETCHED
         self._switch_map = None
         self._switch_map_by_id = None
+        self._switch_records_by_id = None
 
     def _load_switch_maps(self) -> None:
         """
@@ -203,6 +207,7 @@ class FabricContext:
         switches = (result.get("switches") or []) if result else []
         self._switch_map = {sw["fabricManagementIp"]: sw["switchId"] for sw in switches if sw.get("fabricManagementIp") and sw.get("switchId")}
         self._switch_map_by_id = {sw["switchId"]: sw["fabricManagementIp"] for sw in switches if sw.get("switchId") and sw.get("fabricManagementIp")}
+        self._switch_records_by_id = {sw["switchId"]: sw for sw in switches if sw.get("switchId")}
 
     @property
     def switch_map(self) -> dict[str, str]:
@@ -277,6 +282,51 @@ class FabricContext:
             return self.switch_map_by_id[switch_id]
         except KeyError as e:
             raise RuntimeError(f"No switch found with switchId '{switch_id}' in fabric '{self._fabric_name}'.") from e
+
+    @staticmethod
+    def _normalize_config_sync_status(value: object) -> bool | None:
+        """Normalize controller switch synchronization spellings to true, false, or unknown."""
+        if not isinstance(value, str):
+            return None
+        normalized = "".join(character for character in value.casefold() if character.isalnum())
+        if normalized in {"insync", "synced", "synchronized", "synchronised"}:
+            return True
+        if normalized in {"outofsync", "notsync", "notsynced", "notsynchronized", "notsynchronised", "pending"}:
+            return False
+        return None
+
+    def switch_config_in_sync(self, switch_id: str) -> bool | None:
+        """
+        # Summary
+
+        Return the cached switch configuration synchronization state.
+
+        The Manage Switches inventory commonly reports `configSyncStatus` under `additionalData`, with some API
+        variants returning it at the top level. `True` means explicitly synchronized, `False` means explicitly
+        out of sync or pending, and `None` means the controller omitted or returned an unrecognized status. This
+        method reuses the switch inventory already loaded for IP/ID resolution and does not issue a separate request.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If the switches API query fails.
+        """
+        self._load_switch_maps()
+        if self._switch_records_by_id is None:
+            raise AssertionError("switch records are None after _load_switch_maps()")
+        record = self._switch_records_by_id.get(switch_id)
+        if not isinstance(record, Mapping):
+            return None
+        additional_data = record.get("additionalData")
+        containers = (additional_data, record)
+        for container in containers:
+            if not isinstance(container, Mapping):
+                continue
+            normalized = self._normalize_config_sync_status(container.get("configSyncStatus"))
+            if normalized is not None:
+                return normalized
+        return None
 
     def validate_for_mutation(self) -> None:
         """

--- a/plugins/module_utils/interface_config_normalizer.py
+++ b/plugins/module_utils/interface_config_normalizer.py
@@ -1,0 +1,78 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Shared input normalization for interface resource modules and workflows."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+def validate_ethernet_interface_names(config_list: list[dict[str, Any]]) -> None:
+    """Reject null, non-string, and empty entries in grouped Ethernet input."""
+    for item_index, group in enumerate(config_list):
+        switch_ip = group.get("switch_ip")
+        interface_names = group.get("interface_names") or []
+        for entry_index, name in enumerate(interface_names):
+            if isinstance(name, str) and name:
+                continue
+            if name is None:
+                reason = "null"
+            elif not isinstance(name, str):
+                reason = f"not a string (got {type(name).__name__})"
+            else:
+                reason = "empty"
+            raise ValueError(
+                f"interface_names[{entry_index}] for switch '{switch_ip}' (config item {item_index}) is "
+                f"{reason}. Every entry must be a non-empty interface name."
+            )
+
+
+def validate_ethernet_within_item_duplicates(config_list: list[dict[str, Any]]) -> None:
+    """Reject a repeated case-insensitive name within one Ethernet group."""
+    for item_index, group in enumerate(config_list):
+        switch_ip = group.get("switch_ip")
+        interface_names = group.get("interface_names") or []
+        seen: set[str] = set()
+        for name in interface_names:
+            key = name.lower()
+            if key in seen:
+                raise ValueError(
+                    f"Duplicate interface '{name}' in interface_names for switch '{switch_ip}' "
+                    f"(config item {item_index}). Each interface may appear only once per config item."
+                )
+            seen.add(key)
+
+
+def validate_ethernet_across_item_duplicates(config_list: list[dict[str, Any]]) -> None:
+    """Reject a repeated case-insensitive switch/name identity across groups."""
+    seen: dict[tuple[Any, str], int] = {}
+    for item_index, group in enumerate(config_list):
+        switch_ip = group.get("switch_ip")
+        interface_names = group.get("interface_names") or []
+        for name in interface_names:
+            key = (switch_ip, name.lower())
+            if key in seen:
+                raise ValueError(
+                    f"Interface '{name}' on switch '{switch_ip}' is specified in multiple config items "
+                    f"({seen[key]} and {item_index}). Each switch/interface pair may appear only once."
+                )
+            seen[key] = item_index
+
+
+def expand_ethernet_config(config_list: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Expand standalone-style ``interface_names`` groups into model items."""
+    validate_ethernet_interface_names(config_list)
+    validate_ethernet_within_item_duplicates(config_list)
+    validate_ethernet_across_item_duplicates(config_list)
+
+    expanded: list[dict[str, Any]] = []
+    for group in config_list:
+        for name in group.get("interface_names") or []:
+            item = deepcopy(group)
+            item.pop("interface_names", None)
+            item["interface_name"] = name
+            expanded.append(item)
+    return expanded

--- a/plugins/module_utils/interface_family_adapters.py
+++ b/plugins/module_utils/interface_family_adapters.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from ansible_collections.cisco.nd.plugins.module_utils.interface_config_normalizer import expand_ethernet_config
@@ -36,10 +37,34 @@ from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import Res
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
 
 ConfigNormalizer = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
+IMPLICIT_TRANSITION_STATES = frozenset({"merged", "replaced"})
 
 
 class InterfaceWorkflowValidationError(ValueError):
     """Raised when a resource group cannot be validated by its standalone family contract."""
+
+
+class InterfaceTransitionStrategy(str, Enum):
+    """Mutation method used when an interface changes policy family."""
+
+    UPDATE = "update"
+
+
+class InterfaceDeleteStrategy(str, Enum):
+    """Controller operation used to remove or reset an interface."""
+
+    NORMALIZE = "normalize"
+    REMOVE = "remove"
+    DELETE = "delete"
+
+
+@dataclass(frozen=True)
+class InterfaceFamilySafety:
+    """Structural dependency guards required by an interface family."""
+
+    requires_pair_consistency: bool = False
+    owns_physical_members: bool = False
+    guards_child_subinterfaces: bool = False
 
 
 @dataclass(frozen=True)
@@ -52,6 +77,10 @@ class InterfaceFamilyAdapter:
     ownership_domain: str
     interface_types: frozenset[str]
     policy_types: frozenset[str]
+    delete_strategy: InterfaceDeleteStrategy
+    transition_strategy: InterfaceTransitionStrategy = InterfaceTransitionStrategy.UPDATE
+    transition_states: frozenset[str] = IMPLICIT_TRANSITION_STATES
+    safety: InterfaceFamilySafety = InterfaceFamilySafety()
     config_normalizer: ConfigNormalizer | None = None
     supported_states: frozenset[str] = SUPPORTED_STATES
 
@@ -113,6 +142,8 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "ethernet",
         "interface_types": frozenset({"ethernet"}),
         "policy_types": frozenset({"accessHost"}),
+        "delete_strategy": InterfaceDeleteStrategy.NORMALIZE,
+        "safety": InterfaceFamilySafety(guards_child_subinterfaces=True),
         "config_normalizer": expand_ethernet_config,
     },
     {
@@ -122,6 +153,8 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "ethernet",
         "interface_types": frozenset({"ethernet"}),
         "policy_types": frozenset({"trunkHost"}),
+        "delete_strategy": InterfaceDeleteStrategy.NORMALIZE,
+        "safety": InterfaceFamilySafety(guards_child_subinterfaces=True),
         "config_normalizer": expand_ethernet_config,
     },
     {
@@ -131,6 +164,7 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "loopback",
         "interface_types": frozenset({"loopback"}),
         "policy_types": frozenset({"loopback"}),
+        "delete_strategy": InterfaceDeleteStrategy.REMOVE,
     },
     {
         "resource_type": "port_channel_access",
@@ -139,6 +173,8 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "port_channel",
         "interface_types": frozenset({"portChannel"}),
         "policy_types": frozenset({"accessPoHost"}),
+        "delete_strategy": InterfaceDeleteStrategy.REMOVE,
+        "safety": InterfaceFamilySafety(owns_physical_members=True, guards_child_subinterfaces=True),
     },
     {
         "resource_type": "port_channel_trunk_host",
@@ -147,6 +183,8 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "port_channel",
         "interface_types": frozenset({"portChannel"}),
         "policy_types": frozenset({"trunkPoHost"}),
+        "delete_strategy": InterfaceDeleteStrategy.REMOVE,
+        "safety": InterfaceFamilySafety(owns_physical_members=True, guards_child_subinterfaces=True),
     },
     {
         "resource_type": "subinterface_managed",
@@ -155,6 +193,7 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "subinterface",
         "interface_types": frozenset({"subInterface"}),
         "policy_types": frozenset({"subinterface"}),
+        "delete_strategy": InterfaceDeleteStrategy.REMOVE,
     },
     {
         "resource_type": "subinterface_unmanaged",
@@ -163,6 +202,7 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "subinterface",
         "interface_types": frozenset({"subInterface"}),
         "policy_types": frozenset({"monitorSubinterface"}),
+        "delete_strategy": InterfaceDeleteStrategy.REMOVE,
     },
     {
         "resource_type": "svi",
@@ -171,6 +211,7 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "svi",
         "interface_types": frozenset({"svi"}),
         "policy_types": frozenset({"svi"}),
+        "delete_strategy": InterfaceDeleteStrategy.REMOVE,
     },
     {
         "resource_type": "vpc_access",
@@ -179,6 +220,8 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "vpc",
         "interface_types": frozenset({"vpc"}),
         "policy_types": frozenset({"accessVpcHost"}),
+        "delete_strategy": InterfaceDeleteStrategy.DELETE,
+        "safety": InterfaceFamilySafety(requires_pair_consistency=True, owns_physical_members=True),
     },
     {
         "resource_type": "vpc_trunk_host",
@@ -187,6 +230,8 @@ _ADAPTER_DEFINITIONS = (
         "ownership_domain": "vpc",
         "interface_types": frozenset({"vpc"}),
         "policy_types": frozenset({"trunkVpcHost"}),
+        "delete_strategy": InterfaceDeleteStrategy.DELETE,
+        "safety": InterfaceFamilySafety(requires_pair_consistency=True, owns_physical_members=True),
     },
 )
 

--- a/plugins/module_utils/interface_family_adapters.py
+++ b/plugins/module_utils/interface_family_adapters.py
@@ -1,0 +1,204 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Authoritative interface-family bindings for the aggregate workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.interface_config_normalizer import expand_ethernet_config
+from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_plan import NDStatePlan, NDStatePlanner, SUPPORTED_STATES
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import EthernetAccessInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import EthernetTrunkHostInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_access_interface import PortChannelAccessInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_managed_interface import (
+    SubinterfaceManagedInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_unmanaged_interface import (
+    SubinterfaceUnmanagedInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.svi_interface import SviInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_access_interface import AccessVpcHostInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_trunk_host_interface import TrunkVpcHostInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
+
+ConfigNormalizer = Callable[[list[dict[str, Any]]], list[dict[str, Any]]]
+
+
+class InterfaceWorkflowValidationError(ValueError):
+    """Raised when a resource group cannot be validated by its standalone family contract."""
+
+
+@dataclass(frozen=True)
+class InterfaceFamilyAdapter:
+    """Connect one workflow resource type to its existing model and orchestrator."""
+
+    resource_type: str
+    module_name: str
+    orchestrator_class: type[NDBaseInterfaceOrchestrator]
+    ownership_domain: str
+    interface_types: frozenset[str]
+    policy_types: frozenset[str]
+    config_normalizer: ConfigNormalizer | None = None
+    supported_states: frozenset[str] = SUPPORTED_STATES
+
+    @property
+    def model_class(self) -> type[NDBaseModel]:
+        """Return the concrete model already owned by the standalone orchestrator."""
+        return self.orchestrator_class.model_class
+
+    def validate_config(self, config: list[dict[str, Any]], state: str, resource_index: int) -> NDConfigCollection:
+        """Normalize and validate config through the existing family model."""
+        if state not in self.supported_states:
+            choices = ", ".join(sorted(self.supported_states))
+            raise InterfaceWorkflowValidationError(
+                f"resources[{resource_index}] type '{self.resource_type}' does not support state '{state}'; supported states: {choices}."
+            )
+        if not isinstance(config, list):
+            raise InterfaceWorkflowValidationError(
+                f"resources[{resource_index}] type '{self.resource_type}' config must be a list using {self.module_name} input."
+            )
+        try:
+            normalized = self.config_normalizer(config) if self.config_normalizer is not None else config
+            return NDConfigCollection.from_ansible_config(data=normalized, model_class=self.model_class, context={"state": state})
+        except Exception as exc:
+            raise InterfaceWorkflowValidationError(
+                f"resources[{resource_index}] type '{self.resource_type}' validation failed using {self.module_name} "
+                f"({self.model_class.__name__}, state={state!r}): {exc}"
+            ) from exc
+
+    def build_orchestrator(
+        self,
+        *,
+        rest_send: RestSend,
+        snapshot: InterfaceStateSnapshot,
+        results: Results | None = None,
+    ) -> NDBaseInterfaceOrchestrator:
+        """Construct the existing family orchestrator with the shared snapshot."""
+        return self.orchestrator_class(rest_send=rest_send, results=results, interface_state_snapshot=snapshot)
+
+    def existing_collection(self, orchestrator: NDBaseInterfaceOrchestrator) -> NDConfigCollection:
+        """Select and deserialize existing family state through the existing query implementation."""
+        try:
+            response = orchestrator.query_all()
+            return NDConfigCollection.from_api_response(response_data=response, model_class=self.model_class)
+        except Exception as exc:
+            raise InterfaceWorkflowValidationError(
+                f"Existing-state selection for type '{self.resource_type}' failed through {self.module_name}: {exc}"
+            ) from exc
+
+    def plan(self, *, before: NDConfigCollection, proposed: NDConfigCollection, state: str) -> NDStatePlan:
+        """Calculate operations using the shared pure state planner."""
+        return NDStatePlanner.plan(state=state, before=before, proposed=proposed)
+
+
+_ADAPTER_DEFINITIONS = (
+    {
+        "resource_type": "ethernet_access",
+        "module_name": "cisco.nd.nd_interface_ethernet_access",
+        "orchestrator_class": EthernetAccessInterfaceOrchestrator,
+        "ownership_domain": "ethernet",
+        "interface_types": frozenset({"ethernet"}),
+        "policy_types": frozenset({"accessHost"}),
+        "config_normalizer": expand_ethernet_config,
+    },
+    {
+        "resource_type": "ethernet_trunk_host",
+        "module_name": "cisco.nd.nd_interface_ethernet_trunk_host",
+        "orchestrator_class": EthernetTrunkHostInterfaceOrchestrator,
+        "ownership_domain": "ethernet",
+        "interface_types": frozenset({"ethernet"}),
+        "policy_types": frozenset({"trunkHost"}),
+        "config_normalizer": expand_ethernet_config,
+    },
+    {
+        "resource_type": "loopback",
+        "module_name": "cisco.nd.nd_interface_loopback",
+        "orchestrator_class": LoopbackInterfaceOrchestrator,
+        "ownership_domain": "loopback",
+        "interface_types": frozenset({"loopback"}),
+        "policy_types": frozenset({"loopback"}),
+    },
+    {
+        "resource_type": "port_channel_access",
+        "module_name": "cisco.nd.nd_interface_port_channel_access",
+        "orchestrator_class": PortChannelAccessInterfaceOrchestrator,
+        "ownership_domain": "port_channel",
+        "interface_types": frozenset({"portChannel"}),
+        "policy_types": frozenset({"accessPoHost"}),
+    },
+    {
+        "resource_type": "port_channel_trunk_host",
+        "module_name": "cisco.nd.nd_interface_port_channel_trunk_host",
+        "orchestrator_class": PortChannelTrunkHostInterfaceOrchestrator,
+        "ownership_domain": "port_channel",
+        "interface_types": frozenset({"portChannel"}),
+        "policy_types": frozenset({"trunkPoHost"}),
+    },
+    {
+        "resource_type": "subinterface_managed",
+        "module_name": "cisco.nd.nd_interface_subinterface_managed",
+        "orchestrator_class": SubinterfaceManagedInterfaceOrchestrator,
+        "ownership_domain": "subinterface",
+        "interface_types": frozenset({"subInterface"}),
+        "policy_types": frozenset({"subinterface"}),
+    },
+    {
+        "resource_type": "subinterface_unmanaged",
+        "module_name": "cisco.nd.nd_interface_subinterface_unmanaged",
+        "orchestrator_class": SubinterfaceUnmanagedInterfaceOrchestrator,
+        "ownership_domain": "subinterface",
+        "interface_types": frozenset({"subInterface"}),
+        "policy_types": frozenset({"monitorSubinterface"}),
+    },
+    {
+        "resource_type": "svi",
+        "module_name": "cisco.nd.nd_interface_svi",
+        "orchestrator_class": SviInterfaceOrchestrator,
+        "ownership_domain": "svi",
+        "interface_types": frozenset({"svi"}),
+        "policy_types": frozenset({"svi"}),
+    },
+    {
+        "resource_type": "vpc_access",
+        "module_name": "cisco.nd.nd_interface_vpc_access",
+        "orchestrator_class": AccessVpcHostInterfaceOrchestrator,
+        "ownership_domain": "vpc",
+        "interface_types": frozenset({"vpc"}),
+        "policy_types": frozenset({"accessVpcHost"}),
+    },
+    {
+        "resource_type": "vpc_trunk_host",
+        "module_name": "cisco.nd.nd_interface_vpc_trunk_host",
+        "orchestrator_class": TrunkVpcHostInterfaceOrchestrator,
+        "ownership_domain": "vpc",
+        "interface_types": frozenset({"vpc"}),
+        "policy_types": frozenset({"trunkVpcHost"}),
+    },
+)
+
+INTERFACE_FAMILY_ADAPTERS: dict[str, InterfaceFamilyAdapter] = {
+    definition["resource_type"]: InterfaceFamilyAdapter(**definition) for definition in _ADAPTER_DEFINITIONS
+}
+
+
+def get_interface_family_adapter(resource_type: str) -> InterfaceFamilyAdapter:
+    """Return a registered family adapter or raise a workflow-oriented validation error."""
+    try:
+        return INTERFACE_FAMILY_ADAPTERS[resource_type]
+    except KeyError as exc:
+        choices = ", ".join(INTERFACE_FAMILY_ADAPTERS)
+        raise InterfaceWorkflowValidationError(f"Unsupported interface resource type '{resource_type}'; supported types: {choices}.") from exc

--- a/plugins/module_utils/interface_family_adapters.py
+++ b/plugins/module_utils/interface_family_adapters.py
@@ -19,6 +19,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection impo
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_plan import NDStatePlan, NDStatePlanner, SUPPORTED_STATES
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import EthernetAccessInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_routed_interface import EthernetRoutedInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import EthernetTrunkHostInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_access_interface import PortChannelAccessInterfaceOrchestrator
@@ -150,6 +151,17 @@ _ADAPTER_DEFINITIONS = (
         "delete_strategy": InterfaceDeleteStrategy.NORMALIZE,
         "safety": InterfaceFamilySafety(guards_child_subinterfaces=True),
         "config_normalizer": expand_ethernet_config,
+    },
+    {
+        "resource_type": "ethernet_routed",
+        "module_name": "cisco.nd.nd_interface_ethernet_routed",
+        "orchestrator_class": EthernetRoutedInterfaceOrchestrator,
+        "ownership_domain": "ethernet",
+        "interface_types": frozenset({"ethernet"}),
+        "policy_types": frozenset({"routedHost", "iosXeRoutedHost"}),
+        "delete_strategy": InterfaceDeleteStrategy.NORMALIZE,
+        "supports_intra_family_policy_transitions": True,
+        "safety": InterfaceFamilySafety(guards_child_subinterfaces=True),
     },
     {
         "resource_type": "ethernet_trunk_host",

--- a/plugins/module_utils/interface_state_snapshot.py
+++ b/plugins/module_utils/interface_state_snapshot.py
@@ -1,0 +1,268 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Shared, execution-scoped interface inventory for Nexus Dashboard.
+
+``InterfaceStateSnapshot`` owns the expensive per-switch interface-list reads
+used by the interface resource orchestrators. A standalone orchestrator creates
+one lazily, while the aggregate interface workflow can inject one instance into
+several orchestrators so every family observes the same initial state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from copy import deepcopy
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import EpManageInterfacesListGet
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+
+
+class InterfaceStateSnapshot:
+    """Cache and index interface state for one fabric and module execution.
+
+    The provider intentionally returns deep copies of cached records. Several
+    existing family orchestrators enrich selected records with ``switchIp``;
+    isolating those working copies keeps one family from changing the shared
+    source observed by another family.
+    """
+
+    def __init__(
+        self,
+        *,
+        fabric_name: str,
+        fabric_context: FabricContext,
+        request: Callable[..., Any],
+        page_size: int | None = 500,
+    ) -> None:
+        if not fabric_name:
+            raise ValueError("InterfaceStateSnapshot requires a non-empty fabric_name.")
+        if fabric_context.fabric_name != fabric_name:
+            raise ValueError(f"InterfaceStateSnapshot fabric '{fabric_name}' does not match FabricContext fabric " f"'{fabric_context.fabric_name}'.")
+        if page_size is not None and page_size < 1:
+            raise ValueError("InterfaceStateSnapshot page_size must be at least 1 or None.")
+
+        self.fabric_name = fabric_name
+        self.fabric_context = fabric_context
+        self._request = request
+        self.page_size = page_size
+        self._interfaces_by_switch: dict[str, dict[str, dict]] = {}
+        self._original_interfaces_by_switch: dict[str, dict[str, dict]] = {}
+        self._dirty_switches: set[str] = set()
+        self._requested_switches: set[str] = set()
+        self._interface_inventory_gets = 0
+        self._interface_inventory_pages = 0
+        self._cache_hits = 0
+        self._interface_inventory_refreshes = 0
+        self._dirty_refetches = 0
+        self._snapshot_overlays = 0
+
+    @staticmethod
+    def _normalise_switch_ids(switch_ids: str | Iterable[str]) -> list[str]:
+        """Return de-duplicated switch IDs while preserving caller order."""
+        values = [switch_ids] if isinstance(switch_ids, str) else list(switch_ids)
+        return list(dict.fromkeys(values))
+
+    @staticmethod
+    def _interface_key(interface: dict) -> str | None:
+        """Return the case-insensitive interface-name cache key, if present."""
+        interface_name = interface.get("interfaceName")
+        if not isinstance(interface_name, str) or not interface_name:
+            return None
+        return interface_name.lower()
+
+    @staticmethod
+    def policy_type(interface: dict) -> str | None:
+        """Return an interface's policy type while tolerating null API fields."""
+        config_data = interface.get("configData") or {}
+        network_os = config_data.get("networkOS") or {}
+        policy = network_os.get("policy") or {}
+        return policy.get("policyType")
+
+    def _fetch_switch(self, switch_id: str) -> dict[str, dict]:
+        """Fetch all pages for ``switch_id`` and key records by interface name."""
+        interfaces_by_name: dict[str, dict] = {}
+        offset = 0
+        seen_full_pages: set[tuple[str, ...]] = set()
+
+        while True:
+            endpoint = EpManageInterfacesListGet()
+            endpoint.fabric_name = self.fabric_name
+            endpoint.switch_sn = switch_id
+            if self.page_size is not None:
+                endpoint.endpoint_params.max = self.page_size
+                endpoint.endpoint_params.offset = offset
+
+            self._interface_inventory_gets += 1
+            self._interface_inventory_pages += 1
+            result = self._request(path=endpoint.path, verb=endpoint.verb, not_found_ok=True)
+            page = result.get("interfaces", []) or [] if isinstance(result, dict) else []
+            if not isinstance(page, list):
+                page = []
+
+            keyed_page: list[tuple[str, dict]] = []
+            for interface in page:
+                if not isinstance(interface, dict):
+                    continue
+                key = self._interface_key(interface)
+                if key is not None:
+                    keyed_page.append((key, interface))
+
+            if self.page_size is not None and len(page) >= self.page_size:
+                signature = tuple(key for key, _interface in keyed_page)
+                if signature in seen_full_pages:
+                    raise RuntimeError(f"Interface inventory pagination repeated a full page for switch '{switch_id}' " f"at offset {offset}.")
+                seen_full_pages.add(signature)
+
+            for key, interface in keyed_page:
+                interfaces_by_name[key] = deepcopy(interface)
+
+            if self.page_size is None or len(page) < self.page_size:
+                break
+            offset += len(page)
+
+        return interfaces_by_name
+
+    def load_switch(self, switch_id: str) -> dict[str, dict]:
+        """Return current state, automatically refetching a dirty switch."""
+        if not switch_id:
+            raise ValueError("InterfaceStateSnapshot.load_switch requires a non-empty switch_id.")
+        if switch_id in self._interfaces_by_switch and switch_id not in self._dirty_switches:
+            self._cache_hits += 1
+            return deepcopy(self._interfaces_by_switch[switch_id])
+
+        if switch_id in self._dirty_switches:
+            self._dirty_refetches += 1
+        interfaces = self._fetch_switch(switch_id)
+        self._interfaces_by_switch[switch_id] = interfaces
+        self._original_interfaces_by_switch.setdefault(switch_id, deepcopy(interfaces))
+        self._requested_switches.add(switch_id)
+        self._dirty_switches.discard(switch_id)
+        return deepcopy(interfaces)
+
+    def load_switches(self, switch_ids: Iterable[str]) -> dict[str, dict[str, dict]]:
+        """Load several switches, de-duplicating IDs supplied by the caller."""
+        return {switch_id: self.load_switch(switch_id) for switch_id in self._normalise_switch_ids(switch_ids)}
+
+    @property
+    def interfaces_by_switch(self) -> dict[str, dict[str, dict]]:
+        """Return current cached state keyed by switch ID and interface name."""
+        return deepcopy(self._interfaces_by_switch)
+
+    @property
+    def interfaces_by_switch_ip(self) -> dict[str, dict[str, dict]]:
+        """Return current cached state keyed by switch management IP."""
+        return {self.fabric_context.get_switch_ip(switch_id): deepcopy(interfaces) for switch_id, interfaces in self._interfaces_by_switch.items()}
+
+    @property
+    def original_interfaces_by_switch(self) -> dict[str, dict[str, dict]]:
+        """Return an isolated copy of the immutable, initially fetched state."""
+        return deepcopy(self._original_interfaces_by_switch)
+
+    @property
+    def interfaces_by_identity(self) -> dict[tuple[str, str], dict]:
+        """Return cached records keyed by ``(switch_id, interface_name)``."""
+        return {
+            (switch_id, interface_name): deepcopy(interface)
+            for switch_id, interfaces in self._interfaces_by_switch.items()
+            for interface_name, interface in interfaces.items()
+        }
+
+    @property
+    def interfaces_by_type(self) -> dict[str, dict[tuple[str, str], dict]]:
+        """Return cached records partitioned by API ``interfaceType``."""
+        index: dict[str, dict[tuple[str, str], dict]] = {}
+        for identity, interface in self.interfaces_by_identity.items():
+            interface_type = interface.get("interfaceType")
+            if interface_type:
+                index.setdefault(interface_type, {})[identity] = interface
+        return index
+
+    @property
+    def interfaces_by_policy_type(self) -> dict[str, dict[tuple[str, str], dict]]:
+        """Return cached records partitioned by API policy type."""
+        index: dict[str, dict[tuple[str, str], dict]] = {}
+        for identity, interface in self.interfaces_by_identity.items():
+            policy_type = self.policy_type(interface)
+            if policy_type:
+                index.setdefault(policy_type, {})[identity] = interface
+        return index
+
+    @property
+    def dirty_switches(self) -> set[str]:
+        """Return switches whose cached state may no longer match the controller."""
+        return set(self._dirty_switches)
+
+    def apply_overlay(
+        self,
+        switch_id: str,
+        *,
+        upserts: Iterable[dict[str, Any]] = (),
+        deletes: Iterable[str] = (),
+    ) -> dict[str, dict]:
+        """Atomically apply known successful changes to a clean loaded switch."""
+        if switch_id not in self._interfaces_by_switch:
+            raise ValueError(f"Cannot apply an overlay before switch '{switch_id}' has been loaded.")
+        if switch_id in self._dirty_switches:
+            raise RuntimeError(f"Cannot apply an overlay to dirty switch '{switch_id}'; refetch it first.")
+
+        prepared_upserts: dict[str, dict] = {}
+        for interface in upserts:
+            if not isinstance(interface, dict):
+                raise ValueError("InterfaceStateSnapshot overlay upserts must be dictionaries.")
+            key = self._interface_key(interface)
+            if key is None:
+                raise ValueError("InterfaceStateSnapshot overlay upserts require a non-empty interfaceName.")
+            if key in prepared_upserts:
+                raise ValueError(f"InterfaceStateSnapshot overlay contains duplicate upsert '{interface.get('interfaceName')}'.")
+            prepared_upserts[key] = deepcopy(interface)
+
+        prepared_deletes: set[str] = set()
+        for interface_name in deletes:
+            if not isinstance(interface_name, str) or not interface_name:
+                raise ValueError("InterfaceStateSnapshot overlay deletes require non-empty interface names.")
+            prepared_deletes.add(interface_name.lower())
+
+        overlap = set(prepared_upserts) & prepared_deletes
+        if overlap:
+            raise ValueError(f"InterfaceStateSnapshot overlay cannot upsert and delete the same interface(s): {sorted(overlap)}.")
+
+        candidate = deepcopy(self._interfaces_by_switch[switch_id])
+        for interface_name in prepared_deletes:
+            candidate.pop(interface_name, None)
+        candidate.update(prepared_upserts)
+        self._interfaces_by_switch[switch_id] = candidate
+        self._snapshot_overlays += 1
+        return deepcopy(candidate)
+
+    def mark_dirty(self, switch_ids: str | Iterable[str]) -> None:
+        """Mark one or more switches as stale after an uncertain mutation."""
+        self._dirty_switches.update(self._normalise_switch_ids(switch_ids))
+
+    def invalidate(self, switch_ids: str | Iterable[str]) -> None:
+        """Discard current cached state for switches while retaining originals."""
+        for switch_id in self._normalise_switch_ids(switch_ids):
+            self._interfaces_by_switch.pop(switch_id, None)
+            self._dirty_switches.add(switch_id)
+
+    def refresh(self, switch_ids: str | Iterable[str]) -> dict[str, dict[str, dict]]:
+        """Refetch one or more switches and clear their dirty markers."""
+        normalised = self._normalise_switch_ids(switch_ids)
+        self._interface_inventory_refreshes += len(normalised)
+        self.invalidate(normalised)
+        return self.load_switches(normalised)
+
+    @property
+    def request_stats(self) -> dict[str, int]:
+        """Return interface-inventory and snapshot lifecycle counts."""
+        return {
+            "switches": len(self._requested_switches),
+            "interface_inventory_gets": self._interface_inventory_gets,
+            "interface_inventory_pages": self._interface_inventory_pages,
+            "interface_inventory_cache_hits": self._cache_hits,
+            "interface_inventory_refreshes": self._interface_inventory_refreshes,
+            "interface_inventory_dirty_refetches": self._dirty_refetches,
+            "snapshot_overlays": self._snapshot_overlays,
+        }

--- a/plugins/module_utils/interface_state_snapshot.py
+++ b/plugins/module_utils/interface_state_snapshot.py
@@ -16,7 +16,10 @@ from collections.abc import Callable, Iterable
 from copy import deepcopy
 from typing import Any
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import EpManageInterfacesListGet
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesListGet,
+    EpManageInterfacesSummaryGet,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
 
 
@@ -50,11 +53,16 @@ class InterfaceStateSnapshot:
         self.page_size = page_size
         self._interfaces_by_switch: dict[str, dict[str, dict]] = {}
         self._original_interfaces_by_switch: dict[str, dict[str, dict]] = {}
+        self._interface_summaries_by_switch: dict[str, dict[str, dict]] = {}
         self._dirty_switches: set[str] = set()
         self._requested_switches: set[str] = set()
+        self._requested_summary_switches: set[str] = set()
         self._interface_inventory_gets = 0
         self._interface_inventory_pages = 0
         self._cache_hits = 0
+        self._interface_summary_gets = 0
+        self._interface_summary_pages = 0
+        self._interface_summary_cache_hits = 0
         self._interface_inventory_refreshes = 0
         self._dirty_refetches = 0
         self._snapshot_overlays = 0
@@ -91,6 +99,7 @@ class InterfaceStateSnapshot:
             endpoint = EpManageInterfacesListGet()
             endpoint.fabric_name = self.fabric_name
             endpoint.switch_sn = switch_id
+            endpoint.endpoint_params.sort = "interfaceName:asc"
             if self.page_size is not None:
                 endpoint.endpoint_params.max = self.page_size
                 endpoint.endpoint_params.offset = offset
@@ -125,6 +134,75 @@ class InterfaceStateSnapshot:
 
         return interfaces_by_name
 
+    def _fetch_interface_summary_switch(self, switch_id: str) -> dict[str, dict]:
+        """Fetch all interface-summary pages for one switch and key them by name."""
+        summaries_by_name: dict[str, dict] = {}
+        offset = 0
+        seen_full_pages: set[tuple[tuple[str, str], ...]] = set()
+
+        while True:
+            endpoint = EpManageInterfacesSummaryGet()
+            endpoint.fabric_name = self.fabric_name
+            # Some ND releases treat switchId as advisory and return fabric-wide rows. The Lucene filter keeps those
+            # responses small where supported; exact client-side switch selection below remains authoritative.
+            endpoint.endpoint_params.switch_id = switch_id
+            endpoint.endpoint_params.filter = f"switchId:{switch_id}"
+            endpoint.endpoint_params.sort = "interfaceName:asc"
+            if self.page_size is not None:
+                endpoint.endpoint_params.max = self.page_size
+                endpoint.endpoint_params.offset = offset
+
+            self._interface_summary_gets += 1
+            self._interface_summary_pages += 1
+            result = self._request(path=endpoint.path, verb=endpoint.verb, not_found_ok=True)
+            page = result.get("interfaces", []) or [] if isinstance(result, dict) else []
+            if not isinstance(page, list):
+                page = []
+
+            keyed_page: list[tuple[str, dict]] = []
+            page_identities: list[tuple[str, str]] = []
+            page_keys: set[str] = set()
+            for summary in page:
+                if not isinstance(summary, dict):
+                    continue
+                returned_switch_id = summary.get("switchId")
+                if not isinstance(returned_switch_id, str) or not returned_switch_id:
+                    raise RuntimeError(
+                        f"Interface summary row has invalid switchId {returned_switch_id!r} while fetching switch '{switch_id}'."
+                    )
+                key = self._interface_key(summary)
+                if key is None:
+                    continue
+                page_identities.append((returned_switch_id, key))
+                # Valid rows for another switch can appear even with both server-side selectors. Keep them in the raw
+                # pagination signature, but never cache them under the requested switch.
+                if returned_switch_id != switch_id:
+                    continue
+                if key in page_keys or key in summaries_by_name:
+                    raise RuntimeError(
+                        f"Interface summary contains duplicate case-insensitive interface identity '{key}' "
+                        f"for switch '{switch_id}'."
+                    )
+                page_keys.add(key)
+                keyed_page.append((key, summary))
+
+            if self.page_size is not None and len(page) >= self.page_size:
+                signature = tuple(page_identities)
+                if signature in seen_full_pages:
+                    raise RuntimeError(
+                        f"Interface summary pagination repeated a full page for switch '{switch_id}' at offset {offset}."
+                    )
+                seen_full_pages.add(signature)
+
+            for key, summary in keyed_page:
+                summaries_by_name[key] = deepcopy(summary)
+
+            if self.page_size is None or len(page) < self.page_size:
+                break
+            offset += len(page)
+
+        return summaries_by_name
+
     def load_switch(self, switch_id: str) -> dict[str, dict]:
         """Return current state, automatically refetching a dirty switch."""
         if not switch_id:
@@ -145,6 +223,36 @@ class InterfaceStateSnapshot:
     def load_switches(self, switch_ids: Iterable[str]) -> dict[str, dict[str, dict]]:
         """Load several switches, de-duplicating IDs supplied by the caller."""
         return {switch_id: self.load_switch(switch_id) for switch_id in self._normalise_switch_ids(switch_ids)}
+
+    def load_interface_summaries(
+        self,
+        identities: Iterable[tuple[str, str]],
+    ) -> dict[tuple[str, str], dict]:
+        """Return requested summary rows after one lazy, cached fetch per switch."""
+        requested_by_switch: dict[str, set[str]] = {}
+        for identity in identities:
+            if not isinstance(identity, tuple) or len(identity) != 2:
+                raise ValueError("Interface summary identities must be (switch_id, interface_name) tuples.")
+            switch_id, interface_name = identity
+            if not isinstance(switch_id, str) or not switch_id:
+                raise ValueError("Interface summary identities require a non-empty switch_id.")
+            if not isinstance(interface_name, str) or not interface_name:
+                raise ValueError("Interface summary identities require a non-empty interface_name.")
+            requested_by_switch.setdefault(switch_id, set()).add(interface_name.lower())
+
+        for switch_id in requested_by_switch:
+            if switch_id in self._interface_summaries_by_switch:
+                self._interface_summary_cache_hits += 1
+                continue
+            self._interface_summaries_by_switch[switch_id] = self._fetch_interface_summary_switch(switch_id)
+            self._requested_summary_switches.add(switch_id)
+
+        return {
+            (switch_id, interface_name): deepcopy(summary)
+            for switch_id, interface_names in requested_by_switch.items()
+            for interface_name in sorted(interface_names)
+            if (summary := self._interface_summaries_by_switch[switch_id].get(interface_name)) is not None
+        }
 
     @property
     def interfaces_by_switch(self) -> dict[str, dict[str, dict]]:
@@ -189,6 +297,15 @@ class InterfaceStateSnapshot:
             if policy_type:
                 index.setdefault(policy_type, {})[identity] = interface
         return index
+
+    @property
+    def interface_summaries_by_identity(self) -> dict[tuple[str, str], dict]:
+        """Return all cached summary rows keyed by switch ID and interface name."""
+        return {
+            (switch_id, interface_name): deepcopy(summary)
+            for switch_id, summaries in self._interface_summaries_by_switch.items()
+            for interface_name, summary in summaries.items()
+        }
 
     @property
     def dirty_switches(self) -> set[str]:
@@ -245,6 +362,7 @@ class InterfaceStateSnapshot:
         """Discard current cached state for switches while retaining originals."""
         for switch_id in self._normalise_switch_ids(switch_ids):
             self._interfaces_by_switch.pop(switch_id, None)
+            self._interface_summaries_by_switch.pop(switch_id, None)
             self._dirty_switches.add(switch_id)
 
     def refresh(self, switch_ids: str | Iterable[str]) -> dict[str, dict[str, dict]]:
@@ -262,6 +380,10 @@ class InterfaceStateSnapshot:
             "interface_inventory_gets": self._interface_inventory_gets,
             "interface_inventory_pages": self._interface_inventory_pages,
             "interface_inventory_cache_hits": self._cache_hits,
+            "interface_summary_switches": len(self._requested_summary_switches),
+            "interface_summary_gets": self._interface_summary_gets,
+            "interface_summary_pages": self._interface_summary_pages,
+            "interface_summary_cache_hits": self._interface_summary_cache_hits,
             "interface_inventory_refreshes": self._interface_inventory_refreshes,
             "interface_inventory_dirty_refetches": self._dirty_refetches,
             "snapshot_overlays": self._snapshot_overlays,

--- a/plugins/module_utils/interface_state_snapshot.py
+++ b/plugins/module_utils/interface_state_snapshot.py
@@ -30,6 +30,13 @@ class InterfaceStateSnapshot:
     existing family orchestrators enrich selected records with ``switchIp``;
     isolating those working copies keeps one family from changing the shared
     source observed by another family.
+
+    A dirty switch means only that this execution-scoped local cache may be
+    stale. It is unrelated to controller configuration synchronization status.
+    Loading a dirty switch increments ``_dirty_refetches`` once before
+    fetching its inventory; pagination is counted separately by
+    ``_interface_inventory_gets``. An explicit refresh invalidates the local
+    entry first, so it increments both the refresh and dirty-refetch counters.
     """
 
     def __init__(
@@ -167,9 +174,7 @@ class InterfaceStateSnapshot:
                     continue
                 returned_switch_id = summary.get("switchId")
                 if not isinstance(returned_switch_id, str) or not returned_switch_id:
-                    raise RuntimeError(
-                        f"Interface summary row has invalid switchId {returned_switch_id!r} while fetching switch '{switch_id}'."
-                    )
+                    raise RuntimeError(f"Interface summary row has invalid switchId {returned_switch_id!r} while fetching switch '{switch_id}'.")
                 key = self._interface_key(summary)
                 if key is None:
                     continue
@@ -179,19 +184,14 @@ class InterfaceStateSnapshot:
                 if returned_switch_id != switch_id:
                     continue
                 if key in page_keys or key in summaries_by_name:
-                    raise RuntimeError(
-                        f"Interface summary contains duplicate case-insensitive interface identity '{key}' "
-                        f"for switch '{switch_id}'."
-                    )
+                    raise RuntimeError(f"Interface summary contains duplicate case-insensitive interface identity '{key}' " f"for switch '{switch_id}'.")
                 page_keys.add(key)
                 keyed_page.append((key, summary))
 
             if self.page_size is not None and len(page) >= self.page_size:
                 signature = tuple(page_identities)
                 if signature in seen_full_pages:
-                    raise RuntimeError(
-                        f"Interface summary pagination repeated a full page for switch '{switch_id}' at offset {offset}."
-                    )
+                    raise RuntimeError(f"Interface summary pagination repeated a full page for switch '{switch_id}' at offset {offset}.")
                 seen_full_pages.add(signature)
 
             for key, summary in keyed_page:
@@ -204,7 +204,13 @@ class InterfaceStateSnapshot:
         return summaries_by_name
 
     def load_switch(self, switch_id: str) -> dict[str, dict]:
-        """Return current state, automatically refetching a dirty switch."""
+        """Return current state, automatically refetching a locally dirty switch.
+
+        A clean cached inventory is returned without a request. A dirty marker
+        causes one logical refetch attempt and increments ``_dirty_refetches``
+        before ``_fetch_switch`` runs. Any paginated HTTP requests made by that
+        fetch are tracked independently by ``_interface_inventory_gets``.
+        """
         if not switch_id:
             raise ValueError("InterfaceStateSnapshot.load_switch requires a non-empty switch_id.")
         if switch_id in self._interfaces_by_switch and switch_id not in self._dirty_switches:
@@ -223,6 +229,22 @@ class InterfaceStateSnapshot:
     def load_switches(self, switch_ids: Iterable[str]) -> dict[str, dict[str, dict]]:
         """Load several switches, de-duplicating IDs supplied by the caller."""
         return {switch_id: self.load_switch(switch_id) for switch_id in self._normalise_switch_ids(switch_ids)}
+
+    def cached_interface(
+        self,
+        switch_id: str,
+        interface_name: str,
+        *,
+        original: bool = False,
+    ) -> dict | None:
+        """Return one cached interface without loading, refetching, or copying the full inventory."""
+        if not isinstance(switch_id, str) or not switch_id:
+            raise ValueError("InterfaceStateSnapshot.cached_interface requires a non-empty switch_id.")
+        if not isinstance(interface_name, str) or not interface_name:
+            raise ValueError("InterfaceStateSnapshot.cached_interface requires a non-empty interface_name.")
+        inventory = self._original_interfaces_by_switch if original else self._interfaces_by_switch
+        current = inventory.get(switch_id, {}).get(interface_name.lower())
+        return deepcopy(current) if current is not None else None
 
     def load_interface_summaries(
         self,
@@ -355,18 +377,30 @@ class InterfaceStateSnapshot:
         return deepcopy(candidate)
 
     def mark_dirty(self, switch_ids: str | Iterable[str]) -> None:
-        """Mark one or more switches as stale after an uncertain mutation."""
+        """Mark local switch inventories stale without issuing a request.
+
+        This is used after mutation requests, or any other event that can make
+        cached controller intent unreliable. It does not inspect or change the
+        controller configuration synchronization status.
+        """
         self._dirty_switches.update(self._normalise_switch_ids(switch_ids))
 
     def invalidate(self, switch_ids: str | Iterable[str]) -> None:
-        """Discard current cached state for switches while retaining originals."""
+        """Discard current switch caches, retain originals, and mark locally dirty."""
         for switch_id in self._normalise_switch_ids(switch_ids):
             self._interfaces_by_switch.pop(switch_id, None)
             self._interface_summaries_by_switch.pop(switch_id, None)
             self._dirty_switches.add(switch_id)
 
     def refresh(self, switch_ids: str | Iterable[str]) -> dict[str, dict[str, dict]]:
-        """Refetch one or more switches and clear their dirty markers."""
+        """Explicitly refetch unique switches and clear their local dirty markers.
+
+        Each switch increments ``_interface_inventory_refreshes`` before the
+        attempt. ``invalidate`` then marks it dirty and ``load_switch`` increments
+        ``_dirty_refetches`` before fetching. Therefore one explicit refresh
+        normally contributes one to both counters; HTTP pages are counted by
+        ``_interface_inventory_gets``.
+        """
         normalised = self._normalise_switch_ids(switch_ids)
         self._interface_inventory_refreshes += len(normalised)
         self.invalidate(normalised)
@@ -374,7 +408,7 @@ class InterfaceStateSnapshot:
 
     @property
     def request_stats(self) -> dict[str, int]:
-        """Return interface-inventory and snapshot lifecycle counts."""
+        """Return logical snapshot lifecycle counts and separate HTTP request counts."""
         return {
             "switches": len(self._requested_switches),
             "interface_inventory_gets": self._interface_inventory_gets,

--- a/plugins/module_utils/interface_workflow_coordinator.py
+++ b/plugins/module_utils/interface_workflow_coordinator.py
@@ -1,0 +1,336 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Public-module coordination for the aggregate interface workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_vpc_pairs import (
+    EpVpcPairsListGet,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import (
+    FabricContext,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import (
+    InterfaceStateSnapshot,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_executor import (
+    InterfaceWorkflowExecution,
+    InterfaceWorkflowExecutor,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planner import (
+    InterfaceWorkflowPlan,
+    InterfaceWorkflowPlanner,
+    InterfaceWorkflowValidationError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sender
+
+PlannerFactory = Callable[..., InterfaceWorkflowPlanner]
+ExecutorFactory = Callable[..., InterfaceWorkflowExecutor]
+
+
+class InterfaceWorkflowExecutionFailed(RuntimeError):
+    """Raised with complete output when normal-mode execution is not fully successful."""
+
+    def __init__(self, result: dict[str, Any], message: str) -> None:
+        self.result = result
+        super().__init__(message)
+
+
+class InterfaceWorkflowCoordinator:
+    """Build one shared snapshot, plan all groups, and coordinate execution."""
+
+    def __init__(
+        self,
+        module: AnsibleModule,
+        planner_factory: PlannerFactory = InterfaceWorkflowPlanner,
+        executor_factory: ExecutorFactory = InterfaceWorkflowExecutor,
+    ) -> None:
+        self.module = module
+        self.planner_factory = planner_factory
+        self.executor_factory = executor_factory
+        self._vpc_pair_gets = 0
+        self._snapshot: InterfaceStateSnapshot | None = None
+
+    def _new_rest_send(
+        self, params: dict[str, Any] | None = None, *, check_mode: bool | None = None
+    ) -> RestSend:
+        """Build an authenticated collection REST runtime for this module invocation."""
+        sender = Sender()
+        sender.ansible_module = self.module
+        rest_send_params = dict(params if params is not None else self.module.params)
+        rest_send_params["check_mode"] = (
+            self.module.check_mode if check_mode is None else check_mode
+        )
+        rest_send = RestSend(rest_send_params)
+        rest_send.sender = sender
+        rest_send.response_handler = ResponseHandler()
+        return rest_send
+
+    @staticmethod
+    def _request(
+        rest_send: RestSend,
+        *,
+        path: str,
+        verb: HttpVerbEnum,
+        not_found_ok: bool = False,
+    ) -> dict[str, Any]:
+        """Send one read request and return its normalized DATA object."""
+        rest_send.path = path
+        rest_send.verb = verb
+        rest_send.commit()
+        if not_found_ok and rest_send.return_code == 404:
+            return {}
+        if not rest_send.success:
+            raise RuntimeError(f"Request failed {rest_send.error_summary}")
+        data = rest_send.response_current.get("DATA", {})
+        return data if isinstance(data, dict) else {}
+
+    @staticmethod
+    def _uses_vpc(resources: list[dict[str, Any]]) -> bool:
+        return any(
+            isinstance(resource, dict)
+            and resource.get("type") in {"vpc_access", "vpc_trunk_host"}
+            for resource in resources
+        )
+
+    def _vpc_pair_map(
+        self,
+        *,
+        resources: list[dict[str, Any]],
+        fabric_context: FabricContext,
+        rest_send: RestSend,
+    ) -> dict[str, str]:
+        """Return authoritative primary-IP to peer-ID mappings for requested vPC resources."""
+        if not self._uses_vpc(resources):
+            return {}
+
+        endpoint = EpVpcPairsListGet()
+        endpoint.fabric_name = fabric_context.fabric_name
+        self._vpc_pair_gets += 1
+        data = self._request(
+            rest_send, path=endpoint.path, verb=endpoint.verb, not_found_ok=True
+        )
+        records = data.get("vpcPairs") or data.get("items") or []
+        if not isinstance(records, list):
+            raise InterfaceWorkflowValidationError(
+                "The Nexus Dashboard vPC-pair response must contain a list in 'vpcPairs'."
+            )
+
+        pair_by_switch_ip: dict[str, str] = {}
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            first = record.get("switchId") or record.get("peer1SwitchId")
+            second = record.get("peerSwitchId") or record.get("peer2SwitchId")
+            if (
+                not isinstance(first, str)
+                or not first
+                or not isinstance(second, str)
+                or not second
+            ):
+                continue
+            try:
+                pair_by_switch_ip[fabric_context.get_switch_ip(first)] = second
+                pair_by_switch_ip[fabric_context.get_switch_ip(second)] = first
+            except RuntimeError:
+                continue
+
+        for resource_index, resource in enumerate(resources):
+            if not isinstance(resource, dict) or resource.get("type") not in {
+                "vpc_access",
+                "vpc_trunk_host",
+            }:
+                continue
+            for config_index, item in enumerate(resource.get("config") or []):
+                switch_ip = item.get("switch_ip") if isinstance(item, dict) else None
+                if switch_ip not in pair_by_switch_ip:
+                    raise InterfaceWorkflowValidationError(
+                        f"resources[{resource_index}].config[{config_index}] switch_ip '{switch_ip}' is not present in the "
+                        f"authoritative vPC-pair inventory for fabric '{fabric_context.fabric_name}'."
+                    )
+        return pair_by_switch_ip
+
+    def _build_plan(self) -> InterfaceWorkflowPlan:
+        """Construct the live shared provider and run every adapter before execution."""
+        resources = self.module.params.get("resources") or []
+        rest_send = self._new_rest_send()
+        fabric_name = self.module.params["fabric_name"]
+        fabric_context = FabricContext(rest_send=rest_send, fabric_name=fabric_name)
+        snapshot = InterfaceStateSnapshot(
+            fabric_name=fabric_name,
+            fabric_context=fabric_context,
+            request=lambda **kwargs: self._request(rest_send, **kwargs),
+        )
+        self._snapshot = snapshot
+        vpc_pair_by_switch_ip = self._vpc_pair_map(
+            resources=resources,
+            fabric_context=fabric_context,
+            rest_send=rest_send,
+        )
+        planner = self.planner_factory(
+            snapshot=snapshot,
+            rest_send_factory=lambda params: self._new_rest_send(
+                params=params, check_mode=True
+            ),
+            vpc_pair_by_switch_ip=vpc_pair_by_switch_ip,
+            run_capability_preflight=True,
+        )
+        return planner.plan(resources)
+
+    @staticmethod
+    def _config_diff(before, after) -> dict[str, Any]:
+        """Return an Ansible-style before/after diff when collections differ."""
+        if not before.get_diff_collection(after):
+            return {}
+        return {
+            "before": before.to_ansible_config(),
+            "after": after.to_ansible_config(),
+        }
+
+    @classmethod
+    def _resource_result(
+        cls, resource, *, after, include_proposed: bool, after_verified: bool
+    ) -> dict[str, Any]:
+        """Serialize one indexed group without losing repeated resource types."""
+        changed = bool(resource.before.get_diff_collection(after))
+        result = {
+            "resource_index": resource.resource_index,
+            "type": resource.resource_type,
+            "module": resource.adapter.module_name,
+            "state": resource.state,
+            "changed": changed,
+            "planned_changed": resource.changed,
+            "before": resource.before.to_ansible_config(),
+            "after": after.to_ansible_config(),
+            "diff": cls._config_diff(resource.before, after),
+            "after_verified": after_verified,
+            "created": [item.to_config() for item in resource.operations.creates],
+            "updated": [item.to_config() for item in resource.operations.updates],
+            "deleted": [item.to_config() for item in resource.operations.deletes],
+        }
+        if include_proposed:
+            result["proposed"] = resource.proposed.to_ansible_config()
+        return result
+
+    def _format_result(
+        self,
+        plan: InterfaceWorkflowPlan,
+        execution: InterfaceWorkflowExecution | None = None,
+    ) -> dict[str, Any]:
+        """Return stable aggregate and indexed per-resource output."""
+        output_level = self.module.params.get("output_level", "normal")
+        resource_results = []
+        for resource in plan.resources:
+            actual = (
+                execution.actual_after_by_resource.get(resource.resource_index)
+                if execution is not None
+                else None
+            )
+            after = actual if actual is not None else resource.operations.after
+            after_verified = actual is not None or (
+                execution is None and not self.module.check_mode
+            )
+            resource_results.append(
+                self._resource_result(
+                    resource,
+                    after=after,
+                    include_proposed=output_level in {"info", "debug"},
+                    after_verified=after_verified,
+                )
+            )
+
+        request_stats = dict(
+            self._snapshot.request_stats
+            if self._snapshot is not None
+            else plan.request_stats
+        )
+        request_stats.update(
+            {
+                "vpc_pair_gets": self._vpc_pair_gets,
+                "mutation_requests": (
+                    execution.mutation_requests if execution is not None else 0
+                ),
+                "deploy_requests": (
+                    execution.deploy_requests if execution is not None else 0
+                ),
+            }
+        )
+
+        def aggregate(field: str) -> list[dict[str, Any]]:
+            return [
+                {
+                    "resource_index": resource["resource_index"],
+                    "type": resource["type"],
+                    "config": resource[field],
+                }
+                for resource in resource_results
+            ]
+
+        if execution is not None:
+            execution_result = execution.to_dict()
+            changed = execution.changed
+        else:
+            deploy = bool(
+                (self.module.params.get("config_actions") or {}).get("deploy", True)
+            )
+            execution_result = {
+                "status": "check_mode" if self.module.check_mode else "no_change",
+                "mutations_sent": 0,
+                "deployments_sent": 0,
+                "affected_switch_ids": [],
+                "items": [],
+                "deployment": {
+                    "requested": deploy,
+                    "status": "not_needed",
+                    "targets": [],
+                },
+                "errors": [],
+            }
+            changed = plan.changed if self.module.check_mode else False
+
+        return {
+            "changed": changed,
+            "planned_changed": plan.changed,
+            "check_mode": self.module.check_mode,
+            "output_level": output_level,
+            "fabric_name": plan.fabric_name,
+            "config_actions": dict(self.module.params.get("config_actions") or {}),
+            "mutation_count": plan.mutation_count,
+            "target_switch_ids": list(plan.target_switch_ids),
+            "resources": resource_results,
+            "before": aggregate("before"),
+            "after": aggregate("after"),
+            "diff": aggregate("diff"),
+            "request_stats": request_stats,
+            "execution": execution_result,
+        }
+
+    def run(self) -> dict[str, Any]:
+        """Plan the complete workflow, then execute only after all validation succeeds."""
+        plan = self._build_plan()
+        if self.module.check_mode or not plan.changed:
+            return self._format_result(plan)
+        if self._snapshot is None:
+            raise RuntimeError("Interface workflow snapshot was not initialized.")
+        deploy = bool(
+            (self.module.params.get("config_actions") or {}).get("deploy", True)
+        )
+        execution = self.executor_factory(
+            snapshot=self._snapshot, deploy=deploy
+        ).execute(plan)
+        result = self._format_result(plan, execution)
+        if execution.failed:
+            result["failed"] = True
+            raise InterfaceWorkflowExecutionFailed(result, execution.message)
+        return result

--- a/plugins/module_utils/interface_workflow_coordinator.py
+++ b/plugins/module_utils/interface_workflow_coordinator.py
@@ -6,7 +6,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import re
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from ansible.module_utils.basic import AnsibleModule
@@ -16,6 +17,10 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import (
     FabricContext,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_family_adapters import (
+    INTERFACE_FAMILY_ADAPTERS,
+    InterfaceDeleteStrategy,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import (
     InterfaceStateSnapshot,
@@ -29,6 +34,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planne
     InterfaceWorkflowPlanner,
     InterfaceWorkflowValidationError,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import (
+    InterfaceDefaultConfig,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
     ResponseHandler,
 )
@@ -37,7 +45,17 @@ from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sen
 
 PlannerFactory = Callable[..., InterfaceWorkflowPlanner]
 ExecutorFactory = Callable[..., InterfaceWorkflowExecutor]
+Target = tuple[str, str]
 VPC_PAIR_PAGE_SIZE = 500
+_CAMEL_WORD_BOUNDARY = re.compile(r"(.)([A-Z][a-z]+)")
+_CAMEL_LETTER_BOUNDARY = re.compile(r"([a-z0-9])([A-Z])")
+_MISSING = object()
+_ADAPTER_BY_WIRE_IDENTITY = {
+    (interface_type, policy_type): adapter
+    for adapter in INTERFACE_FAMILY_ADAPTERS.values()
+    for interface_type in adapter.interface_types
+    for policy_type in adapter.policy_types
+}
 
 
 class InterfaceWorkflowExecutionFailed(RuntimeError):
@@ -137,17 +155,17 @@ class InterfaceWorkflowCoordinator:
 
             signature = tuple(
                 (
-                    (record.get("switchId") or record.get("peer1SwitchId")),
-                    (record.get("peerSwitchId") or record.get("peer2SwitchId")),
+                    (
+                        (record.get("switchId") or record.get("peer1SwitchId")),
+                        (record.get("peerSwitchId") or record.get("peer2SwitchId")),
+                    )
+                    if isinstance(record, dict)
+                    else (None, None)
                 )
-                if isinstance(record, dict)
-                else (None, None)
                 for record in page
             )
             if page and signature in seen_page_signatures:
-                raise InterfaceWorkflowValidationError(
-                    f"The Nexus Dashboard vPC-pair pagination repeated a page at offset {offset}."
-                )
+                raise InterfaceWorkflowValidationError(f"The Nexus Dashboard vPC-pair pagination repeated a page at offset {offset}.")
             if page:
                 seen_page_signatures.add(signature)
             records.extend(page)
@@ -166,9 +184,7 @@ class InterfaceWorkflowCoordinator:
             if not has_next:
                 break
             if not page:
-                raise InterfaceWorkflowValidationError(
-                    f"The Nexus Dashboard vPC-pair response reports more records after empty offset {offset}."
-                )
+                raise InterfaceWorkflowValidationError(f"The Nexus Dashboard vPC-pair response reports more records after empty offset {offset}.")
             offset += len(page)
 
         declared_peer_by_switch_id: dict[str, str] = {}
@@ -180,14 +196,11 @@ class InterfaceWorkflowCoordinator:
             if not isinstance(first, str) or not first or not isinstance(second, str) or not second:
                 continue
             if first.casefold() == second.casefold():
-                raise InterfaceWorkflowValidationError(
-                    f"The authoritative vPC-pair inventory contains a self-pair for switch '{first}'."
-                )
+                raise InterfaceWorkflowValidationError(f"The authoritative vPC-pair inventory contains a self-pair for switch '{first}'.")
             existing_peer = declared_peer_by_switch_id.get(first)
             if existing_peer is not None and existing_peer != second:
                 raise InterfaceWorkflowValidationError(
-                    f"The authoritative vPC-pair inventory contains conflicting mappings for switch '{first}': "
-                    f"'{existing_peer}' and '{second}'."
+                    f"The authoritative vPC-pair inventory contains conflicting mappings for switch '{first}': " f"'{existing_peer}' and '{second}'."
                 )
             declared_peer_by_switch_id[first] = second
 
@@ -205,8 +218,7 @@ class InterfaceWorkflowCoordinator:
                 existing_peer = peer_by_switch_id.get(switch_id)
                 if existing_peer is not None and existing_peer != peer_id:
                     raise InterfaceWorkflowValidationError(
-                        f"The authoritative vPC-pair inventory contains conflicting mappings for switch '{switch_id}': "
-                        f"'{existing_peer}' and '{peer_id}'."
+                        f"The authoritative vPC-pair inventory contains conflicting mappings for switch '{switch_id}': " f"'{existing_peer}' and '{peer_id}'."
                     )
                 peer_by_switch_id[switch_id] = peer_id
 
@@ -264,47 +276,623 @@ class InterfaceWorkflowCoordinator:
         )
         return planner.plan(resources)
 
+    @classmethod
+    def _leaf_changes(cls, before: Any, after: Any, path: str = "") -> list[dict[str, Any]]:
+        """Return deterministic changed leaf paths without embedding complete state snapshots."""
+        if before is not _MISSING and after is not _MISSING and before == after:
+            return []
+
+        before_is_mapping = isinstance(before, Mapping)
+        after_is_mapping = isinstance(after, Mapping)
+        if before_is_mapping or after_is_mapping:
+            if (before is not _MISSING and not before_is_mapping) or (after is not _MISSING and not after_is_mapping):
+                return [
+                    {
+                        "path": path,
+                        "before": None if before is _MISSING else before,
+                        "after": None if after is _MISSING else after,
+                    }
+                ]
+            before_mapping = before if before_is_mapping else {}
+            after_mapping = after if after_is_mapping else {}
+            keys = sorted(set(before_mapping) | set(after_mapping), key=str)
+            if not keys:
+                return [
+                    {
+                        "path": path,
+                        "before": None if before is _MISSING else before,
+                        "after": None if after is _MISSING else after,
+                    }
+                ]
+            changes = []
+            for key in keys:
+                child_path = f"{path}.{key}" if path else str(key)
+                changes.extend(
+                    cls._leaf_changes(
+                        before_mapping.get(key, _MISSING),
+                        after_mapping.get(key, _MISSING),
+                        child_path,
+                    )
+                )
+            return changes
+
+        return [
+            {
+                "path": path,
+                "before": None if before is _MISSING else before,
+                "after": None if after is _MISSING else after,
+            }
+        ]
+
     @staticmethod
-    def _config_diff(before, after) -> dict[str, Any]:
-        """Return an Ansible-style before/after diff when collections differ."""
-        if not before.get_diff_collection(after):
-            return {}
-        return {
-            "before": before.to_ansible_config(),
-            "after": after.to_ansible_config(),
-        }
+    def _serialized_target_key(config: Mapping[str, Any]) -> tuple[str, str] | None:
+        """Return a case-insensitive switch-IP/interface-name key for serialized target state."""
+        switch_ip = config.get("switch_ip")
+        interface_name = config.get("interface_name")
+        if not isinstance(switch_ip, str) or not switch_ip or not isinstance(interface_name, str) or not interface_name:
+            return None
+        return switch_ip.casefold(), interface_name.casefold()
 
     @classmethod
-    def _resource_result(cls, resource, *, after, include_proposed: bool, after_verified: bool) -> dict[str, Any]:
+    def _target_index(cls, config: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+        """Index serialized target state without copying full model dictionaries."""
+        return {key: item for item in config if (key := cls._serialized_target_key(item)) is not None}
+
+    @staticmethod
+    def _execution_item_key(item: Mapping[str, Any]) -> tuple[int, str, str, str] | None:
+        """Return the stable key shared by planned operations and executor outcomes."""
+        resource_index = item.get("resource_index")
+        action = item.get("action")
+        switch_ip = item.get("switch_ip")
+        interface_name = item.get("interface_name")
+        if not isinstance(resource_index, int) or not isinstance(action, str) or not isinstance(switch_ip, str) or not isinstance(interface_name, str):
+            return None
+        return resource_index, action, switch_ip.casefold(), interface_name.casefold()
+
+    def _operation_result(
+        self,
+        resource,
+        *,
+        action: str,
+        switch_ip: str,
+        switch_id: str,
+        interface_name: str,
+        before_by_target: Mapping[tuple[str, str], dict[str, Any]],
+        after_by_target: Mapping[tuple[str, str], dict[str, Any]],
+        execution_items: Mapping[tuple[int, str, str, str], Mapping[str, Any]],
+        from_policy_type: str | None = None,
+        to_policy_type: str | None = None,
+    ) -> dict[str, Any]:
+        """Merge one planned action with its execution status and compact changed paths."""
+        execution_key = (resource.resource_index, action, switch_ip.casefold(), interface_name.casefold())
+        execution_item = execution_items.get(execution_key, {})
+        public_action = action
+        if action == "delete" and getattr(resource.adapter, "delete_strategy", None) == InterfaceDeleteStrategy.NORMALIZE:
+            public_action = "reset"
+        result = {
+            "action": public_action,
+            "switch_ip": switch_ip,
+            "switch_id": switch_id,
+            "interface_name": interface_name,
+            "status": execution_item.get("status", "planned" if self.module.check_mode else "not_attempted"),
+        }
+        if from_policy_type is not None:
+            result["from_policy_type"] = from_policy_type
+        if to_policy_type is not None:
+            result["to_policy_type"] = to_policy_type
+        if message := execution_item.get("message"):
+            result["message"] = message
+
+        if public_action in {"reset", "transition", "update"}:
+            target_key = (switch_ip.casefold(), interface_name.casefold())
+            before = before_by_target.get(target_key, _MISSING)
+            after = after_by_target.get(target_key, _MISSING)
+            changes = self._leaf_changes(before, after)
+            if changes:
+                result["changes"] = changes
+        return result
+
+    def _resource_operations(
+        self,
+        resource,
+        *,
+        before_config: list[dict[str, Any]],
+        after_config: list[dict[str, Any]],
+        execution_items: Mapping[tuple[int, str, str, str], Mapping[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Return one compact, action-tagged operation list for a resource group."""
+        before_by_target = self._target_index(before_config)
+        after_by_target = self._target_index(after_config)
+        context = resource.orchestrator.fabric_context
+        operations = []
+
+        for model in resource.operations.deletes:
+            switch_ip = getattr(model, "switch_ip")
+            interface_name = getattr(model, "interface_name")
+            operations.append(
+                self._operation_result(
+                    resource,
+                    action="delete",
+                    switch_ip=switch_ip,
+                    switch_id=context.get_switch_id(switch_ip),
+                    interface_name=interface_name,
+                    before_by_target=before_by_target,
+                    after_by_target=after_by_target,
+                    execution_items=execution_items,
+                )
+            )
+
+        for transition in resource.transitions:
+            operations.append(
+                self._operation_result(
+                    resource,
+                    action="transition",
+                    switch_ip=transition.switch_ip,
+                    switch_id=transition.switch_id,
+                    interface_name=transition.interface_name,
+                    before_by_target=before_by_target,
+                    after_by_target=after_by_target,
+                    execution_items=execution_items,
+                    from_policy_type=transition.from_policy_type,
+                    to_policy_type=transition.to_policy_type,
+                )
+            )
+
+        for action, models in (("update", resource.operations.updates), ("create", resource.operations.creates)):
+            for model in models:
+                switch_ip = getattr(model, "switch_ip")
+                interface_name = getattr(model, "interface_name")
+                operations.append(
+                    self._operation_result(
+                        resource,
+                        action=action,
+                        switch_ip=switch_ip,
+                        switch_id=context.get_switch_id(switch_ip),
+                        interface_name=interface_name,
+                        before_by_target=before_by_target,
+                        after_by_target=after_by_target,
+                        execution_items=execution_items,
+                    )
+                )
+        return operations
+
+    @staticmethod
+    def _snake_case_key(value: str) -> str:
+        """Convert one controller camelCase key to Ansible snake_case."""
+        first_pass = _CAMEL_WORD_BOUNDARY.sub(r"\1_\2", value)
+        converted = _CAMEL_LETTER_BOUNDARY.sub(r"\1_\2", first_pass).replace("-", "_").lower()
+        return re.sub(r"^i_pv([46])", r"ipv\1", converted)
+
+    @classmethod
+    def _snake_case_data(cls, value: Any) -> Any:
+        """Recursively normalize controller keys for unknown-policy observations."""
+        if isinstance(value, Mapping):
+            return {cls._snake_case_key(str(key)): cls._snake_case_data(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [cls._snake_case_data(item) for item in value]
+        return value
+
+    @staticmethod
+    def _canonical_interface_type(value: Any) -> Any:
+        """Normalize raw interface-type aliases used by different ND releases."""
+        return {"switchVirtualInterface": "svi"}.get(value, value)
+
+    @staticmethod
+    def _model_policy_type(model) -> str | None:
+        """Return one model's wire policy discriminator without exposing its full payload."""
+        try:
+            return InterfaceStateSnapshot.policy_type(model.to_payload())
+        except Exception:  # pylint: disable=broad-except
+            return None
+
+    @classmethod
+    def _serialize_model_target(cls, model) -> dict[str, Any]:
+        """Serialize a known-family model with an explicit reporting policy discriminator."""
+        result = model.to_config()
+        policy_type = cls._model_policy_type(model)
+        config_data = result.get("config_data")
+        network_os = config_data.get("network_os") if isinstance(config_data, Mapping) else None
+        policy = network_os.get("policy") if isinstance(network_os, Mapping) else None
+        if isinstance(policy, dict):
+            policy.pop("policy_type", None)
+        if policy_type is not None:
+            result["policy_type"] = policy_type
+        return result
+
+    @classmethod
+    def _serialize_raw_target(cls, raw: Mapping[str, Any], switch_ip: str) -> dict[str, Any]:
+        """Serialize a raw target through its source-family model when one is known."""
+        current = dict(raw)
+        interface_type = cls._canonical_interface_type(current.get("interfaceType"))
+        current["interfaceType"] = interface_type
+        current["switchIp"] = switch_ip
+        policy_type = InterfaceStateSnapshot.policy_type(current)
+        adapter = _ADAPTER_BY_WIRE_IDENTITY.get((interface_type, policy_type))
+        if adapter is not None:
+            try:
+                return cls._serialize_model_target(adapter.model_class.from_response(current))
+            except Exception:  # pylint: disable=broad-except
+                # Result formatting must remain forward-compatible with new controller fields.
+                pass
+
+        result = {
+            "switch_ip": switch_ip,
+            "interface_name": current.get("interfaceName"),
+            "interface_type": interface_type,
+            "policy_type": policy_type,
+        }
+        config_data = current.get("configData")
+        if isinstance(config_data, Mapping):
+            result["config_data"] = cls._snake_case_data(config_data)
+            network_os = result["config_data"].get("network_os")
+            policy = network_os.get("policy") if isinstance(network_os, Mapping) else None
+            if isinstance(policy, dict):
+                policy.pop("policy_type", None)
+        return {key: value for key, value in result.items() if value is not None}
+
+    @staticmethod
+    def _target_key(model) -> Any:
+        """Return the family model's switch/IP-aware composite identifier."""
+        return model.get_identifier_value()
+
+    @staticmethod
+    def _collection_sort_key(model) -> tuple[str, ...]:
+        """Return a deterministic string key for full-scope collection presentation."""
+        identifier = model.get_identifier_value()
+        values = identifier if isinstance(identifier, tuple) else (identifier,)
+        return tuple(str(value).casefold() for value in values)
+
+    @classmethod
+    def _serialize_family_collection(cls, collection) -> list[dict[str, Any]]:
+        """Serialize a full family collection in deterministic identity order."""
+        return [item.to_config() for item in sorted(collection, key=cls._collection_sort_key)]
+
+    @classmethod
+    def _project_collection(cls, resource, collection) -> list[dict[str, Any]]:
+        """Select requested identities from a destination-family collection in playbook order."""
+        if resource.state == "overridden":
+            return [cls._serialize_model_target(item) for item in sorted(collection, key=cls._collection_sort_key)]
+        if not hasattr(collection, "get"):
+            return collection.to_ansible_config()
+        projected = []
+        for desired in resource.proposed:
+            current = collection.get(cls._target_key(desired))
+            if current is not None:
+                projected.append(cls._serialize_model_target(current))
+        return projected
+
+    @staticmethod
+    def _operation_keys(resource) -> set[Any]:
+        """Return requested identities with an actual planned mutation."""
+        models = (
+            *resource.operations.creates,
+            *resource.operations.updates,
+            *resource.operations.deletes,
+            *(transition.desired for transition in resource.transitions),
+        )
+        return {model.get_identifier_value() for model in models}
+
+    @staticmethod
+    def _model_deployment_target(resource, model) -> Target:
+        """Return the exact controller deployment identity for one configured model."""
+        switch_id = resource.orchestrator.fabric_context.get_switch_id(getattr(model, "switch_ip"))
+        return getattr(model, "interface_name"), switch_id
+
+    @classmethod
+    def _operation_deployment_targets(cls, plan: InterfaceWorkflowPlan) -> tuple[Target, ...]:
+        """Return exact targets that would be queued by the current mutation plan."""
+        targets = []
+        for resource in plan.resources:
+            orchestrator = getattr(resource, "orchestrator", None)
+            if getattr(orchestrator, "fabric_context", None) is None:
+                continue
+            models = (
+                *resource.operations.deletes,
+                *(transition.desired for transition in resource.transitions),
+                *resource.operations.updates,
+                *resource.operations.creates,
+            )
+            for model in models:
+                targets.append(cls._model_deployment_target(resource, model))
+        return tuple(dict.fromkeys(targets))
+
+    @classmethod
+    def _pending_deployment_targets(cls, plan: InterfaceWorkflowPlan) -> tuple[Target, ...]:
+        """Select explicit no-mutation targets on switches the cached inventory reports out of sync or pending."""
+        targets = []
+        for resource in plan.resources:
+            orchestrator = getattr(resource, "orchestrator", None)
+            context = getattr(orchestrator, "fabric_context", None)
+            if context is None or not hasattr(context, "switch_config_in_sync"):
+                continue
+            operation_keys = cls._operation_keys(resource)
+            for desired in resource.proposed:
+                if cls._target_key(desired) in operation_keys:
+                    continue
+                primary_switch_id = context.get_switch_id(getattr(desired, "switch_ip"))
+                switch_scope = [primary_switch_id]
+                if resource.adapter.ownership_domain == "vpc":
+                    peer_switch_id = getattr(orchestrator, "_peer_serial_cache", {}).get(primary_switch_id)
+                    if peer_switch_id is not None:
+                        switch_scope.append(peer_switch_id)
+                if any(context.switch_config_in_sync(switch_id) is False for switch_id in switch_scope):
+                    targets.append((getattr(desired, "interface_name"), primary_switch_id))
+        return tuple(dict.fromkeys(targets))
+
+    @staticmethod
+    def _deployment_preview(targets: tuple[Target, ...]) -> list[dict[str, str]]:
+        """Serialize exact deployment targets for check-mode output."""
+        return [
+            {
+                "interface_name": interface_name,
+                "switch_id": switch_id,
+                "status": "would_deploy",
+            }
+            for interface_name, switch_id in targets
+        ]
+
+    def _raw_target(self, resource, desired, *, original: bool) -> tuple[str, dict | None]:
+        """Resolve one requested model to its primary raw snapshot record."""
+        switch_ip = getattr(desired, "switch_ip")
+        switch_id = resource.orchestrator.fabric_context.get_switch_id(switch_ip)
+        snapshot = self._snapshot
+        if snapshot is None:
+            return switch_ip, None
+        raw = snapshot.cached_interface(
+            switch_id,
+            getattr(desired, "interface_name"),
+            original=original,
+        )
+        return switch_ip, raw
+
+    def _supports_raw_projection(self, resource) -> bool:
+        """Return whether real snapshot and fabric context are available for result projection."""
+        return (
+            self._snapshot is not None
+            and hasattr(self._snapshot, "cached_interface")
+            and getattr(resource, "orchestrator", None) is not None
+            and getattr(resource.orchestrator, "fabric_context", None) is not None
+        )
+
+    def _target_before(self, resource) -> list[dict[str, Any]]:
+        """Return observed initial state for only the requested logical identities."""
+        if resource.state == "overridden" or not self._supports_raw_projection(resource):
+            return self._project_collection(resource, resource.before)
+        projected = []
+        for desired in resource.proposed:
+            switch_ip, raw = self._raw_target(resource, desired, original=True)
+            if raw is not None:
+                projected.append(self._serialize_raw_target(raw, switch_ip))
+        return projected
+
+    @classmethod
+    def _default_ethernet_target(cls, desired) -> dict[str, Any]:
+        """Return the canonical prospective state after a physical-port reset."""
+        raw = InterfaceDefaultConfig().to_payload()
+        raw["interfaceName"] = getattr(desired, "interface_name")
+        raw["interfaceType"] = "ethernet"
+        return cls._serialize_raw_target(raw, getattr(desired, "switch_ip"))
+
+    def _planned_target_after(self, resource) -> list[dict[str, Any]]:
+        """Return target-scoped prospective state without changing the shared snapshot."""
+        if resource.state == "overridden":
+            return self._project_collection(resource, resource.operations.after)
+        operation_keys = self._operation_keys(resource)
+        projected = []
+        for desired in resource.proposed:
+            key = self._target_key(desired)
+            if key not in operation_keys:
+                if self._supports_raw_projection(resource):
+                    switch_ip, raw = self._raw_target(resource, desired, original=True)
+                    if raw is not None:
+                        projected.append(self._serialize_raw_target(raw, switch_ip))
+                else:
+                    current = resource.operations.after.get(key)
+                    if current is not None:
+                        projected.append(self._serialize_model_target(current))
+                continue
+            if resource.state == "deleted":
+                if resource.adapter.delete_strategy == InterfaceDeleteStrategy.NORMALIZE:
+                    projected.append(self._default_ethernet_target(desired))
+                continue
+            current = resource.operations.after.get(key)
+            if current is not None:
+                projected.append(self._serialize_model_target(current))
+        return projected
+
+    @staticmethod
+    def _vpc_peer_reference_matches(raw: Mapping[str, Any], expected_peer_id: str) -> bool:
+        """Return whether one vPC record references its authoritative peer, when populated."""
+        config_data = raw.get("configData")
+        network_os = config_data.get("networkOS") if isinstance(config_data, Mapping) else None
+        policy = network_os.get("policy") if isinstance(network_os, Mapping) else None
+        configured_peer_id = policy.get("peerSwitchId") if isinstance(policy, Mapping) else None
+        return configured_peer_id is None or configured_peer_id == expected_peer_id
+
+    def _vpc_target_is_pair_consistent(self, resource, desired, primary_raw: dict | None) -> bool:
+        """Return whether a reconciled vPC target is absent or coherent on both authoritative peers."""
+        if not resource.adapter.safety.requires_pair_consistency:
+            return True
+        snapshot = self._snapshot
+        if snapshot is None:
+            return False
+        context = resource.orchestrator.fabric_context
+        primary_id = context.get_switch_id(getattr(desired, "switch_ip"))
+        peer_id = getattr(resource.orchestrator, "_peer_serial_cache", {}).get(primary_id)
+        if peer_id is None:
+            return False
+        peer_raw = snapshot.cached_interface(peer_id, getattr(desired, "interface_name"))
+        if primary_raw is None or peer_raw is None:
+            return primary_raw is None and peer_raw is None
+        scope = tuple(sorted((primary_id, peer_id)))
+        if not self._vpc_peer_reference_matches(primary_raw, peer_id):
+            return False
+        if not self._vpc_peer_reference_matches(peer_raw, primary_id):
+            return False
+        if self._canonical_interface_type(primary_raw.get("interfaceType")) != self._canonical_interface_type(peer_raw.get("interfaceType")):
+            return False
+        if InterfaceStateSnapshot.policy_type(primary_raw) != InterfaceStateSnapshot.policy_type(peer_raw):
+            return False
+        return InterfaceWorkflowPlanner._vpc_record_fingerprint(
+            primary_raw,
+            primary_id,
+            scope,
+        ) == InterfaceWorkflowPlanner._vpc_record_fingerprint(peer_raw, peer_id, scope)
+
+    def _observed_target_after(self, resource, fallback) -> tuple[list[dict[str, Any]], bool]:
+        """Return target state and vPC pair-verification from the cached reconciled snapshot."""
+        if not self._supports_raw_projection(resource):
+            return self._project_collection(resource, fallback), True
+        projected = []
+        pair_verified = True
+        for desired in resource.proposed:
+            switch_ip, raw = self._raw_target(resource, desired, original=False)
+            pair_verified = pair_verified and self._vpc_target_is_pair_consistent(resource, desired, raw)
+            if raw is not None:
+                projected.append(self._serialize_raw_target(raw, switch_ip))
+        return projected, pair_verified
+
+    def _observed_overridden_vpc_after(self, resource, fallback) -> tuple[list[dict[str, Any]], bool]:
+        """Return complete pair-keyed vPC family state from the refreshed raw snapshot."""
+        if resource.adapter.ownership_domain != "vpc" or not self._supports_raw_projection(resource) or not hasattr(self._snapshot, "interfaces_by_identity"):
+            return self._project_collection(resource, fallback), True
+
+        context = resource.orchestrator.fabric_context
+        peer_by_switch = getattr(resource.orchestrator, "_peer_serial_cache", {})
+        grouped: dict[tuple[tuple[str, ...], str], dict[str, dict[str, Any]]] = {}
+        for (switch_id, interface_name), raw in self._snapshot.interfaces_by_identity.items():
+            interface_type = self._canonical_interface_type(raw.get("interfaceType"))
+            policy_type = InterfaceStateSnapshot.policy_type(raw)
+            if interface_type not in resource.adapter.interface_types or policy_type not in resource.adapter.policy_types:
+                continue
+            peer_id = peer_by_switch.get(switch_id)
+            scope = tuple(sorted((switch_id, peer_id))) if peer_id is not None else (switch_id,)
+            grouped.setdefault((scope, interface_name), {})[switch_id] = raw
+
+        preferred_by_key = {}
+        for desired in resource.proposed:
+            primary_id = context.get_switch_id(getattr(desired, "switch_ip"))
+            peer_id = peer_by_switch.get(primary_id)
+            scope = tuple(sorted((primary_id, peer_id))) if peer_id is not None else (primary_id,)
+            preferred_by_key[(scope, getattr(desired, "interface_name").lower())] = primary_id
+
+        projected = []
+        pair_verified = True
+        for key in sorted(grouped):
+            scope, _interface_name = key
+            records = grouped[key]
+            coherent = len(scope) == 2 and set(records) == set(scope)
+            if coherent:
+                for switch_id, raw in records.items():
+                    expected_peer_id = next(candidate for candidate in scope if candidate != switch_id)
+                    if not self._vpc_peer_reference_matches(raw, expected_peer_id):
+                        coherent = False
+                        break
+            if coherent:
+                fingerprints = [InterfaceWorkflowPlanner._vpc_record_fingerprint(raw, switch_id, scope) for switch_id, raw in records.items()]
+                coherent = all(fingerprint == fingerprints[0] for fingerprint in fingerprints[1:])
+            pair_verified = pair_verified and coherent
+            selected_id = preferred_by_key.get(key)
+            if selected_id not in records:
+                selected_id = min(records)
+            projected.append(self._serialize_raw_target(records[selected_id], context.get_switch_ip(selected_id)))
+        projected.sort(
+            key=lambda item: (
+                str(item.get("switch_ip", "")).casefold(),
+                str(item.get("interface_name", "")).casefold(),
+            )
+        )
+        return projected, pair_verified
+
+    def _resource_result(
+        self,
+        resource,
+        *,
+        after,
+        execution_items: Mapping[tuple[int, str, str, str], Mapping[str, Any]],
+        include_proposed: bool,
+        include_family: bool,
+        after_verified: bool,
+        use_observed_after: bool,
+    ) -> dict[str, Any]:
         """Serialize one indexed group without losing repeated resource types."""
-        changed = bool(resource.before.get_diff_collection(after))
+        before_config = self._target_before(resource)
+        observed_pair_verified = True
+        if resource.state == "overridden" and use_observed_after:
+            after_config, observed_pair_verified = self._observed_overridden_vpc_after(resource, after)
+        elif resource.state == "overridden":
+            after_config = self._project_collection(resource, after)
+        elif use_observed_after:
+            after_config, observed_pair_verified = self._observed_target_after(resource, after)
+        else:
+            after_config = self._planned_target_after(resource)
+        after_verified = after_verified and observed_pair_verified
         result = {
             "resource_index": resource.resource_index,
             "type": resource.resource_type,
             "module": resource.adapter.module_name,
             "state": resource.state,
-            "transitions": [transition.to_dict() for transition in resource.transitions],
-            "changed": changed,
+            "changed": before_config != after_config,
             "planned_changed": resource.changed,
-            "before": resource.before.to_ansible_config(),
-            "after": after.to_ansible_config(),
-            "diff": cls._config_diff(resource.before, after),
+            "before": before_config,
+            "after": after_config,
             "after_verified": after_verified,
-            "created": [item.to_config() for item in resource.operations.creates],
-            "updated": [item.to_config() for item in resource.operations.updates],
-            "deleted": [item.to_config() for item in resource.operations.deletes],
+            "operations": self._resource_operations(
+                resource,
+                before_config=before_config,
+                after_config=after_config,
+                execution_items=execution_items,
+            ),
         }
         if include_proposed:
             result["proposed"] = resource.proposed.to_ansible_config()
+        if include_family:
+            family_before = self._serialize_family_collection(resource.before)
+            if resource.state == "overridden" and resource.adapter.ownership_domain == "vpc" and use_observed_after:
+                family_after = [{key: value for key, value in item.items() if key != "policy_type"} for item in after_config]
+            else:
+                family_after = self._serialize_family_collection(after)
+            result["family_before"] = family_before
+            result["family_after"] = family_after
         return result
 
     def _format_result(
         self,
         plan: InterfaceWorkflowPlan,
         execution: InterfaceWorkflowExecution | None = None,
+        deployment_targets: tuple[Target, ...] = (),
     ) -> dict[str, Any]:
-        """Return stable aggregate and indexed per-resource output."""
+        """Return compact indexed resources plus aggregate read and execution metadata."""
         output_level = self.module.params.get("output_level", "normal")
+
+        if execution is not None:
+            execution_result = execution.to_dict()
+        else:
+            deploy = bool((self.module.params.get("config_actions") or {}).get("deploy", False))
+            would_deploy = self.module.check_mode and deploy and bool(deployment_targets)
+            execution_result = {
+                "status": "check_mode" if self.module.check_mode else "no_change",
+                "mutations_sent": 0,
+                "deployments_sent": 0,
+                "affected_switch_ids": [],
+                "items": [],
+                "deployment": {
+                    "requested": deploy,
+                    "status": "would_deploy" if would_deploy else "not_needed",
+                    "targets": self._deployment_preview(deployment_targets) if would_deploy else [],
+                },
+                "errors": [],
+            }
+
+        raw_execution_items = execution_result.pop("items", [])
+        execution_items = {}
+        for item in raw_execution_items:
+            if not isinstance(item, Mapping):
+                continue
+            key = self._execution_item_key(item)
+            if key is not None:
+                execution_items[key] = item
+
         resource_results = []
         for resource in plan.resources:
             actual = execution.actual_after_by_resource.get(resource.resource_index) if execution is not None else None
@@ -314,63 +902,31 @@ class InterfaceWorkflowCoordinator:
                 self._resource_result(
                     resource,
                     after=after,
+                    execution_items=execution_items,
                     include_proposed=output_level in {"info", "debug"},
+                    include_family=output_level == "debug",
                     after_verified=after_verified,
+                    use_observed_after=after_verified,
                 )
             )
 
         request_stats = dict(self._snapshot.request_stats if self._snapshot is not None else plan.request_stats)
-        request_stats.update(
-            {
-                "vpc_pair_gets": self._vpc_pair_gets,
-                "mutation_requests": (execution.mutation_requests if execution is not None else 0),
-                "deploy_requests": (execution.deploy_requests if execution is not None else 0),
-            }
-        )
-
-        def aggregate(field: str) -> list[dict[str, Any]]:
-            return [
-                {
-                    "resource_index": resource["resource_index"],
-                    "type": resource["type"],
-                    "config": resource[field],
-                }
-                for resource in resource_results
-            ]
+        request_stats.pop("mutation_requests", None)
+        request_stats.pop("deploy_requests", None)
+        request_stats["vpc_pair_gets"] = self._vpc_pair_gets
 
         if execution is not None:
-            execution_result = execution.to_dict()
-            changed = execution.changed
+            observed_projection_changed = any(resource["changed"] and resource["after_verified"] for resource in resource_results)
+            changed = execution.changed or observed_projection_changed
         else:
-            deploy = bool((self.module.params.get("config_actions") or {}).get("deploy", False))
-            execution_result = {
-                "status": "check_mode" if self.module.check_mode else "no_change",
-                "mutations_sent": 0,
-                "deployments_sent": 0,
-                "affected_switch_ids": [],
-                "items": [],
-                "deployment": {
-                    "requested": deploy,
-                    "status": "not_needed",
-                    "targets": [],
-                },
-                "errors": [],
-            }
-            changed = plan.changed if self.module.check_mode else False
+            changed = (plan.changed or bool(deployment_targets)) if self.module.check_mode else False
 
         return {
             "changed": changed,
             "planned_changed": plan.changed,
-            "check_mode": self.module.check_mode,
-            "output_level": output_level,
-            "fabric_name": plan.fabric_name,
-            "config_actions": dict(self.module.params.get("config_actions") or {}),
             "mutation_count": plan.mutation_count,
             "target_switch_ids": list(plan.target_switch_ids),
             "resources": resource_results,
-            "before": aggregate("before"),
-            "after": aggregate("after"),
-            "diff": aggregate("diff"),
             "request_stats": request_stats,
             "execution": execution_result,
         }
@@ -378,12 +934,19 @@ class InterfaceWorkflowCoordinator:
     def run(self) -> dict[str, Any]:
         """Plan the complete workflow, then execute only after all validation succeeds."""
         plan = self._build_plan()
-        if self.module.check_mode or not plan.changed:
+        deploy = bool((self.module.params.get("config_actions") or {}).get("deploy", False))
+        pending_deployment_targets = self._pending_deployment_targets(plan) if deploy else ()
+        if self.module.check_mode:
+            preview_targets = tuple(dict.fromkeys((*self._operation_deployment_targets(plan), *pending_deployment_targets))) if deploy else ()
+            return self._format_result(plan, deployment_targets=preview_targets)
+        if not plan.changed and not pending_deployment_targets:
             return self._format_result(plan)
         if self._snapshot is None:
             raise RuntimeError("Interface workflow snapshot was not initialized.")
-        deploy = bool((self.module.params.get("config_actions") or {}).get("deploy", False))
-        execution = self.executor_factory(snapshot=self._snapshot, deploy=deploy).execute(plan)
+        execution = self.executor_factory(snapshot=self._snapshot, deploy=deploy).execute(
+            plan,
+            deployment_targets=pending_deployment_targets,
+        )
         result = self._format_result(plan, execution)
         if execution.failed:
             result["failed"] = True

--- a/plugins/module_utils/interface_workflow_coordinator.py
+++ b/plugins/module_utils/interface_workflow_coordinator.py
@@ -952,6 +952,7 @@ class InterfaceWorkflowCoordinator:
         """Plan the complete workflow, then execute only after all validation succeeds."""
         plan = self._build_plan()
         deploy = bool((self.module.params.get("config_actions") or {}).get("deploy", False))
+        verify = bool((self.module.params.get("verify") or {}).get("enabled", False))
         pending_deployment_targets = self._pending_deployment_targets(plan) if deploy else ()
         if self.module.check_mode:
             preview_targets = tuple(dict.fromkeys((*self._operation_deployment_targets(plan), *pending_deployment_targets))) if deploy else ()
@@ -960,7 +961,7 @@ class InterfaceWorkflowCoordinator:
             return self._format_result(plan)
         if self._snapshot is None:
             raise RuntimeError("Interface workflow snapshot was not initialized.")
-        execution = self.executor_factory(snapshot=self._snapshot, deploy=deploy).execute(
+        execution = self.executor_factory(snapshot=self._snapshot, deploy=deploy, verify=verify).execute(
             plan,
             deployment_targets=pending_deployment_targets,
         )

--- a/plugins/module_utils/interface_workflow_coordinator.py
+++ b/plugins/module_utils/interface_workflow_coordinator.py
@@ -62,16 +62,12 @@ class InterfaceWorkflowCoordinator:
         self._vpc_pair_gets = 0
         self._snapshot: InterfaceStateSnapshot | None = None
 
-    def _new_rest_send(
-        self, params: dict[str, Any] | None = None, *, check_mode: bool | None = None
-    ) -> RestSend:
+    def _new_rest_send(self, params: dict[str, Any] | None = None, *, check_mode: bool | None = None) -> RestSend:
         """Build an authenticated collection REST runtime for this module invocation."""
         sender = Sender()
         sender.ansible_module = self.module
         rest_send_params = dict(params if params is not None else self.module.params)
-        rest_send_params["check_mode"] = (
-            self.module.check_mode if check_mode is None else check_mode
-        )
+        rest_send_params["check_mode"] = self.module.check_mode if check_mode is None else check_mode
         rest_send = RestSend(rest_send_params)
         rest_send.sender = sender
         rest_send.response_handler = ResponseHandler()
@@ -98,11 +94,7 @@ class InterfaceWorkflowCoordinator:
 
     @staticmethod
     def _uses_vpc(resources: list[dict[str, Any]]) -> bool:
-        return any(
-            isinstance(resource, dict)
-            and resource.get("type") in {"vpc_access", "vpc_trunk_host"}
-            for resource in resources
-        )
+        return any(isinstance(resource, dict) and resource.get("type") in {"vpc_access", "vpc_trunk_host"} for resource in resources)
 
     def _vpc_pair_map(
         self,
@@ -118,14 +110,10 @@ class InterfaceWorkflowCoordinator:
         endpoint = EpVpcPairsListGet()
         endpoint.fabric_name = fabric_context.fabric_name
         self._vpc_pair_gets += 1
-        data = self._request(
-            rest_send, path=endpoint.path, verb=endpoint.verb, not_found_ok=True
-        )
+        data = self._request(rest_send, path=endpoint.path, verb=endpoint.verb, not_found_ok=True)
         records = data.get("vpcPairs") or data.get("items") or []
         if not isinstance(records, list):
-            raise InterfaceWorkflowValidationError(
-                "The Nexus Dashboard vPC-pair response must contain a list in 'vpcPairs'."
-            )
+            raise InterfaceWorkflowValidationError("The Nexus Dashboard vPC-pair response must contain a list in 'vpcPairs'.")
 
         pair_by_switch_ip: dict[str, str] = {}
         for record in records:
@@ -133,12 +121,7 @@ class InterfaceWorkflowCoordinator:
                 continue
             first = record.get("switchId") or record.get("peer1SwitchId")
             second = record.get("peerSwitchId") or record.get("peer2SwitchId")
-            if (
-                not isinstance(first, str)
-                or not first
-                or not isinstance(second, str)
-                or not second
-            ):
+            if not isinstance(first, str) or not first or not isinstance(second, str) or not second:
                 continue
             try:
                 pair_by_switch_ip[fabric_context.get_switch_ip(first)] = second
@@ -180,9 +163,7 @@ class InterfaceWorkflowCoordinator:
         )
         planner = self.planner_factory(
             snapshot=snapshot,
-            rest_send_factory=lambda params: self._new_rest_send(
-                params=params, check_mode=True
-            ),
+            rest_send_factory=lambda params: self._new_rest_send(params=params, check_mode=True),
             vpc_pair_by_switch_ip=vpc_pair_by_switch_ip,
             run_capability_preflight=True,
         )
@@ -199,9 +180,7 @@ class InterfaceWorkflowCoordinator:
         }
 
     @classmethod
-    def _resource_result(
-        cls, resource, *, after, include_proposed: bool, after_verified: bool
-    ) -> dict[str, Any]:
+    def _resource_result(cls, resource, *, after, include_proposed: bool, after_verified: bool) -> dict[str, Any]:
         """Serialize one indexed group without losing repeated resource types."""
         changed = bool(resource.before.get_diff_collection(after))
         result = {
@@ -232,15 +211,9 @@ class InterfaceWorkflowCoordinator:
         output_level = self.module.params.get("output_level", "normal")
         resource_results = []
         for resource in plan.resources:
-            actual = (
-                execution.actual_after_by_resource.get(resource.resource_index)
-                if execution is not None
-                else None
-            )
+            actual = execution.actual_after_by_resource.get(resource.resource_index) if execution is not None else None
             after = actual if actual is not None else resource.operations.after
-            after_verified = actual is not None or (
-                execution is None and not self.module.check_mode
-            )
+            after_verified = actual is not None or (execution is None and not self.module.check_mode)
             resource_results.append(
                 self._resource_result(
                     resource,
@@ -250,20 +223,12 @@ class InterfaceWorkflowCoordinator:
                 )
             )
 
-        request_stats = dict(
-            self._snapshot.request_stats
-            if self._snapshot is not None
-            else plan.request_stats
-        )
+        request_stats = dict(self._snapshot.request_stats if self._snapshot is not None else plan.request_stats)
         request_stats.update(
             {
                 "vpc_pair_gets": self._vpc_pair_gets,
-                "mutation_requests": (
-                    execution.mutation_requests if execution is not None else 0
-                ),
-                "deploy_requests": (
-                    execution.deploy_requests if execution is not None else 0
-                ),
+                "mutation_requests": (execution.mutation_requests if execution is not None else 0),
+                "deploy_requests": (execution.deploy_requests if execution is not None else 0),
             }
         )
 
@@ -281,9 +246,7 @@ class InterfaceWorkflowCoordinator:
             execution_result = execution.to_dict()
             changed = execution.changed
         else:
-            deploy = bool(
-                (self.module.params.get("config_actions") or {}).get("deploy", True)
-            )
+            deploy = bool((self.module.params.get("config_actions") or {}).get("deploy", False))
             execution_result = {
                 "status": "check_mode" if self.module.check_mode else "no_change",
                 "mutations_sent": 0,
@@ -323,12 +286,8 @@ class InterfaceWorkflowCoordinator:
             return self._format_result(plan)
         if self._snapshot is None:
             raise RuntimeError("Interface workflow snapshot was not initialized.")
-        deploy = bool(
-            (self.module.params.get("config_actions") or {}).get("deploy", True)
-        )
-        execution = self.executor_factory(
-            snapshot=self._snapshot, deploy=deploy
-        ).execute(plan)
+        deploy = bool((self.module.params.get("config_actions") or {}).get("deploy", False))
+        execution = self.executor_factory(snapshot=self._snapshot, deploy=deploy).execute(plan)
         result = self._format_result(plan, execution)
         if execution.failed:
             result["failed"] = True

--- a/plugins/module_utils/interface_workflow_coordinator.py
+++ b/plugins/module_utils/interface_workflow_coordinator.py
@@ -37,6 +37,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.rest.sender_nd import Sen
 
 PlannerFactory = Callable[..., InterfaceWorkflowPlanner]
 ExecutorFactory = Callable[..., InterfaceWorkflowExecutor]
+VPC_PAIR_PAGE_SIZE = 500
 
 
 class InterfaceWorkflowExecutionFailed(RuntimeError):
@@ -96,6 +97,17 @@ class InterfaceWorkflowCoordinator:
     def _uses_vpc(resources: list[dict[str, Any]]) -> bool:
         return any(isinstance(resource, dict) and resource.get("type") in {"vpc_access", "vpc_trunk_host"} for resource in resources)
 
+    @staticmethod
+    def _coerce_nonnegative_int(value: Any) -> int | None:
+        """Return a non-negative integer response count, or None when unusable."""
+        if isinstance(value, bool):
+            return None
+        try:
+            converted = int(value)
+        except (TypeError, ValueError):
+            return None
+        return converted if converted >= 0 else None
+
     def _vpc_pair_map(
         self,
         *,
@@ -107,15 +119,59 @@ class InterfaceWorkflowCoordinator:
         if not self._uses_vpc(resources):
             return {}
 
-        endpoint = EpVpcPairsListGet()
-        endpoint.fabric_name = fabric_context.fabric_name
-        self._vpc_pair_gets += 1
-        data = self._request(rest_send, path=endpoint.path, verb=endpoint.verb, not_found_ok=True)
-        records = data.get("vpcPairs") or data.get("items") or []
-        if not isinstance(records, list):
-            raise InterfaceWorkflowValidationError("The Nexus Dashboard vPC-pair response must contain a list in 'vpcPairs'.")
+        records: list[Any] = []
+        offset = 0
+        seen_page_signatures: set[tuple[tuple[str | None, str | None], ...]] = set()
+        while True:
+            endpoint = EpVpcPairsListGet()
+            endpoint.fabric_name = fabric_context.fabric_name
+            endpoint.endpoint_params.view = "intendedPairs"
+            endpoint.lucene_params.max = VPC_PAIR_PAGE_SIZE
+            endpoint.lucene_params.offset = offset
+            endpoint.lucene_params.sort = "switchId:asc"
+            self._vpc_pair_gets += 1
+            data = self._request(rest_send, path=endpoint.path, verb=endpoint.verb, not_found_ok=True)
+            page = data.get("vpcPairs") or data.get("items") or []
+            if not isinstance(page, list):
+                raise InterfaceWorkflowValidationError("The Nexus Dashboard vPC-pair response must contain a list in 'vpcPairs'.")
 
-        pair_by_switch_ip: dict[str, str] = {}
+            signature = tuple(
+                (
+                    (record.get("switchId") or record.get("peer1SwitchId")),
+                    (record.get("peerSwitchId") or record.get("peer2SwitchId")),
+                )
+                if isinstance(record, dict)
+                else (None, None)
+                for record in page
+            )
+            if page and signature in seen_page_signatures:
+                raise InterfaceWorkflowValidationError(
+                    f"The Nexus Dashboard vPC-pair pagination repeated a page at offset {offset}."
+                )
+            if page:
+                seen_page_signatures.add(signature)
+            records.extend(page)
+
+            metadata = data.get("meta") or data.get("metadata") or {}
+            counts = metadata.get("counts") if isinstance(metadata, dict) else {}
+            counts = counts if isinstance(counts, dict) else {}
+            total = self._coerce_nonnegative_int(counts.get("total"))
+            remaining = self._coerce_nonnegative_int(counts.get("remaining"))
+            if total is not None:
+                has_next = offset + len(page) < total
+            elif remaining is not None:
+                has_next = remaining > 0
+            else:
+                has_next = len(page) >= VPC_PAIR_PAGE_SIZE
+            if not has_next:
+                break
+            if not page:
+                raise InterfaceWorkflowValidationError(
+                    f"The Nexus Dashboard vPC-pair response reports more records after empty offset {offset}."
+                )
+            offset += len(page)
+
+        declared_peer_by_switch_id: dict[str, str] = {}
         for record in records:
             if not isinstance(record, dict):
                 continue
@@ -123,11 +179,50 @@ class InterfaceWorkflowCoordinator:
             second = record.get("peerSwitchId") or record.get("peer2SwitchId")
             if not isinstance(first, str) or not first or not isinstance(second, str) or not second:
                 continue
+            if first.casefold() == second.casefold():
+                raise InterfaceWorkflowValidationError(
+                    f"The authoritative vPC-pair inventory contains a self-pair for switch '{first}'."
+                )
+            existing_peer = declared_peer_by_switch_id.get(first)
+            if existing_peer is not None and existing_peer != second:
+                raise InterfaceWorkflowValidationError(
+                    f"The authoritative vPC-pair inventory contains conflicting mappings for switch '{first}': "
+                    f"'{existing_peer}' and '{second}'."
+                )
+            declared_peer_by_switch_id[first] = second
+
+        for first, second in declared_peer_by_switch_id.items():
+            inverse_peer = declared_peer_by_switch_id.get(second)
+            if inverse_peer is not None and inverse_peer != first:
+                raise InterfaceWorkflowValidationError(
+                    "The authoritative vPC-pair inventory contains inverse-inconsistent records: "
+                    f"switch '{second}' maps to '{inverse_peer}' instead of '{first}'."
+                )
+
+        peer_by_switch_id: dict[str, str] = {}
+        for first, second in declared_peer_by_switch_id.items():
+            for switch_id, peer_id in ((first, second), (second, first)):
+                existing_peer = peer_by_switch_id.get(switch_id)
+                if existing_peer is not None and existing_peer != peer_id:
+                    raise InterfaceWorkflowValidationError(
+                        f"The authoritative vPC-pair inventory contains conflicting mappings for switch '{switch_id}': "
+                        f"'{existing_peer}' and '{peer_id}'."
+                    )
+                peer_by_switch_id[switch_id] = peer_id
+
+        pair_by_switch_ip: dict[str, str] = {}
+        for switch_id, peer_id in peer_by_switch_id.items():
             try:
-                pair_by_switch_ip[fabric_context.get_switch_ip(first)] = second
-                pair_by_switch_ip[fabric_context.get_switch_ip(second)] = first
+                switch_ip = fabric_context.get_switch_ip(switch_id)
             except RuntimeError:
                 continue
+            existing_peer = pair_by_switch_ip.get(switch_ip)
+            if existing_peer is not None and existing_peer != peer_id:
+                raise InterfaceWorkflowValidationError(
+                    f"The authoritative vPC-pair inventory contains conflicting mappings for management IP '{switch_ip}': "
+                    f"'{existing_peer}' and '{peer_id}'."
+                )
+            pair_by_switch_ip[switch_ip] = peer_id
 
         for resource_index, resource in enumerate(resources):
             if not isinstance(resource, dict) or resource.get("type") not in {
@@ -188,6 +283,7 @@ class InterfaceWorkflowCoordinator:
             "type": resource.resource_type,
             "module": resource.adapter.module_name,
             "state": resource.state,
+            "transitions": [transition.to_dict() for transition in resource.transitions],
             "changed": changed,
             "planned_changed": resource.changed,
             "before": resource.before.to_ansible_config(),

--- a/plugins/module_utils/interface_workflow_coordinator.py
+++ b/plugins/module_utils/interface_workflow_coordinator.py
@@ -688,8 +688,25 @@ class InterfaceWorkflowCoordinator:
         return projected
 
     @classmethod
-    def _default_ethernet_target(cls, desired) -> dict[str, Any]:
-        """Return the canonical prospective state after a physical-port reset."""
+    def _default_ethernet_target(cls, desired, current: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        """Return the platform-correct prospective state after a physical-port reset."""
+        network_os = ((current or {}).get("configData") or {}).get("networkOS") or {}
+        if network_os.get("networkOSType") == "ios-xe":
+            raw = {
+                "interfaceName": getattr(desired, "interface_name"),
+                "interfaceType": "ethernet",
+                "configData": {
+                    "mode": "routed",
+                    "networkOS": {
+                        "networkOSType": "ios-xe",
+                        "policy": {
+                            "policyType": "iosXeRoutedHost",
+                            "adminState": True,
+                        },
+                    },
+                },
+            }
+            return cls._serialize_raw_target(raw, getattr(desired, "switch_ip"))
         raw = InterfaceDefaultConfig().to_payload()
         raw["interfaceName"] = getattr(desired, "interface_name")
         raw["interfaceType"] = "ethernet"
@@ -715,7 +732,8 @@ class InterfaceWorkflowCoordinator:
                 continue
             if resource.state == "deleted":
                 if resource.adapter.delete_strategy == InterfaceDeleteStrategy.NORMALIZE:
-                    projected.append(self._default_ethernet_target(desired))
+                    _switch_ip, current = self._raw_target(resource, desired, original=True)
+                    projected.append(self._default_ethernet_target(desired, current))
                 continue
             current = resource.operations.after.get(key)
             if current is not None:
@@ -927,7 +945,9 @@ class InterfaceWorkflowCoordinator:
                 )
             )
 
-        request_stats = dict(self._snapshot.request_stats if self._snapshot is not None else plan.request_stats)
+        request_stats = dict(plan.request_stats)
+        if self._snapshot is not None:
+            request_stats.update(self._snapshot.request_stats)
         request_stats.pop("mutation_requests", None)
         request_stats.pop("deploy_requests", None)
         request_stats["vpc_pair_gets"] = self._vpc_pair_gets

--- a/plugins/module_utils/interface_workflow_executor.py
+++ b/plugins/module_utils/interface_workflow_executor.py
@@ -45,6 +45,8 @@ class InterfaceExecutionItem:
     switch_ip: str
     switch_id: str
     interface_name: str
+    from_policy_type: str | None = None
+    to_policy_type: str | None = None
     status: str = "not_attempted"
     message: str | None = None
 
@@ -64,6 +66,10 @@ class InterfaceExecutionItem:
             "interface_name": self.interface_name,
             "status": self.status,
         }
+        if self.from_policy_type is not None:
+            result["from_policy_type"] = self.from_policy_type
+        if self.to_policy_type is not None:
+            result["to_policy_type"] = self.to_policy_type
         if self.message:
             result["message"] = self.message
         return result
@@ -124,8 +130,35 @@ class InterfaceWorkflowExecutor:
 
     def _build_items(self, plan: InterfaceWorkflowPlan) -> None:
         for resource in plan.resources:
+            for model in resource.operations.deletes:
+                interface_name, switch_id = self._model_target(resource, model)
+                item = InterfaceExecutionItem(
+                    resource_index=resource.resource_index,
+                    resource_type=resource.resource_type,
+                    action="delete",
+                    switch_ip=getattr(model, "switch_ip"),
+                    switch_id=switch_id,
+                    interface_name=interface_name,
+                )
+                self._items.append(item)
+                self._item_by_key[(resource.resource_index, "delete", model.get_identifier_value())] = item
+
+            for transition in resource.transitions:
+                model = transition.desired
+                item = InterfaceExecutionItem(
+                    resource_index=resource.resource_index,
+                    resource_type=resource.resource_type,
+                    action="transition",
+                    switch_ip=transition.switch_ip,
+                    switch_id=transition.switch_id,
+                    interface_name=transition.interface_name,
+                    from_policy_type=transition.from_policy_type,
+                    to_policy_type=transition.to_policy_type,
+                )
+                self._items.append(item)
+                self._item_by_key[(resource.resource_index, "transition", model.get_identifier_value())] = item
+
             for action, models in (
-                ("delete", resource.operations.deletes),
                 ("update", resource.operations.updates),
                 ("create", resource.operations.creates),
             ):
@@ -259,7 +292,8 @@ class InterfaceWorkflowExecutor:
             for resource in plan.resources:
                 if resource.state == "deleted":
                     continue
-                resource.orchestrator.preflight_create(resource.operations.creates)
+                create_candidates = [*resource.operations.creates, *(transition.desired for transition in resource.transitions)]
+                resource.orchestrator.preflight_create(create_candidates)
                 resource.orchestrator.preflight(list(resource.proposed))
         except Exception as exc:  # pylint: disable=broad-except
             self._errors.append(f"Pre-mutation prerequisite validation failed: {exc}")
@@ -369,6 +403,22 @@ class InterfaceWorkflowExecutor:
             return False
         for item in [*normalize_items, *reset_items]:
             item.status = "succeeded"
+        return True
+
+    def _execute_transitions(self, plan: InterfaceWorkflowPlan) -> bool:
+        """Replace approved foreign policies through destination-family PUTs."""
+        for resource in plan.resources:
+            for transition in resource.transitions:
+                item = self._item(resource, "transition", transition.desired)
+                if not self._call_items(
+                    resource.orchestrator,
+                    [item],
+                    lambda resource=resource, transition=transition: resource.orchestrator.update(
+                        transition.desired, existing_data=transition.current
+                    ),
+                    f"resources[{resource.resource_index}] {resource.resource_type} policy transition failed",
+                ):
+                    return False
         return True
 
     def _execute_updates(self, plan: InterfaceWorkflowPlan) -> bool:
@@ -498,7 +548,7 @@ class InterfaceWorkflowExecutor:
         return actual
 
     def execute(self, plan: InterfaceWorkflowPlan) -> InterfaceWorkflowExecution:
-        """Execute delete, update, create, and deploy phases, then refetch actual state."""
+        """Execute delete, transition, update, create, and deploy phases, then refetch actual state."""
         self._build_items(plan)
         phases_ok = self._enable_writes_and_preflight(plan)
         if phases_ok:
@@ -507,6 +557,8 @@ class InterfaceWorkflowExecutor:
             phases_ok = self._flush_base_removes(plan)
         if phases_ok:
             phases_ok = self._flush_ethernet_removes(plan)
+        if phases_ok:
+            phases_ok = self._execute_transitions(plan)
         if phases_ok:
             phases_ok = self._execute_updates(plan)
         if phases_ok:

--- a/plugins/module_utils/interface_workflow_executor.py
+++ b/plugins/module_utils/interface_workflow_executor.py
@@ -1,0 +1,660 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Mutation execution for a completely validated aggregate interface plan."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable
+
+from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import (
+    InterfaceStateSnapshot,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planner import (
+    InterfaceResourcePlan,
+    InterfaceWorkflowPlan,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
+    NDConfigCollection,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
+    NDBaseInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import (
+    EthernetBaseOrchestrator,
+)
+
+Target = tuple[str, str]
+
+_FAILURE_STATUSES = frozenset({"failed", "failure", "error"})
+_SUCCESS_STATUSES = frozenset({"success"})
+_OUTCOME_KEYS = ("results", "switchIds", "links")
+
+
+@dataclass
+class InterfaceExecutionItem:
+    """Execution outcome for one planned model mutation."""
+
+    resource_index: int
+    resource_type: str
+    action: str
+    switch_ip: str
+    switch_id: str
+    interface_name: str
+    status: str = "not_attempted"
+    message: str | None = None
+
+    @property
+    def target(self) -> Target:
+        """Return the controller action identity."""
+        return self.interface_name, self.switch_id
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this item for module output."""
+        result = {
+            "resource_index": self.resource_index,
+            "type": self.resource_type,
+            "action": self.action,
+            "switch_ip": self.switch_ip,
+            "switch_id": self.switch_id,
+            "interface_name": self.interface_name,
+            "status": self.status,
+        }
+        if self.message:
+            result["message"] = self.message
+        return result
+
+
+@dataclass
+class InterfaceWorkflowExecution:
+    """Complete execution and reconciliation result."""
+
+    status: str
+    changed: bool
+    failed: bool
+    items: tuple[InterfaceExecutionItem, ...]
+    mutation_requests: int
+    deploy_requests: int
+    affected_switch_ids: tuple[str, ...]
+    deployment: dict[str, Any]
+    errors: tuple[str, ...] = ()
+    actual_after_by_resource: dict[int, NDConfigCollection] = field(
+        default_factory=dict, repr=False
+    )
+
+    @property
+    def message(self) -> str:
+        """Return one useful module failure summary."""
+        return (
+            "; ".join(self.errors)
+            if self.errors
+            else "Interface workflow execution failed."
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize execution details while keeping model collections internal."""
+        return {
+            "status": self.status,
+            "mutations_sent": self.mutation_requests,
+            "deployments_sent": self.deploy_requests,
+            "affected_switch_ids": list(self.affected_switch_ids),
+            "items": [item.to_dict() for item in self.items],
+            "deployment": self.deployment,
+            "errors": list(self.errors),
+        }
+
+
+class InterfaceWorkflowExecutor:
+    """Execute one precomputed plan using the current develop orchestrators."""
+
+    def __init__(
+        self, *, snapshot: InterfaceStateSnapshot, deploy: bool = True
+    ) -> None:
+        self.snapshot = snapshot
+        self.deploy = deploy
+        self._items: list[InterfaceExecutionItem] = []
+        self._item_by_key: dict[tuple[int, str, Any], InterfaceExecutionItem] = {}
+        self._errors: list[str] = []
+        self._deployment: dict[str, Any] = {
+            "requested": deploy,
+            "status": "not_attempted",
+            "targets": [],
+        }
+
+    @staticmethod
+    def _model_target(resource: InterfaceResourcePlan, model: NDBaseModel) -> Target:
+        switch_id = resource.orchestrator.fabric_context.get_switch_id(
+            getattr(model, "switch_ip")
+        )
+        return getattr(model, "interface_name"), switch_id
+
+    def _build_items(self, plan: InterfaceWorkflowPlan) -> None:
+        for resource in plan.resources:
+            for action, models in (
+                ("delete", resource.operations.deletes),
+                ("update", resource.operations.updates),
+                ("create", resource.operations.creates),
+            ):
+                for model in models:
+                    interface_name, switch_id = self._model_target(resource, model)
+                    item = InterfaceExecutionItem(
+                        resource_index=resource.resource_index,
+                        resource_type=resource.resource_type,
+                        action=action,
+                        switch_ip=getattr(model, "switch_ip"),
+                        switch_id=switch_id,
+                        interface_name=interface_name,
+                    )
+                    self._items.append(item)
+                    self._item_by_key[
+                        (resource.resource_index, action, model.get_identifier_value())
+                    ] = item
+
+    def _item(
+        self, resource: InterfaceResourcePlan, action: str, model: NDBaseModel
+    ) -> InterfaceExecutionItem:
+        return self._item_by_key[
+            (resource.resource_index, action, model.get_identifier_value())
+        ]
+
+    @staticmethod
+    def _write_history(
+        rest_send, response_start: int, result_start: int
+    ) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+        responses = rest_send.responses[response_start:]
+        results = rest_send.results[result_start:]
+        return list(zip(responses, results))
+
+    @staticmethod
+    def _response_outcomes(response: dict[str, Any]) -> list[dict[str, Any]]:
+        data = response.get("DATA")
+        if not isinstance(data, dict):
+            return []
+        outcomes: list[dict[str, Any]] = []
+        for key in _OUTCOME_KEYS:
+            values = data.get(key)
+            if isinstance(values, list):
+                outcomes.extend(
+                    value
+                    for value in values
+                    if isinstance(value, dict) and value.get("status") is not None
+                )
+        return outcomes
+
+    @staticmethod
+    def _outcome_target(
+        outcome: dict[str, Any], targets: Iterable[Target]
+    ) -> Target | None:
+        name_value = outcome.get("interfaceName") or outcome.get("name")
+        switch_value = outcome.get("switchId") or outcome.get("serialNumber")
+        candidates = list(targets)
+        if name_value is not None:
+            candidates = [
+                target
+                for target in candidates
+                if target[0].lower() == str(name_value).lower()
+            ]
+        if switch_value is not None:
+            candidates = [
+                target for target in candidates if target[1] == str(switch_value)
+            ]
+        return candidates[0] if len(candidates) == 1 else None
+
+    @classmethod
+    def _classify_response(
+        cls,
+        targets: Iterable[Target],
+        response: dict[str, Any] | None,
+        result: dict[str, Any] | None,
+        error: str,
+    ) -> dict[Target, tuple[str, str | None]]:
+        target_list = list(dict.fromkeys(targets))
+        response = response or {}
+        result = result or {}
+        if result.get("success") is True:
+            return {target: ("succeeded", None) for target in target_list}
+
+        outcomes = cls._response_outcomes(response)
+        classified: dict[Target, tuple[str, str | None]] = {}
+        for outcome in outcomes:
+            target = cls._outcome_target(outcome, target_list)
+            if target is None:
+                continue
+            status = str(outcome.get("status") or "").strip().lower()
+            message = outcome.get("message") or outcome.get("warningMessage")
+            if status in _SUCCESS_STATUSES:
+                classified[target] = ("succeeded", str(message) if message else None)
+            elif status in _FAILURE_STATUSES:
+                classified[target] = ("failed", str(message) if message else error)
+
+        changed_on_failure = result.get("changed") is True
+        for target in target_list:
+            if target not in classified:
+                classified[target] = (
+                    "uncertain" if changed_on_failure or outcomes else "failed",
+                    error,
+                )
+        return classified
+
+    @staticmethod
+    def _apply_outcomes(
+        items: Iterable[InterfaceExecutionItem],
+        outcomes: dict[Target, tuple[str, str | None]],
+    ) -> None:
+        for item in items:
+            status, message = outcomes.get(
+                item.target,
+                ("uncertain", "Controller response did not identify this interface."),
+            )
+            item.status = status
+            item.message = message
+
+    def _call_items(
+        self,
+        orchestrator: NDBaseInterfaceOrchestrator,
+        items: list[InterfaceExecutionItem],
+        operation: Callable[[], Any],
+        context: str,
+    ) -> bool:
+        response_start = len(orchestrator.rest_send.responses)
+        result_start = len(orchestrator.rest_send.results)
+        try:
+            operation()
+        except Exception as exc:  # pylint: disable=broad-except
+            error = f"{context}: {exc}"
+            history = self._write_history(
+                orchestrator.rest_send, response_start, result_start
+            )
+            response, result = history[-1] if history else ({}, {})
+            outcomes = self._classify_response(
+                (item.target for item in items), response, result, error
+            )
+            self._apply_outcomes(items, outcomes)
+            self._errors.append(error)
+            return False
+        for item in items:
+            item.status = "succeeded"
+        return True
+
+    def _enable_writes_and_preflight(self, plan: InterfaceWorkflowPlan) -> bool:
+        for resource in plan.resources:
+            resource.orchestrator.rest_send.check_mode = False
+            resource.orchestrator.rest_send.params["check_mode"] = False
+            resource.orchestrator.deploy = False
+            if resource.orchestrator.results is not None:
+                resource.orchestrator.results.check_mode = False
+        try:
+            if plan.resources:
+                plan.resources[0].orchestrator.validate_prerequisites()
+            for resource in plan.resources:
+                if resource.state == "deleted":
+                    continue
+                resource.orchestrator.preflight_create(resource.operations.creates)
+                resource.orchestrator.preflight(list(resource.proposed))
+        except Exception as exc:  # pylint: disable=broad-except
+            self._errors.append(f"Pre-mutation prerequisite validation failed: {exc}")
+            return False
+        return True
+
+    def _queue_deletes(self, plan: InterfaceWorkflowPlan) -> bool:
+        for resource in plan.resources:
+            models = list(resource.operations.deletes)
+            if not models:
+                continue
+            orchestrator = resource.orchestrator
+            items = [self._item(resource, "delete", model) for model in models]
+            if orchestrator.supports_bulk_delete:
+                if not self._call_items(
+                    orchestrator,
+                    items,
+                    lambda orchestrator=orchestrator, models=models: orchestrator.delete_bulk(
+                        models
+                    ),
+                    f"resources[{resource.resource_index}] {resource.resource_type} delete preparation failed",
+                ):
+                    return False
+                for item in items:
+                    if isinstance(orchestrator, EthernetBaseOrchestrator):
+                        queued = (
+                            item.target in orchestrator.pending_normalizes
+                            or item.target in orchestrator.pending_resets
+                        )
+                    else:
+                        queued = item.target in orchestrator.pending_removes
+                    if queued:
+                        item.status = "queued"
+                    else:
+                        item.status = "skipped"
+                        item.message = "The develop orchestrator intentionally skipped this deletion."
+                continue
+
+            for model, item in zip(models, items):
+                if not self._call_items(
+                    orchestrator,
+                    [item],
+                    lambda orchestrator=orchestrator, model=model: orchestrator.delete(
+                        model
+                    ),
+                    f"resources[{resource.resource_index}] {resource.resource_type} delete failed",
+                ):
+                    return False
+        return True
+
+    def _flush_base_removes(self, plan: InterfaceWorkflowPlan) -> bool:
+        sources = [
+            resource.orchestrator
+            for resource in plan.resources
+            if not isinstance(resource.orchestrator, EthernetBaseOrchestrator)
+            and resource.orchestrator.pending_removes
+        ]
+        if not sources:
+            return True
+        target = sources[0]
+        targets = tuple(
+            dict.fromkeys(pair for source in sources for pair in source.pending_removes)
+        )
+        target.queue_remove_targets(targets)
+        items = [
+            item
+            for item in self._items
+            if item.action == "delete"
+            and item.status == "queued"
+            and item.target in targets
+        ]
+        return self._call_items(
+            target,
+            items,
+            target.remove_pending,
+            "Consolidated interface removal failed",
+        )
+
+    def _flush_ethernet_removes(self, plan: InterfaceWorkflowPlan) -> bool:
+        sources = [
+            resource.orchestrator
+            for resource in plan.resources
+            if isinstance(resource.orchestrator, EthernetBaseOrchestrator)
+        ]
+        normalizes = tuple(
+            dict.fromkeys(
+                pair for source in sources for pair in source.pending_normalizes
+            )
+        )
+        resets = tuple(
+            dict.fromkeys(pair for source in sources for pair in source.pending_resets)
+        )
+        if not normalizes and not resets:
+            return True
+        target = next(
+            source
+            for source in sources
+            if source.pending_normalizes or source.pending_resets
+        )
+        target.queue_normalize_targets(normalizes)
+        target.queue_reset_targets(resets)
+        normalize_items = [
+            item
+            for item in self._items
+            if item.action == "delete"
+            and item.status == "queued"
+            and item.target in normalizes
+        ]
+        reset_items = [
+            item
+            for item in self._items
+            if item.action == "delete"
+            and item.status == "queued"
+            and item.target in resets
+        ]
+
+        response_start = len(target.rest_send.responses)
+        result_start = len(target.rest_send.results)
+        try:
+            target.remove_pending()
+        except Exception as exc:  # pylint: disable=broad-except
+            error = f"Consolidated Ethernet normalization/reset failed: {exc}"
+            history = self._write_history(
+                target.rest_send, response_start, result_start
+            )
+            cursor = 0
+            if normalize_items:
+                response, result = (
+                    history[cursor] if cursor < len(history) else ({}, {})
+                )
+                cursor += 1 if cursor < len(history) else 0
+                self._apply_outcomes(
+                    normalize_items,
+                    self._classify_response(
+                        (item.target for item in normalize_items),
+                        response,
+                        result,
+                        error,
+                    ),
+                )
+            for item in reset_items:
+                if cursor >= len(history):
+                    item.status = "not_attempted"
+                    item.message = error
+                    continue
+                response, result = history[cursor]
+                cursor += 1
+                self._apply_outcomes(
+                    [item],
+                    self._classify_response([item.target], response, result, error),
+                )
+            self._errors.append(error)
+            return False
+        for item in [*normalize_items, *reset_items]:
+            item.status = "succeeded"
+        return True
+
+    def _execute_updates(self, plan: InterfaceWorkflowPlan) -> bool:
+        for resource in plan.resources:
+            for model in resource.operations.updates:
+                item = self._item(resource, "update", model)
+                if not self._call_items(
+                    resource.orchestrator,
+                    [item],
+                    lambda resource=resource, model=model: resource.orchestrator.update(
+                        model
+                    ),
+                    f"resources[{resource.resource_index}] {resource.resource_type} update failed",
+                ):
+                    return False
+        return True
+
+    def _execute_creates(self, plan: InterfaceWorkflowPlan) -> bool:
+        for resource in plan.resources:
+            models = list(resource.operations.creates)
+            if not models:
+                continue
+            if resource.orchestrator.supports_bulk_create:
+                groups: dict[str, list[NDBaseModel]] = defaultdict(list)
+                for model in models:
+                    groups[self._model_target(resource, model)[1]].append(model)
+                for switch_id, group in groups.items():
+                    items = [self._item(resource, "create", model) for model in group]
+                    if not self._call_items(
+                        resource.orchestrator,
+                        items,
+                        lambda resource=resource, group=group: resource.orchestrator.create_bulk(
+                            group
+                        ),
+                        f"resources[{resource.resource_index}] {resource.resource_type} bulk create failed on {switch_id}",
+                    ):
+                        return False
+                continue
+            for model in models:
+                item = self._item(resource, "create", model)
+                if not self._call_items(
+                    resource.orchestrator,
+                    [item],
+                    lambda resource=resource, model=model: resource.orchestrator.create(
+                        model
+                    ),
+                    f"resources[{resource.resource_index}] {resource.resource_type} create failed",
+                ):
+                    return False
+        return True
+
+    def _deploy_pending(self, plan: InterfaceWorkflowPlan) -> bool:
+        targets = tuple(
+            dict.fromkeys(
+                pair
+                for resource in plan.resources
+                for pair in resource.orchestrator.pending_deploys
+            )
+        )
+        self._deployment = {
+            "requested": self.deploy,
+            "status": (
+                "not_needed"
+                if not targets
+                else ("disabled" if not self.deploy else "pending")
+            ),
+            "targets": [
+                {
+                    "interface_name": interface_name,
+                    "switch_id": switch_id,
+                    "status": "not_attempted",
+                }
+                for interface_name, switch_id in targets
+            ],
+        }
+        if not targets or not self.deploy:
+            return True
+        target = plan.resources[0].orchestrator
+        target.deploy = True
+        target.queue_deploy_targets(targets)
+        response_start = len(target.rest_send.responses)
+        result_start = len(target.rest_send.results)
+        try:
+            target.deploy_pending()
+        except Exception as exc:  # pylint: disable=broad-except
+            error = f"Consolidated interface deployment failed: {exc}"
+            history = self._write_history(
+                target.rest_send, response_start, result_start
+            )
+            response, result = history[-1] if history else ({}, {})
+            outcomes = self._classify_response(targets, response, result, error)
+            for entry in self._deployment["targets"]:
+                status, message = outcomes[
+                    (entry["interface_name"], entry["switch_id"])
+                ]
+                entry["status"] = status
+                if message:
+                    entry["message"] = message
+            statuses = {entry["status"] for entry in self._deployment["targets"]}
+            self._deployment["status"] = (
+                "partial_failure"
+                if "succeeded" in statuses or "uncertain" in statuses
+                else "failed"
+            )
+            self._deployment["message"] = error
+            self._errors.append(error)
+            return False
+        for entry in self._deployment["targets"]:
+            entry["status"] = "succeeded"
+        self._deployment["status"] = "succeeded"
+        return True
+
+    @staticmethod
+    def _write_observations(plan: InterfaceWorkflowPlan) -> tuple[int, int, bool]:
+        mutation_requests = 0
+        deploy_requests = 0
+        mutation_changed = False
+        seen: set[int] = set()
+        for resource in plan.resources:
+            rest_send = resource.orchestrator.rest_send
+            if id(rest_send) in seen:
+                continue
+            seen.add(id(rest_send))
+            for response, result in zip(rest_send.responses, rest_send.results):
+                method = str(response.get("METHOD") or "").upper()
+                if method == "GET" or method.endswith(".GET"):
+                    continue
+                path = str(response.get("REQUEST_PATH") or "")
+                if "interfaceActions/deploy" in path:
+                    deploy_requests += 1
+                else:
+                    mutation_requests += 1
+                    mutation_changed = mutation_changed or result.get("changed") is True
+        return mutation_requests, deploy_requests, mutation_changed
+
+    def _reconcile(
+        self, plan: InterfaceWorkflowPlan, *, wrote: bool
+    ) -> dict[int, NDConfigCollection]:
+        if wrote:
+            try:
+                self.snapshot.mark_dirty(plan.target_switch_ids)
+                self.snapshot.refresh(plan.target_switch_ids)
+            except Exception as exc:  # pylint: disable=broad-except
+                self._errors.append(
+                    f"Post-mutation interface snapshot refresh failed: {exc}"
+                )
+                return {}
+        actual: dict[int, NDConfigCollection] = {}
+        try:
+            for resource in plan.resources:
+                actual[resource.resource_index] = resource.adapter.existing_collection(
+                    resource.orchestrator
+                )
+        except Exception as exc:  # pylint: disable=broad-except
+            self._errors.append(f"Post-mutation actual-state selection failed: {exc}")
+            return {}
+        return actual
+
+    def execute(self, plan: InterfaceWorkflowPlan) -> InterfaceWorkflowExecution:
+        """Execute delete, update, create, and deploy phases, then refetch actual state."""
+        self._build_items(plan)
+        phases_ok = self._enable_writes_and_preflight(plan)
+        if phases_ok:
+            phases_ok = self._queue_deletes(plan)
+        if phases_ok:
+            phases_ok = self._flush_base_removes(plan)
+        if phases_ok:
+            phases_ok = self._flush_ethernet_removes(plan)
+        if phases_ok:
+            phases_ok = self._execute_updates(plan)
+        if phases_ok:
+            phases_ok = self._execute_creates(plan)
+        if phases_ok:
+            phases_ok = self._deploy_pending(plan)
+
+        mutation_requests, deploy_requests, mutation_changed = self._write_observations(
+            plan
+        )
+        actual = self._reconcile(plan, wrote=bool(mutation_requests))
+        actual_changed = any(
+            resource.before.get_diff_collection(actual[resource.resource_index])
+            for resource in plan.resources
+            if resource.resource_index in actual
+        )
+        failed = not phases_ok or bool(self._errors)
+        changed = mutation_changed or actual_changed
+        if failed:
+            item_statuses = {item.status for item in self._items}
+            status = (
+                "partial_failure"
+                if changed or item_statuses & {"succeeded", "uncertain"}
+                else "failed"
+            )
+        elif self.deploy:
+            status = "completed"
+        else:
+            status = "staged"
+        return InterfaceWorkflowExecution(
+            status=status,
+            changed=changed,
+            failed=failed,
+            items=tuple(self._items),
+            mutation_requests=mutation_requests,
+            deploy_requests=deploy_requests,
+            affected_switch_ids=plan.target_switch_ids if mutation_requests else (),
+            deployment=self._deployment,
+            errors=tuple(self._errors),
+            actual_after_by_resource=actual,
+        )

--- a/plugins/module_utils/interface_workflow_executor.py
+++ b/plugins/module_utils/interface_workflow_executor.py
@@ -112,9 +112,16 @@ class InterfaceWorkflowExecution:
 class InterfaceWorkflowExecutor:
     """Execute one precomputed plan using the current develop orchestrators."""
 
-    def __init__(self, *, snapshot: InterfaceStateSnapshot, deploy: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        snapshot: InterfaceStateSnapshot,
+        deploy: bool = False,
+        verify: bool = False,
+    ) -> None:
         self.snapshot = snapshot
         self.deploy = deploy
+        self.verify = verify
         self._items: list[InterfaceExecutionItem] = []
         self._item_by_key: dict[tuple[int, str, Any], InterfaceExecutionItem] = {}
         self._errors: list[str] = []
@@ -606,8 +613,17 @@ class InterfaceWorkflowExecutor:
                     mutation_changed = mutation_changed or result.get("changed") is True
         return mutation_requests, deploy_requests, mutation_changed
 
-    def _reconcile(self, plan: InterfaceWorkflowPlan, *, wrote: bool) -> dict[int, NDConfigCollection]:
-        if wrote:
+    def _reconcile(
+        self,
+        plan: InterfaceWorkflowPlan,
+        *,
+        mutation_attempted: bool,
+        force_after_write: bool,
+    ) -> dict[int, NDConfigCollection]:
+        """Return observed state, skipping successful post-write refresh when verification is disabled."""
+        if mutation_attempted and not (self.verify or force_after_write):
+            return {}
+        if mutation_attempted:
             try:
                 self.snapshot.mark_dirty(plan.target_switch_ids)
                 self.snapshot.refresh(plan.target_switch_ids)
@@ -658,13 +674,20 @@ class InterfaceWorkflowExecutor:
             phases_ok = self._deploy_pending(plan, deployment_targets)
 
         mutation_requests, deploy_requests, mutation_changed = self._write_observations(plan)
-        actual = self._reconcile(plan, wrote=bool(mutation_requests))
+        execution_failed = not phases_ok or bool(self._errors)
+        mutation_attempted = bool(mutation_requests) or any(item.status in {"succeeded", "failed", "uncertain"} for item in self._items)
+        actual = self._reconcile(
+            plan,
+            mutation_attempted=mutation_attempted,
+            force_after_write=execution_failed,
+        )
         actual_changed = any(
             resource.before.get_diff_collection(actual[resource.resource_index]) for resource in plan.resources if resource.resource_index in actual
         )
         failed = not phases_ok or bool(self._errors)
         deployment_changed = any(target["status"] in {"succeeded", "uncertain"} for target in self._deployment["targets"])
-        changed = mutation_changed or actual_changed or deployment_changed
+        exact_mutation_success = any(item.status == "succeeded" for item in self._items)
+        changed = mutation_changed or exact_mutation_success or actual_changed or deployment_changed
         if failed:
             item_statuses = {item.status for item in self._items}
             status = "partial_failure" if changed or item_statuses & {"succeeded", "uncertain"} else "failed"
@@ -679,7 +702,7 @@ class InterfaceWorkflowExecutor:
             items=tuple(self._items),
             mutation_requests=mutation_requests,
             deploy_requests=deploy_requests,
-            affected_switch_ids=plan.target_switch_ids if mutation_requests else (),
+            affected_switch_ids=plan.target_switch_ids if mutation_attempted else (),
             deployment=self._deployment,
             errors=tuple(self._errors),
             actual_after_by_resource=actual,

--- a/plugins/module_utils/interface_workflow_executor.py
+++ b/plugins/module_utils/interface_workflow_executor.py
@@ -82,18 +82,12 @@ class InterfaceWorkflowExecution:
     affected_switch_ids: tuple[str, ...]
     deployment: dict[str, Any]
     errors: tuple[str, ...] = ()
-    actual_after_by_resource: dict[int, NDConfigCollection] = field(
-        default_factory=dict, repr=False
-    )
+    actual_after_by_resource: dict[int, NDConfigCollection] = field(default_factory=dict, repr=False)
 
     @property
     def message(self) -> str:
         """Return one useful module failure summary."""
-        return (
-            "; ".join(self.errors)
-            if self.errors
-            else "Interface workflow execution failed."
-        )
+        return "; ".join(self.errors) if self.errors else "Interface workflow execution failed."
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize execution details while keeping model collections internal."""
@@ -111,9 +105,7 @@ class InterfaceWorkflowExecution:
 class InterfaceWorkflowExecutor:
     """Execute one precomputed plan using the current develop orchestrators."""
 
-    def __init__(
-        self, *, snapshot: InterfaceStateSnapshot, deploy: bool = True
-    ) -> None:
+    def __init__(self, *, snapshot: InterfaceStateSnapshot, deploy: bool = False) -> None:
         self.snapshot = snapshot
         self.deploy = deploy
         self._items: list[InterfaceExecutionItem] = []
@@ -127,9 +119,7 @@ class InterfaceWorkflowExecutor:
 
     @staticmethod
     def _model_target(resource: InterfaceResourcePlan, model: NDBaseModel) -> Target:
-        switch_id = resource.orchestrator.fabric_context.get_switch_id(
-            getattr(model, "switch_ip")
-        )
+        switch_id = resource.orchestrator.fabric_context.get_switch_id(getattr(model, "switch_ip"))
         return getattr(model, "interface_name"), switch_id
 
     def _build_items(self, plan: InterfaceWorkflowPlan) -> None:
@@ -150,21 +140,13 @@ class InterfaceWorkflowExecutor:
                         interface_name=interface_name,
                     )
                     self._items.append(item)
-                    self._item_by_key[
-                        (resource.resource_index, action, model.get_identifier_value())
-                    ] = item
+                    self._item_by_key[(resource.resource_index, action, model.get_identifier_value())] = item
 
-    def _item(
-        self, resource: InterfaceResourcePlan, action: str, model: NDBaseModel
-    ) -> InterfaceExecutionItem:
-        return self._item_by_key[
-            (resource.resource_index, action, model.get_identifier_value())
-        ]
+    def _item(self, resource: InterfaceResourcePlan, action: str, model: NDBaseModel) -> InterfaceExecutionItem:
+        return self._item_by_key[(resource.resource_index, action, model.get_identifier_value())]
 
     @staticmethod
-    def _write_history(
-        rest_send, response_start: int, result_start: int
-    ) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    def _write_history(rest_send, response_start: int, result_start: int) -> list[tuple[dict[str, Any], dict[str, Any]]]:
         responses = rest_send.responses[response_start:]
         results = rest_send.results[result_start:]
         return list(zip(responses, results))
@@ -178,30 +160,18 @@ class InterfaceWorkflowExecutor:
         for key in _OUTCOME_KEYS:
             values = data.get(key)
             if isinstance(values, list):
-                outcomes.extend(
-                    value
-                    for value in values
-                    if isinstance(value, dict) and value.get("status") is not None
-                )
+                outcomes.extend(value for value in values if isinstance(value, dict) and value.get("status") is not None)
         return outcomes
 
     @staticmethod
-    def _outcome_target(
-        outcome: dict[str, Any], targets: Iterable[Target]
-    ) -> Target | None:
+    def _outcome_target(outcome: dict[str, Any], targets: Iterable[Target]) -> Target | None:
         name_value = outcome.get("interfaceName") or outcome.get("name")
         switch_value = outcome.get("switchId") or outcome.get("serialNumber")
         candidates = list(targets)
         if name_value is not None:
-            candidates = [
-                target
-                for target in candidates
-                if target[0].lower() == str(name_value).lower()
-            ]
+            candidates = [target for target in candidates if target[0].lower() == str(name_value).lower()]
         if switch_value is not None:
-            candidates = [
-                target for target in candidates if target[1] == str(switch_value)
-            ]
+            candidates = [target for target in candidates if target[1] == str(switch_value)]
         return candidates[0] if len(candidates) == 1 else None
 
     @classmethod
@@ -266,13 +236,9 @@ class InterfaceWorkflowExecutor:
             operation()
         except Exception as exc:  # pylint: disable=broad-except
             error = f"{context}: {exc}"
-            history = self._write_history(
-                orchestrator.rest_send, response_start, result_start
-            )
+            history = self._write_history(orchestrator.rest_send, response_start, result_start)
             response, result = history[-1] if history else ({}, {})
-            outcomes = self._classify_response(
-                (item.target for item in items), response, result, error
-            )
+            outcomes = self._classify_response((item.target for item in items), response, result, error)
             self._apply_outcomes(items, outcomes)
             self._errors.append(error)
             return False
@@ -311,18 +277,13 @@ class InterfaceWorkflowExecutor:
                 if not self._call_items(
                     orchestrator,
                     items,
-                    lambda orchestrator=orchestrator, models=models: orchestrator.delete_bulk(
-                        models
-                    ),
+                    lambda orchestrator=orchestrator, models=models: orchestrator.delete_bulk(models),
                     f"resources[{resource.resource_index}] {resource.resource_type} delete preparation failed",
                 ):
                     return False
                 for item in items:
                     if isinstance(orchestrator, EthernetBaseOrchestrator):
-                        queued = (
-                            item.target in orchestrator.pending_normalizes
-                            or item.target in orchestrator.pending_resets
-                        )
+                        queued = item.target in orchestrator.pending_normalizes or item.target in orchestrator.pending_resets
                     else:
                         queued = item.target in orchestrator.pending_removes
                     if queued:
@@ -336,9 +297,7 @@ class InterfaceWorkflowExecutor:
                 if not self._call_items(
                     orchestrator,
                     [item],
-                    lambda orchestrator=orchestrator, model=model: orchestrator.delete(
-                        model
-                    ),
+                    lambda orchestrator=orchestrator, model=model: orchestrator.delete(model),
                     f"resources[{resource.resource_index}] {resource.resource_type} delete failed",
                 ):
                     return False
@@ -348,23 +307,14 @@ class InterfaceWorkflowExecutor:
         sources = [
             resource.orchestrator
             for resource in plan.resources
-            if not isinstance(resource.orchestrator, EthernetBaseOrchestrator)
-            and resource.orchestrator.pending_removes
+            if not isinstance(resource.orchestrator, EthernetBaseOrchestrator) and resource.orchestrator.pending_removes
         ]
         if not sources:
             return True
         target = sources[0]
-        targets = tuple(
-            dict.fromkeys(pair for source in sources for pair in source.pending_removes)
-        )
+        targets = tuple(dict.fromkeys(pair for source in sources for pair in source.pending_removes))
         target.queue_remove_targets(targets)
-        items = [
-            item
-            for item in self._items
-            if item.action == "delete"
-            and item.status == "queued"
-            and item.target in targets
-        ]
+        items = [item for item in self._items if item.action == "delete" and item.status == "queued" and item.target in targets]
         return self._call_items(
             target,
             items,
@@ -373,42 +323,16 @@ class InterfaceWorkflowExecutor:
         )
 
     def _flush_ethernet_removes(self, plan: InterfaceWorkflowPlan) -> bool:
-        sources = [
-            resource.orchestrator
-            for resource in plan.resources
-            if isinstance(resource.orchestrator, EthernetBaseOrchestrator)
-        ]
-        normalizes = tuple(
-            dict.fromkeys(
-                pair for source in sources for pair in source.pending_normalizes
-            )
-        )
-        resets = tuple(
-            dict.fromkeys(pair for source in sources for pair in source.pending_resets)
-        )
+        sources = [resource.orchestrator for resource in plan.resources if isinstance(resource.orchestrator, EthernetBaseOrchestrator)]
+        normalizes = tuple(dict.fromkeys(pair for source in sources for pair in source.pending_normalizes))
+        resets = tuple(dict.fromkeys(pair for source in sources for pair in source.pending_resets))
         if not normalizes and not resets:
             return True
-        target = next(
-            source
-            for source in sources
-            if source.pending_normalizes or source.pending_resets
-        )
+        target = next(source for source in sources if source.pending_normalizes or source.pending_resets)
         target.queue_normalize_targets(normalizes)
         target.queue_reset_targets(resets)
-        normalize_items = [
-            item
-            for item in self._items
-            if item.action == "delete"
-            and item.status == "queued"
-            and item.target in normalizes
-        ]
-        reset_items = [
-            item
-            for item in self._items
-            if item.action == "delete"
-            and item.status == "queued"
-            and item.target in resets
-        ]
+        normalize_items = [item for item in self._items if item.action == "delete" and item.status == "queued" and item.target in normalizes]
+        reset_items = [item for item in self._items if item.action == "delete" and item.status == "queued" and item.target in resets]
 
         response_start = len(target.rest_send.responses)
         result_start = len(target.rest_send.results)
@@ -416,14 +340,10 @@ class InterfaceWorkflowExecutor:
             target.remove_pending()
         except Exception as exc:  # pylint: disable=broad-except
             error = f"Consolidated Ethernet normalization/reset failed: {exc}"
-            history = self._write_history(
-                target.rest_send, response_start, result_start
-            )
+            history = self._write_history(target.rest_send, response_start, result_start)
             cursor = 0
             if normalize_items:
-                response, result = (
-                    history[cursor] if cursor < len(history) else ({}, {})
-                )
+                response, result = history[cursor] if cursor < len(history) else ({}, {})
                 cursor += 1 if cursor < len(history) else 0
                 self._apply_outcomes(
                     normalize_items,
@@ -458,9 +378,7 @@ class InterfaceWorkflowExecutor:
                 if not self._call_items(
                     resource.orchestrator,
                     [item],
-                    lambda resource=resource, model=model: resource.orchestrator.update(
-                        model
-                    ),
+                    lambda resource=resource, model=model: resource.orchestrator.update(model),
                     f"resources[{resource.resource_index}] {resource.resource_type} update failed",
                 ):
                     return False
@@ -480,9 +398,7 @@ class InterfaceWorkflowExecutor:
                     if not self._call_items(
                         resource.orchestrator,
                         items,
-                        lambda resource=resource, group=group: resource.orchestrator.create_bulk(
-                            group
-                        ),
+                        lambda resource=resource, group=group: resource.orchestrator.create_bulk(group),
                         f"resources[{resource.resource_index}] {resource.resource_type} bulk create failed on {switch_id}",
                     ):
                         return False
@@ -492,29 +408,17 @@ class InterfaceWorkflowExecutor:
                 if not self._call_items(
                     resource.orchestrator,
                     [item],
-                    lambda resource=resource, model=model: resource.orchestrator.create(
-                        model
-                    ),
+                    lambda resource=resource, model=model: resource.orchestrator.create(model),
                     f"resources[{resource.resource_index}] {resource.resource_type} create failed",
                 ):
                     return False
         return True
 
     def _deploy_pending(self, plan: InterfaceWorkflowPlan) -> bool:
-        targets = tuple(
-            dict.fromkeys(
-                pair
-                for resource in plan.resources
-                for pair in resource.orchestrator.pending_deploys
-            )
-        )
+        targets = tuple(dict.fromkeys(pair for resource in plan.resources for pair in resource.orchestrator.pending_deploys))
         self._deployment = {
             "requested": self.deploy,
-            "status": (
-                "not_needed"
-                if not targets
-                else ("disabled" if not self.deploy else "pending")
-            ),
+            "status": ("not_needed" if not targets else ("disabled" if not self.deploy else "pending")),
             "targets": [
                 {
                     "interface_name": interface_name,
@@ -535,24 +439,16 @@ class InterfaceWorkflowExecutor:
             target.deploy_pending()
         except Exception as exc:  # pylint: disable=broad-except
             error = f"Consolidated interface deployment failed: {exc}"
-            history = self._write_history(
-                target.rest_send, response_start, result_start
-            )
+            history = self._write_history(target.rest_send, response_start, result_start)
             response, result = history[-1] if history else ({}, {})
             outcomes = self._classify_response(targets, response, result, error)
             for entry in self._deployment["targets"]:
-                status, message = outcomes[
-                    (entry["interface_name"], entry["switch_id"])
-                ]
+                status, message = outcomes[(entry["interface_name"], entry["switch_id"])]
                 entry["status"] = status
                 if message:
                     entry["message"] = message
             statuses = {entry["status"] for entry in self._deployment["targets"]}
-            self._deployment["status"] = (
-                "partial_failure"
-                if "succeeded" in statuses or "uncertain" in statuses
-                else "failed"
-            )
+            self._deployment["status"] = "partial_failure" if "succeeded" in statuses or "uncertain" in statuses else "failed"
             self._deployment["message"] = error
             self._errors.append(error)
             return False
@@ -584,24 +480,18 @@ class InterfaceWorkflowExecutor:
                     mutation_changed = mutation_changed or result.get("changed") is True
         return mutation_requests, deploy_requests, mutation_changed
 
-    def _reconcile(
-        self, plan: InterfaceWorkflowPlan, *, wrote: bool
-    ) -> dict[int, NDConfigCollection]:
+    def _reconcile(self, plan: InterfaceWorkflowPlan, *, wrote: bool) -> dict[int, NDConfigCollection]:
         if wrote:
             try:
                 self.snapshot.mark_dirty(plan.target_switch_ids)
                 self.snapshot.refresh(plan.target_switch_ids)
             except Exception as exc:  # pylint: disable=broad-except
-                self._errors.append(
-                    f"Post-mutation interface snapshot refresh failed: {exc}"
-                )
+                self._errors.append(f"Post-mutation interface snapshot refresh failed: {exc}")
                 return {}
         actual: dict[int, NDConfigCollection] = {}
         try:
             for resource in plan.resources:
-                actual[resource.resource_index] = resource.adapter.existing_collection(
-                    resource.orchestrator
-                )
+                actual[resource.resource_index] = resource.adapter.existing_collection(resource.orchestrator)
         except Exception as exc:  # pylint: disable=broad-except
             self._errors.append(f"Post-mutation actual-state selection failed: {exc}")
             return {}
@@ -624,24 +514,16 @@ class InterfaceWorkflowExecutor:
         if phases_ok:
             phases_ok = self._deploy_pending(plan)
 
-        mutation_requests, deploy_requests, mutation_changed = self._write_observations(
-            plan
-        )
+        mutation_requests, deploy_requests, mutation_changed = self._write_observations(plan)
         actual = self._reconcile(plan, wrote=bool(mutation_requests))
         actual_changed = any(
-            resource.before.get_diff_collection(actual[resource.resource_index])
-            for resource in plan.resources
-            if resource.resource_index in actual
+            resource.before.get_diff_collection(actual[resource.resource_index]) for resource in plan.resources if resource.resource_index in actual
         )
         failed = not phases_ok or bool(self._errors)
         changed = mutation_changed or actual_changed
         if failed:
             item_statuses = {item.status for item in self._items}
-            status = (
-                "partial_failure"
-                if changed or item_statuses & {"succeeded", "uncertain"}
-                else "failed"
-            )
+            status = "partial_failure" if changed or item_statuses & {"succeeded", "uncertain"} else "failed"
         elif self.deploy:
             status = "completed"
         else:

--- a/plugins/module_utils/interface_workflow_executor.py
+++ b/plugins/module_utils/interface_workflow_executor.py
@@ -16,6 +16,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot 
 from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planner import (
     InterfaceResourcePlan,
     InterfaceWorkflowPlan,
+    InterfaceWorkflowPlanner,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import (
@@ -290,6 +291,9 @@ class InterfaceWorkflowExecutor:
             if plan.resources:
                 plan.resources[0].orchestrator.validate_prerequisites()
             for resource in plan.resources:
+                has_mutations = bool(resource.transitions or resource.operations.deletes or resource.operations.updates or resource.operations.creates)
+                if not has_mutations:
+                    continue
                 if resource.state == "deleted":
                     continue
                 create_candidates = [*resource.operations.creates, *(transition.desired for transition in resource.transitions)]
@@ -413,9 +417,7 @@ class InterfaceWorkflowExecutor:
                 if not self._call_items(
                     resource.orchestrator,
                     [item],
-                    lambda resource=resource, transition=transition: resource.orchestrator.update(
-                        transition.desired, existing_data=transition.current
-                    ),
+                    lambda resource=resource, transition=transition: resource.orchestrator.update(transition.desired, existing_data=transition.current),
                     f"resources[{resource.resource_index}] {resource.resource_type} policy transition failed",
                 ):
                     return False
@@ -464,8 +466,13 @@ class InterfaceWorkflowExecutor:
                     return False
         return True
 
-    def _deploy_pending(self, plan: InterfaceWorkflowPlan) -> bool:
-        targets = tuple(dict.fromkeys(pair for resource in plan.resources for pair in resource.orchestrator.pending_deploys))
+    def _deploy_pending(
+        self,
+        plan: InterfaceWorkflowPlan,
+        supplemental_targets: Iterable[Target] = (),
+    ) -> bool:
+        mutation_targets = (pair for resource in plan.resources for pair in resource.orchestrator.pending_deploys)
+        targets = tuple(dict.fromkeys((*mutation_targets, *supplemental_targets)))
         self._deployment = {
             "requested": self.deploy,
             "status": ("not_needed" if not targets else ("disabled" if not self.deploy else "pending")),
@@ -539,16 +546,31 @@ class InterfaceWorkflowExecutor:
                 self._errors.append(f"Post-mutation interface snapshot refresh failed: {exc}")
                 return {}
         actual: dict[int, NDConfigCollection] = {}
+        vpc_inventory = None
         try:
             for resource in plan.resources:
-                actual[resource.resource_index] = resource.adapter.existing_collection(resource.orchestrator)
+                if resource.adapter.ownership_domain != "vpc":
+                    actual[resource.resource_index] = resource.adapter.existing_collection(resource.orchestrator)
+                    continue
+                if vpc_inventory is None:
+                    vpc_inventory = self.snapshot.interfaces_by_identity
+                actual[resource.resource_index] = InterfaceWorkflowPlanner.pair_scoped_vpc_collection(
+                    inventory=vpc_inventory,
+                    adapter=resource.adapter,
+                    orchestrator=resource.orchestrator,
+                    proposed=resource.proposed,
+                )
         except Exception as exc:  # pylint: disable=broad-except
             self._errors.append(f"Post-mutation actual-state selection failed: {exc}")
             return {}
         return actual
 
-    def execute(self, plan: InterfaceWorkflowPlan) -> InterfaceWorkflowExecution:
-        """Execute delete, transition, update, create, and deploy phases, then refetch actual state."""
+    def execute(
+        self,
+        plan: InterfaceWorkflowPlan,
+        deployment_targets: Iterable[Target] = (),
+    ) -> InterfaceWorkflowExecution:
+        """Execute mutation and exact-target deployment phases, then reconcile intended state."""
         self._build_items(plan)
         phases_ok = self._enable_writes_and_preflight(plan)
         if phases_ok:
@@ -564,7 +586,7 @@ class InterfaceWorkflowExecutor:
         if phases_ok:
             phases_ok = self._execute_creates(plan)
         if phases_ok:
-            phases_ok = self._deploy_pending(plan)
+            phases_ok = self._deploy_pending(plan, deployment_targets)
 
         mutation_requests, deploy_requests, mutation_changed = self._write_observations(plan)
         actual = self._reconcile(plan, wrote=bool(mutation_requests))
@@ -572,7 +594,8 @@ class InterfaceWorkflowExecutor:
             resource.before.get_diff_collection(actual[resource.resource_index]) for resource in plan.resources if resource.resource_index in actual
         )
         failed = not phases_ok or bool(self._errors)
-        changed = mutation_changed or actual_changed
+        deployment_changed = any(target["status"] in {"succeeded", "uncertain"} for target in self._deployment["targets"])
+        changed = mutation_changed or actual_changed or deployment_changed
         if failed:
             item_statuses = {item.status for item in self._items}
             status = "partial_failure" if changed or item_statuses & {"succeeded", "uncertain"} else "failed"

--- a/plugins/module_utils/interface_workflow_executor.py
+++ b/plugins/module_utils/interface_workflow_executor.py
@@ -23,6 +23,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection impo
     NDConfigCollection,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
+    DeferredDeleteRequestGroup,
     NDBaseInterfaceOrchestrator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import (
@@ -130,6 +131,30 @@ class InterfaceWorkflowExecutor:
             "status": "not_attempted",
             "targets": [],
         }
+
+    @staticmethod
+    def _all_orchestrators(plan: InterfaceWorkflowPlan) -> tuple[NDBaseInterfaceOrchestrator, ...]:
+        """Return resource and auxiliary orchestrators once, preserving construction order."""
+        values = [resource.orchestrator for resource in plan.resources]
+        values.extend(getattr(plan, "auxiliary_orchestrators", ()))
+        unique: list[NDBaseInterfaceOrchestrator] = []
+        seen: set[int] = set()
+        for orchestrator in values:
+            if id(orchestrator) in seen:
+                continue
+            seen.add(id(orchestrator))
+            unique.append(orchestrator)
+        return tuple(unique)
+
+    @staticmethod
+    def _routed_delete_orchestrator(plan: InterfaceWorkflowPlan) -> NDBaseInterfaceOrchestrator | None:
+        """Return the planner-selected orchestrator that accepts platform-specific reset work."""
+        candidates = [*getattr(plan, "auxiliary_orchestrators", ())]
+        candidates.extend(resource.orchestrator for resource in plan.resources)
+        return next(
+            (orchestrator for orchestrator in candidates if "platform_reset" in orchestrator.deferred_delete_queue_names),
+            None,
+        )
 
     @staticmethod
     def _model_target(resource: InterfaceResourcePlan, model: NDBaseModel) -> Target:
@@ -322,12 +347,12 @@ class InterfaceWorkflowExecutor:
         return True
 
     def _enable_writes_and_preflight(self, plan: InterfaceWorkflowPlan) -> bool:
-        for resource in plan.resources:
-            resource.orchestrator.rest_send.check_mode = False
-            resource.orchestrator.rest_send.params["check_mode"] = False
-            resource.orchestrator.deploy = False
-            if resource.orchestrator.results is not None:
-                resource.orchestrator.results.check_mode = False
+        for orchestrator in self._all_orchestrators(plan):
+            orchestrator.rest_send.check_mode = False
+            orchestrator.rest_send.params["check_mode"] = False
+            orchestrator.deploy = False
+            if orchestrator.results is not None:
+                orchestrator.results.check_mode = False
         try:
             if plan.resources:
                 plan.resources[0].orchestrator.validate_prerequisites()
@@ -336,6 +361,12 @@ class InterfaceWorkflowExecutor:
                 if not has_mutations:
                     continue
                 if resource.state == "deleted":
+                    resource.orchestrator.preflight_delete(list(resource.operations.deletes))
+                    if resource.platform_deletes:
+                        routed_orchestrator = self._routed_delete_orchestrator(plan)
+                        if routed_orchestrator is None:
+                            raise RuntimeError("Platform-specific physical deletes were planned without a routed reset orchestrator.")
+                        routed_orchestrator.preflight_delete(list(resource.platform_deletes))
                     continue
                 create_candidates = [*resource.operations.creates, *(transition.desired for transition in resource.transitions)]
                 resource.orchestrator.preflight_create(create_candidates)
@@ -345,123 +376,166 @@ class InterfaceWorkflowExecutor:
             return False
         return True
 
+    def _queue_delete_batch(
+        self,
+        resource: InterfaceResourcePlan,
+        orchestrator: NDBaseInterfaceOrchestrator,
+        models: list[NDBaseModel],
+    ) -> bool:
+        """Queue one model batch and mark only targets accepted into the orchestrator's deferred contract."""
+        if not models:
+            return True
+        items = [self._item(resource, "delete", model) for model in models]
+        if orchestrator.supports_bulk_delete:
+            if not self._call_items(
+                orchestrator,
+                items,
+                lambda: orchestrator.delete_bulk(models),
+                f"resources[{resource.resource_index}] {resource.resource_type} delete preparation failed",
+            ):
+                return False
+            pending = set(orchestrator.pending_deferred_delete_targets)
+            for item in items:
+                if item.target in pending:
+                    item.status = "queued"
+                else:
+                    item.status = "skipped"
+                    item.message = "The develop orchestrator intentionally skipped this deletion."
+            return True
+
+        for model, item in zip(models, items):
+            if not self._call_items(
+                orchestrator,
+                [item],
+                lambda model=model: orchestrator.delete(model),
+                f"resources[{resource.resource_index}] {resource.resource_type} delete failed",
+            ):
+                return False
+        return True
+
     def _queue_deletes(self, plan: InterfaceWorkflowPlan) -> bool:
         for resource in plan.resources:
             models = list(resource.operations.deletes)
             if not models:
                 continue
-            orchestrator = resource.orchestrator
-            items = [self._item(resource, "delete", model) for model in models]
-            if orchestrator.supports_bulk_delete:
-                if not self._call_items(
-                    orchestrator,
-                    items,
-                    lambda orchestrator=orchestrator, models=models: orchestrator.delete_bulk(models),
-                    f"resources[{resource.resource_index}] {resource.resource_type} delete preparation failed",
-                ):
-                    return False
-                for item in items:
-                    if isinstance(orchestrator, EthernetBaseOrchestrator):
-                        queued = item.target in orchestrator.pending_normalizes or item.target in orchestrator.pending_resets
-                    else:
-                        queued = item.target in orchestrator.pending_removes
-                    if queued:
-                        item.status = "queued"
-                    else:
-                        item.status = "skipped"
-                        item.message = "The develop orchestrator intentionally skipped this deletion."
+            platform_by_identifier = {model.get_identifier_value(): model for model in getattr(resource, "platform_deletes", ())}
+            ordinary = [model for model in models if model.get_identifier_value() not in platform_by_identifier]
+            if not self._queue_delete_batch(resource, resource.orchestrator, ordinary):
+                return False
+            if not platform_by_identifier:
                 continue
-
-            for model, item in zip(models, items):
-                if not self._call_items(
-                    orchestrator,
-                    [item],
-                    lambda orchestrator=orchestrator, model=model: orchestrator.delete(model),
-                    f"resources[{resource.resource_index}] {resource.resource_type} delete failed",
-                ):
-                    return False
+            routed_orchestrator = self._routed_delete_orchestrator(plan)
+            if routed_orchestrator is None:
+                self._errors.append(
+                    f"resources[{resource.resource_index}] {resource.resource_type} platform-specific delete has no routed reset orchestrator."
+                )
+                return False
+            if not self._queue_delete_batch(resource, routed_orchestrator, list(platform_by_identifier.values())):
+                return False
         return True
 
-    def _flush_base_removes(self, plan: InterfaceWorkflowPlan) -> bool:
-        sources = [
-            resource.orchestrator
-            for resource in plan.resources
-            if not isinstance(resource.orchestrator, EthernetBaseOrchestrator) and resource.orchestrator.pending_removes
-        ]
-        if not sources:
-            return True
-        target = sources[0]
-        targets = tuple(dict.fromkeys(pair for source in sources for pair in source.pending_removes))
-        target.queue_remove_targets(targets)
-        items = [item for item in self._items if item.action == "delete" and item.status == "queued" and item.target in targets]
-        return self._call_items(
-            target,
-            items,
-            target.remove_pending,
-            "Consolidated interface removal failed",
-        )
+    def _apply_deferred_history(
+        self,
+        groups: tuple[DeferredDeleteRequestGroup, ...],
+        history: list[tuple[dict[str, Any], dict[str, Any]]],
+        error: str,
+        *,
+        raised: bool,
+    ) -> bool:
+        """Apply each response only to the exact deferred request group that produced it."""
+        success = not raised
+        failure_located = False
+        for index, group in enumerate(groups):
+            items = [item for item in self._items if item.action == "delete" and item.status == "queued" and item.target in group.targets]
+            if not items:
+                continue
+            if index < len(history):
+                response, result = history[index]
+                if result.get("success") is True:
+                    group_ok = self._apply_success_response(items, response, result, error)
+                else:
+                    self._apply_outcomes(
+                        items,
+                        self._classify_response((item.target for item in items), response, result, error),
+                    )
+                    group_ok = False
+                if not group_ok:
+                    success = False
+                    failure_located = True
+                continue
+            if raised and not failure_located:
+                for item in items:
+                    item.status = "failed"
+                    item.message = error
+                failure_located = True
+                success = False
+                continue
+            for item in items:
+                item.status = "not_attempted"
+                item.message = error
+            success = False
+        return success
 
-    def _flush_ethernet_removes(self, plan: InterfaceWorkflowPlan) -> bool:
-        sources = [resource.orchestrator for resource in plan.resources if isinstance(resource.orchestrator, EthernetBaseOrchestrator)]
-        normalizes = tuple(dict.fromkeys(pair for source in sources for pair in source.pending_normalizes))
-        resets = tuple(dict.fromkeys(pair for source in sources for pair in source.pending_resets))
-        if not normalizes and not resets:
+    def _transfer_and_flush_deletes(
+        self,
+        sources: list[NDBaseInterfaceOrchestrator],
+        context: str,
+    ) -> bool:
+        """Consolidate compatible deferred queues, flush once, and correlate every request boundary."""
+        source_queues: list[tuple[NDBaseInterfaceOrchestrator, dict[str, tuple[Target, ...]]]] = []
+        queues: dict[str, tuple[Target, ...]] = {}
+        for source in sources:
+            local = {queue_name: targets for queue_name, targets in source.deferred_delete_queues.items() if targets}
+            source_queues.append((source, local))
+            for queue_name, targets in local.items():
+                queues[queue_name] = tuple(dict.fromkeys((*queues.get(queue_name, ()), *targets)))
+        if not queues:
             return True
-        target = next(source for source in sources if source.pending_normalizes or source.pending_resets)
-        target.queue_normalize_targets(normalizes)
-        target.queue_reset_targets(resets)
-        normalize_items = [item for item in self._items if item.action == "delete" and item.status == "queued" and item.target in normalizes]
-        reset_items = [item for item in self._items if item.action == "delete" and item.status == "queued" and item.target in resets]
-
+        required = frozenset(queues)
+        target = next((source for source in sources if required.issubset(source.deferred_delete_queue_names)), None)
+        if target is None:
+            self._errors.append(f"{context}: no orchestrator accepts deferred queues {sorted(required)}.")
+            return False
+        for queue_name, targets in queues.items():
+            target.queue_deferred_delete_targets(queue_name, targets)
+        for source, local in source_queues:
+            if source is target:
+                continue
+            for queue_name, targets in local.items():
+                source.dequeue_deferred_delete_targets(queue_name, targets)
+        groups = target.deferred_delete_request_groups()
         response_start = len(target.rest_send.responses)
         result_start = len(target.rest_send.results)
         try:
             target.remove_pending()
         except Exception as exc:  # pylint: disable=broad-except
-            error = f"Consolidated Ethernet normalization/reset failed: {exc}"
+            error = f"{context}: {exc}"
             history = self._write_history(target.rest_send, response_start, result_start)
-            cursor = 0
-            if normalize_items:
-                response, result = history[cursor] if cursor < len(history) else ({}, {})
-                cursor += 1 if cursor < len(history) else 0
-                self._apply_outcomes(
-                    normalize_items,
-                    self._classify_response(
-                        (item.target for item in normalize_items),
-                        response,
-                        result,
-                        error,
-                    ),
-                )
-            for item in reset_items:
-                if cursor >= len(history):
-                    item.status = "not_attempted"
-                    item.message = error
-                    continue
-                response, result = history[cursor]
-                cursor += 1
-                self._apply_outcomes(
-                    [item],
-                    self._classify_response([item.target], response, result, error),
-                )
+            self._apply_deferred_history(groups, history, error, raised=True)
             self._errors.append(error)
             return False
         history = self._write_history(target.rest_send, response_start, result_start)
-        error = "Consolidated Ethernet normalization/reset failed: HTTP 207 response did not report exact success for every requested interface."
-        cursor = 0
-        success = True
-        if normalize_items:
-            response, result = history[cursor] if cursor < len(history) else ({}, {})
-            cursor += 1 if cursor < len(history) else 0
-            success = self._apply_success_response(normalize_items, response, result, error) and success
-        for item in reset_items:
-            response, result = history[cursor] if cursor < len(history) else ({}, {})
-            cursor += 1 if cursor < len(history) else 0
-            success = self._apply_success_response([item], response, result, error) and success
-        if not success:
+        error = f"{context}: controller responses did not report exact success for every requested interface."
+        if not self._apply_deferred_history(groups, history, error, raised=False):
             self._errors.append(error)
             return False
         return True
+
+    def _flush_base_removes(self, plan: InterfaceWorkflowPlan) -> bool:
+        sources = [
+            orchestrator
+            for orchestrator in self._all_orchestrators(plan)
+            if not isinstance(orchestrator, EthernetBaseOrchestrator) and orchestrator.pending_deferred_delete_targets
+        ]
+        return self._transfer_and_flush_deletes(sources, "Consolidated interface removal failed")
+
+    def _flush_ethernet_removes(self, plan: InterfaceWorkflowPlan) -> bool:
+        sources = [
+            orchestrator
+            for orchestrator in self._all_orchestrators(plan)
+            if isinstance(orchestrator, EthernetBaseOrchestrator) and orchestrator.pending_deferred_delete_targets
+        ]
+        return self._transfer_and_flush_deletes(sources, "Consolidated Ethernet normalization/reset failed")
 
     def _execute_transitions(self, plan: InterfaceWorkflowPlan) -> bool:
         """Replace approved foreign policies through destination-family PUTs."""
@@ -529,9 +603,12 @@ class InterfaceWorkflowExecutor:
         self,
         plan: InterfaceWorkflowPlan,
         supplemental_targets: Iterable[Target] = (),
+        mutation_targets: Iterable[Target] | None = None,
     ) -> bool:
-        mutation_targets = (pair for resource in plan.resources for pair in resource.orchestrator.pending_deploys)
-        targets = tuple(dict.fromkeys((*mutation_targets, *supplemental_targets)))
+        selected_mutations = (
+            (pair for orchestrator in self._all_orchestrators(plan) for pair in orchestrator.pending_deploys) if mutation_targets is None else mutation_targets
+        )
+        targets = tuple(dict.fromkeys((*selected_mutations, *supplemental_targets)))
         self._deployment = {
             "requested": self.deploy,
             "status": ("not_needed" if not targets else ("disabled" if not self.deploy else "pending")),
@@ -548,11 +625,10 @@ class InterfaceWorkflowExecutor:
             return True
         target = plan.resources[0].orchestrator
         target.deploy = True
-        target.queue_deploy_targets(targets)
         response_start = len(target.rest_send.responses)
         result_start = len(target.rest_send.results)
         try:
-            target.deploy_pending()
+            target.deploy_targets(targets)
         except Exception as exc:  # pylint: disable=broad-except
             error = f"Consolidated interface deployment failed: {exc}"
             history = self._write_history(target.rest_send, response_start, result_start)
@@ -566,6 +642,7 @@ class InterfaceWorkflowExecutor:
             statuses = {entry["status"] for entry in self._deployment["targets"]}
             self._deployment["status"] = "partial_failure" if "succeeded" in statuses or "uncertain" in statuses else "failed"
             self._deployment["message"] = error
+            self._dequeue_deployed_targets(plan)
             self._errors.append(error)
             return False
         history = self._write_history(target.rest_send, response_start, result_start)
@@ -582,13 +659,23 @@ class InterfaceWorkflowExecutor:
             if statuses != {"succeeded"}:
                 self._deployment["status"] = "partial_failure" if "succeeded" in statuses else "failed"
                 self._deployment["message"] = error
+                self._dequeue_deployed_targets(plan)
                 self._errors.append(error)
                 return False
         else:
             for entry in self._deployment["targets"]:
                 entry["status"] = "succeeded"
         self._deployment["status"] = "succeeded"
+        self._dequeue_deployed_targets(plan)
         return True
+
+    def _dequeue_deployed_targets(self, plan: InterfaceWorkflowPlan) -> None:
+        """Drain only targets backed by exact successful deployment evidence from every source queue."""
+        succeeded = {(entry["interface_name"], entry["switch_id"]) for entry in self._deployment["targets"] if entry["status"] == "succeeded"}
+        if not succeeded:
+            return
+        for orchestrator in self._all_orchestrators(plan):
+            orchestrator.dequeue_deploy_targets(succeeded)
 
     @staticmethod
     def _write_observations(plan: InterfaceWorkflowPlan) -> tuple[int, int, bool]:
@@ -596,8 +683,8 @@ class InterfaceWorkflowExecutor:
         deploy_requests = 0
         mutation_changed = False
         seen: set[int] = set()
-        for resource in plan.resources:
-            rest_send = resource.orchestrator.rest_send
+        for orchestrator in InterfaceWorkflowExecutor._all_orchestrators(plan):
+            rest_send = orchestrator.rest_send
             if id(rest_send) in seen:
                 continue
             seen.add(id(rest_send))
@@ -672,6 +759,10 @@ class InterfaceWorkflowExecutor:
             phases_ok = self._execute_creates(plan)
         if phases_ok:
             phases_ok = self._deploy_pending(plan, deployment_targets)
+        elif self.deploy:
+            accepted_targets = tuple(dict.fromkeys(item.target for item in self._items if item.status == "succeeded"))
+            if accepted_targets:
+                self._deploy_pending(plan, mutation_targets=accepted_targets)
 
         mutation_requests, deploy_requests, mutation_changed = self._write_observations(plan)
         execution_failed = not phases_ok or bool(self._errors)

--- a/plugins/module_utils/interface_workflow_planner.py
+++ b/plugins/module_utils/interface_workflow_planner.py
@@ -273,9 +273,7 @@ class InterfaceWorkflowPlanner:
             request_stats=self.snapshot.request_stats,
         )
 
-    def _validate_resource_groups(
-        self, resources: list[dict[str, Any]]
-    ) -> list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]:
+    def _validate_resource_groups(self, resources: list[dict[str, Any]]) -> list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]:
         """Validate group envelopes and delegate each config to its family adapter."""
         if not isinstance(resources, list):
             raise InterfaceWorkflowValidationError("resources must be a list.")
@@ -300,9 +298,7 @@ class InterfaceWorkflowPlanner:
             validated.append((resource_index, adapter, state, proposed))
         return validated
 
-    def _target_switch_ids(
-        self, validated: list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]
-    ) -> tuple[str, ...]:
+    def _target_switch_ids(self, validated: list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]) -> tuple[str, ...]:
         """Resolve the union of configured switches, expanding override to the fabric."""
         fabric_wide = any(state == "overridden" for _index, _adapter, state, _proposed in validated)
         switch_ids: list[str] = []
@@ -364,16 +360,6 @@ class InterfaceWorkflowPlanner:
             self._inventory_by_identity = self.snapshot.interfaces_by_identity
         return self._inventory_by_identity
 
-    def _vpc_pair_scopes_by_switch_id(self) -> dict[str, tuple[str, ...]]:
-        """Return authoritative pair scopes indexed by either member switch ID."""
-        scopes: dict[str, tuple[str, ...]] = {}
-        for switch_ip in self.vpc_pair_by_switch_ip:
-            scope = self._vpc_pair_scope(switch_ip)
-            if len(scope) == 2:
-                for switch_id in scope:
-                    scopes[switch_id] = scope
-        return scopes
-
     def _shared_vpc_peer_serial_cache(self) -> dict[str, str]:
         """Return one authoritative peer cache shared by all workflow vPC orchestrators."""
         if self._vpc_peer_serial_cache is None:
@@ -386,28 +372,33 @@ class InterfaceWorkflowPlanner:
             self._vpc_peer_serial_cache = cache
         return self._vpc_peer_serial_cache
 
-    def _existing_collection(
-        self,
+    @classmethod
+    def pair_scoped_vpc_collection(
+        cls,
+        *,
+        inventory: Mapping[tuple[str, str], dict[str, Any]],
         adapter: InterfaceFamilyAdapter,
         orchestrator: NDBaseInterfaceOrchestrator,
         proposed: NDConfigCollection,
     ) -> NDConfigCollection:
-        """Select pair-scoped vPC state without name-global query deduplication."""
-        if adapter.ownership_domain != "vpc":
-            return adapter.existing_collection(orchestrator)
+        """Select one stable representative per authoritative vPC pair and interface name."""
+        context = orchestrator.fabric_context
+        peer_by_switch = getattr(orchestrator, "_peer_serial_cache", {})
+        scopes_by_switch_id: dict[str, tuple[str, ...]] = {}
+        for switch_id, peer_id in peer_by_switch.items():
+            scope = tuple(sorted((switch_id, peer_id)))
+            scopes_by_switch_id[switch_id] = scope
+            scopes_by_switch_id[peer_id] = scope
 
-        orchestrator.validate_prerequisites()
-        scopes_by_switch_id = self._vpc_pair_scopes_by_switch_id()
-        preferred_switch_by_key = {
-            (
-                self._vpc_pair_scope(getattr(item, "switch_ip")),
-                getattr(item, "interface_name").lower(),
-            ): self.fabric_context.get_switch_id(getattr(item, "switch_ip"))
-            for item in proposed
-        }
+        preferred_switch_by_key = {}
+        for item in proposed:
+            primary_id = context.get_switch_id(getattr(item, "switch_ip"))
+            scope = scopes_by_switch_id.get(primary_id, (primary_id,))
+            preferred_switch_by_key[(scope, getattr(item, "interface_name").lower())] = primary_id
+
         selected: dict[tuple[tuple[str, ...], str], tuple[tuple[int, str], str, dict[str, Any]]] = {}
-        for (switch_id, interface_name), current in self._inventory().items():
-            if self._canonical_interface_type(current.get("interfaceType")) != "vpc":
+        for (switch_id, interface_name), current in inventory.items():
+            if cls._canonical_interface_type(current.get("interfaceType")) != "vpc":
                 continue
             if InterfaceStateSnapshot.policy_type(current) not in adapter.policy_types:
                 continue
@@ -423,9 +414,22 @@ class InterfaceWorkflowPlanner:
         for key in sorted(selected):
             _rank, switch_id, current = selected[key]
             enriched = deepcopy(current)
-            enriched["switchIp"] = self.fabric_context.get_switch_ip(switch_id)
+            enriched["switchIp"] = context.get_switch_ip(switch_id)
             response.append(enriched)
         return NDConfigCollection.from_api_response(response_data=response, model_class=adapter.model_class)
+
+    def _existing_collection(
+        self,
+        adapter: InterfaceFamilyAdapter,
+        orchestrator: NDBaseInterfaceOrchestrator,
+        proposed: NDConfigCollection,
+    ) -> NDConfigCollection:
+        """Select pair-scoped vPC state without name-global query deduplication."""
+        if adapter.ownership_domain != "vpc":
+            return adapter.existing_collection(orchestrator)
+
+        orchestrator.validate_prerequisites()
+        return self.pair_scoped_vpc_collection(inventory=self._inventory(), adapter=adapter, orchestrator=orchestrator, proposed=proposed)
 
     @classmethod
     def _desired_policy_type(cls, model: NDBaseModel) -> str | None:
@@ -517,17 +521,13 @@ class InterfaceWorkflowPlanner:
         scope = self._vpc_pair_scope(switch_ip)
         label = f"{switch_ip}/{getattr(model, 'interface_name')}"
         if len(scope) != 2:
-            raise InterfaceWorkflowValidationError(
-                f"{label} requires an authoritative two-switch vPC pair; resolved scope is {list(scope)}."
-            )
+            raise InterfaceWorkflowValidationError(f"{label} requires an authoritative two-switch vPC pair; resolved scope is {list(scope)}.")
         present = tuple((switch_id, inventory[(switch_id, interface_name)]) for switch_id in scope if (switch_id, interface_name) in inventory)
         if not present:
             return ()
         if len(present) != 2:
             missing = sorted(set(scope) - {switch_id for switch_id, _current in present})
-            raise InterfaceWorkflowValidationError(
-                f"{label} has inconsistent vPC pair state: the interface record is missing on peer(s) {missing}."
-            )
+            raise InterfaceWorkflowValidationError(f"{label} has inconsistent vPC pair state: the interface record is missing on peer(s) {missing}.")
 
         for switch_id, current in present:
             peer_ids = [candidate for candidate in scope if candidate != switch_id]
@@ -591,9 +591,7 @@ class InterfaceWorkflowPlanner:
         if check_membership and resource.adapter.ownership_domain == "ethernet" and current_records:
             port_channel_id = self._effective_port_channel_id(current_records[0][1])
             if port_channel_id is not None:
-                errors.append(
-                    f"{label} cannot {action} while it is a member of port-channel {port_channel_id}. Remove the membership first."
-                )
+                errors.append(f"{label} cannot {action} while it is a member of port-channel {port_channel_id}. Remove the membership first.")
         if resource.adapter.safety.guards_child_subinterfaces:
             switch_ids = {switch_id for switch_id, _current in current_records}
             if not switch_ids:
@@ -616,11 +614,7 @@ class InterfaceWorkflowPlanner:
         values = value.split(",") if isinstance(value, str) else value
         if not isinstance(values, Iterable) or isinstance(values, (bytes, Mapping)):
             return ()
-        return tuple(
-            member.strip().lower()
-            for item in values
-            if isinstance(item, str) and (member := item.strip())
-        )
+        return tuple(member.strip().lower() for item in values if isinstance(item, str) and (member := item.strip()))
 
     def _duplicate_member_errors(self, resource: InterfaceResourcePlan) -> list[str]:
         """Reject duplicate final members within one aggregate interface."""
@@ -633,11 +627,7 @@ class InterfaceWorkflowPlanner:
             policy = self._policy(item)
             if policy is None:
                 continue
-            fields = (
-                ("ports",)
-                if resource.adapter.ownership_domain == "port_channel"
-                else ("peer1_member_ports", "peer2_member_ports")
-            )
+            fields = ("ports",) if resource.adapter.ownership_domain == "port_channel" else ("peer1_member_ports", "peer2_member_ports")
             for field_name in fields:
                 members = self._member_names(getattr(policy, field_name, None))
                 seen: set[str] = set()
@@ -681,10 +671,7 @@ class InterfaceWorkflowPlanner:
         """Validate raw/summary agreement and controller eligibility."""
         desired_policy_type = self._desired_policy_type(candidate.desired)
         desired_network_os_type = self._desired_network_os_type(candidate.desired)
-        label = (
-            f"resources[{resource.resource_index}] {getattr(candidate.desired, 'switch_ip')}/"
-            f"{getattr(candidate.desired, 'interface_name')}"
-        )
+        label = f"resources[{resource.resource_index}] {getattr(candidate.desired, 'switch_ip')}/" f"{getattr(candidate.desired, 'interface_name')}"
         errors: list[str] = []
         if action == "transition":
             if desired_policy_type is None:
@@ -774,10 +761,7 @@ class InterfaceWorkflowPlanner:
                             f"{getattr(desired, 'switch_ip')}/{getattr(desired, 'interface_name')}: {exc}"
                         )
             if resource.adapter.safety.guards_child_subinterfaces:
-                parent_writes: list[tuple[str, NDBaseModel]] = [
-                    ("update", desired)
-                    for desired in resource.operations.updates
-                ]
+                parent_writes: list[tuple[str, NDBaseModel]] = [("update", desired) for desired in resource.operations.updates]
                 if resource.state not in resource.adapter.transition_states:
                     parent_writes.extend(("create", desired) for desired in resource.operations.creates)
                 for action, desired in parent_writes:
@@ -831,10 +815,7 @@ class InterfaceWorkflowPlanner:
                     if not current_records:
                         retained_creates.append(desired)
                         continue
-                    current_types = {
-                        self._canonical_interface_type(current.get("interfaceType"))
-                        for _switch_id, current in current_records
-                    }
+                    current_types = {self._canonical_interface_type(current.get("interfaceType")) for _switch_id, current in current_records}
                     if not current_types.issubset(resource.adapter.interface_types):
                         structural_collisions.append(self._structural_collision(resource, desired, current_records))
                         continue
@@ -873,10 +854,7 @@ class InterfaceWorkflowPlanner:
                     continue
                 if not current_records:
                     continue
-                current_types = {
-                    self._canonical_interface_type(current.get("interfaceType"))
-                    for _switch_id, current in current_records
-                }
+                current_types = {self._canonical_interface_type(current.get("interfaceType")) for _switch_id, current in current_records}
                 if not current_types.issubset(resource.adapter.interface_types):
                     structural_collisions.append(self._structural_collision(resource, desired, current_records))
                     continue
@@ -932,9 +910,7 @@ class InterfaceWorkflowPlanner:
             from_policy_type = InterfaceStateSnapshot.policy_type(current)
             to_policy_type = self._desired_policy_type(candidate.desired)
             if from_policy_type is None or to_policy_type is None:
-                raise InterfaceWorkflowValidationError(
-                    f"resources[{resource.resource_index}] cannot transition without source and destination policy types."
-                )
+                raise InterfaceWorkflowValidationError(f"resources[{resource.resource_index}] cannot transition without source and destination policy types.")
             transitions_by_index[resource.resource_index].append(
                 InterfacePolicyTransition(
                     desired=candidate.desired,
@@ -1128,18 +1104,12 @@ class InterfaceWorkflowPlanner:
                     interface_type = self._canonical_interface_type(current.get("interfaceType"))
                     required_policy = routed_policy_by_type.get(interface_type)
                     if required_policy is None:
-                        reason = (
-                            f"the parent has structural interfaceType {current.get('interfaceType')!r}, "
-                            "expected 'ethernet' or 'portChannel'"
-                        )
+                        reason = f"the parent has structural interfaceType {current.get('interfaceType')!r}, " "expected 'ethernet' or 'portChannel'"
                     else:
                         policy_type = InterfaceStateSnapshot.policy_type(current)
                         if policy_type == required_policy:
                             continue
-                        reason = (
-                            f"the parent policyType is {policy_type!r}, "
-                            f"expected routed policy {required_policy!r}"
-                        )
+                        reason = f"the parent policyType is {policy_type!r}, " f"expected routed policy {required_policy!r}"
                 add(
                     "subinterface_parent_prerequisite",
                     parent_identity,
@@ -1382,11 +1352,7 @@ class InterfaceWorkflowPlanner:
             port_channel_id = self._effective_port_channel_id(ethernet)
             if port_channel_id is not None:
                 matching_owners = existing_owners.intersection(logical_identities)
-                expected_ids = {
-                    expected_id
-                    for owner in matching_owners
-                    for expected_id in current_owner_ids.get(member_identity, {}).get(owner, set())
-                }
+                expected_ids = {expected_id for owner in matching_owners for expected_id in current_owner_ids.get(member_identity, {}).get(owner, set())}
                 if not matching_owners or not expected_ids:
                     add(
                         "operational_member_ownership",
@@ -1432,11 +1398,7 @@ class InterfaceWorkflowPlanner:
                     continue
                 membership_record = self._ethernet_membership_record(ethernet)
                 if membership_record is ethernet and operational_id is None:
-                    expected_ids = {
-                        expected_id
-                        for owner in existing_owners
-                        for expected_id in current_owner_ids.get(member_identity, {}).get(owner, set())
-                    }
+                    expected_ids = {expected_id for owner in existing_owners for expected_id in current_owner_ids.get(member_identity, {}).get(owner, set())}
                     membership_record = deepcopy(ethernet) if ethernet is not None else {}
                     membership_record["operData"] = {
                         **(membership_record.get("operData") or {}),

--- a/plugins/module_utils/interface_workflow_planner.py
+++ b/plugins/module_utils/interface_workflow_planner.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass, field
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 from ansible_collections.cisco.nd.plugins.module_utils.interface_family_adapters import (
     INTERFACE_FAMILY_ADAPTERS,
+    InterfaceDeleteStrategy,
     InterfaceFamilyAdapter,
     InterfaceWorkflowValidationError,
     get_interface_family_adapter,
@@ -22,8 +24,12 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBase
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_plan import NDStatePlan
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import EthernetBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import (
     EthernetTrunkHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import (
+    VpcInterfaceBaseOrchestrator,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
@@ -76,6 +82,45 @@ class InterfaceWorkflowConflictError(ValueError):
 
 
 @dataclass(frozen=True)
+class InterfacePolicyTransition:
+    """One implicit destination-family policy replacement planned by the workflow."""
+
+    desired: NDBaseModel = field(repr=False, compare=False)
+    current: dict[str, Any] = field(repr=False, compare=False)
+    switch_ip: str
+    switch_id: str
+    interface_name: str
+    from_policy_type: str
+    to_policy_type: str
+    current_records: tuple[tuple[str, dict[str, Any]], ...] = field(default=(), repr=False, compare=False)
+
+    @property
+    def target(self) -> tuple[str, str]:
+        """Return the controller interface-action identity."""
+        return self.interface_name, self.switch_id
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize auditable transition metadata without exposing raw controller state."""
+        return {
+            "action": "transition",
+            "switch_ip": self.switch_ip,
+            "switch_id": self.switch_id,
+            "interface_name": self.interface_name,
+            "from_policy_type": self.from_policy_type,
+            "to_policy_type": self.to_policy_type,
+        }
+
+
+@dataclass(frozen=True)
+class _PolicyRewriteCandidate:
+    """Internal foreign-policy operation awaiting shared safety validation."""
+
+    resource_index: int
+    desired: NDBaseModel = field(repr=False, compare=False)
+    current_records: tuple[tuple[str, dict[str, Any]], ...] = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True)
 class InterfaceResourcePlan:
     """Validated current state and pure operation plan for one resource group."""
 
@@ -86,6 +131,7 @@ class InterfaceResourcePlan:
     before: NDConfigCollection = field(repr=False, compare=False)
     operations: NDStatePlan = field(repr=False, compare=False)
     orchestrator: NDBaseInterfaceOrchestrator = field(repr=False, compare=False)
+    transitions: tuple[InterfacePolicyTransition, ...] = field(default=(), repr=False, compare=False)
 
     @property
     def resource_type(self) -> str:
@@ -95,7 +141,12 @@ class InterfaceResourcePlan:
     @property
     def changed(self) -> bool:
         """Return whether this group has a planned mutation."""
-        return self.operations.changed
+        return bool(self.transitions) or self.operations.changed
+
+    @property
+    def mutation_count(self) -> int:
+        """Return ordinary operations plus explicit policy transitions."""
+        return len(self.transitions) + self.operations.mutation_count
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the read-only plan using replayable model config."""
@@ -108,6 +159,7 @@ class InterfaceResourcePlan:
             "before": self.before.to_ansible_config(),
             "proposed": self.proposed.to_ansible_config(),
             "after": self.operations.after.to_ansible_config(),
+            "transitions": [transition.to_dict() for transition in self.transitions],
             "created": [item.to_config() for item in self.operations.creates],
             "updated": [item.to_config() for item in self.operations.updates],
             "deleted": [item.to_config() for item in self.operations.deletes],
@@ -131,7 +183,7 @@ class InterfaceWorkflowPlan:
     @property
     def mutation_count(self) -> int:
         """Return the total planned mutation count."""
-        return sum(resource.operations.mutation_count for resource in self.resources)
+        return sum(resource.mutation_count for resource in self.resources)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the aggregate read-only plan."""
@@ -164,12 +216,15 @@ class InterfaceWorkflowPlanner:
         self.vpc_pair_by_switch_ip = dict(vpc_pair_by_switch_ip or {})
         self.run_capability_preflight = run_capability_preflight
         self._vpc_pair_scope_cache: dict[str, tuple[str, ...]] = {}
+        self._vpc_peer_serial_cache: dict[str, str] | None = None
+        self._inventory_by_identity: dict[tuple[str, str], dict[str, Any]] | None = None
 
     def plan(self, resources: list[dict[str, Any]]) -> InterfaceWorkflowPlan:
         """Return a complete read-only plan or raise before any mutation method is called."""
         validated = self._validate_resource_groups(resources)
         target_switch_ids = self._target_switch_ids(validated)
         self.snapshot.load_switches(target_switch_ids)
+        self._inventory_by_identity = self.snapshot.interfaces_by_identity
 
         resource_plans: list[InterfaceResourcePlan] = []
         for resource_index, adapter, state, proposed in validated:
@@ -185,7 +240,9 @@ class InterfaceWorkflowPlanner:
                 results.state = state
                 results.check_mode = True
                 orchestrator = adapter.build_orchestrator(rest_send=rest_send, snapshot=self.snapshot, results=results)
-                before = adapter.existing_collection(orchestrator)
+                if isinstance(orchestrator, VpcInterfaceBaseOrchestrator):
+                    orchestrator.share_peer_serial_cache(self._shared_vpc_peer_serial_cache())
+                before = self._existing_collection(adapter, orchestrator, proposed)
                 operations = adapter.plan(before=before, proposed=proposed, state=state)
             except Exception as exc:
                 raise InterfaceWorkflowValidationError(
@@ -203,6 +260,7 @@ class InterfaceWorkflowPlanner:
                 )
             )
 
+        resource_plans = self._rewrite_policy_operations(resource_plans)
         conflicts = self._find_conflicts(resource_plans)
         if conflicts:
             raise InterfaceWorkflowConflictError(conflicts)
@@ -215,7 +273,9 @@ class InterfaceWorkflowPlanner:
             request_stats=self.snapshot.request_stats,
         )
 
-    def _validate_resource_groups(self, resources: list[dict[str, Any]]) -> list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]:
+    def _validate_resource_groups(
+        self, resources: list[dict[str, Any]]
+    ) -> list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]:
         """Validate group envelopes and delegate each config to its family adapter."""
         if not isinstance(resources, list):
             raise InterfaceWorkflowValidationError("resources must be a list.")
@@ -240,7 +300,9 @@ class InterfaceWorkflowPlanner:
             validated.append((resource_index, adapter, state, proposed))
         return validated
 
-    def _target_switch_ids(self, validated: list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]) -> tuple[str, ...]:
+    def _target_switch_ids(
+        self, validated: list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]
+    ) -> tuple[str, ...]:
         """Resolve the union of configured switches, expanding override to the fabric."""
         fabric_wide = any(state == "overridden" for _index, _adapter, state, _proposed in validated)
         switch_ids: list[str] = []
@@ -296,9 +358,619 @@ class InterfaceWorkflowPlanner:
             return InterfaceIdentity("vpc_pair", self._vpc_pair_scope(switch_ip), interface_name)
         return InterfaceIdentity("switch", (self.fabric_context.get_switch_id(switch_ip),), interface_name)
 
+    def _inventory(self) -> Mapping[tuple[str, str], dict[str, Any]]:
+        """Return the once-materialized raw inventory index for this plan."""
+        if self._inventory_by_identity is None:
+            self._inventory_by_identity = self.snapshot.interfaces_by_identity
+        return self._inventory_by_identity
+
+    def _vpc_pair_scopes_by_switch_id(self) -> dict[str, tuple[str, ...]]:
+        """Return authoritative pair scopes indexed by either member switch ID."""
+        scopes: dict[str, tuple[str, ...]] = {}
+        for switch_ip in self.vpc_pair_by_switch_ip:
+            scope = self._vpc_pair_scope(switch_ip)
+            if len(scope) == 2:
+                for switch_id in scope:
+                    scopes[switch_id] = scope
+        return scopes
+
+    def _shared_vpc_peer_serial_cache(self) -> dict[str, str]:
+        """Return one authoritative peer cache shared by all workflow vPC orchestrators."""
+        if self._vpc_peer_serial_cache is None:
+            cache: dict[str, str] = {}
+            for switch_ip in self.vpc_pair_by_switch_ip:
+                primary_id = self.fabric_context.get_switch_id(switch_ip)
+                scope = self._vpc_pair_scope(switch_ip)
+                if len(scope) == 2:
+                    cache[primary_id] = next(switch_id for switch_id in scope if switch_id != primary_id)
+            self._vpc_peer_serial_cache = cache
+        return self._vpc_peer_serial_cache
+
+    def _existing_collection(
+        self,
+        adapter: InterfaceFamilyAdapter,
+        orchestrator: NDBaseInterfaceOrchestrator,
+        proposed: NDConfigCollection,
+    ) -> NDConfigCollection:
+        """Select pair-scoped vPC state without name-global query deduplication."""
+        if adapter.ownership_domain != "vpc":
+            return adapter.existing_collection(orchestrator)
+
+        orchestrator.validate_prerequisites()
+        scopes_by_switch_id = self._vpc_pair_scopes_by_switch_id()
+        preferred_switch_by_key = {
+            (
+                self._vpc_pair_scope(getattr(item, "switch_ip")),
+                getattr(item, "interface_name").lower(),
+            ): self.fabric_context.get_switch_id(getattr(item, "switch_ip"))
+            for item in proposed
+        }
+        selected: dict[tuple[tuple[str, ...], str], tuple[tuple[int, str], str, dict[str, Any]]] = {}
+        for (switch_id, interface_name), current in self._inventory().items():
+            if self._canonical_interface_type(current.get("interfaceType")) != "vpc":
+                continue
+            if InterfaceStateSnapshot.policy_type(current) not in adapter.policy_types:
+                continue
+            scope = scopes_by_switch_id.get(switch_id, (switch_id,))
+            key = (scope, interface_name)
+            preferred_switch = preferred_switch_by_key.get(key)
+            rank = (0 if switch_id == preferred_switch else 1, switch_id)
+            existing = selected.get(key)
+            if existing is None or rank < existing[0]:
+                selected[key] = (rank, switch_id, current)
+
+        response: list[dict[str, Any]] = []
+        for key in sorted(selected):
+            _rank, switch_id, current = selected[key]
+            enriched = deepcopy(current)
+            enriched["switchIp"] = self.fabric_context.get_switch_ip(switch_id)
+            response.append(enriched)
+        return NDConfigCollection.from_api_response(response_data=response, model_class=adapter.model_class)
+
+    @classmethod
+    def _desired_policy_type(cls, model: NDBaseModel) -> str | None:
+        """Return the destination model's frozen wire policy discriminator."""
+        policy = cls._policy(model)
+        policy_type = getattr(policy, "policy_type", None) if policy is not None else None
+        value = getattr(policy_type, "value", policy_type)
+        return value if isinstance(value, str) and value else None
+
+    @classmethod
+    def _desired_network_os_type(cls, model: NDBaseModel) -> str | None:
+        """Return the destination model's frozen network-OS discriminator."""
+        config_data = getattr(model, "config_data", None)
+        network_os = getattr(config_data, "network_os", None) if config_data is not None else None
+        network_os_type = getattr(network_os, "network_os_type", None) if network_os is not None else None
+        value = getattr(network_os_type, "value", network_os_type)
+        return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _wire_policy(current: Mapping[str, Any]) -> dict[str, Any]:
+        """Return one raw interface policy dictionary."""
+        config_data = current.get("configData") or {}
+        network_os = config_data.get("networkOS") or {} if isinstance(config_data, Mapping) else {}
+        policy = network_os.get("policy") or {} if isinstance(network_os, Mapping) else {}
+        return dict(policy) if isinstance(policy, Mapping) else {}
+
+    @staticmethod
+    def _wire_network_os_type(current: Mapping[str, Any]) -> str | None:
+        """Return one raw interface network-OS discriminator."""
+        config_data = current.get("configData") or {}
+        network_os = config_data.get("networkOS") or {} if isinstance(config_data, Mapping) else {}
+        value = network_os.get("networkOSType") if isinstance(network_os, Mapping) else None
+        return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _canonical_interface_type(value: Any) -> Any:
+        """Normalize known raw/summary interface-type aliases."""
+        return {"switchVirtualInterface": "svi"}.get(value, value)
+
+    @classmethod
+    def _vpc_record_fingerprint(
+        cls,
+        current: Mapping[str, Any],
+        switch_id: str,
+        scope: tuple[str, ...],
+    ) -> Any:
+        """Return peer-independent configured vPC state for pair comparison."""
+
+        peer_ids = [candidate for candidate in scope if candidate != switch_id]
+        peer_id = peer_ids[0] if len(peer_ids) == 1 else None
+
+        def scrub(value: Any) -> Any:
+            if isinstance(value, Mapping):
+                ignored = {"switchId", "peerSwitchId", "policyId"}
+                normalized = {}
+                for key, item in value.items():
+                    if key in ignored:
+                        continue
+                    normalized_key = key
+                    if key.startswith("peer1") and len(key) > 5:
+                        normalized_key = f"peer[{switch_id}]{key[5:]}"
+                    elif peer_id is not None and key.startswith("peer2") and len(key) > 5:
+                        normalized_key = f"peer[{peer_id}]{key[5:]}"
+                    normalized_item = scrub(item)
+                    if key.endswith("MemberPorts") and isinstance(item, list) and all(isinstance(member, str) for member in item):
+                        normalized_item = tuple(sorted(member.strip().lower() for member in item))
+                    normalized[normalized_key] = normalized_item
+                return normalized
+            if isinstance(value, list):
+                return [scrub(item) for item in value]
+            return value
+
+        return scrub(deepcopy(current.get("configData") or {}))
+
+    def _current_records(
+        self,
+        adapter: InterfaceFamilyAdapter,
+        model: NDBaseModel,
+        inventory: Mapping[tuple[str, str], dict[str, Any]],
+    ) -> tuple[tuple[str, dict[str, Any]], ...]:
+        """Return raw current records, requiring coherent two-peer state for vPC."""
+        switch_ip = getattr(model, "switch_ip")
+        primary_id = self.fabric_context.get_switch_id(switch_ip)
+        interface_name = getattr(model, "interface_name").lower()
+        if not adapter.safety.requires_pair_consistency:
+            current = inventory.get((primary_id, interface_name))
+            return () if current is None else ((primary_id, current),)
+
+        scope = self._vpc_pair_scope(switch_ip)
+        label = f"{switch_ip}/{getattr(model, 'interface_name')}"
+        if len(scope) != 2:
+            raise InterfaceWorkflowValidationError(
+                f"{label} requires an authoritative two-switch vPC pair; resolved scope is {list(scope)}."
+            )
+        present = tuple((switch_id, inventory[(switch_id, interface_name)]) for switch_id in scope if (switch_id, interface_name) in inventory)
+        if not present:
+            return ()
+        if len(present) != 2:
+            missing = sorted(set(scope) - {switch_id for switch_id, _current in present})
+            raise InterfaceWorkflowValidationError(
+                f"{label} has inconsistent vPC pair state: the interface record is missing on peer(s) {missing}."
+            )
+
+        for switch_id, current in present:
+            peer_ids = [candidate for candidate in scope if candidate != switch_id]
+            expected_peer_id = peer_ids[0]
+            configured_peer_id = self._wire_policy(current).get("peerSwitchId")
+            if configured_peer_id is not None and configured_peer_id != expected_peer_id:
+                raise InterfaceWorkflowValidationError(
+                    f"{label} has inconsistent vPC pair records: switch {switch_id} reports peerSwitchId "
+                    f"{configured_peer_id!r}, expected {expected_peer_id!r} from authoritative pair inventory."
+                )
+
+        interface_types = {current.get("interfaceType") for _switch_id, current in present}
+        policy_types = {InterfaceStateSnapshot.policy_type(current) for _switch_id, current in present}
+        fingerprints = [self._vpc_record_fingerprint(current, switch_id, scope) for switch_id, current in present]
+        if len(interface_types) != 1 or len(policy_types) != 1 or fingerprints[0] != fingerprints[1]:
+            raise InterfaceWorkflowValidationError(
+                f"{label} has inconsistent vPC pair records: interfaceType={sorted(str(value) for value in interface_types)}, "
+                f"policyType={sorted(str(value) for value in policy_types)}, or configured policy data differs between peers."
+            )
+        return present
+
+    @staticmethod
+    def _children_by_parent(
+        inventory: Mapping[tuple[str, str], dict[str, Any]],
+    ) -> dict[tuple[str, str], tuple[str, ...]]:
+        """Index current subinterfaces by switch and structural parent."""
+        collected: dict[tuple[str, str], list[str]] = defaultdict(list)
+        for (switch_id, candidate_name), current in inventory.items():
+            if current.get("interfaceType") != "subInterface" or "." not in candidate_name:
+                continue
+            parent_name = candidate_name.rsplit(".", 1)[0]
+            collected[(switch_id, parent_name)].append(str(current.get("interfaceName") or candidate_name))
+        return {identity: tuple(sorted(names, key=str.lower)) for identity, names in collected.items()}
+
+    @staticmethod
+    def _is_unconfigured_ethernet_default(
+        adapter: InterfaceFamilyAdapter,
+        current_records: tuple[tuple[str, dict[str, Any]], ...],
+    ) -> bool:
+        """Return whether one physical port is already at the fabric default."""
+        return (
+            adapter.delete_strategy == InterfaceDeleteStrategy.NORMALIZE
+            and len(current_records) == 1
+            and InterfaceStateSnapshot.policy_type(current_records[0][1]) == "trunkHost"
+            and EthernetTrunkHostInterfaceOrchestrator._is_unconfigured_default(current_records[0][1])
+        )
+
+    def _dependency_errors(
+        self,
+        *,
+        resource: InterfaceResourcePlan,
+        desired: NDBaseModel,
+        current_records: tuple[tuple[str, dict[str, Any]], ...],
+        children_by_parent: Mapping[tuple[str, str], tuple[str, ...]],
+        action: str,
+        check_membership: bool = True,
+    ) -> list[str]:
+        """Return current topology conditions that make an operation unsafe."""
+        label = f"resources[{resource.resource_index}] {getattr(desired, 'switch_ip')}/{getattr(desired, 'interface_name')}"
+        errors: list[str] = []
+        if check_membership and resource.adapter.ownership_domain == "ethernet" and current_records:
+            port_channel_id = self._effective_port_channel_id(current_records[0][1])
+            if port_channel_id is not None:
+                errors.append(
+                    f"{label} cannot {action} while it is a member of port-channel {port_channel_id}. Remove the membership first."
+                )
+        if resource.adapter.safety.guards_child_subinterfaces:
+            switch_ids = {switch_id for switch_id, _current in current_records}
+            if not switch_ids:
+                switch_ids.add(self.fabric_context.get_switch_id(getattr(desired, "switch_ip")))
+            parent_name = getattr(desired, "interface_name").lower()
+            for switch_id in sorted(switch_ids):
+                children = children_by_parent.get((switch_id, parent_name), ())
+                if children:
+                    errors.append(
+                        f"{label} cannot {action} while child subinterfaces exist on switch {switch_id}: {', '.join(children)}. "
+                        "Remove the child subinterfaces first."
+                    )
+        return errors
+
+    @staticmethod
+    def _member_names(value: Any) -> tuple[str, ...]:
+        """Return canonical physical member names while preserving duplicates."""
+        if value is None:
+            return ()
+        values = value.split(",") if isinstance(value, str) else value
+        if not isinstance(values, Iterable) or isinstance(values, (bytes, Mapping)):
+            return ()
+        return tuple(
+            member.strip().lower()
+            for item in values
+            if isinstance(item, str) and (member := item.strip())
+        )
+
+    def _duplicate_member_errors(self, resource: InterfaceResourcePlan) -> list[str]:
+        """Reject duplicate final members within one aggregate interface."""
+        if not resource.adapter.safety.owns_physical_members:
+            return []
+        errors: list[str] = []
+        for action, item in self._iter_operations(resource):
+            if action == "delete":
+                continue
+            policy = self._policy(item)
+            if policy is None:
+                continue
+            fields = (
+                ("ports",)
+                if resource.adapter.ownership_domain == "port_channel"
+                else ("peer1_member_ports", "peer2_member_ports")
+            )
+            for field_name in fields:
+                members = self._member_names(getattr(policy, field_name, None))
+                seen: set[str] = set()
+                duplicates = sorted({member for member in members if member in seen or seen.add(member)})
+                if duplicates:
+                    errors.append(
+                        f"resources[{resource.resource_index}] {getattr(item, 'switch_ip')}/"
+                        f"{getattr(item, 'interface_name')} contains duplicate {field_name}: {duplicates}."
+                    )
+        return errors
+
+    def _structural_collision(
+        self,
+        resource: InterfaceResourcePlan,
+        desired: NDBaseModel,
+        current_records: tuple[tuple[str, dict[str, Any]], ...],
+    ) -> InterfaceWorkflowConflict:
+        """Build a structured same-name/different-kind collision."""
+        identity = self._identity(resource.adapter, desired)
+        current_types = sorted({str(current.get("interfaceType")) for _switch_id, current in current_records})
+        expected = sorted(resource.adapter.interface_types)
+        return InterfaceWorkflowConflict(
+            code="structural_type_collision",
+            identity=identity,
+            resource_indices=(resource.resource_index,),
+            resource_types=(resource.resource_type,),
+            message=(
+                f"resources[{resource.resource_index}] type '{resource.resource_type}' targets {identity.label}, but an existing "
+                f"same-name record has structural interfaceType {current_types}; expected {expected}."
+            ),
+        )
+
+    def _candidate_safety_errors(
+        self,
+        *,
+        candidate: _PolicyRewriteCandidate,
+        resource: InterfaceResourcePlan,
+        summaries: Mapping[tuple[str, str], dict[str, Any]],
+        action: str,
+    ) -> list[str]:
+        """Validate raw/summary agreement and controller eligibility."""
+        desired_policy_type = self._desired_policy_type(candidate.desired)
+        desired_network_os_type = self._desired_network_os_type(candidate.desired)
+        label = (
+            f"resources[{resource.resource_index}] {getattr(candidate.desired, 'switch_ip')}/"
+            f"{getattr(candidate.desired, 'interface_name')}"
+        )
+        errors: list[str] = []
+        if action == "transition":
+            if desired_policy_type is None:
+                return [f"{label} cannot {action} without a destination policy type."]
+            if desired_network_os_type is None:
+                return [f"{label} cannot {action} without a destination network-OS type."]
+
+        for switch_id, current in candidate.current_records:
+            interface_name = getattr(candidate.desired, "interface_name").lower()
+            summary = summaries.get((switch_id, interface_name))
+            if summary is None:
+                errors.append(f"{label} cannot {action}: interfacesSummary has no exact row for {switch_id}/{interface_name}.")
+                continue
+
+            current_type = current.get("interfaceType")
+            current_policy_type = InterfaceStateSnapshot.policy_type(current)
+            summary_type = self._canonical_interface_type(summary.get("interfaceType"))
+            current_type = self._canonical_interface_type(current_type)
+            summary_policy_type = summary.get("policyType")
+            current_network_os_type = self._wire_network_os_type(current)
+            if summary.get("switchId") not in (None, switch_id):
+                errors.append(f"{label} cannot {action}: interfacesSummary returned the wrong switch identity for {switch_id}.")
+            if summary_type != current_type or summary_policy_type != current_policy_type:
+                errors.append(
+                    f"{label} cannot {action}: raw and summary records disagree on switch {switch_id} "
+                    f"(interfaceType {current_type!r}/{summary_type!r}, policyType {current_policy_type!r}/{summary_policy_type!r})."
+                )
+            if current_policy_type is None:
+                errors.append(f"{label} cannot {action}: the current policy type is missing on switch {switch_id}.")
+            if action == "transition" and current_network_os_type != desired_network_os_type:
+                errors.append(
+                    f"{label} cannot {action}: current networkOSType {current_network_os_type!r} on switch {switch_id} "
+                    f"is incompatible with destination {desired_network_os_type!r}."
+                )
+
+            blockers: list[str] = []
+            if summary.get("editAllowed") is not True:
+                blockers.append("editAllowed is not true")
+            if summary.get("rbacAccessible") is not True:
+                blockers.append("rbacAccessible is not true")
+            if summary.get("blockConfig") is not False:
+                blockers.append("blockConfig is not false")
+            if summary.get("markDeleted") is not False:
+                blockers.append("markDeleted is not false")
+            if summary.get("hasDeletedOverlay") is not False:
+                blockers.append("hasDeletedOverlay is not false")
+            if action == "transition" or resource.adapter.delete_strategy == InterfaceDeleteStrategy.NORMALIZE:
+                if summary.get("policyChangeSupported") is not True:
+                    blockers.append("policyChangeSupported is not true")
+            elif summary.get("deletable") is not True:
+                blockers.append("deletable is not true")
+            if blockers:
+                reason = summary.get("editBlockReason")
+                reason_suffix = f"; editBlockReason={reason!r}" if reason else ""
+                errors.append(f"{label} cannot {action} on switch {switch_id}: {', '.join(blockers)}{reason_suffix}.")
+        return errors
+
+    def _rewrite_policy_operations(self, resources: list[InterfaceResourcePlan]) -> list[InterfaceResourcePlan]:
+        """Plan implicit transitions and explicit policy-independent deletes."""
+        inventory = self._inventory()
+        children_by_parent = self._children_by_parent(inventory)
+        resources_by_index = {resource.resource_index: resource for resource in resources}
+        creates_by_index = {resource.resource_index: list(resource.operations.creates) for resource in resources}
+        deletes_by_index = {resource.resource_index: list(resource.operations.deletes) for resource in resources}
+        transitions_by_index: dict[int, list[InterfacePolicyTransition]] = defaultdict(list)
+        transition_candidates: list[_PolicyRewriteCandidate] = []
+        delete_candidates: list[_PolicyRewriteCandidate] = []
+        summary_identities: set[tuple[str, str]] = set()
+        structural_collisions: list[InterfaceWorkflowConflict] = []
+        errors: list[str] = []
+        pair_validation_failures: set[tuple[int, Any]] = set()
+
+        for resource in resources:
+            errors.extend(self._duplicate_member_errors(resource))
+            if isinstance(resource.orchestrator, EthernetBaseOrchestrator):
+                for desired in resource.operations.updates:
+                    switch_id = self.fabric_context.get_switch_id(getattr(desired, "switch_ip"))
+                    current = inventory.get((switch_id, getattr(desired, "interface_name").lower()))
+                    try:
+                        resource.orchestrator._check_port_channel_restrictions(
+                            desired,
+                            self._ethernet_membership_record(current),
+                        )
+                    except Exception as exc:
+                        errors.append(
+                            f"resources[{resource.resource_index}] cannot update "
+                            f"{getattr(desired, 'switch_ip')}/{getattr(desired, 'interface_name')}: {exc}"
+                        )
+            if resource.adapter.safety.guards_child_subinterfaces:
+                parent_writes: list[tuple[str, NDBaseModel]] = [
+                    ("update", desired)
+                    for desired in resource.operations.updates
+                ]
+                if resource.state not in resource.adapter.transition_states:
+                    parent_writes.extend(("create", desired) for desired in resource.operations.creates)
+                for action, desired in parent_writes:
+                    current_records = self._current_records(resource.adapter, desired, inventory)
+                    errors.extend(
+                        self._dependency_errors(
+                            resource=resource,
+                            desired=desired,
+                            current_records=current_records,
+                            children_by_parent=children_by_parent,
+                            action=action,
+                            check_membership=False,
+                        )
+                    )
+            if resource.state == "overridden" and resource.adapter.safety.guards_child_subinterfaces:
+                for desired in resource.operations.deletes:
+                    current_records = self._current_records(resource.adapter, desired, inventory)
+                    errors.extend(
+                        self._dependency_errors(
+                            resource=resource,
+                            desired=desired,
+                            current_records=current_records,
+                            children_by_parent=children_by_parent,
+                            action="override-delete or reset",
+                        )
+                    )
+
+            if resource.adapter.safety.requires_pair_consistency:
+                checked: set[Any] = set()
+                for desired in (*resource.proposed, *resource.operations.deletes):
+                    identifier = desired.get_identifier_value()
+                    if identifier in checked:
+                        continue
+                    checked.add(identifier)
+                    try:
+                        self._current_records(resource.adapter, desired, inventory)
+                    except InterfaceWorkflowValidationError as exc:
+                        errors.append(f"resources[{resource.resource_index}] {exc}")
+                        pair_validation_failures.add((resource.resource_index, identifier))
+
+            if resource.state in resource.adapter.transition_states:
+                retained_creates: list[NDBaseModel] = []
+                for desired in resource.operations.creates:
+                    if (resource.resource_index, desired.get_identifier_value()) in pair_validation_failures:
+                        continue
+                    try:
+                        current_records = self._current_records(resource.adapter, desired, inventory)
+                    except InterfaceWorkflowValidationError as exc:
+                        errors.append(f"resources[{resource.resource_index}] {exc}")
+                        continue
+                    if not current_records:
+                        retained_creates.append(desired)
+                        continue
+                    current_types = {
+                        self._canonical_interface_type(current.get("interfaceType"))
+                        for _switch_id, current in current_records
+                    }
+                    if not current_types.issubset(resource.adapter.interface_types):
+                        structural_collisions.append(self._structural_collision(resource, desired, current_records))
+                        continue
+                    default_ethernet = self._is_unconfigured_ethernet_default(resource.adapter, current_records)
+                    errors.extend(
+                        self._dependency_errors(
+                            resource=resource,
+                            desired=desired,
+                            current_records=current_records,
+                            children_by_parent=children_by_parent,
+                            action="change policy",
+                        )
+                    )
+                    if default_ethernet:
+                        retained_creates.append(desired)
+                        continue
+                    current_policy_type = InterfaceStateSnapshot.policy_type(current_records[0][1])
+                    if current_policy_type in resource.adapter.policy_types:
+                        retained_creates.append(desired)
+                        continue
+                    candidate = _PolicyRewriteCandidate(resource.resource_index, desired, current_records)
+                    transition_candidates.append(candidate)
+                    summary_identities.update((switch_id, getattr(desired, "interface_name")) for switch_id, _current in current_records)
+                creates_by_index[resource.resource_index] = retained_creates
+
+            if resource.state != "deleted":
+                continue
+            deletes_by_index[resource.resource_index] = []
+            for desired in resource.proposed:
+                if (resource.resource_index, desired.get_identifier_value()) in pair_validation_failures:
+                    continue
+                try:
+                    current_records = self._current_records(resource.adapter, desired, inventory)
+                except InterfaceWorkflowValidationError as exc:
+                    errors.append(f"resources[{resource.resource_index}] {exc}")
+                    continue
+                if not current_records:
+                    continue
+                current_types = {
+                    self._canonical_interface_type(current.get("interfaceType"))
+                    for _switch_id, current in current_records
+                }
+                if not current_types.issubset(resource.adapter.interface_types):
+                    structural_collisions.append(self._structural_collision(resource, desired, current_records))
+                    continue
+                if self._is_unconfigured_ethernet_default(resource.adapter, current_records):
+                    continue
+                errors.extend(
+                    self._dependency_errors(
+                        resource=resource,
+                        desired=desired,
+                        current_records=current_records,
+                        children_by_parent=children_by_parent,
+                        action="delete or reset",
+                    )
+                )
+                current_policy_type = InterfaceStateSnapshot.policy_type(current_records[0][1])
+                if current_policy_type in resource.adapter.policy_types:
+                    deletes_by_index[resource.resource_index].append(desired)
+                    continue
+                candidate = _PolicyRewriteCandidate(resource.resource_index, desired, current_records)
+                delete_candidates.append(candidate)
+                summary_identities.update((switch_id, getattr(desired, "interface_name")) for switch_id, _current in current_records)
+
+        if structural_collisions:
+            raise InterfaceWorkflowConflictError(structural_collisions)
+        if errors:
+            raise InterfaceWorkflowValidationError("Interface policy operation validation failed: " + "; ".join(errors))
+
+        summaries = self.snapshot.load_interface_summaries(summary_identities) if summary_identities else {}
+        for action, candidates in (("transition", transition_candidates), ("delete or reset", delete_candidates)):
+            for candidate in candidates:
+                resource = resources_by_index[candidate.resource_index]
+                errors.extend(
+                    self._candidate_safety_errors(
+                        candidate=candidate,
+                        resource=resource,
+                        summaries=summaries,
+                        action=action,
+                    )
+                )
+        if errors:
+            raise InterfaceWorkflowValidationError("Interface policy safety validation failed: " + "; ".join(errors))
+
+        for candidate in transition_candidates:
+            resource = resources_by_index[candidate.resource_index]
+            primary_id = self.fabric_context.get_switch_id(getattr(candidate.desired, "switch_ip"))
+            current_by_switch = dict(candidate.current_records)
+            current = current_by_switch.get(primary_id)
+            if current is None:
+                raise InterfaceWorkflowValidationError(
+                    f"resources[{resource.resource_index}] cannot transition {getattr(candidate.desired, 'interface_name')}: "
+                    f"the configured primary switch {primary_id} has no current record."
+                )
+            from_policy_type = InterfaceStateSnapshot.policy_type(current)
+            to_policy_type = self._desired_policy_type(candidate.desired)
+            if from_policy_type is None or to_policy_type is None:
+                raise InterfaceWorkflowValidationError(
+                    f"resources[{resource.resource_index}] cannot transition without source and destination policy types."
+                )
+            transitions_by_index[resource.resource_index].append(
+                InterfacePolicyTransition(
+                    desired=candidate.desired,
+                    current=current,
+                    switch_ip=getattr(candidate.desired, "switch_ip"),
+                    switch_id=primary_id,
+                    interface_name=getattr(candidate.desired, "interface_name"),
+                    from_policy_type=from_policy_type,
+                    to_policy_type=to_policy_type,
+                    current_records=candidate.current_records,
+                )
+            )
+        for candidate in delete_candidates:
+            deletes_by_index[candidate.resource_index].append(candidate.desired)
+
+        updated_resources: list[InterfaceResourcePlan] = []
+        for resource in resources:
+            operations = replace(
+                resource.operations,
+                creates=tuple(creates_by_index[resource.resource_index]),
+                deletes=tuple(deletes_by_index[resource.resource_index]),
+            )
+            updated_resources.append(
+                replace(
+                    resource,
+                    operations=operations,
+                    transitions=tuple(transitions_by_index[resource.resource_index]),
+                )
+            )
+        return updated_resources
+
     @staticmethod
     def _iter_operations(resource: InterfaceResourcePlan) -> Iterable[tuple[str, NDBaseModel]]:
         """Yield action/model pairs in deterministic execution order."""
+        for transition in resource.transitions:
+            yield "transition", transition.desired
         for item in resource.operations.updates:
             yield "update", item
         for item in resource.operations.creates:
@@ -391,13 +1063,94 @@ class InterfaceWorkflowPlanner:
                         f"resources[{resource.resource_index}] overridden deletion of {identity.label} conflicts with another desired group.",
                     )
 
+        self._find_parent_subinterface_conflicts(resources, add)
+        self._find_subinterface_parent_prerequisite_conflicts(resources, add)
         self._find_existing_policy_conflicts(resources, add)
-        self._find_member_conflicts(resources, actions, add)
+        self._find_member_conflicts(resources, add)
         return tuple(conflicts)
+
+    def _find_parent_subinterface_conflicts(self, resources: list[InterfaceResourcePlan], add: Callable[..., None]) -> None:
+        """Reject any parent mutation combined with a child mutation."""
+        parent_writes: dict[InterfaceIdentity, list[InterfaceResourcePlan]] = defaultdict(list)
+        for resource in resources:
+            if not resource.adapter.safety.guards_child_subinterfaces:
+                continue
+            for _action, item in self._iter_operations(resource):
+                switch_id = self.fabric_context.get_switch_id(getattr(item, "switch_ip"))
+                parent_identity = InterfaceIdentity("switch", (switch_id,), getattr(item, "interface_name").lower())
+                parent_writes[parent_identity].append(resource)
+
+        for resource in resources:
+            if resource.adapter.ownership_domain != "subinterface":
+                continue
+            for action, item in self._iter_operations(resource):
+                child_name = getattr(item, "interface_name")
+                if "." not in child_name:
+                    continue
+                switch_id = self.fabric_context.get_switch_id(getattr(item, "switch_ip"))
+                parent_identity = InterfaceIdentity("switch", (switch_id,), child_name.rsplit(".", 1)[0].lower())
+                parent_resources = parent_writes.get(parent_identity, [])
+                if not parent_resources:
+                    continue
+                add(
+                    "parent_subinterface_collision",
+                    parent_identity,
+                    [*parent_resources, resource],
+                    f"{parent_identity.label} is mutated while child subinterface '{child_name}' has action '{action}'; "
+                    "split parent and child operations into separate workflows.",
+                )
+
+    def _find_subinterface_parent_prerequisite_conflicts(
+        self,
+        resources: list[InterfaceResourcePlan],
+        add: Callable[..., None],
+    ) -> None:
+        """Require every written subinterface to have an existing routed parent."""
+        inventory = self._inventory()
+        routed_policy_by_type = {
+            "ethernet": "routedHost",
+            "portChannel": "l3PortChannel",
+        }
+        for resource in resources:
+            if resource.adapter.ownership_domain != "subinterface":
+                continue
+            for action, item in self._iter_operations(resource):
+                if action == "delete":
+                    continue
+                switch_id = self.fabric_context.get_switch_id(getattr(item, "switch_ip"))
+                child_name = getattr(item, "interface_name")
+                parent_name = child_name.rsplit(".", 1)[0].lower()
+                parent_identity = InterfaceIdentity("switch", (switch_id,), parent_name)
+                current = inventory.get((switch_id, parent_name))
+                if current is None:
+                    reason = "the parent does not exist in current controller inventory"
+                else:
+                    interface_type = self._canonical_interface_type(current.get("interfaceType"))
+                    required_policy = routed_policy_by_type.get(interface_type)
+                    if required_policy is None:
+                        reason = (
+                            f"the parent has structural interfaceType {current.get('interfaceType')!r}, "
+                            "expected 'ethernet' or 'portChannel'"
+                        )
+                    else:
+                        policy_type = InterfaceStateSnapshot.policy_type(current)
+                        if policy_type == required_policy:
+                            continue
+                        reason = (
+                            f"the parent policyType is {policy_type!r}, "
+                            f"expected routed policy {required_policy!r}"
+                        )
+                add(
+                    "subinterface_parent_prerequisite",
+                    parent_identity,
+                    [resource],
+                    f"Subinterface {switch_id}/{child_name} cannot perform action '{action}': {reason}. "
+                    "Configure the routed parent in a separate completed workflow first.",
+                )
 
     def _find_existing_policy_conflicts(self, resources: list[InterfaceResourcePlan], add: Callable[..., None]) -> None:
         """Reject creates that would collide with a sibling or unmanaged current policy."""
-        inventory = self.snapshot.interfaces_by_identity
+        inventory = self._inventory()
         policy_owner = {policy_type: adapter.resource_type for adapter in INTERFACE_FAMILY_ADAPTERS.values() for policy_type in adapter.policy_types}
         for resource in resources:
             for item in resource.operations.creates:
@@ -407,7 +1160,16 @@ class InterfaceWorkflowPlanner:
                 scope = self._vpc_pair_scope(switch_ip) if resource.adapter.ownership_domain == "vpc" else (switch_id,)
                 current_records = [inventory[(candidate_id, interface_name)] for candidate_id in scope if (candidate_id, interface_name) in inventory]
                 for current in current_records:
-                    if current.get("interfaceType") not in resource.adapter.interface_types:
+                    if self._canonical_interface_type(current.get("interfaceType")) not in resource.adapter.interface_types:
+                        identity = self._identity(resource.adapter, item)
+                        add(
+                            "structural_type_collision",
+                            identity,
+                            [resource],
+                            f"resources[{resource.resource_index}] type '{resource.resource_type}' targets {identity.label}, but the "
+                            f"same-name record has structural interfaceType {current.get('interfaceType')!r}; "
+                            f"expected {sorted(resource.adapter.interface_types)}.",
+                        )
                         continue
                     policy_type = InterfaceStateSnapshot.policy_type(current)
                     if policy_type == "trunkHost" and EthernetTrunkHostInterfaceOrchestrator._is_unconfigured_default(current):
@@ -421,7 +1183,8 @@ class InterfaceWorkflowPlanner:
                         identity,
                         [resource],
                         f"resources[{resource.resource_index}] type '{resource.resource_type}' would create {identity.label}, but current "
-                        f"policyType '{policy_type}' is owned by {owner}; an explicit transition plan is required.",
+                        f"policyType '{policy_type}' is owned by {owner}; implicit policy transitions are supported only for "
+                        f"{sorted(resource.adapter.transition_states)}, not state '{resource.state}'.",
                     )
 
     @staticmethod
@@ -431,55 +1194,168 @@ class InterfaceWorkflowPlanner:
         network_os = getattr(config_data, "network_os", None) if config_data is not None else None
         return getattr(network_os, "policy", None) if network_os is not None else None
 
-    def _new_member_claims(self, resource: InterfaceResourcePlan) -> Iterable[tuple[InterfaceIdentity, InterfaceIdentity]]:
-        """Yield newly attached physical member and owning logical identities."""
-        if resource.adapter.ownership_domain not in {"port_channel", "vpc"}:
+    @staticmethod
+    def _positive_port_channel_id(value: Any) -> int | None:
+        """Return a positive numeric port-channel identifier."""
+        if isinstance(value, int) and value > 0:
+            return value
+        if isinstance(value, str):
+            candidate = value.lower().removeprefix("port-channel")
+            if candidate.isdigit() and int(candidate) > 0:
+                return int(candidate)
+        return None
+
+    @classmethod
+    def _configured_port_channel_id(cls, current: Mapping[str, Any] | None) -> int | None:
+        """Return configured membership when ND operational data is stale."""
+        if current is None:
+            return None
+        policy = cls._wire_policy(current)
+        policy_type = policy.get("policyType")
+        primary_interface = policy.get("primaryInterface")
+        has_member_policy = isinstance(policy_type, str) and "pomember" in policy_type.lower()
+        has_primary = isinstance(primary_interface, str) and bool(primary_interface.strip())
+        if not has_member_policy and not has_primary:
+            return None
+        return cls._positive_port_channel_id(policy.get("portChannelId"))
+
+    @classmethod
+    def _effective_port_channel_id(cls, current: Mapping[str, Any] | None) -> int | None:
+        """Prefer operational membership, then use the configured member-policy signal."""
+        operational_id = EthernetTrunkHostInterfaceOrchestrator._existing_port_channel_id(current)
+        return operational_id if operational_id is not None else cls._configured_port_channel_id(current)
+
+    @classmethod
+    def _ethernet_membership_record(cls, current: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Expose configured membership to the existing whitelist checker."""
+        if current is None or EthernetTrunkHostInterfaceOrchestrator._existing_port_channel_id(current) is not None:
+            return current
+        configured_id = cls._configured_port_channel_id(current)
+        if configured_id is None:
+            return current
+        effective = deepcopy(current)
+        effective["operData"] = {**(effective.get("operData") or {}), "portChannelId": configured_id}
+        return effective
+
+    def _current_member_owners(
+        self,
+    ) -> tuple[
+        dict[InterfaceIdentity, set[InterfaceIdentity]],
+        dict[InterfaceIdentity, dict[InterfaceIdentity, set[int]]],
+    ]:
+        """Index aggregate owners and their expected operational port-channel IDs."""
+        owners: dict[InterfaceIdentity, set[InterfaceIdentity]] = defaultdict(set)
+        owner_ids: dict[InterfaceIdentity, dict[InterfaceIdentity, set[int]]] = defaultdict(lambda: defaultdict(set))
+        known_vpc_scope: dict[str, tuple[str, ...]] = {}
+        for switch_ip in self.vpc_pair_by_switch_ip:
+            scope = self._vpc_pair_scope(switch_ip)
+            if len(scope) == 2:
+                for switch_id in scope:
+                    known_vpc_scope[switch_id] = scope
+
+        def register(member: InterfaceIdentity, owner: InterfaceIdentity, port_channel_id: Any) -> None:
+            owners[member].add(owner)
+            if (normalized_id := self._positive_port_channel_id(port_channel_id)) is not None:
+                owner_ids[member][owner].add(normalized_id)
+
+        for (switch_id, interface_name), current in self._inventory().items():
+            interface_type = self._canonical_interface_type(current.get("interfaceType"))
+            policy = self._wire_policy(current)
+            if interface_type == "portChannel":
+                owner = InterfaceIdentity("switch", (switch_id,), interface_name)
+                port_channel_id = self._positive_port_channel_id(policy.get("portChannelId"))
+                if port_channel_id is None:
+                    port_channel_id = self._positive_port_channel_id(interface_name)
+                for member in self._member_names(policy.get("ports")):
+                    register(InterfaceIdentity("switch", (switch_id,), member), owner, port_channel_id)
+                continue
+            if interface_type != "vpc":
+                continue
+
+            configured_peer_id = policy.get("peerSwitchId")
+            authoritative_scope = known_vpc_scope.get(switch_id)
+            if authoritative_scope is not None:
+                peer_id = next(candidate for candidate in authoritative_scope if candidate != switch_id)
+                if configured_peer_id is not None and configured_peer_id != peer_id:
+                    raise InterfaceWorkflowValidationError(
+                        f"Raw vPC owner {switch_id}/{interface_name} reports peerSwitchId {configured_peer_id!r}, "
+                        f"expected {peer_id!r} from authoritative pair inventory."
+                    )
+                scope = authoritative_scope
+            else:
+                peer_id = configured_peer_id
+                has_raw_peer = isinstance(peer_id, str) and bool(peer_id) and peer_id != switch_id
+                scope = tuple(sorted((switch_id, peer_id))) if has_raw_peer else (switch_id,)
+
+            has_peer = isinstance(peer_id, str) and bool(peer_id) and peer_id != switch_id
+            owner = InterfaceIdentity("vpc_pair", scope, interface_name)
+            for member in self._member_names(policy.get("peer1MemberPorts")):
+                register(
+                    InterfaceIdentity("switch", (switch_id,), member),
+                    owner,
+                    policy.get("peer1PortChannelId"),
+                )
+            if has_peer:
+                for member in self._member_names(policy.get("peer2MemberPorts")):
+                    register(
+                        InterfaceIdentity("switch", (peer_id,), member),
+                        owner,
+                        policy.get("peer2PortChannelId"),
+                    )
+        return owners, owner_ids
+
+    def _protected_member_claims(self, resource: InterfaceResourcePlan) -> Iterable[tuple[InterfaceIdentity, InterfaceIdentity]]:
+        """Yield current and final physical members protected by one aggregate action."""
+        if not resource.adapter.safety.owns_physical_members:
             return
-        for _action, item in self._iter_operations(resource):
-            if _action == "delete":
-                continue
-            policy = self._policy(item)
-            if policy is None:
-                continue
-            previous = resource.before.get(item.get_identifier_value())
-            previous_policy = self._policy(previous) if previous is not None else None
+
+        inventory = self._inventory()
+        for action, item in self._iter_operations(resource):
+            final_policy = self._policy(item) if action != "delete" else None
             logical_identity = self._identity(resource.adapter, item)
             switch_ip = getattr(item, "switch_ip")
             primary_id = self.fabric_context.get_switch_id(switch_ip)
+            interface_name = getattr(item, "interface_name").lower()
+            current = inventory.get((primary_id, interface_name))
+            current_policy = self._wire_policy(current or {})
 
             if resource.adapter.ownership_domain == "port_channel":
-                final_members = set(getattr(policy, "ports", None) or [])
-                previous_members = set(getattr(previous_policy, "ports", None) or []) if previous_policy is not None else set()
-                for member in sorted(final_members - previous_members):
-                    yield InterfaceIdentity("switch", (primary_id,), member.lower()), logical_identity
+                current_members = set(self._member_names(current_policy.get("ports")))
+                final_members = set(self._member_names(getattr(final_policy, "ports", None))) if final_policy is not None else set()
+                for member in sorted(current_members | final_members, key=str.lower):
+                    yield InterfaceIdentity("switch", (primary_id,), member), logical_identity
                 continue
 
             pair_scope = self._vpc_pair_scope(switch_ip)
             peer_ids = [switch_id for switch_id in pair_scope if switch_id != primary_id]
-            member_fields = (("peer1_member_ports", primary_id),)
+            member_fields: tuple[tuple[str, str, str], ...] = (("peer1_member_ports", "peer1MemberPorts", primary_id),)
             if len(peer_ids) == 1:
-                member_fields += (("peer2_member_ports", peer_ids[0]),)
-            for field_name, switch_id in member_fields:
-                final_members = set(getattr(policy, field_name, None) or [])
-                previous_members = set(getattr(previous_policy, field_name, None) or []) if previous_policy is not None else set()
-                for member in sorted(final_members - previous_members):
-                    yield InterfaceIdentity("switch", (switch_id,), member.lower()), logical_identity
+                member_fields += (("peer2_member_ports", "peer2MemberPorts", peer_ids[0]),)
+            for model_field, wire_field, switch_id in member_fields:
+                current_members = set(self._member_names(current_policy.get(wire_field)))
+                final_members = set(self._member_names(getattr(final_policy, model_field, None))) if final_policy is not None else set()
+                for member in sorted(current_members | final_members, key=str.lower):
+                    yield InterfaceIdentity("switch", (switch_id,), member), logical_identity
 
     def _find_member_conflicts(
         self,
         resources: list[InterfaceResourcePlan],
-        actions: dict[InterfaceIdentity, list[tuple[InterfaceResourcePlan, str]]],
         add: Callable[..., None],
     ) -> None:
         """Reject duplicate member ownership and simultaneous Ethernet/member edits."""
         claims: dict[InterfaceIdentity, list[tuple[InterfaceResourcePlan, InterfaceIdentity]]] = defaultdict(list)
-        ethernet_actions: dict[InterfaceIdentity, list[InterfaceResourcePlan]] = defaultdict(list)
-        for identity, entries in actions.items():
-            for resource, _action in entries:
-                if resource.adapter.ownership_domain == "ethernet":
-                    ethernet_actions[identity].append(resource)
+        ethernet_actions: dict[
+            InterfaceIdentity,
+            list[tuple[InterfaceResourcePlan, str, NDBaseModel]],
+        ] = defaultdict(list)
+        current_owners, current_owner_ids = self._current_member_owners()
+        inventory = self._inventory()
         for resource in resources:
-            for member_identity, logical_identity in self._new_member_claims(resource):
+            if resource.adapter.ownership_domain == "ethernet":
+                for action, item in self._iter_operations(resource):
+                    ethernet_actions[self._identity(resource.adapter, item)].append((resource, action, item))
+        for resource in resources:
+            for member_identity, logical_identity in self._protected_member_claims(resource):
                 claims[member_identity].append((resource, logical_identity))
 
         for member_identity, entries in claims.items():
@@ -490,15 +1366,93 @@ class InterfaceWorkflowPlanner:
                     "duplicate_member_ownership",
                     member_identity,
                     participants,
-                    f"Physical member {member_identity.label} is newly assigned to multiple aggregate interfaces.",
+                    f"Physical member {member_identity.label} is a current or final member of multiple aggregate interfaces.",
                 )
-            ethernet_participants = ethernet_actions.get(member_identity, [])
-            if ethernet_participants:
+            existing_owners = current_owners.get(member_identity, set())
+            foreign_owners = existing_owners - logical_identities
+            if foreign_owners:
+                add(
+                    "existing_member_ownership",
+                    member_identity,
+                    participants,
+                    f"Physical member {member_identity.label} is already owned by aggregate interface(s) "
+                    f"{sorted(owner.label for owner in foreign_owners)}.",
+                )
+            ethernet = inventory.get((member_identity.scope[0], member_identity.interface_name))
+            port_channel_id = self._effective_port_channel_id(ethernet)
+            if port_channel_id is not None:
+                matching_owners = existing_owners.intersection(logical_identities)
+                expected_ids = {
+                    expected_id
+                    for owner in matching_owners
+                    for expected_id in current_owner_ids.get(member_identity, {}).get(owner, set())
+                }
+                if not matching_owners or not expected_ids:
+                    add(
+                        "operational_member_ownership",
+                        member_identity,
+                        participants,
+                        f"Physical member {member_identity.label} reports operational port-channel membership "
+                        f"{port_channel_id}, but no matching aggregate owner and ID can be proven from raw inventory.",
+                    )
+                elif port_channel_id not in expected_ids:
+                    add(
+                        "operational_member_mismatch",
+                        member_identity,
+                        participants,
+                        f"Physical member {member_identity.label} reports operational port-channel membership "
+                        f"{port_channel_id}, but its matching aggregate owner expects {sorted(expected_ids)}.",
+                    )
+            ethernet_entries = ethernet_actions.get(member_identity, [])
+            if ethernet_entries:
                 add(
                     "ethernet_member_collision",
                     member_identity,
-                    [*participants, *ethernet_participants],
-                    f"Physical member {member_identity.label} is mutated as Ethernet while being newly attached to an aggregate interface.",
+                    [*participants, *(resource for resource, _action, _item in ethernet_entries)],
+                    f"Physical member {member_identity.label} is mutated as Ethernet while protected as a current or final aggregate member.",
+                )
+
+        for member_identity, ethernet_entries in ethernet_actions.items():
+            if member_identity in claims:
+                continue
+            existing_owners = current_owners.get(member_identity, set())
+            ethernet = inventory.get((member_identity.scope[0], member_identity.interface_name))
+            configured_id = self._configured_port_channel_id(ethernet)
+            operational_id = EthernetTrunkHostInterfaceOrchestrator._existing_port_channel_id(ethernet)
+            if not existing_owners and configured_id is None and operational_id is None:
+                continue
+
+            protected: list[InterfaceResourcePlan] = []
+            for resource, action, item in ethernet_entries:
+                if action != "update":
+                    protected.append(resource)
+                    continue
+                if not isinstance(resource.orchestrator, EthernetBaseOrchestrator):
+                    protected.append(resource)
+                    continue
+                membership_record = self._ethernet_membership_record(ethernet)
+                if membership_record is ethernet and operational_id is None:
+                    expected_ids = {
+                        expected_id
+                        for owner in existing_owners
+                        for expected_id in current_owner_ids.get(member_identity, {}).get(owner, set())
+                    }
+                    membership_record = deepcopy(ethernet) if ethernet is not None else {}
+                    membership_record["operData"] = {
+                        **(membership_record.get("operData") or {}),
+                        "portChannelId": min(expected_ids) if expected_ids else 1,
+                    }
+                try:
+                    resource.orchestrator._check_port_channel_restrictions(item, membership_record)
+                except Exception:
+                    protected.append(resource)
+            if protected:
+                add(
+                    "ethernet_member_collision",
+                    member_identity,
+                    protected,
+                    f"Physical member {member_identity.label} is mutated as Ethernet while owned by current aggregate "
+                    f"interface(s) {sorted(owner.label for owner in existing_owners)}.",
                 )
 
     def _run_preflights(self, resources: list[InterfaceResourcePlan]) -> None:
@@ -507,7 +1461,8 @@ class InterfaceWorkflowPlanner:
             if resource.state == "deleted":
                 continue
             try:
-                resource.orchestrator.preflight_create(resource.operations.creates)
+                create_candidates = [*resource.operations.creates, *(transition.desired for transition in resource.transitions)]
+                resource.orchestrator.preflight_create(create_candidates)
                 if self.run_capability_preflight:
                     resource.orchestrator.preflight(list(resource.proposed))
             except Exception as exc:

--- a/plugins/module_utils/interface_workflow_planner.py
+++ b/plugins/module_utils/interface_workflow_planner.py
@@ -1,0 +1,516 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Read-only planning and cross-family conflict detection for interfaces."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from ansible_collections.cisco.nd.plugins.module_utils.interface_family_adapters import (
+    INTERFACE_FAMILY_ADAPTERS,
+    InterfaceFamilyAdapter,
+    InterfaceWorkflowValidationError,
+    get_interface_family_adapter,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_plan import NDStatePlan
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import (
+    EthernetTrunkHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.module_utils.rest.results import Results
+
+RestSendFactory = Callable[[dict[str, Any]], RestSend]
+
+
+@dataclass(frozen=True, order=True)
+class InterfaceIdentity:
+    """Canonical ownership identity independent of a family model's identifier."""
+
+    scope_kind: str
+    scope: tuple[str, ...]
+    interface_name: str
+
+    @property
+    def label(self) -> str:
+        """Return a compact identity for diagnostics."""
+        return f"{self.scope_kind}[{','.join(self.scope)}]/{self.interface_name}"
+
+
+@dataclass(frozen=True)
+class InterfaceWorkflowConflict:
+    """One deterministic conflict discovered across resource plans."""
+
+    code: str
+    identity: InterfaceIdentity
+    resource_indices: tuple[int, ...]
+    resource_types: tuple[str, ...]
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the conflict for future aggregate module output."""
+        return {
+            "code": self.code,
+            "identity": self.identity.label,
+            "resource_indices": list(self.resource_indices),
+            "resource_types": list(self.resource_types),
+            "message": self.message,
+        }
+
+
+class InterfaceWorkflowConflictError(ValueError):
+    """Raised after all compatible cross-family conflicts have been collected."""
+
+    def __init__(self, conflicts: Iterable[InterfaceWorkflowConflict]) -> None:
+        self.conflicts = tuple(conflicts)
+        summary = "; ".join(conflict.message for conflict in self.conflicts)
+        super().__init__(f"Interface workflow has {len(self.conflicts)} conflict(s): {summary}")
+
+
+@dataclass(frozen=True)
+class InterfaceResourcePlan:
+    """Validated current state and pure operation plan for one resource group."""
+
+    resource_index: int
+    adapter: InterfaceFamilyAdapter
+    state: str
+    proposed: NDConfigCollection = field(repr=False, compare=False)
+    before: NDConfigCollection = field(repr=False, compare=False)
+    operations: NDStatePlan = field(repr=False, compare=False)
+    orchestrator: NDBaseInterfaceOrchestrator = field(repr=False, compare=False)
+
+    @property
+    def resource_type(self) -> str:
+        """Return the public resource discriminator."""
+        return self.adapter.resource_type
+
+    @property
+    def changed(self) -> bool:
+        """Return whether this group has a planned mutation."""
+        return self.operations.changed
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the read-only plan using replayable model config."""
+        return {
+            "resource_index": self.resource_index,
+            "type": self.resource_type,
+            "module": self.adapter.module_name,
+            "state": self.state,
+            "changed": self.changed,
+            "before": self.before.to_ansible_config(),
+            "proposed": self.proposed.to_ansible_config(),
+            "after": self.operations.after.to_ansible_config(),
+            "created": [item.to_config() for item in self.operations.creates],
+            "updated": [item.to_config() for item in self.operations.updates],
+            "deleted": [item.to_config() for item in self.operations.deletes],
+        }
+
+
+@dataclass(frozen=True)
+class InterfaceWorkflowPlan:
+    """Complete mutation-free plan across all requested interface families."""
+
+    fabric_name: str
+    target_switch_ids: tuple[str, ...]
+    resources: tuple[InterfaceResourcePlan, ...]
+    request_stats: dict[str, int]
+
+    @property
+    def changed(self) -> bool:
+        """Return whether any resource group has a planned mutation."""
+        return any(resource.changed for resource in self.resources)
+
+    @property
+    def mutation_count(self) -> int:
+        """Return the total planned mutation count."""
+        return sum(resource.operations.mutation_count for resource in self.resources)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the aggregate read-only plan."""
+        return {
+            "fabric_name": self.fabric_name,
+            "changed": self.changed,
+            "mutation_count": self.mutation_count,
+            "target_switch_ids": list(self.target_switch_ids),
+            "resources": [resource.to_dict() for resource in self.resources],
+            "request_stats": dict(self.request_stats),
+        }
+
+
+class InterfaceWorkflowPlanner:
+    """Validate and plan all resource groups before any interface mutation."""
+
+    _GROUP_KEYS = frozenset({"type", "state", "config"})
+
+    def __init__(
+        self,
+        *,
+        snapshot: InterfaceStateSnapshot,
+        rest_send_factory: RestSendFactory | None = None,
+        vpc_pair_by_switch_ip: Mapping[str, str | Iterable[str]] | None = None,
+        run_capability_preflight: bool = False,
+    ) -> None:
+        self.snapshot = snapshot
+        self.fabric_context = snapshot.fabric_context
+        self.rest_send_factory = rest_send_factory or RestSend
+        self.vpc_pair_by_switch_ip = dict(vpc_pair_by_switch_ip or {})
+        self.run_capability_preflight = run_capability_preflight
+        self._vpc_pair_scope_cache: dict[str, tuple[str, ...]] = {}
+
+    def plan(self, resources: list[dict[str, Any]]) -> InterfaceWorkflowPlan:
+        """Return a complete read-only plan or raise before any mutation method is called."""
+        validated = self._validate_resource_groups(resources)
+        target_switch_ids = self._target_switch_ids(validated)
+        self.snapshot.load_switches(target_switch_ids)
+
+        resource_plans: list[InterfaceResourcePlan] = []
+        for resource_index, adapter, state, proposed in validated:
+            try:
+                params = {
+                    "fabric_name": self.snapshot.fabric_name,
+                    "state": state,
+                    "config": proposed.to_ansible_config(),
+                    "check_mode": True,
+                }
+                rest_send = self.rest_send_factory(params)
+                results = Results()
+                results.state = state
+                results.check_mode = True
+                orchestrator = adapter.build_orchestrator(rest_send=rest_send, snapshot=self.snapshot, results=results)
+                before = adapter.existing_collection(orchestrator)
+                operations = adapter.plan(before=before, proposed=proposed, state=state)
+            except Exception as exc:
+                raise InterfaceWorkflowValidationError(
+                    f"resources[{resource_index}] type '{adapter.resource_type}' planning failed through {adapter.module_name}: {exc}"
+                ) from exc
+            resource_plans.append(
+                InterfaceResourcePlan(
+                    resource_index=resource_index,
+                    adapter=adapter,
+                    state=state,
+                    proposed=proposed,
+                    before=before,
+                    operations=operations,
+                    orchestrator=orchestrator,
+                )
+            )
+
+        conflicts = self._find_conflicts(resource_plans)
+        if conflicts:
+            raise InterfaceWorkflowConflictError(conflicts)
+
+        self._run_preflights(resource_plans)
+        return InterfaceWorkflowPlan(
+            fabric_name=self.snapshot.fabric_name,
+            target_switch_ids=target_switch_ids,
+            resources=tuple(resource_plans),
+            request_stats=self.snapshot.request_stats,
+        )
+
+    def _validate_resource_groups(self, resources: list[dict[str, Any]]) -> list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]:
+        """Validate group envelopes and delegate each config to its family adapter."""
+        if not isinstance(resources, list):
+            raise InterfaceWorkflowValidationError("resources must be a list.")
+
+        validated: list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]] = []
+        for resource_index, resource in enumerate(resources):
+            if not isinstance(resource, dict):
+                raise InterfaceWorkflowValidationError(f"resources[{resource_index}] must be a dictionary.")
+            unknown = set(resource) - self._GROUP_KEYS
+            if unknown:
+                raise InterfaceWorkflowValidationError(f"resources[{resource_index}] contains unsupported keys: {', '.join(sorted(unknown))}.")
+            resource_type = resource.get("type")
+            if not isinstance(resource_type, str) or not resource_type:
+                raise InterfaceWorkflowValidationError(f"resources[{resource_index}].type must be a non-empty string.")
+            if "config" not in resource:
+                raise InterfaceWorkflowValidationError(f"resources[{resource_index}].config is required.")
+            state = resource.get("state", "merged")
+            if not isinstance(state, str):
+                raise InterfaceWorkflowValidationError(f"resources[{resource_index}].state must be a string.")
+            adapter = get_interface_family_adapter(resource_type)
+            proposed = adapter.validate_config(resource["config"], state, resource_index)
+            validated.append((resource_index, adapter, state, proposed))
+        return validated
+
+    def _target_switch_ids(self, validated: list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]) -> tuple[str, ...]:
+        """Resolve the union of configured switches, expanding override to the fabric."""
+        fabric_wide = any(state == "overridden" for _index, _adapter, state, _proposed in validated)
+        switch_ids: list[str] = []
+        for resource_index, adapter, _state, proposed in validated:
+            for item in proposed:
+                switch_ip = getattr(item, "switch_ip", None)
+                try:
+                    switch_id = self.fabric_context.get_switch_id(switch_ip)
+                except Exception as exc:
+                    raise InterfaceWorkflowValidationError(
+                        f"resources[{resource_index}] type '{adapter.resource_type}' cannot resolve switch_ip '{switch_ip}': {exc}"
+                    ) from exc
+                switch_ids.append(switch_id)
+                if adapter.ownership_domain == "vpc":
+                    switch_ids.extend(self._vpc_pair_scope(switch_ip))
+        if fabric_wide:
+            return tuple(dict.fromkeys(self.fabric_context.switch_map.values()))
+        return tuple(dict.fromkeys(switch_ids))
+
+    def _vpc_pair_scope(self, switch_ip: str) -> tuple[str, ...]:
+        """Return an unordered pair of switch IDs, or a primary-only fallback."""
+        if switch_ip in self._vpc_pair_scope_cache:
+            return self._vpc_pair_scope_cache[switch_ip]
+
+        primary_id = self.fabric_context.get_switch_id(switch_ip)
+        configured = self.vpc_pair_by_switch_ip.get(switch_ip)
+        if configured is None:
+            scope = (primary_id,)
+        else:
+            tokens = [switch_ip]
+            tokens.extend([configured] if isinstance(configured, str) else list(configured))
+            resolved: set[str] = set()
+            for token in tokens:
+                if token in self.fabric_context.switch_map:
+                    resolved.add(self.fabric_context.switch_map[token])
+                elif token in self.fabric_context.switch_map_by_id:
+                    resolved.add(token)
+                else:
+                    raise InterfaceWorkflowValidationError(f"vPC pair context for switch_ip '{switch_ip}' contains unknown switch '{token}'.")
+            if len(resolved) != 2:
+                raise InterfaceWorkflowValidationError(
+                    f"vPC pair context for switch_ip '{switch_ip}' must resolve to exactly two switches; got {sorted(resolved)}."
+                )
+            scope = tuple(sorted(resolved))
+        self._vpc_pair_scope_cache[switch_ip] = scope
+        return scope
+
+    def _identity(self, adapter: InterfaceFamilyAdapter, item: NDBaseModel) -> InterfaceIdentity:
+        """Build a switch- or pair-scoped global ownership identity."""
+        switch_ip = getattr(item, "switch_ip")
+        interface_name = getattr(item, "interface_name").lower()
+        if adapter.ownership_domain == "vpc":
+            return InterfaceIdentity("vpc_pair", self._vpc_pair_scope(switch_ip), interface_name)
+        return InterfaceIdentity("switch", (self.fabric_context.get_switch_id(switch_ip),), interface_name)
+
+    @staticmethod
+    def _iter_operations(resource: InterfaceResourcePlan) -> Iterable[tuple[str, NDBaseModel]]:
+        """Yield action/model pairs in deterministic execution order."""
+        for item in resource.operations.updates:
+            yield "update", item
+        for item in resource.operations.creates:
+            yield "create", item
+        for item in resource.operations.deletes:
+            yield "delete", item
+
+    def _find_conflicts(self, resources: list[InterfaceResourcePlan]) -> tuple[InterfaceWorkflowConflict, ...]:
+        """Collect ownership, action, transition, and member dependency conflicts."""
+        conflicts: list[InterfaceWorkflowConflict] = []
+        seen_conflicts: set[tuple[str, InterfaceIdentity, tuple[int, ...]]] = set()
+
+        def add(
+            code: str,
+            identity: InterfaceIdentity,
+            participants: Iterable[InterfaceResourcePlan],
+            message: str,
+        ) -> None:
+            unique = {participant.resource_index: participant for participant in participants}
+            ordered = tuple(unique[index] for index in sorted(unique))
+            indices = tuple(participant.resource_index for participant in ordered)
+            key = (code, identity, indices)
+            if key in seen_conflicts:
+                return
+            seen_conflicts.add(key)
+            conflicts.append(
+                InterfaceWorkflowConflict(
+                    code=code,
+                    identity=identity,
+                    resource_indices=indices,
+                    resource_types=tuple(participant.resource_type for participant in ordered),
+                    message=message,
+                )
+            )
+
+        desired_claims: dict[InterfaceIdentity, list[InterfaceResourcePlan]] = defaultdict(list)
+        for resource in resources:
+            if resource.state == "deleted":
+                continue
+            for item in resource.proposed:
+                desired_claims[self._identity(resource.adapter, item)].append(resource)
+
+        for identity, participants in desired_claims.items():
+            indices = sorted({participant.resource_index for participant in participants})
+            if len(indices) > 1:
+                add(
+                    "duplicate_ownership",
+                    identity,
+                    participants,
+                    f"{identity.label} is claimed by multiple resource groups {indices}.",
+                )
+
+        actions: dict[InterfaceIdentity, list[tuple[InterfaceResourcePlan, str]]] = defaultdict(list)
+        for resource in resources:
+            for action, item in self._iter_operations(resource):
+                actions[self._identity(resource.adapter, item)].append((resource, action))
+
+        for identity, entries in actions.items():
+            participants = [resource for resource, _action in entries]
+            indices = sorted({participant.resource_index for participant in participants})
+            if len(indices) < 2:
+                continue
+            action_names = {action for _resource, action in entries}
+            if "delete" in action_names and action_names - {"delete"}:
+                add(
+                    "delete_write_collision",
+                    identity,
+                    participants,
+                    f"{identity.label} is deleted and created or updated by resource groups {indices}.",
+                )
+            else:
+                add(
+                    "duplicate_mutation",
+                    identity,
+                    participants,
+                    f"{identity.label} has overlapping mutations from resource groups {indices}.",
+                )
+
+        for resource in resources:
+            if resource.state != "overridden":
+                continue
+            for item in resource.operations.deletes:
+                identity = self._identity(resource.adapter, item)
+                other_claims = [claim for claim in desired_claims.get(identity, []) if claim.resource_index != resource.resource_index]
+                if other_claims:
+                    add(
+                        "overridden_ownership",
+                        identity,
+                        [resource, *other_claims],
+                        f"resources[{resource.resource_index}] overridden deletion of {identity.label} conflicts with another desired group.",
+                    )
+
+        self._find_existing_policy_conflicts(resources, add)
+        self._find_member_conflicts(resources, actions, add)
+        return tuple(conflicts)
+
+    def _find_existing_policy_conflicts(self, resources: list[InterfaceResourcePlan], add: Callable[..., None]) -> None:
+        """Reject creates that would collide with a sibling or unmanaged current policy."""
+        inventory = self.snapshot.interfaces_by_identity
+        policy_owner = {policy_type: adapter.resource_type for adapter in INTERFACE_FAMILY_ADAPTERS.values() for policy_type in adapter.policy_types}
+        for resource in resources:
+            for item in resource.operations.creates:
+                switch_ip = getattr(item, "switch_ip")
+                switch_id = self.fabric_context.get_switch_id(switch_ip)
+                interface_name = getattr(item, "interface_name").lower()
+                scope = self._vpc_pair_scope(switch_ip) if resource.adapter.ownership_domain == "vpc" else (switch_id,)
+                current_records = [inventory[(candidate_id, interface_name)] for candidate_id in scope if (candidate_id, interface_name) in inventory]
+                for current in current_records:
+                    if current.get("interfaceType") not in resource.adapter.interface_types:
+                        continue
+                    policy_type = InterfaceStateSnapshot.policy_type(current)
+                    if policy_type == "trunkHost" and EthernetTrunkHostInterfaceOrchestrator._is_unconfigured_default(current):
+                        continue
+                    if policy_type in resource.adapter.policy_types:
+                        continue
+                    identity = self._identity(resource.adapter, item)
+                    owner = policy_owner.get(policy_type, "an unmanaged controller policy")
+                    add(
+                        "existing_policy_ownership",
+                        identity,
+                        [resource],
+                        f"resources[{resource.resource_index}] type '{resource.resource_type}' would create {identity.label}, but current "
+                        f"policyType '{policy_type}' is owned by {owner}; an explicit transition plan is required.",
+                    )
+
+    @staticmethod
+    def _policy(model: NDBaseModel) -> Any | None:
+        """Return a model's nested interface policy, if present."""
+        config_data = getattr(model, "config_data", None)
+        network_os = getattr(config_data, "network_os", None) if config_data is not None else None
+        return getattr(network_os, "policy", None) if network_os is not None else None
+
+    def _new_member_claims(self, resource: InterfaceResourcePlan) -> Iterable[tuple[InterfaceIdentity, InterfaceIdentity]]:
+        """Yield newly attached physical member and owning logical identities."""
+        if resource.adapter.ownership_domain not in {"port_channel", "vpc"}:
+            return
+        for _action, item in self._iter_operations(resource):
+            if _action == "delete":
+                continue
+            policy = self._policy(item)
+            if policy is None:
+                continue
+            previous = resource.before.get(item.get_identifier_value())
+            previous_policy = self._policy(previous) if previous is not None else None
+            logical_identity = self._identity(resource.adapter, item)
+            switch_ip = getattr(item, "switch_ip")
+            primary_id = self.fabric_context.get_switch_id(switch_ip)
+
+            if resource.adapter.ownership_domain == "port_channel":
+                final_members = set(getattr(policy, "ports", None) or [])
+                previous_members = set(getattr(previous_policy, "ports", None) or []) if previous_policy is not None else set()
+                for member in sorted(final_members - previous_members):
+                    yield InterfaceIdentity("switch", (primary_id,), member.lower()), logical_identity
+                continue
+
+            pair_scope = self._vpc_pair_scope(switch_ip)
+            peer_ids = [switch_id for switch_id in pair_scope if switch_id != primary_id]
+            member_fields = (("peer1_member_ports", primary_id),)
+            if len(peer_ids) == 1:
+                member_fields += (("peer2_member_ports", peer_ids[0]),)
+            for field_name, switch_id in member_fields:
+                final_members = set(getattr(policy, field_name, None) or [])
+                previous_members = set(getattr(previous_policy, field_name, None) or []) if previous_policy is not None else set()
+                for member in sorted(final_members - previous_members):
+                    yield InterfaceIdentity("switch", (switch_id,), member.lower()), logical_identity
+
+    def _find_member_conflicts(
+        self,
+        resources: list[InterfaceResourcePlan],
+        actions: dict[InterfaceIdentity, list[tuple[InterfaceResourcePlan, str]]],
+        add: Callable[..., None],
+    ) -> None:
+        """Reject duplicate member ownership and simultaneous Ethernet/member edits."""
+        claims: dict[InterfaceIdentity, list[tuple[InterfaceResourcePlan, InterfaceIdentity]]] = defaultdict(list)
+        ethernet_actions: dict[InterfaceIdentity, list[InterfaceResourcePlan]] = defaultdict(list)
+        for identity, entries in actions.items():
+            for resource, _action in entries:
+                if resource.adapter.ownership_domain == "ethernet":
+                    ethernet_actions[identity].append(resource)
+        for resource in resources:
+            for member_identity, logical_identity in self._new_member_claims(resource):
+                claims[member_identity].append((resource, logical_identity))
+
+        for member_identity, entries in claims.items():
+            logical_identities = {logical_identity for _resource, logical_identity in entries}
+            participants = [resource for resource, _logical_identity in entries]
+            if len(logical_identities) > 1:
+                add(
+                    "duplicate_member_ownership",
+                    member_identity,
+                    participants,
+                    f"Physical member {member_identity.label} is newly assigned to multiple aggregate interfaces.",
+                )
+            ethernet_participants = ethernet_actions.get(member_identity, [])
+            if ethernet_participants:
+                add(
+                    "ethernet_member_collision",
+                    member_identity,
+                    [*participants, *ethernet_participants],
+                    f"Physical member {member_identity.label} is mutated as Ethernet while being newly attached to an aggregate interface.",
+                )
+
+    def _run_preflights(self, resources: list[InterfaceResourcePlan]) -> None:
+        """Run local create guards and optional API-backed capability checks after conflicts."""
+        for resource in resources:
+            if resource.state == "deleted":
+                continue
+            try:
+                resource.orchestrator.preflight_create(resource.operations.creates)
+                if self.run_capability_preflight:
+                    resource.orchestrator.preflight(list(resource.proposed))
+            except Exception as exc:
+                raise InterfaceWorkflowValidationError(
+                    f"resources[{resource.resource_index}] type '{resource.resource_type}' preflight failed: {exc}"
+                ) from exc

--- a/plugins/module_utils/interface_workflow_planner.py
+++ b/plugins/module_utils/interface_workflow_planner.py
@@ -25,6 +25,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection impo
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_plan import NDStatePlan
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import EthernetBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_routed_interface import EthernetRoutedInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import (
     EthernetTrunkHostInterfaceOrchestrator,
 )
@@ -132,6 +133,7 @@ class InterfaceResourcePlan:
     operations: NDStatePlan = field(repr=False, compare=False)
     orchestrator: NDBaseInterfaceOrchestrator = field(repr=False, compare=False)
     transitions: tuple[InterfacePolicyTransition, ...] = field(default=(), repr=False, compare=False)
+    platform_deletes: tuple[NDBaseModel, ...] = field(default=(), repr=False, compare=False)
 
     @property
     def resource_type(self) -> str:
@@ -174,6 +176,7 @@ class InterfaceWorkflowPlan:
     target_switch_ids: tuple[str, ...]
     resources: tuple[InterfaceResourcePlan, ...]
     request_stats: dict[str, int]
+    auxiliary_orchestrators: tuple[NDBaseInterfaceOrchestrator, ...] = field(default=(), repr=False, compare=False)
 
     @property
     def changed(self) -> bool:
@@ -218,6 +221,8 @@ class InterfaceWorkflowPlanner:
         self._vpc_pair_scope_cache: dict[str, tuple[str, ...]] = {}
         self._vpc_peer_serial_cache: dict[str, str] | None = None
         self._inventory_by_identity: dict[tuple[str, str], dict[str, Any]] | None = None
+        self._routed_delete_orchestrator: EthernetRoutedInterfaceOrchestrator | None = None
+        self._routed_link_cache_owner: EthernetRoutedInterfaceOrchestrator | None = None
 
     def plan(self, resources: list[dict[str, Any]]) -> InterfaceWorkflowPlan:
         """Return a complete read-only plan or raise before any mutation method is called."""
@@ -242,10 +247,10 @@ class InterfaceWorkflowPlanner:
                 orchestrator = adapter.build_orchestrator(rest_send=rest_send, snapshot=self.snapshot, results=results)
                 if isinstance(orchestrator, VpcInterfaceBaseOrchestrator):
                     orchestrator.share_peer_serial_cache(self._shared_vpc_peer_serial_cache())
+                if isinstance(orchestrator, EthernetRoutedInterfaceOrchestrator):
+                    self._register_routed_orchestrator(orchestrator)
                 before = self._existing_collection(adapter, orchestrator, proposed)
-                planning_before = self._planning_before_for_policy_transitions(
-                    adapter=adapter, before=before, proposed=proposed, state=state
-                )
+                planning_before = self._planning_before_for_policy_transitions(adapter=adapter, before=before, proposed=proposed, state=state)
                 operations = adapter.plan(before=planning_before, proposed=proposed, state=state)
                 if planning_before is not before:
                     operations = replace(operations, before=before)
@@ -272,11 +277,15 @@ class InterfaceWorkflowPlanner:
             raise InterfaceWorkflowConflictError(conflicts)
 
         self._run_preflights(resource_plans)
+        auxiliary_orchestrators = () if self._routed_delete_orchestrator is None else (self._routed_delete_orchestrator,)
+        request_stats = dict(self.snapshot.request_stats)
+        request_stats["fabric_link_gets"] = self._fabric_link_gets([*(resource.orchestrator for resource in resource_plans), *auxiliary_orchestrators])
         return InterfaceWorkflowPlan(
             fabric_name=self.snapshot.fabric_name,
             target_switch_ids=target_switch_ids,
             resources=tuple(resource_plans),
-            request_stats=self.snapshot.request_stats,
+            request_stats=request_stats,
+            auxiliary_orchestrators=auxiliary_orchestrators,
         )
 
     def _validate_resource_groups(self, resources: list[dict[str, Any]]) -> list[tuple[int, InterfaceFamilyAdapter, str, NDConfigCollection]]:
@@ -604,12 +613,94 @@ class InterfaceWorkflowPlanner:
         current_records: tuple[tuple[str, dict[str, Any]], ...],
     ) -> bool:
         """Return whether one physical port is already at the fabric default."""
-        return (
-            adapter.delete_strategy == InterfaceDeleteStrategy.NORMALIZE
-            and len(current_records) == 1
-            and InterfaceStateSnapshot.policy_type(current_records[0][1]) == "trunkHost"
-            and EthernetTrunkHostInterfaceOrchestrator._is_unconfigured_default(current_records[0][1])
-        )
+        if adapter.delete_strategy != InterfaceDeleteStrategy.NORMALIZE or len(current_records) != 1:
+            return False
+        current = current_records[0][1]
+        policy_type = InterfaceStateSnapshot.policy_type(current)
+        if policy_type == "trunkHost":
+            return EthernetTrunkHostInterfaceOrchestrator._is_unconfigured_default(current)
+        if policy_type == "iosXeRoutedHost":
+            return EthernetRoutedInterfaceOrchestrator._is_unconfigured_default(current)
+        return False
+
+    def _platform_delete_models(
+        self,
+        resource: InterfaceResourcePlan,
+        operations: NDStatePlan,
+        inventory: Mapping[tuple[str, str], dict[str, Any]],
+    ) -> tuple[NDBaseModel, ...]:
+        """Build routed proxy models for physical deletes requiring a platform-specific reset implementation."""
+        if resource.adapter.ownership_domain != "ethernet":
+            return ()
+        model_class = get_interface_family_adapter("ethernet_routed").model_class
+        platform_deletes: list[NDBaseModel] = []
+        for desired in operations.deletes:
+            switch_id = self.fabric_context.get_switch_id(getattr(desired, "switch_ip"))
+            current = inventory.get((switch_id, getattr(desired, "interface_name").lower()))
+            if self._wire_network_os_type(current or {}) != "ios-xe":
+                continue
+            platform_deletes.append(
+                model_class(
+                    switch_ip=getattr(desired, "switch_ip"),
+                    interface_name=getattr(desired, "interface_name"),
+                    config_data={"network_os": {"network_os_type": "ios-xe"}},
+                )
+            )
+        if (
+            platform_deletes
+            and resource.state == "deleted"
+            and isinstance(resource.orchestrator, EthernetRoutedInterfaceOrchestrator)
+            and self._routed_delete_orchestrator is None
+        ):
+            self._routed_delete_orchestrator = resource.orchestrator
+        return tuple(platform_deletes)
+
+    def _register_routed_orchestrator(self, orchestrator: EthernetRoutedInterfaceOrchestrator) -> None:
+        """Share one lazy fabric-link cache across every routed orchestrator in this workflow."""
+        if self._routed_link_cache_owner is None:
+            self._routed_link_cache_owner = orchestrator
+            return
+        orchestrator.share_fabric_link_cache(self._routed_link_cache_owner)
+
+    @staticmethod
+    def _fabric_link_gets(orchestrators: Iterable[NDBaseInterfaceOrchestrator]) -> int:
+        """Count unique routed fabric-link GET responses used by safety preflight."""
+        count = 0
+        seen: set[int] = set()
+        for orchestrator in orchestrators:
+            rest_send = orchestrator.rest_send
+            if id(rest_send) in seen:
+                continue
+            seen.add(id(rest_send))
+            for response in rest_send.responses:
+                method = getattr(response.get("METHOD"), "value", response.get("METHOD"))
+                path = str(response.get("REQUEST_PATH") or "")
+                if str(method).upper() == "GET" and "/links" in path:
+                    count += 1
+        return count
+
+    def _shared_routed_delete_orchestrator(self) -> EthernetRoutedInterfaceOrchestrator:
+        """Return one routed orchestrator shared by every platform-specific physical reset in this workflow."""
+        if self._routed_delete_orchestrator is None:
+            params = {
+                "fabric_name": self.snapshot.fabric_name,
+                "state": "deleted",
+                "config": [],
+                "check_mode": True,
+            }
+            results = Results()
+            results.state = "deleted"
+            results.check_mode = True
+            orchestrator = get_interface_family_adapter("ethernet_routed").build_orchestrator(
+                rest_send=self.rest_send_factory(params),
+                snapshot=self.snapshot,
+                results=results,
+            )
+            if not isinstance(orchestrator, EthernetRoutedInterfaceOrchestrator):
+                raise InterfaceWorkflowValidationError("The ethernet_routed adapter did not build its routed orchestrator.")
+            self._register_routed_orchestrator(orchestrator)
+            self._routed_delete_orchestrator = orchestrator
+        return self._routed_delete_orchestrator
 
     def _dependency_errors(
         self,
@@ -974,6 +1065,7 @@ class InterfaceWorkflowPlanner:
                     resource,
                     operations=operations,
                     transitions=tuple(transitions_by_index[resource.resource_index]),
+                    platform_deletes=self._platform_delete_models(resource, operations, inventory),
                 )
             )
         return updated_resources
@@ -1454,11 +1546,15 @@ class InterfaceWorkflowPlanner:
                 )
 
     def _run_preflights(self, resources: list[InterfaceResourcePlan]) -> None:
-        """Run local create guards and optional API-backed capability checks after conflicts."""
+        """Run explicit-delete, local create, and optional API-backed capability guards after conflicts."""
         for resource in resources:
-            if resource.state == "deleted":
-                continue
             try:
+                if resource.state == "deleted":
+                    resource.orchestrator.preflight_delete(list(resource.operations.deletes))
+                    if resource.platform_deletes:
+                        routed_orchestrator = self._shared_routed_delete_orchestrator()
+                        routed_orchestrator.preflight_delete(list(resource.platform_deletes))
+                    continue
                 create_candidates = [*resource.operations.creates, *(transition.desired for transition in resource.transitions)]
                 resource.orchestrator.preflight_create(create_candidates)
                 if self.run_capability_preflight:

--- a/plugins/module_utils/manage_vpc_pair/resources.py
+++ b/plugins/module_utils/manage_vpc_pair/resources.py
@@ -321,7 +321,7 @@ class VpcPairStateMachine(NDStateMachine):
         if state in ["merged", "replaced", "overridden"]:
             self._manage_create_update_state(state, unwanted_keys)
             if state == "overridden":
-                self._manage_override_deletions(override_exceptions)
+                self._manage_vpc_override_deletions(override_exceptions)
         elif state == "deleted":
             self._manage_delete_state()
         else:
@@ -439,7 +439,7 @@ class VpcPairStateMachine(NDStateMachine):
                         error=str(e),
                     )
 
-    def _manage_override_deletions(self, override_exceptions: list[Any]) -> None:
+    def _manage_vpc_override_deletions(self, override_exceptions: list[Any]) -> None:
         """
         Delete pairs that exist on controller but are not in proposed config.
 

--- a/plugins/module_utils/models/interfaces/netflow.py
+++ b/plugins/module_utils/models/interfaces/netflow.py
@@ -1,0 +1,53 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Shared atomic NetFlow merge behavior for interface policy models."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
+
+_NETFLOW_VALIDATION_SUSPENDED: ContextVar[bool] = ContextVar("netflow_validation_suspended", default=False)
+
+
+def netflow_validation_suspended() -> bool:
+    """Return whether an atomic NetFlow merge is in progress."""
+    return _NETFLOW_VALIDATION_SUSPENDED.get()
+
+
+class NetflowAtomicMergeMixin(StormControlMutexMixin):
+    """Merge NetFlow enablement and its required monitor as one valid change."""
+
+    def merge(self, other: NDBaseModel) -> NDBaseModel:
+        """
+        Merge NetFlow intent without exposing an invalid intermediate assignment.
+
+        NDBaseModel.merge assigns explicit fields in model order. Since netflow
+        precedes netflow_monitor, assignment validation would otherwise reject
+        a valid proposal containing both before the monitor assignment occurs.
+        Validate the final pair before mutation, then suspend only this
+        invariant while the shared merge applies all fields.
+        """
+        if not isinstance(other, type(self)):
+            return super().merge(other)
+
+        final_netflow = (
+            getattr(other, "netflow") if "netflow" in other.model_fields_set and getattr(other, "netflow") is not None else getattr(self, "netflow", None)
+        )
+        final_monitor = (
+            getattr(other, "netflow_monitor")
+            if "netflow_monitor" in other.model_fields_set and getattr(other, "netflow_monitor") is not None
+            else getattr(self, "netflow_monitor", None)
+        )
+        if final_netflow is True and not final_monitor:
+            raise ValueError("netflow_monitor must be provided when netflow is true.")
+
+        token = _NETFLOW_VALIDATION_SUSPENDED.set(True)
+        try:
+            return super().merge(other)
+        finally:
+            _NETFLOW_VALIDATION_SUSPENDED.reset(token)

--- a/plugins/module_utils/models/interfaces/port_channel_access_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_access_interface.py
@@ -52,7 +52,10 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     SpeedEnum,
     StormControlActionEnum,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.netflow import (
+    NetflowAtomicMergeMixin,
+    netflow_validation_suspended,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
@@ -65,7 +68,7 @@ _INTERFACE_NAME_PREFIX_RE = re.compile(r"^([A-Za-z]+)(.*)$")
 _CANONICAL_MEMBER_TYPE = "Ethernet"
 
 
-class PortChannelAccessPolicyModel(StormControlMutexMixin):
+class PortChannelAccessPolicyModel(NetflowAtomicMergeMixin):
     """
     # Summary
 
@@ -172,6 +175,8 @@ class PortChannelAccessPolicyModel(StormControlMutexMixin):
 
         - If `netflow` is true and `netflow_monitor` is missing or empty.
         """
+        if netflow_validation_suspended():
+            return self
         if self.netflow is True and not self.netflow_monitor:
             raise ValueError("netflow_monitor must be provided when netflow is true.")
         return self

--- a/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/port_channel_trunk_host_interface.py
@@ -55,7 +55,10 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums i
     StormControlActionEnum,
     TrunkPoHostPolicyTypeEnum,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.storm_control import StormControlMutexMixin
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.netflow import (
+    NetflowAtomicMergeMixin,
+    netflow_validation_suspended,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
@@ -209,7 +212,7 @@ class PortChannelTrunkHostVlanMappingEntryModel(NDNestedModel):
     provider_vlan_id: int | None = Field(default=None, alias="providerVlanId", ge=1, le=4094, description="Provider VLAN id")
 
 
-class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
+class PortChannelTrunkHostPolicyModel(NetflowAtomicMergeMixin):
     """
     # Summary
 
@@ -343,6 +346,8 @@ class PortChannelTrunkHostPolicyModel(StormControlMutexMixin):
 
         - If `netflow` is true and `netflow_monitor` is missing or empty.
         """
+        if netflow_validation_suspended():
+            return self
         if self.netflow is True and not self.netflow_monitor:
             raise ValueError("netflow_monitor must be provided when netflow is true.")
         return self

--- a/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
+++ b/plugins/module_utils/models/interfaces/subinterface_managed_interface.py
@@ -38,6 +38,7 @@ routing tag, MTU, PIM, ip-redirects, admin-state, and netflow. The "unmanaged" s
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from typing import Any, ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -47,11 +48,17 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SubinterfaceManagedPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.netflow import (
+    NetflowAtomicMergeMixin,
+    netflow_validation_suspended,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
+_ADDRESS_PAIR_VALIDATION_SUSPENDED: ContextVar[bool] = ContextVar("subinterface_address_pair_validation_suspended", default=False)
 
-class SubinterfaceManagedPolicyModel(NDNestedModel):
+
+class SubinterfaceManagedPolicyModel(NetflowAtomicMergeMixin):
     """
     # Summary
 
@@ -143,6 +150,8 @@ class SubinterfaceManagedPolicyModel(NDNestedModel):
 
         - If `netflow` is true and `netflow_monitor` is missing or empty.
         """
+        if netflow_validation_suspended():
+            return self
         if self.netflow is True and not self.netflow_monitor:
             raise ValueError("netflow_monitor must be provided when netflow is true.")
         return self
@@ -162,11 +171,38 @@ class SubinterfaceManagedPolicyModel(NDNestedModel):
         - If exactly one of `ip` / `prefix` is set.
         - If exactly one of `ipv6` / `ipv6_prefix` is set.
         """
+        if _ADDRESS_PAIR_VALIDATION_SUSPENDED.get():
+            return self
         if (self.ip is None) != (self.prefix is None):
             raise ValueError("ip and prefix are required together; set both or neither.")
         if (self.ipv6 is None) != (self.ipv6_prefix is None):
             raise ValueError("ipv6 and ipv6_prefix are required together; set both or neither.")
         return self
+
+    def merge(self, other: NDBaseModel) -> NDBaseModel:
+        """Merge IPv4 and IPv6 address/prefix pairs without invalid intermediate assignments."""
+        if not isinstance(other, type(self)):
+            return super().merge(other)
+
+        for address_field, prefix_field in (("ip", "prefix"), ("ipv6", "ipv6_prefix")):
+            final_address = (
+                getattr(other, address_field)
+                if address_field in other.model_fields_set and getattr(other, address_field) is not None
+                else getattr(self, address_field)
+            )
+            final_prefix = (
+                getattr(other, prefix_field)
+                if prefix_field in other.model_fields_set and getattr(other, prefix_field) is not None
+                else getattr(self, prefix_field)
+            )
+            if (final_address is None) != (final_prefix is None):
+                raise ValueError(f"{address_field} and {prefix_field} are required together; set both or neither.")
+
+        token = _ADDRESS_PAIR_VALIDATION_SUSPENDED.set(True)
+        try:
+            return super().merge(other)
+        finally:
+            _ADDRESS_PAIR_VALIDATION_SUSPENDED.reset(token)
 
 
 class SubinterfaceManagedNetworkOSModel(NDNestedModel):

--- a/plugins/module_utils/models/interfaces/svi_interface.py
+++ b/plugins/module_utils/models/interfaces/svi_interface.py
@@ -33,6 +33,7 @@ ND GUI exposes for managed SVIs on Nexus. OSPF / ISIS / BFD / replication-mode f
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from typing import ClassVar, Literal
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
@@ -42,11 +43,18 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import SviPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.netflow import (
+    NetflowAtomicMergeMixin,
+    netflow_validation_suspended,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.types import AsciiDescription
 
 
-class SviPolicyModel(NDNestedModel):
+_ADDRESS_PAIR_VALIDATION_SUSPENDED: ContextVar[bool] = ContextVar("svi_address_pair_validation_suspended", default=False)
+
+
+class SviPolicyModel(NetflowAtomicMergeMixin):
     """
     # Summary
 
@@ -148,6 +156,8 @@ class SviPolicyModel(NDNestedModel):
 
         - If `netflow` is true and `netflow_monitor` is missing or empty.
         """
+        if netflow_validation_suspended():
+            return self
         if self.netflow is True and not self.netflow_monitor:
             raise ValueError("netflow_monitor must be provided when netflow is true.")
         return self
@@ -167,11 +177,38 @@ class SviPolicyModel(NDNestedModel):
         - If exactly one of `ip` / `prefix` is set.
         - If exactly one of `ipv6` / `prefixv6` is set.
         """
+        if _ADDRESS_PAIR_VALIDATION_SUSPENDED.get():
+            return self
         if (self.ip is None) != (self.prefix is None):
             raise ValueError("ip and prefix are required together; set both or neither.")
         if (self.ipv6 is None) != (self.prefixv6 is None):
             raise ValueError("ipv6 and prefixv6 are required together; set both or neither.")
         return self
+
+    def merge(self, other: NDBaseModel) -> NDBaseModel:
+        """Merge IPv4 and IPv6 address/prefix pairs without invalid intermediate assignments."""
+        if not isinstance(other, type(self)):
+            return super().merge(other)
+
+        for address_field, prefix_field in (("ip", "prefix"), ("ipv6", "prefixv6")):
+            final_address = (
+                getattr(other, address_field)
+                if address_field in other.model_fields_set and getattr(other, address_field) is not None
+                else getattr(self, address_field)
+            )
+            final_prefix = (
+                getattr(other, prefix_field)
+                if prefix_field in other.model_fields_set and getattr(other, prefix_field) is not None
+                else getattr(self, prefix_field)
+            )
+            if (final_address is None) != (final_prefix is None):
+                raise ValueError(f"{address_field} and {prefix_field} are required together; set both or neither.")
+
+        token = _ADDRESS_PAIR_VALIDATION_SUSPENDED.set(True)
+        try:
+            return super().merge(other)
+        finally:
+            _ADDRESS_PAIR_VALIDATION_SUSPENDED.reset(token)
 
 
 class SviNetworkOSModel(NDNestedModel):

--- a/plugins/module_utils/models/interfaces/vpc_access_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_access_interface.py
@@ -355,13 +355,14 @@ class AccessVpcHostInterfaceModel(NDBaseModel):
     # --- Identifier Configuration ---
     # TODO(4.2.1) vpc-interface-dual-peer-duplicate
     # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in the per-switch
-    # `/interfaces` GET (with identical `configData` and only `switchId` / `peerSwitchId` swapping). Using a composite
-    # (switch_ip, interface_name) identifier caused `_manage_override_deletions` to delete the peer-side duplicate. The
-    # identifier is therefore `interface_name` only; `switch_ip` is kept as a field for routing (URL-path resolution +
-    # peer-resolution) but is excluded from diff and dedup'd in `query_all`.
+    # `/interfaces` GET. The aggregate workflow selects one echo by `interfaceName` plus the authoritative unordered
+    # peer-pair set, so the composite identifier below stays safe: two vPC pairs in one fabric may legally reuse the same
+    # vPC id (ND's `vpcId` resource pool is devicePair-scoped; issue #356), which a name-only identity cannot represent.
+    # Standalone readers must provide equivalent pair-aware deduplication before constructing a multi-pair collection.
+    # `switch_ip` remains excluded from payload and diff because it is routing-only on the wire.
 
-    identifiers: ClassVar[list[str] | None] = ["interface_name"]
-    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
 
     # --- Serialization Configuration ---
 

--- a/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
+++ b/plugins/module_utils/models/interfaces/vpc_trunk_host_interface.py
@@ -19,8 +19,8 @@ use the ND-native `peer1_*` / `peer2_*` naming where `peer1` corresponds to `swi
 ## Model Hierarchy
 
 - `TrunkVpcHostInterfaceModel` (top-level, `NDBaseModel`)
-    - `switch_ip` (routing field; excluded from diff/payload)
-    - `interface_name` (identifier; e.g. `vpc100`)
+    - `switch_ip` (composite identifier; routing field excluded from diff/payload)
+    - `interface_name` (composite identifier; e.g. `vpc100`)
     - `interface_type` (frozen: "vpc")
     - `config_data` -> `TrunkVpcHostConfigDataModel`
         - `mode` (frozen: "trunk")
@@ -514,14 +514,15 @@ class TrunkVpcHostInterfaceModel(NDBaseModel):
 
     # --- Identifier Configuration ---
     # TODO(4.2.1) vpc-interface-dual-peer-duplicate
-    # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in
-    # the per-switch `/interfaces` GET (with identical `configData` and only `switchId` / `peerSwitchId` swapping).
-    # Using a composite (switch_ip, interface_name) identifier caused `_manage_override_deletions` to delete the
-    # peer-side duplicate. The identifier is therefore `interface_name` only; `switch_ip` is kept as a field for
-    # routing (URL-path resolution + peer-resolution) but is excluded from diff and dedup'd in `query_all`.
+    # A vPC interface is a single fabric-level resource, but ND echoes it from BOTH peer switches in the per-switch
+    # `/interfaces` GET. The aggregate workflow selects one echo by `interfaceName` plus the authoritative unordered
+    # peer-pair set, so the composite identifier below stays safe: two vPC pairs in one fabric may legally reuse the same
+    # vPC id (ND's `vpcId` resource pool is devicePair-scoped; issue #356), which a name-only identity cannot represent.
+    # Standalone readers must provide equivalent pair-aware deduplication before constructing a multi-pair collection.
+    # `switch_ip` remains excluded from payload and diff because it is routing-only on the wire.
 
-    identifiers: ClassVar[list[str] | None] = ["interface_name"]
-    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+    identifiers: ClassVar[list[str] | None] = ["switch_ip", "interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "composite"
 
     # --- Serialization Configuration ---
 

--- a/plugins/module_utils/nd_state_machine.py
+++ b/plugins/module_utils/nd_state_machine.py
@@ -12,6 +12,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.nd_output import NDOutput
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_plan import NDStatePlan, NDStatePlanner
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
@@ -92,15 +93,15 @@ class NDStateMachine:
         """
         Manage state according to desired configuration.
         """
+        plan = self._build_plan()
         if self.state in ["merged", "replaced", "overridden"]:
             proposed_items = list(self.proposed)
 
             # Policy-required-on-create guard (issue #350) runs FIRST: it is local-only (self.existing is
             # already in memory), so it fails before the API-backed capability preflight below and before
-            # _manage_create_update_state mutates self.existing, which NDOutput aliases as `after`. Create
-            # subset = proposed items not present in the existing inventory -- the same key-membership
-            # criterion get_diff_config uses to classify "new" (PR #362 review).
-            items_to_create = [item for item in proposed_items if self.existing.get(item.get_identifier_value()) is None]
+            # _manage_create_update_state mutates self.existing, which NDOutput aliases as `after`. The shared
+            # planner supplies the exact create subset used by standalone and aggregate workflows.
+            items_to_create = list(plan.creates)
 
             # Normalize preflight failures to NDStateMachineError (PR #362 review, gmicol). Both preflight
             # hooks raise a bare RuntimeError (base_interface.preflight_create / the capability preflight),
@@ -121,15 +122,15 @@ class NDStateMachine:
             except Exception as e:
                 raise NDStateMachineError(f"Preflight failed: {e}") from e
 
-            self._manage_create_update_state()
+            self._manage_create_update_state(plan)
 
             if self.state == "overridden":
-                self._manage_override_deletions()
+                self._manage_override_deletions(plan)
 
         elif self.state == "deleted":
             # Capability preflight intentionally NOT run for deletes: removing configuration does not
             # depend on a switch's capability to host the interface type (PR #275 scope decision).
-            self._manage_delete_state()
+            self._manage_delete_state(plan)
 
         else:
             raise NDStateMachineError(f"Invalid state: {self.state}")
@@ -152,54 +153,30 @@ class NDStateMachine:
                 raise NDStateMachineError(error_msg) from e
         return None
 
-    def _manage_create_update_state(self) -> None:
-        """
-        Handle merged/replaced/overridden states.
-        """
-        items_to_create: list[NDBaseModel] = []
-        items_to_update: list[NDBaseModel] = []
+    def _build_plan(self) -> NDStatePlan:
+        """Calculate all operations without invoking an orchestrator mutation method."""
+        try:
+            return NDStatePlanner.plan(
+                state=self.state,
+                before=self.before,
+                proposed=self.proposed,
+                ignore_errors=self.ignore_errors,
+            )
+        except Exception as e:
+            raise NDStateMachineError(str(e)) from e
 
-        for proposed_item in self.proposed:
-            identifier = None
-            try:
-                # Extract identifier
-                identifier = proposed_item.get_identifier_value()
-                # Determine diff status
-                # For merged state, only compare fields explicitly provided by
-                # the user so that Pydantic default values do not trigger false
-                # diffs or overwrite existing configuration.
-                exclude_unset = self.state == "merged"
-                diff_status = self.existing.get_diff_config(proposed_item, exclude_unset=exclude_unset)
+    def _manage_create_update_state(self, plan: NDStatePlan | None = None) -> None:
+        """Execute the create/update portion of a precomputed state plan."""
+        plan = plan or self._build_plan()
+        items_to_create = list(plan.creates)
+        items_to_update = list(plan.updates)
 
-                # No changes needed
-                if diff_status == "no_diff":
-                    continue
-
-                # Prepare final config based on state
-                if self.state == "merged":
-                    # Merge with existing
-                    final_item = self.existing.merge(proposed_item)
-                else:
-                    # Replace or creates
-                    if diff_status == "changed":
-                        self.existing.replace(proposed_item)
-                    else:
-                        self.existing.add(proposed_item)
-                    final_item = proposed_item
-
-                # Categorize by operation type
-                if diff_status == "changed":
-                    items_to_update.append(final_item)
-                elif diff_status == "new":
-                    items_to_create.append(final_item)
-
-            except Exception as e:
-                if identifier:
-                    error_msg = f"Failed to process {identifier}: {e}"
-                else:
-                    error_msg = f"Failed to process: {e}"
-                if not self.ignore_errors:
-                    raise NDStateMachineError(error_msg) from e
+        # Preserve the existing state machine's prospective-output timing: it calculated every diff and
+        # updated `existing` before sending the first operation.
+        for item in items_to_update:
+            self.existing.replace(item)
+        for item in items_to_create:
+            self.existing.add(item)
 
         # The policy-required-on-create guard (issue #350) runs in manage_state, before the capability
         # preflight and before this method mutates self.existing (PR #362 review).
@@ -224,20 +201,15 @@ class NDStateMachine:
         # Log operation
         self.output.assign(after=self.existing)
 
-    def _manage_override_deletions(self) -> None:
-        """
-        Delete items not in proposed config (for overridden state).
-        """
-        diff_identifiers = self.before.get_diff_identifiers(self.proposed)
-        items_to_delete = [existing_item for identifier in diff_identifiers if (existing_item := self.existing.get(identifier)) is not None]
-        self._delete_items(items_to_delete)
+    def _manage_override_deletions(self, plan: NDStatePlan | None = None) -> None:
+        """Delete items not in proposed config for overridden state."""
+        plan = plan or self._build_plan()
+        self._delete_items(list(plan.deletes))
 
-    def _manage_delete_state(self) -> None:
+    def _manage_delete_state(self, plan: NDStatePlan | None = None) -> None:
         """Handle deleted state."""
-        items_to_delete = [
-            existing_item for proposed_item in self.proposed if (existing_item := self.existing.get(proposed_item.get_identifier_value())) is not None
-        ]
-        self._delete_items(items_to_delete)
+        plan = plan or self._build_plan()
+        self._delete_items(list(plan.deletes))
 
     def _delete_items(self, items: list[NDBaseModel]) -> None:
         """Delete a list of items individually or in bulk."""

--- a/plugins/module_utils/nd_state_plan.py
+++ b/plugins/module_utils/nd_state_plan.py
@@ -1,0 +1,111 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Pure configuration planning shared by state machines and aggregate workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+
+SupportedState = Literal["merged", "replaced", "overridden", "deleted"]
+SUPPORTED_STATES: frozenset[str] = frozenset({"merged", "replaced", "overridden", "deleted"})
+
+
+@dataclass(frozen=True)
+class NDStatePlan:
+    """Immutable operation lists and planned after-state for one resource family."""
+
+    state: str
+    before: NDConfigCollection
+    proposed: NDConfigCollection
+    after: NDConfigCollection
+    creates: tuple[NDBaseModel, ...] = ()
+    updates: tuple[NDBaseModel, ...] = ()
+    deletes: tuple[NDBaseModel, ...] = ()
+    errors: tuple[str, ...] = ()
+
+    @property
+    def changed(self) -> bool:
+        """Return whether the plan contains any mutation."""
+        return bool(self.creates or self.updates or self.deletes)
+
+    @property
+    def mutation_count(self) -> int:
+        """Return the total number of planned create, update, and delete operations."""
+        return len(self.creates) + len(self.updates) + len(self.deletes)
+
+
+class NDStatePlanner:
+    """Calculate state operations without invoking an orchestrator mutation method."""
+
+    @classmethod
+    def plan(
+        cls,
+        *,
+        state: str,
+        before: NDConfigCollection,
+        proposed: NDConfigCollection,
+        ignore_errors: bool = False,
+    ) -> NDStatePlan:
+        """Return the create/update/delete plan and resulting in-memory state."""
+        if state not in SUPPORTED_STATES:
+            raise ValueError(f"Invalid state: {state}")
+
+        after = before.copy()
+        creates: list[NDBaseModel] = []
+        updates: list[NDBaseModel] = []
+        deletes: list[NDBaseModel] = []
+        errors: list[str] = []
+
+        if state in {"merged", "replaced", "overridden"}:
+            for proposed_item in proposed:
+                identifier = None
+                try:
+                    identifier = proposed_item.get_identifier_value()
+                    diff_status = after.get_diff_config(proposed_item, exclude_unset=state == "merged")
+                    if diff_status == "no_diff":
+                        continue
+
+                    if state == "merged":
+                        final_item = after.merge(proposed_item)
+                    else:
+                        if diff_status == "changed":
+                            after.replace(proposed_item)
+                        else:
+                            after.add(proposed_item)
+                        final_item = proposed_item
+
+                    if diff_status == "changed":
+                        updates.append(final_item)
+                    elif diff_status == "new":
+                        creates.append(final_item)
+                except Exception as exc:
+                    message = f"Failed to process {identifier}: {exc}" if identifier is not None else f"Failed to process: {exc}"
+                    if not ignore_errors:
+                        raise ValueError(message) from exc
+                    errors.append(message)
+
+            if state == "overridden":
+                diff_identifiers = before.get_diff_identifiers(proposed)
+                deletes = [existing_item for identifier in diff_identifiers if (existing_item := after.get(identifier)) is not None]
+                after.delete_many([item.get_identifier_value() for item in deletes])
+
+        elif state == "deleted":
+            deletes = [existing_item for proposed_item in proposed if (existing_item := after.get(proposed_item.get_identifier_value())) is not None]
+            after.delete_many([item.get_identifier_value() for item in deletes])
+
+        return NDStatePlan(
+            state=state,
+            before=before,
+            proposed=proposed,
+            after=after,
+            creates=tuple(creates),
+            updates=tuple(updates),
+            deletes=tuple(deletes),
+            errors=tuple(errors),
+        )

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -54,7 +54,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
     - Via `remove_pending` if the bulk remove API request fails.
     """
 
-    deploy: bool = True
+    deploy: bool = False
     interface_state_snapshot: InterfaceStateSnapshot | None = Field(default=None, exclude=True, repr=False)
 
     # Subclasses opt in to capability preflight by setting BOTH ClassVars (e.g. loopback sets

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import ClassVar
 
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesDeploy,
     EpManageInterfacesRemove,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
 from ansible_collections.cisco.nd.plugins.module_utils.interface_capability_preflight import InterfaceCapabilityPreflight
+from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import ModelType, NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
@@ -53,6 +55,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
     """
 
     deploy: bool = True
+    interface_state_snapshot: InterfaceStateSnapshot | None = Field(default=None, exclude=True, repr=False)
 
     # Subclasses opt in to capability preflight by setting BOTH ClassVars (e.g. loopback sets
     # `interface_type = "loopback"` and `interface_mode = "managed"`). Leaving `interface_type` as ""
@@ -69,7 +72,8 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         Initialize mutable private state after Pydantic model construction. Pydantic disallows `Field()` on
         underscore-prefixed names, so these are set here to ensure each instance gets its own container: the
-        deploy/remove queues and the per-switch interface cache read by `_switch_interfaces`.
+        deploy/remove queues. Interface inventory is owned by the injected or lazily-created
+        `InterfaceStateSnapshot` provider.
 
         ## Raises
 
@@ -77,7 +81,11 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         """
         self._pending_deploys: list[tuple[str, str]] = []
         self._pending_removes: list[tuple[str, str]] = []
-        self._switch_interfaces_cache: dict[str, dict[str, dict]] = {}
+        if self.interface_state_snapshot is not None and self.interface_state_snapshot.fabric_name != self.fabric_name:
+            raise ValueError(
+                f"Injected InterfaceStateSnapshot fabric {self.interface_state_snapshot.fabric_name} does not match "
+                f"orchestrator fabric {self.fabric_name}."
+            )
 
     @property
     def fabric_name(self) -> str:
@@ -103,9 +111,22 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         None
         """
+        if self.interface_state_snapshot is not None:
+            return self.interface_state_snapshot.fabric_context
         if self._fabric_context is None:
             self._fabric_context = FabricContext(rest_send=self.rest_send, fabric_name=self.fabric_name)
         return self._fabric_context
+
+    @property
+    def state_snapshot(self) -> InterfaceStateSnapshot:
+        """Return the injected provider or lazily create a standalone provider."""
+        if self.interface_state_snapshot is None:
+            self.interface_state_snapshot = InterfaceStateSnapshot(
+                fabric_name=self.fabric_name,
+                fabric_context=self.fabric_context,
+                request=self._request,
+            )
+        return self.interface_state_snapshot
 
     def _resolve_switch_id(self, switch_ip: str) -> str:
         """
@@ -140,12 +161,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         - Via `_request` if the interface-list API request fails with a non-404 status.
         """
-        if switch_id not in self._switch_interfaces_cache:
-            api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-            interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
-            self._switch_interfaces_cache[switch_id] = {iface["interfaceName"].lower(): iface for iface in interfaces if iface.get("interfaceName")}
-        return self._switch_interfaces_cache[switch_id]
+        return self.state_snapshot.load_switch(switch_id)
 
     def _switches_to_query(self) -> dict[str, str]:
         """
@@ -343,6 +359,16 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         if pair not in self._pending_deploys:
             self._pending_deploys.append(pair)
 
+    @property
+    def pending_deploys(self) -> tuple[tuple[str, str], ...]:
+        """Return an immutable view of interfaces queued for deployment."""
+        return tuple(self._pending_deploys)
+
+    def queue_deploy_targets(self, targets: Sequence[tuple[str, str]]) -> None:
+        """Add pre-resolved interface targets to the deployment queue."""
+        for interface_name, switch_id in targets:
+            self._queue_deploy(interface_name, switch_id)
+
     def _queue_remove(self, interface_name: str, switch_id: str) -> None:
         """
         # Summary
@@ -357,6 +383,16 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         pair = (interface_name, switch_id)
         if pair not in self._pending_removes:
             self._pending_removes.append(pair)
+
+    @property
+    def pending_removes(self) -> tuple[tuple[str, str], ...]:
+        """Return an immutable view of interfaces queued for removal."""
+        return tuple(self._pending_removes)
+
+    def queue_remove_targets(self, targets: Sequence[tuple[str, str]]) -> None:
+        """Add pre-resolved interface targets to the removal queue."""
+        for interface_name, switch_id in targets:
+            self._queue_remove(interface_name, switch_id)
 
     def deploy_pending(self) -> ResponseType | None:
         """

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
@@ -30,6 +31,16 @@ from ansible_collections.cisco.nd.plugins.module_utils.interface_capability_pref
 from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import ModelType, NDBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+_UNSET_RESPONSE = object()
+
+
+@dataclass(frozen=True)
+class DeferredDeleteRequestGroup:
+    """One controller request boundary for queued interface delete/reset work."""
+
+    queue_name: str
+    targets: tuple[tuple[str, str], ...]
 
 
 class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
@@ -64,6 +75,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
     # opts out — used by interface types with no capability endpoint (e.g. future breakout).
     interface_type: ClassVar[str] = ""
     interface_mode: ClassVar[str] = ""
+    deferred_delete_queue_names: ClassVar[frozenset[str]] = frozenset({"remove"})
 
     _fabric_context: FabricContext | None = None
     _capability_preflight: InterfaceCapabilityPreflight | None = None
@@ -436,6 +448,57 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         for interface_name, switch_id in targets:
             self._queue_remove(interface_name, switch_id)
 
+    @property
+    def deferred_delete_queues(self) -> dict[str, tuple[tuple[str, str], ...]]:
+        """Return immutable snapshots of every deferred delete/reset queue this orchestrator can flush."""
+        return {"remove": self.pending_removes}
+
+    @property
+    def pending_deferred_delete_targets(self) -> tuple[tuple[str, str], ...]:
+        """Return every queued delete/reset target once, preserving queue and insertion order."""
+        return tuple(dict.fromkeys(target for targets in self.deferred_delete_queues.values() for target in targets))
+
+    def queue_deferred_delete_targets(self, queue_name: str, targets: Sequence[tuple[str, str]]) -> None:
+        """Import pre-resolved targets into one supported deferred delete/reset queue."""
+        if queue_name != "remove":
+            raise ValueError(f"{type(self).__name__} does not support deferred delete queue {queue_name!r}.")
+        self.queue_remove_targets(targets)
+
+    def dequeue_deferred_delete_targets(self, queue_name: str, targets: Sequence[tuple[str, str]]) -> None:
+        """Remove transferred targets from one supported deferred queue without sending a request."""
+        if queue_name != "remove":
+            raise ValueError(f"{type(self).__name__} does not support deferred delete queue {queue_name!r}.")
+        removed = set(targets)
+        self._pending_removes = [target for target in self._pending_removes if target not in removed]
+
+    def deferred_delete_request_groups(self) -> tuple[DeferredDeleteRequestGroup, ...]:
+        """Describe the exact request groups and order used by `remove_pending`."""
+        if not self.pending_removes:
+            return ()
+        return (DeferredDeleteRequestGroup(queue_name="remove", targets=self.pending_removes),)
+
+    def dequeue_deploy_targets(self, targets: Sequence[tuple[str, str]]) -> None:
+        """Remove exact targets from the pending deploy queue without sending a request."""
+        removed = set(targets)
+        self._pending_deploys = [target for target in self._pending_deploys if target not in removed]
+
+    def deploy_targets(self, targets: Sequence[tuple[str, str]]) -> ResponseType | None:
+        """
+        Deploy exactly the supplied targets in one request without consulting or replacing this orchestrator's pending queue.
+
+        The aggregate workflow uses this after consolidating queues from multiple families. It is safe on a partial-failure path
+        because callers can pass only targets backed by exact controller-success evidence.
+        """
+        if not self.deploy:
+            return None
+        requested = list(dict.fromkeys(targets))
+        if not requested:
+            return None
+        try:
+            return self._deploy_interfaces(requested)
+        except Exception as e:
+            raise RuntimeError(f"Bulk deploy failed for interfaces {requested}: {e}") from e
+
     def deploy_pending(self) -> ResponseType | None:
         """
         # Summary
@@ -454,7 +517,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         if not self.deploy or not self._pending_deploys:
             return None
         try:
-            result = self._deploy_interfaces(self._pending_deploys)
+            result = self.deploy_targets(self._pending_deploys)
             self._pending_deploys = []
             return result
         except Exception as e:
@@ -494,7 +557,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         if not accepted:
             return []
         try:
-            self._deploy_interfaces(accepted)
+            self.deploy_targets(accepted)
         except Exception as e:
             raise RuntimeError(f"Failure-path deploy failed for accepted interfaces {accepted}: {e}") from e
         self._pending_deploys = [pair for pair in self._pending_deploys if pair in unsent]
@@ -515,24 +578,28 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         """
         return set(self._pending_removes)
 
-    def _accepted_multistatus_names(self) -> set[str]:
+    def _accepted_multistatus_names(self, response: Mapping[str, Any] | None | object = _UNSET_RESPONSE) -> set[str]:
         """
         # Summary
 
-        Return the lower-cased `name` of every `DATA.results[]` item in the most recent response whose `status` is exactly
-        `success` (case/whitespace-tolerant). Used after a bulk POST that failed with HTTP 207 Multi-Status to recover the subset
-        the controller accepted, so that subset can still be queued for deploy (PR #550 review). On a 207 the per-item status
+        Return the lower-cased `name` of every `DATA.results[]` item in `response` whose `status` is exactly `success`
+        (case/whitespace-tolerant). Callers handling a request failure pass the response captured for that exact request; this
+        prevents an earlier HTTP 207 from being mistaken for a later request that failed before producing a response (issue #554).
+        When `response` is omitted, the current response is used for backward compatibility. On a 207 the per-item status
         vocabulary is unreliable (vault: `multi-status-207-status-field-inconsistent`; issue #397), so only an exact `success`
         is trusted — the same allowlist `NdV1Strategy.is_success` applies when classifying the response. Returns an empty set
-        when the last response was not a 207 or carries no `results[]` envelope.
+        when the supplied response was not a 207 or carries no `results[]` envelope.
 
         ## Raises
 
         None
         """
-        if self.rest_send.return_code != 207:
+        response = self.rest_send.response_current if response is _UNSET_RESPONSE else response
+        if not isinstance(response, Mapping):
             return set()
-        data = self.rest_send.response_current.get("DATA")
+        if response.get("RETURN_CODE") != 207:
+            return set()
+        data = response.get("DATA")
         results = data.get("results") if isinstance(data, dict) else None
         if not isinstance(results, list):
             return set()

--- a/plugins/module_utils/orchestrators/ethernet_base.py
+++ b/plugins/module_utils/orchestrators/ethernet_base.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import ClassVar
 
 logger = logging.getLogger(__name__)
@@ -139,6 +140,16 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         if pair not in self._pending_normalizes:
             self._pending_normalizes.append(pair)
 
+    @property
+    def pending_normalizes(self) -> tuple[tuple[str, str], ...]:
+        """Return an immutable view of physical interfaces queued for normalization."""
+        return tuple(self._pending_normalizes)
+
+    def queue_normalize_targets(self, targets: Sequence[tuple[str, str]]) -> None:
+        """Add pre-resolved physical-interface targets to the normalize queue."""
+        for interface_name, switch_id in targets:
+            self._queue_normalize(interface_name, switch_id)
+
     def _queue_reset(self, interface_name: str, switch_id: str) -> None:
         """
         # Summary
@@ -156,6 +167,16 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         pair = (interface_name, switch_id)
         if pair not in self._pending_resets:
             self._pending_resets.append(pair)
+
+    @property
+    def pending_resets(self) -> tuple[tuple[str, str], ...]:
+        """Return an immutable view of physical interfaces queued for PUT-as-replace reset."""
+        return tuple(self._pending_resets)
+
+    def queue_reset_targets(self, targets: Sequence[tuple[str, str]]) -> None:
+        """Add pre-resolved physical-interface targets to the reset queue."""
+        for interface_name, switch_id in targets:
+            self._queue_reset(interface_name, switch_id)
 
     @staticmethod
     def _has_unresettable_fields(existing_data: dict | None) -> bool:

--- a/plugins/module_utils/orchestrators/ethernet_base.py
+++ b/plugins/module_utils/orchestrators/ethernet_base.py
@@ -41,7 +41,10 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import InterfaceDefaultConfig
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
+    DeferredDeleteRequestGroup,
+    NDBaseInterfaceOrchestrator,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
 ModelType = NDBaseModel
@@ -79,6 +82,7 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
 
     supports_bulk_create: ClassVar[bool] = True
     supports_bulk_delete: ClassVar[bool] = True
+    deferred_delete_queue_names: ClassVar[frozenset[str]] = frozenset({"normalize", "reset"})
 
     create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
     update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
@@ -211,6 +215,38 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         """Add pre-resolved physical-interface targets to the reset queue."""
         for interface_name, switch_id in targets:
             self._queue_reset(interface_name, switch_id)
+
+    @property
+    def deferred_delete_queues(self) -> dict[str, tuple[tuple[str, str], ...]]:
+        """Return physical normalize and per-interface reset queues through the shared transfer contract."""
+        return {"normalize": self.pending_normalizes, "reset": self.pending_resets}
+
+    def queue_deferred_delete_targets(self, queue_name: str, targets: Sequence[tuple[str, str]]) -> None:
+        """Import pre-resolved targets into a supported physical-interface reset queue."""
+        if queue_name == "normalize":
+            self.queue_normalize_targets(targets)
+            return
+        if queue_name == "reset":
+            self.queue_reset_targets(targets)
+            return
+        raise ValueError(f"{type(self).__name__} does not support deferred delete queue {queue_name!r}.")
+
+    def dequeue_deferred_delete_targets(self, queue_name: str, targets: Sequence[tuple[str, str]]) -> None:
+        """Remove transferred physical reset targets from one local deferred queue."""
+        removed = set(targets)
+        if queue_name == "normalize":
+            self._pending_normalizes = [target for target in self._pending_normalizes if target not in removed]
+            return
+        if queue_name == "reset":
+            self._pending_resets = [target for target in self._pending_resets if target not in removed]
+            return
+        raise ValueError(f"{type(self).__name__} does not support deferred delete queue {queue_name!r}.")
+
+    def deferred_delete_request_groups(self) -> tuple[DeferredDeleteRequestGroup, ...]:
+        """Describe normalize groups followed by the individual PUT reset request boundaries."""
+        groups = [DeferredDeleteRequestGroup(queue_name="normalize", targets=tuple(group)) for group in self._normalize_groups() if group]
+        groups.extend(DeferredDeleteRequestGroup(queue_name="reset", targets=(target,)) for target in self.pending_resets)
+        return tuple(groups)
 
     @staticmethod
     def _has_unresettable_fields(existing_data: dict | None) -> bool:
@@ -418,16 +454,17 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         # Summary
 
         Pre-delete validation run by `NDStateMachine` for `state: deleted` before `delete`/`delete_bulk` — which are skipped
-        in `--check` mode — so a dry run fails on an unresolvable `switch_ip` or on an explicitly named port-channel member
-        exactly like a normal run would (PR #550 review). Wire state comes from the per-switch `interfaceList` cache
-        `query_all` populated; no additional requests. The fabric-wide `overridden` delete set is not routed through this
-        hook: `delete_bulk` skips port-channel members silently there.
+        in `--check` mode — so a dry run fails on an unresolvable `switch_ip`, a fabric-owned policy, or an explicitly named
+        port-channel member exactly like a normal run would. Wire state comes from the per-switch `interfaceList` cache `query_all`
+        populated; no additional requests. The fabric-wide `overridden` delete set is not routed through this hook: `delete_bulk`
+        skips port-channel members silently there.
 
         ## Raises
 
         ### RuntimeError
 
         - If one or more `switch_ip` values do not match any switch in the fabric.
+        - If any named interface carries a fabric-owned policy.
         - If any named interface is a port-channel member.
         - If the interface-list query used to resolve port-channel membership fails.
         """
@@ -435,6 +472,7 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         for model_instance in model_instances:
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             existing_data = self._existing_interface(model_instance.interface_name, switch_id)
+            self._check_fabric_ownership(model_instance, existing_data)
             self._check_port_channel_delete_restriction(model_instance, existing_data)
 
     @staticmethod
@@ -586,10 +624,13 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         groups = self._normalize_groups()
         for index, group in enumerate(groups):
             payload = InterfaceDefaultConfig.to_normalize_payload(group)
+            response_start = len(self.rest_send.responses)
             try:
                 results.append(self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload))
             except Exception as e:
-                accepted = self._dequeue_accepted_normalizes(group)
+                responses = self.rest_send.responses[response_start:]
+                response = responses[-1] if responses else None
+                accepted = self._dequeue_accepted_normalizes(group, response)
                 rejected = [name for name, switch_id in group if (name, switch_id) in self._pending_normalizes]
                 not_attempted = [name for later in groups[index + 1 :] for name, _switch_id in later]
                 msg = f"Bulk normalize failed for {rejected}: {e}."
@@ -604,20 +645,25 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
                 self._pending_normalizes.remove(pair)
         return results
 
-    def _dequeue_accepted_normalizes(self, group: list[tuple[str, str]]) -> list[str]:
+    def _dequeue_accepted_normalizes(
+        self,
+        group: list[tuple[str, str]],
+        response: dict | None = None,
+    ) -> list[str]:
         """
         # Summary
 
-        After a failed normalize request for `group`, dequeue from `_pending_normalizes` every member the most recent response reported
-        as an exact `success` (HTTP 207 Multi-Status only; see `_accepted_multistatus_names`) and return their names in request order.
-        Names are unique within a group by construction (`_normalize_groups`), so a response `name` maps to exactly one pair. Returns an
-        empty list when the failure was not a partial 207.
+        After a failed normalize request for `group`, dequeue from `_pending_normalizes` every member that the response captured for
+        that exact request reported as an exact `success` (HTTP 207 Multi-Status only; see `_accepted_multistatus_names`) and return
+        their names in request order. Names are unique within a group by construction (`_normalize_groups`), so a response `name` maps
+        to exactly one pair. Returns an empty list when the request produced no response or was not a partial 207. The optional fallback
+        preserves compatibility for direct callers while `_normalize_interfaces` always supplies request-scoped evidence (issue #554).
 
         ## Raises
 
         None
         """
-        accepted_names = self._accepted_multistatus_names()
+        accepted_names = self._accepted_multistatus_names(response)
         accepted: list[str] = []
         for interface_name, switch_id in group:
             if interface_name.lower() in accepted_names:
@@ -778,6 +824,7 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         try:
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             existing_data = kwargs.get("existing_data") or self._existing_interface(model_instance.interface_name, switch_id)
+            self._check_fabric_ownership(model_instance, existing_data)
             self._check_port_channel_delete_restriction(model_instance, existing_data)
             if self._has_unresettable_fields(existing_data):
                 self._queue_reset(model_instance.interface_name, switch_id)
@@ -855,27 +902,36 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         # Guarded at runtime by @requires_bulk_support("supports_bulk_create")
         api_endpoint = self._configure_endpoint(self.create_bulk_endpoint(), switch_sn=switch_id)  # pyright: ignore[reportOptionalCall]
         request_body = {"interfaces": [payload for _interface_name, payload in items]}
+        response_start = len(self.rest_send.responses)
         try:
             return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=request_body)
         except Exception as e:
-            accepted = self._queue_accepted_bulk_items(items, switch_id)
+            responses = self.rest_send.responses[response_start:]
+            response = responses[-1] if responses else None
+            accepted = self._queue_accepted_bulk_items(items, switch_id, response)
             if accepted:
                 raise RuntimeError(f"{e}. The controller accepted {accepted} from the same request; their deploy stays queued.") from e
             raise
 
-    def _queue_accepted_bulk_items(self, items: list[tuple[str, dict]], switch_id: str) -> list[str]:
+    def _queue_accepted_bulk_items(
+        self,
+        items: list[tuple[str, dict]],
+        switch_id: str,
+        response: dict | None = None,
+    ) -> list[str]:
         """
         # Summary
 
-        After a failed per-switch bulk POST, queue a deploy for every interface in `items` that the most recent response
-        reported as an exact `success` (HTTP 207 Multi-Status only; see `_accepted_multistatus_names`). Returns the accepted
-        interface names in request order (empty when the failure was not a partial 207).
+        After a failed per-switch bulk POST, queue a deploy for every interface in `items` that the response captured for that exact
+        request reported as an exact `success` (HTTP 207 Multi-Status only; see `_accepted_multistatus_names`). Returns the accepted
+        interface names in request order (empty when the request produced no response or was not a partial 207). The optional fallback
+        preserves compatibility for direct callers while `_post_bulk_group` always supplies request-scoped evidence (issue #554).
 
         ## Raises
 
         None
         """
-        accepted_names = self._accepted_multistatus_names()
+        accepted_names = self._accepted_multistatus_names(response)
         accepted: list[str] = []
         for interface_name, _payload in items:
             if interface_name.lower() in accepted_names:
@@ -911,6 +967,7 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         for model_instance in model_instances:
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             existing_data = kwargs.get("existing_data") or self._existing_interface(model_instance.interface_name, switch_id)
+            self._check_fabric_ownership(model_instance, existing_data)
             port_channel_id = self._existing_port_channel_id(existing_data)
             if port_channel_id is not None:
                 if state == "overridden":

--- a/plugins/module_utils/orchestrators/ethernet_routed_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_routed_interface.py
@@ -34,6 +34,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.etherne
     normalize_ethernet_interface_name,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.policy_base import InterfacePolicyStrictBase
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import DeferredDeleteRequestGroup
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import EthernetBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
 
@@ -114,6 +115,7 @@ class EthernetRoutedInterfaceOrchestrator(EthernetBaseOrchestrator):
     """
 
     model_class: ClassVar[type[NDBaseModel]] = EthernetRoutedInterfaceModel
+    deferred_delete_queue_names: ClassVar[frozenset[str]] = EthernetBaseOrchestrator.deferred_delete_queue_names | frozenset({"platform_reset"})
 
     # TODO(4.2.1) capable-switches-empty-for-ethernet-on-vxlan
     # Deliberate opt-OUT of the capability preflight (both ClassVars ""): the unpublished capableSwitches
@@ -154,6 +156,14 @@ class EthernetRoutedInterfaceOrchestrator(EthernetBaseOrchestrator):
         super().model_post_init(__context)
         self._pending_xe_resets: list[tuple[str, str]] = []
         self._fabric_link_endpoints_cache: dict[tuple[str, str], dict] | None = None
+        self._fabric_link_cache_provider: EthernetRoutedInterfaceOrchestrator | None = None
+
+    def share_fabric_link_cache(self, provider: EthernetRoutedInterfaceOrchestrator) -> None:
+        """Use one routed orchestrator as the workflow-wide owner of lazy fabric-link discovery."""
+        if provider is self:
+            self._fabric_link_cache_provider = None
+            return
+        self._fabric_link_cache_provider = provider
 
     def _fabric_link_endpoints(self) -> dict[tuple[str, str], dict]:
         """
@@ -174,6 +184,8 @@ class EthernetRoutedInterfaceOrchestrator(EthernetBaseOrchestrator):
 
         - Via `_request` if the links query fails with a non-404 status.
         """
+        if self._fabric_link_cache_provider is not None:
+            return self._fabric_link_cache_provider._fabric_link_endpoints()
         if self._fabric_link_endpoints_cache is not None:
             return self._fabric_link_endpoints_cache
         endpoints: dict[tuple[str, str], dict] = {}
@@ -299,6 +311,37 @@ class EthernetRoutedInterfaceOrchestrator(EthernetBaseOrchestrator):
         pair = (interface_name, switch_id)
         if pair not in self._pending_xe_resets:
             self._pending_xe_resets.append(pair)
+
+    @property
+    def pending_platform_resets(self) -> tuple[tuple[str, str], ...]:
+        """Return IOS-XE defaults-only PUT resets through the platform-neutral public contract."""
+        return tuple(self._pending_xe_resets)
+
+    @property
+    def deferred_delete_queues(self) -> dict[str, tuple[tuple[str, str], ...]]:
+        """Extend shared Ethernet queues with platform-specific reset work."""
+        return {**super().deferred_delete_queues, "platform_reset": self.pending_platform_resets}
+
+    def queue_deferred_delete_targets(self, queue_name: str, targets: Sequence[tuple[str, str]]) -> None:
+        """Import shared Ethernet work or IOS-XE platform-reset targets."""
+        if queue_name == "platform_reset":
+            for interface_name, switch_id in targets:
+                self._queue_xe_reset(interface_name, switch_id)
+            return
+        super().queue_deferred_delete_targets(queue_name, targets)
+
+    def dequeue_deferred_delete_targets(self, queue_name: str, targets: Sequence[tuple[str, str]]) -> None:
+        """Remove transferred IOS-XE reset work or delegate a shared Ethernet queue."""
+        if queue_name == "platform_reset":
+            removed = set(targets)
+            self._pending_xe_resets = [target for target in self._pending_xe_resets if target not in removed]
+            return
+        super().dequeue_deferred_delete_targets(queue_name, targets)
+
+    def deferred_delete_request_groups(self) -> tuple[DeferredDeleteRequestGroup, ...]:
+        """Describe IOS-XE PUT resets followed by the shared NX-OS Ethernet request groups."""
+        platform_groups = tuple(DeferredDeleteRequestGroup(queue_name="platform_reset", targets=(target,)) for target in self.pending_platform_resets)
+        return platform_groups + super().deferred_delete_request_groups()
 
     def preflight_delete(self, model_instances: Sequence[NDBaseModel]) -> None:
         """

--- a/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
@@ -12,6 +12,7 @@ for ethernet trunkHost interfaces. It inherits all shared ethernet logic from
 
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
@@ -22,6 +23,28 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.etherne
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import InterfaceDefaultConfig
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import EthernetBaseOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+@lru_cache(maxsize=1)
+def _default_interface_policy() -> dict[str, object]:
+    """Build defaults lazily so sanity imports do not require Pydantic."""
+    return InterfaceDefaultConfig().to_payload()["configData"]["networkOS"]["policy"]
+
+
+def _wire_value_matches_default(value: object, default: object) -> bool:
+    """Compare a raw API value to a normalized default, accepting numeric strings."""
+    if value is None:
+        return True
+    if isinstance(default, bool):
+        return isinstance(value, bool) and value is default
+    if isinstance(default, (int, float)):
+        if isinstance(value, bool):
+            return False
+        try:
+            return float(value) == float(default)
+        except (TypeError, ValueError):
+            return False
+    return value == default
 
 
 class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
@@ -67,10 +90,10 @@ class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
         # Summary
 
         Return `True` if the given interface API response represents an unconfigured `int_trunk_host`
-        default — `allowedVlans` is absent or `"none"`, `description` is absent or empty, `nativeVlan`
-        is absent or `1`, and none of the Class C fields (`InterfaceDefaultConfig.UNRESETTABLE_FIELDS`)
-        are set. Such an interface is indistinguishable from a freshly normalized one and should
-        be treated as out-of-scope for `state: overridden` idempotency.
+        default: every present policy field modeled by `InterfaceDefaultConfig` matches its normalized
+        value, Class C fields are unset, and `vlanMappingEntries` is empty. Absent or null known fields
+        are equivalent to omitted defaults. Such an interface is indistinguishable from a freshly
+        normalized one and should be treated as out-of-scope for `state: overridden` idempotency.
 
         Class C fields are checked because they survive `interfaceActions/normalize` (ND's validator
         rejects 0/null for them); leaving them out of this filter would hide a configured-but-stuck
@@ -82,21 +105,21 @@ class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
         None
         """
         policy = iface.get("configData", {}).get("networkOS", {}).get("policy", {}) or {}
-        allowed_vlans = policy.get("allowedVlans")
-        if allowed_vlans not in (None, "none"):
+        if not isinstance(policy, dict):
             return False
-        description = policy.get("description")
-        if description not in (None, ""):
-            return False
-        native_vlan = policy.get("nativeVlan")
-        if native_vlan not in (None, 1):
-            return False
+        for field, default in _default_interface_policy().items():
+            if field not in policy or policy[field] is None:
+                continue
+            if not _wire_value_matches_default(policy[field], default):
+                return False
         # TODO(4.2.1) normalize-unresettable-policy-fields
         # Class C fields (bandwidth, debounceLinkupTimer, inheritBandwidth) survive interfaceActions/normalize because
         # ND's validator rejects 0/null for them, so a normalized interface still carries any prior value. We must treat
         # such an interface as configured (not an unconfigured default) so `state: deleted` keeps it in scope and routes
         # it to the per-interface PUT-as-replace reset path. See InterfaceDefaultConfig.UNRESETTABLE_FIELDS for the set.
         if any(policy.get(field) is not None for field in InterfaceDefaultConfig.UNRESETTABLE_FIELDS):
+            return False
+        if policy.get("vlanMappingEntries"):
             return False
         return True
 

--- a/plugins/module_utils/orchestrators/port_channel_base.py
+++ b/plugins/module_utils/orchestrators/port_channel_base.py
@@ -271,9 +271,7 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
             self.validate_prerequisites()
             all_port_channels = []
             for switch_ip, switch_id in self._switches_to_query().items():
-                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
+                interfaces = list(self._switch_interfaces(switch_id).values())
                 port_channels = [iface for iface in interfaces if iface.get("interfaceType") == "portChannel"]
                 managed = [
                     iface for iface in port_channels if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -376,9 +376,7 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
 
         - If the interface-list request fails (propagated to `query_all`'s wrapper).
         """
-        api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-        interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
+        interfaces = list(self._switch_interfaces(switch_id).values())
         managed = [iface for iface in interfaces if iface.get("interfaceType") == "vpc" and self._policy_type(iface) in managed_types]
         for iface in managed:
             iface["switchIp"] = switch_ip

--- a/plugins/module_utils/orchestrators/vpc_interface_base.py
+++ b/plugins/module_utils/orchestrators/vpc_interface_base.py
@@ -17,9 +17,10 @@ inherit from this base and provide their own `model_class` and `_managed_policy_
 Inherits shared interface lifecycle operations (deploy queuing, fabric validation, switch resolution) from
 `NDBaseInterfaceOrchestrator` and adds vPC-specific functionality:
 
-- Peer-serial auto-resolution: each create/update reads the per-switch `vpcPair` endpoint to obtain the peer
-  serial, then injects it as `peerSwitchId` in the payload. Results are cached per orchestrator instance so
-  bulk operations make at most one lookup per primary switch.
+- Peer-serial auto-resolution: create/update injects the peer serial as `peerSwitchId` in the payload. Standalone
+  orchestrators resolve a cache miss through the per-switch `vpcPair` endpoint. The aggregate interface workflow
+  shares a cache seeded from its authoritative fabric-wide `vpcPairs` read, so its mutations need no per-primary
+  pair lookups.
 - Standard remove-based deletion (vPC interfaces are virtual and deletable).
 - Fabric-wide `query_all()` filtered by `interfaceType: "vpc"` and per-type policy filtering.
 
@@ -61,8 +62,9 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
     Provides shared logic for all vPC interface types. Subclasses must set `model_class` and implement
     `_managed_policy_types()` to define which policy types they manage.
 
-    Each create/update reads the `vpcPair` record for the primary switch to obtain the peer serial, which is
-    then injected as `peerSwitchId` in the payload. Lookups are cached per orchestrator instance.
+    Each create/update obtains the peer serial from the active cache and injects it as `peerSwitchId` in the
+    payload. Standalone instances populate cache misses from `vpcPair`; aggregate workflows can share a cache
+    pre-seeded from an authoritative `vpcPairs` inventory.
 
     Mutation methods (`create`, `update`) queue deploys for bulk execution. `delete` issues an immediate
     per-interface `DELETE /interfaces/{name}` (the bulk `interfaceActions/remove` endpoint rejects vPC interfaces;
@@ -113,6 +115,10 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         super().model_post_init(__context)
         self._peer_serial_cache: dict[str, str] = {}
 
+    def share_peer_serial_cache(self, cache: dict[str, str]) -> None:
+        """Use a caller-owned peer-serial cache shared by aggregate workflow orchestrators."""
+        self._peer_serial_cache = cache
+
     def _managed_policy_types(self) -> set[str]:
         """
         # Summary
@@ -132,9 +138,9 @@ class VpcInterfaceBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         """
         # Summary
 
-        Resolve the peer switch's serial number for the vPC pair containing `primary_serial`. Reads the per-switch
-        `vpcPair` endpoint. Caches the result per orchestrator instance so bulk operations issue at most one lookup
-        per primary switch.
+        Resolve the peer switch's serial number for the vPC pair containing `primary_serial`. Return a cached value
+        when available; otherwise read the per-switch `vpcPair` endpoint and cache the result. The active cache may
+        be shared with other aggregate-workflow vPC orchestrators.
 
         ## Raises
 

--- a/plugins/module_utils/rest/response_handler_nd.py
+++ b/plugins/module_utils/rest/response_handler_nd.py
@@ -170,6 +170,25 @@ class ResponseHandler:
         else:
             self._handle_post_put_delete_response()
 
+    def _is_terminal_client_error(self, return_code) -> bool:
+        """
+        # Summary
+
+        Return True when `return_code` is a 4xx client error other than 429 (Too Many Requests).
+
+        ## Description
+
+        A 4xx response proves the request reached the application and was rejected: replaying the identical request
+        cannot succeed, so the failure is terminal for every verb. 429 is the one transient 4xx (rate limiting) and
+        stays retryable. No retryable 4xx is documented for any ND 4.2.1 endpoint (the dcnm-era retry-on-400 cases
+        do not carry over). See issue #457.
+
+        ## Raises
+
+        None
+        """
+        return isinstance(return_code, int) and 400 <= return_code <= 499 and return_code != 429
+
     def _handle_get_response(self) -> None:
         """
         # Summary
@@ -183,6 +202,11 @@ class ResponseHandler:
             -   success:
                     -   True if RETURN_CODE in (200, 201, 202, 204, 207, 404)
                     -   False otherwise (error status codes)
+            -   retryable:
+                    -   False when the request succeeded, or when it failed with a 4xx code other than 429 (the
+                        request reached the application and was rejected; an identical replay cannot succeed)
+                    -   True when it failed with any other code (e.g. 5xx — potentially transient, and GET retries
+                        also serve eventual-consistency polling)
         """
         result = {}
         return_code = self.response.get("RETURN_CODE")
@@ -191,14 +215,17 @@ class ResponseHandler:
         if self._strategy.is_not_found(return_code):
             result["found"] = False
             result["success"] = True
+            result["retryable"] = False
         # Success codes with no embedded error - resource found
         elif self._strategy.is_success(self.response):
             result["found"] = True
             result["success"] = True
+            result["retryable"] = False
         # Error codes - request failed
         else:
             result["found"] = False
             result["success"] = False
+            result["retryable"] = not self._is_terminal_client_error(return_code)
 
         self.result = copy.copy(result)
 
@@ -219,8 +246,10 @@ class ResponseHandler:
             -   `retryable`:
                 -   False when the request succeeded, or when it failed with a success-class RETURN_CODE (the application
                     definitively rejected the request, e.g. a Multi-Status per-item failure — replaying the identical
-                    payload cannot succeed, so `RestSend` must not retry)
-                -   True when the request failed with a non-success RETURN_CODE (e.g. 5xx — potentially transient)
+                    payload cannot succeed, so `RestSend` must not retry), or when it failed with a 4xx code other than
+                    429 (the request reached the application and was rejected; same reasoning — see issue #457)
+                -   True when the request failed with any other non-success RETURN_CODE (e.g. 5xx — potentially
+                    transient) or with 429 (rate limiting)
 
         ## Raises
 
@@ -237,12 +266,13 @@ class ResponseHandler:
             result["retryable"] = False
         else:
             # A failure on a success-class RETURN_CODE is an application-level rejection
-            # (embedded error or per-item failure): deterministic, so not retryable.
-            # A failure on a non-success RETURN_CODE keeps the historical retry behavior.
+            # (embedded error or per-item failure): deterministic, so not retryable. A 4xx
+            # other than 429 is equally deterministic — the application rejected the request
+            # (issue #457). Any other non-success RETURN_CODE keeps the historical retry behavior.
             return_code = self.response.get("RETURN_CODE", -1)
             result["success"] = False
             result["changed"] = self._strategy.is_changed_on_failure(self.response)
-            result["retryable"] = return_code not in self._strategy.success_codes
+            result["retryable"] = return_code not in self._strategy.success_codes and not self._is_terminal_client_error(return_code)
 
         self.result = copy.copy(result)
 

--- a/plugins/modules/nd_interface_ethernet_access.py
+++ b/plugins/modules/nd_interface_ethernet_access.py
@@ -411,7 +411,6 @@ EXAMPLES = r"""
 RETURN = r"""
 """
 
-import copy
 import logging
 import traceback
 
@@ -419,6 +418,12 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.interface_config_normalizer import (
+    expand_ethernet_config as _expand_ethernet_config,
+    validate_ethernet_across_item_duplicates as _validate_ethernet_across_item_duplicates,
+    validate_ethernet_interface_names as _validate_ethernet_interface_names,
+    validate_ethernet_within_item_duplicates as _validate_ethernet_within_item_duplicates,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import EthernetAccessInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
@@ -426,130 +431,24 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interf
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import EthernetAccessInterfaceOrchestrator
 
 
-# TODO: When all interface modules using `interface_names: list` are merged, lift
-# `validate_interface_names`, `validate_within_item_duplicates`,
-# `validate_across_item_duplicates`, and `expand_config` into a shared helper module
-# (e.g. `plugins/module_utils/interfaces/config_expansion.py`) and import from there.
 def validate_interface_names(config_list: list[dict]) -> None:
-    """
-    # Summary
-
-    Raise `ValueError` if any element of any `interface_names` list is `None`, an empty string, or not a
-    string. Ansible's `elements="str"` argspec does not reject these (a Jinja loop can easily produce a list
-    with null/empty entries, and a templated value may arrive as a non-string), and downstream `name.lower()`
-    would otherwise raise `AttributeError` / silently insert a blank interface — neither of which is the
-    friendly fail_json the user expects.
-
-    ## Raises
-
-    ### ValueError
-
-    - If any element of `interface_names` is `None`, an empty string, or not a string.
-    """
-    for item_index, group in enumerate(config_list):
-        switch_ip = group.get("switch_ip")
-        interface_names = group.get("interface_names") or []
-        for entry_index, name in enumerate(interface_names):
-            if not isinstance(name, str) or not name:
-                if name is None:
-                    reason = "null"
-                elif not isinstance(name, str):
-                    reason = f"not a string (got {type(name).__name__})"
-                else:
-                    reason = "empty"
-                raise ValueError(
-                    f"interface_names[{entry_index}] for switch '{switch_ip}' (config item {item_index}) is "
-                    f"{reason}. Every entry must be a non-empty interface name."
-                )
+    """Delegate grouped-name validation to the shared workflow normalizer."""
+    _validate_ethernet_interface_names(config_list)
 
 
 def validate_within_item_duplicates(config_list: list[dict]) -> None:
-    """
-    # Summary
-
-    Raise `ValueError` if any single config item lists the same interface name more than once
-    in its `interface_names` list. Comparison is case-insensitive.
-
-    ## Raises
-
-    ### ValueError
-
-    - If an interface name appears more than once within a single config item's `interface_names` list
-    """
-    for item_index, group in enumerate(config_list):
-        switch_ip = group.get("switch_ip")
-        interface_names = group.get("interface_names") or []
-        seen: set[str] = set()
-        for name in interface_names:
-            key = name.lower()
-            if key in seen:
-                raise ValueError(
-                    f"Duplicate interface '{name}' in interface_names for switch '{switch_ip}' "
-                    f"(config item {item_index}). Each interface may appear only once per config item."
-                )
-            seen.add(key)
+    """Delegate within-group duplicate validation to the shared normalizer."""
+    _validate_ethernet_within_item_duplicates(config_list)
 
 
-# TODO: See note above `validate_within_item_duplicates`.
 def validate_across_item_duplicates(config_list: list[dict]) -> None:
-    """
-    # Summary
-
-    Raise `ValueError` if the same `(switch_ip, interface_name)` pair appears in more than one
-    config item. Comparison of interface names is case-insensitive. The error message identifies
-    both offending config item indices so the user can locate them in the playbook.
-
-    ## Raises
-
-    ### ValueError
-
-    - If the same `(switch_ip, interface_name)` pair appears in more than one config item
-    """
-    seen: dict[tuple, int] = {}
-    for item_index, group in enumerate(config_list):
-        switch_ip = group.get("switch_ip")
-        interface_names = group.get("interface_names") or []
-        for name in interface_names:
-            key = (switch_ip, name.lower())
-            if key in seen:
-                raise ValueError(
-                    f"Interface '{name}' on switch '{switch_ip}' is specified in multiple config items "
-                    f"({seen[key]} and {item_index}). Each switch/interface pair may appear only once."
-                )
-            seen[key] = item_index
+    """Delegate cross-group duplicate validation to the shared normalizer."""
+    _validate_ethernet_across_item_duplicates(config_list)
 
 
 def expand_config(config_list: list[dict]) -> list[dict]:
-    """
-    # Summary
-
-    Validate then expand grouped config items (with `interface_names` list) into flat config items
-    (with singular `interface_name`). Each group produces one flat item per interface name, all
-    sharing the same `config_data` and `switch_ip`.
-
-    ## Raises
-
-    ### ValueError
-
-    - If any `interface_names` entry is `None` or an empty string
-    - If an interface name appears more than once within a single config item's `interface_names` list
-    - If the same `(switch_ip, interface_name)` pair appears in more than one config item
-    """
-    validate_interface_names(config_list)
-    validate_within_item_duplicates(config_list)
-    validate_across_item_duplicates(config_list)
-
-    expanded = []
-    for group in config_list:
-        # `or []` (not a `.get` default) so an explicit `interface_names: ~` in YAML,
-        # which yields None, is treated as empty -- consistent with the validators above.
-        interface_names = group.get("interface_names") or []
-        for name in interface_names:
-            item = copy.deepcopy(group)
-            item.pop("interface_names", None)
-            item["interface_name"] = name
-            expanded.append(item)
-    return expanded
+    """Delegate grouped Ethernet expansion to the shared workflow normalizer."""
+    return _expand_ethernet_config(config_list)
 
 
 def main() -> None:

--- a/plugins/modules/nd_interface_ethernet_trunk_host.py
+++ b/plugins/modules/nd_interface_ethernet_trunk_host.py
@@ -540,7 +540,6 @@ msg:
   sample: "Configuration error: ..."
 """
 
-import copy
 import logging
 import traceback
 
@@ -548,6 +547,12 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+from ansible_collections.cisco.nd.plugins.module_utils.interface_config_normalizer import (
+    expand_ethernet_config as _expand_ethernet_config,
+    validate_ethernet_across_item_duplicates as _validate_ethernet_across_item_duplicates,
+    validate_ethernet_interface_names as _validate_ethernet_interface_names,
+    validate_ethernet_within_item_duplicates as _validate_ethernet_within_item_duplicates,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import EthernetTrunkHostInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
@@ -555,130 +560,24 @@ from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interf
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import EthernetTrunkHostInterfaceOrchestrator
 
 
-# TODO: When all interface modules using `interface_names: list` are merged, lift
-# `validate_interface_names`, `validate_within_item_duplicates`,
-# `validate_across_item_duplicates`, and `expand_config` into a shared helper module
-# (e.g. `plugins/module_utils/interfaces/config_expansion.py`) and import from there.
 def validate_interface_names(config_list: list[dict]) -> None:
-    """
-    # Summary
-
-    Raise `ValueError` if any element of any `interface_names` list is `None`, an empty string, or not a
-    string. Ansible's `elements="str"` argspec does not reject these (a Jinja loop can easily produce a list
-    with null/empty entries, and a templated value may arrive as a non-string), and downstream `name.lower()`
-    would otherwise raise `AttributeError` / silently insert a blank interface — neither of which is the
-    friendly fail_json the user expects.
-
-    ## Raises
-
-    ### ValueError
-
-    - If any element of `interface_names` is `None`, an empty string, or not a string.
-    """
-    for item_index, group in enumerate(config_list):
-        switch_ip = group.get("switch_ip")
-        interface_names = group.get("interface_names") or []
-        for entry_index, name in enumerate(interface_names):
-            if not isinstance(name, str) or not name:
-                if name is None:
-                    reason = "null"
-                elif not isinstance(name, str):
-                    reason = f"not a string (got {type(name).__name__})"
-                else:
-                    reason = "empty"
-                raise ValueError(
-                    f"interface_names[{entry_index}] for switch '{switch_ip}' (config item {item_index}) is "
-                    f"{reason}. Every entry must be a non-empty interface name."
-                )
+    """Delegate grouped-name validation to the shared workflow normalizer."""
+    _validate_ethernet_interface_names(config_list)
 
 
 def validate_within_item_duplicates(config_list: list[dict]) -> None:
-    """
-    # Summary
-
-    Raise `ValueError` if any single config item lists the same interface name more than once
-    in its `interface_names` list. Comparison is case-insensitive.
-
-    ## Raises
-
-    ### ValueError
-
-    - If an interface name appears more than once within a single config item's `interface_names` list
-    """
-    for item_index, group in enumerate(config_list):
-        switch_ip = group.get("switch_ip")
-        interface_names = group.get("interface_names") or []
-        seen: set[str] = set()
-        for name in interface_names:
-            key = name.lower()
-            if key in seen:
-                raise ValueError(
-                    f"Duplicate interface '{name}' in interface_names for switch '{switch_ip}' "
-                    f"(config item {item_index}). Each interface may appear only once per config item."
-                )
-            seen.add(key)
+    """Delegate within-group duplicate validation to the shared normalizer."""
+    _validate_ethernet_within_item_duplicates(config_list)
 
 
-# TODO: See note above `validate_within_item_duplicates`.
 def validate_across_item_duplicates(config_list: list[dict]) -> None:
-    """
-    # Summary
-
-    Raise `ValueError` if the same `(switch_ip, interface_name)` pair appears in more than one
-    config item. Comparison of interface names is case-insensitive. The error message identifies
-    both offending config item indices so the user can locate them in the playbook.
-
-    ## Raises
-
-    ### ValueError
-
-    - If the same `(switch_ip, interface_name)` pair appears in more than one config item
-    """
-    seen: dict[tuple, int] = {}
-    for item_index, group in enumerate(config_list):
-        switch_ip = group.get("switch_ip")
-        interface_names = group.get("interface_names") or []
-        for name in interface_names:
-            key = (switch_ip, name.lower())
-            if key in seen:
-                raise ValueError(
-                    f"Interface '{name}' on switch '{switch_ip}' is specified in multiple config items "
-                    f"({seen[key]} and {item_index}). Each switch/interface pair may appear only once."
-                )
-            seen[key] = item_index
+    """Delegate cross-group duplicate validation to the shared normalizer."""
+    _validate_ethernet_across_item_duplicates(config_list)
 
 
 def expand_config(config_list: list[dict]) -> list[dict]:
-    """
-    # Summary
-
-    Validate then expand grouped config items (with `interface_names` list) into flat config items
-    (with singular `interface_name`). Each group produces one flat item per interface name, all
-    sharing the same `config_data` and `switch_ip`.
-
-    ## Raises
-
-    ### ValueError
-
-    - If any `interface_names` entry is `None` or an empty string
-    - If an interface name appears more than once within a single config item's `interface_names` list
-    - If the same `(switch_ip, interface_name)` pair appears in more than one config item
-    """
-    validate_interface_names(config_list)
-    validate_within_item_duplicates(config_list)
-    validate_across_item_duplicates(config_list)
-
-    expanded = []
-    for group in config_list:
-        # `or []` (not a `.get` default) so an explicit `interface_names: ~` in YAML,
-        # which yields None, is treated as empty -- consistent with the validators above.
-        interface_names = group.get("interface_names") or []
-        for name in interface_names:
-            item = copy.deepcopy(group)
-            item.pop("interface_names", None)
-            item["interface_name"] = name
-            expanded.append(item)
-    return expanded
+    """Delegate grouped Ethernet expansion to the shared workflow normalizer."""
+    return _expand_ethernet_config(config_list)
 
 
 def main() -> None:

--- a/plugins/modules/nd_interfaces_workflow.py
+++ b/plugins/modules/nd_interfaces_workflow.py
@@ -14,12 +14,15 @@ description:
 - Coordinates several interface resource families in one module execution.
 - Validates and plans every resource group before the first possible mutation.
 - Fetches the complete configured-interface inventory once per targeted switch and shares it across all requested families.
+- Keeps that complete family inventory internal for planning and safety while reporting only explicitly requested identities for
+  V(merged), V(replaced), and V(deleted). V(overridden) continues to report its complete authoritative family scope.
 - Each O(resources[].config) uses the authoritative input contract and validation logic of the standalone module selected by
   O(resources[].type).
-- Check mode returns the complete multi-family plan, aggregate diff, conflicts, and request statistics without sending mutation or
-  deployment requests.
+- Check mode returns the complete multi-family plan, aggregate diff, conflicts, prospective deployment-only targets, and request
+  statistics without sending mutation or deployment requests.
 - Normal mode executes the complete validated plan in dependency-safe order, consolidates deferred remove and deploy actions, and
-  refetches affected switches to report actual controller state.
+  refetches switches affected by interface mutations to report actual controller state. It can also deploy previously staged intent for
+  explicitly requested interfaces when the current workflow has no interface mutations.
 author:
 - Mike Wiebe (@mikewiebe)
 options:
@@ -93,12 +96,16 @@ options:
     description:
     - Controls actions coordinated after all interface mutation groups complete.
     - Deployment is attempted only after every planned interface mutation succeeds. A mutation failure stops later writes and deployment.
+    - A zero-mutation workflow can deploy previously staged controller intent for explicitly requested interfaces when the already-fetched
+      fabric switch record has an explicit out-of-sync or pending status.
     type: dict
     suboptions:
       deploy:
         description:
-        - Whether changed interfaces should be deployed in one consolidated action after successful mutation groups.
-        - Has no side effect in check mode.
+        - Whether changed interfaces and explicitly requested interfaces with staged controller intent should be deployed in one
+          consolidated action.
+        - An identical replay after O(config_actions.deploy=false) can therefore perform deployment with no new interface mutation.
+        - Check mode reports a prospective deployment but sends no request.
         type: bool
         default: false
 extends_documentation_fragment:
@@ -130,10 +137,34 @@ notes:
   per-interface transition, preserving the workflow's scale advantage.
 - Interface inventories and transition/delete safety data are shared for the complete workflow. They are not fetched once per resource
   group or once per interface; pagination may require more than one GET for a switch or fabric-level safety inventory.
+- Deployment-only candidate detection reuses the fabric switch records already fetched to resolve switch identities. It sends no
+  additional GET request. Only an explicitly normalized out-of-sync or pending switch status qualifies; an in-sync, missing, or unknown status does
+  not cause deployment.
+- Deployment-only requests contain only explicitly requested interface identities and are combined with any mutation-produced targets in
+  one de-duplicated deployment POST. The switch status is coarser than an interface status, so an explicitly requested interface can be
+  harmlessly redeployed when different pending intent keeps the same switch out of sync; unrelated interfaces are never added.
+- For a vPC identity, an explicit out-of-sync or pending status on either authoritative peer qualifies the pair-scoped target. The consolidated
+  request retains the vPC orchestrator's primary-switch target convention.
+- Deployment-only replay cannot reconstruct interfaces implicitly removed by a prior V(overridden) task because those omitted identities
+  are not explicit in the later task. Include an interface explicitly when a later deployment-only action must target it.
+- A successful deployment-only run, or its check-mode preview, reports C(changed=true), C(planned_changed=false), and
+  C(mutation_count=0). Its per-resource C(changed) values remain false because controller intent did not change.
 - The authoritative vPC-pair map is shared with all vPC resource orchestrators, preventing repeated per-resource peer-lookup GETs.
 - The shared snapshot is execution-scoped and is never accepted from arbitrary caller input or persisted across Ansible tasks.
 - Normal-mode execution uses the same current interface model and orchestrator contracts as the standalone modules, so merged validation,
   normalization, and deployment behavior is inherited automatically.
+- For V(merged), V(replaced), and V(deleted), C(resources[].before) and C(resources[].after) contain only identities explicitly listed in
+  that resource group. Aggregate-interface members remain visible inside the requested port-channel or vPC policy instead of being mixed
+  into the result as unrelated Ethernet-family records.
+- Target-scoped C(before) and C(after) include C(policy_type), including when a requested identity starts in another eligible policy family.
+  A deleted logical interface is absent from C(after); a deleted physical Ethernet interface remains present with the normalized default
+  V(trunkHost) policy.
+- C(resources[].operations) is the single operation ledger. It combines create, update, transition, physical-reset, and logical-delete
+  actions with their target identities and execution status; update-like actions can include leaf-level C(changes).
+- Successful output intentionally omits duplicate top-level snapshots and task-input echoes. C(request_stats) contains read, cache,
+  refresh, overlay, and vPC metrics; C(execution) exclusively owns mutation and deployment write counters.
+- At O(output_level=debug), C(resources[].family_before) and C(resources[].family_after) expose the complete selected-family collections
+  used for diagnostics. Result projection is in-memory and sends no additional controller GET requests.
 - Deletes and deferred normalize/reset operations run before transitions, updates, and creates. Deployments are consolidated across
   compatible resource groups.
 - The Ethernet V(routedHost) to V(accessHost) and V(accessHost) to V(trunkHost) cross-policy PUTs have been live-qualified during this
@@ -223,6 +254,24 @@ EXAMPLES = r"""
     config_actions:
       deploy: false
 
+- name: Deploy the same explicitly requested interface after staging it in an earlier task
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: FABRIC1
+    resources:
+      - type: ethernet_access
+        state: merged
+        config:
+          - switch_ip: 192.168.1.11
+            interface_names:
+              - Ethernet1/40
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  access_vlan: 3900
+    config_actions:
+      deploy: true
+
 - name: Reset an explicitly named physical interface regardless of its current policy
   cisco.nd.nd_interfaces_workflow:
     fabric_name: FABRIC1
@@ -240,32 +289,18 @@ EXAMPLES = r"""
 RETURN = r"""
 changed:
   description:
-  - In check mode, whether the plan contains at least one transition, create, update, or delete.
-  - In normal mode, whether mutation responses or the reconciled actual state show a controller change.
+  - In check mode, whether the plan contains a mutation or an explicitly requested deployment-only target.
+  - In normal mode, whether mutation responses, reconciled actual state, or a successful deployment request show a controller action.
   returned: always
   type: bool
 planned_changed:
-  description: Whether the validated aggregate plan contains at least one mutation.
+  description:
+  - Whether the validated aggregate plan contains at least one interface mutation.
+  - Remains V(false) for deployment-only execution.
   returned: always
   type: bool
-check_mode:
-  description: Whether the module executed in Ansible check mode.
-  returned: always
-  type: bool
-output_level:
-  description: Output detail level selected for the task.
-  returned: always
-  type: str
-fabric_name:
-  description: Fabric used by the shared snapshot and every resource group.
-  returned: always
-  type: str
-config_actions:
-  description: Coordinated action settings accepted by the task.
-  returned: always
-  type: dict
 mutation_count:
-  description: Total number of planned transitions, creates, updates, and deletes across resource groups.
+  description: Total number of planned creates, updates, transitions, physical resets, and logical deletes across resource groups.
   returned: always
   type: int
 target_switch_ids:
@@ -292,13 +327,18 @@ resources:
     state:
       description: State planned for this group.
       type: str
-    transitions:
-      description: One-request implicit policy transitions planned for this group.
+    operations:
+      description:
+      - Unified planned or executed operation records for this group.
+      - Update, transition, and physical-reset records include C(changes) when their reported before and after values differ.
+      - Create and logical-delete records omit C(changes).
       type: list
       elements: dict
       contains:
         action:
-          description: Always V(transition).
+          description:
+          - One of V(create), V(update), V(transition), V(reset), or V(delete).
+          - Physical resets use V(reset); logical removals use V(delete).
           type: str
         switch_ip:
           description: Management IP of the target switch.
@@ -309,71 +349,86 @@ resources:
         interface_name:
           description: Interface name.
           type: str
+        status:
+          description:
+          - V(planned) in check mode.
+          - The actual execution outcome in normal mode.
+          type: str
+        message:
+          description: Controller or execution detail associated with this operation outcome.
+          returned: when the controller or executor supplies detail
+          type: str
         from_policy_type:
-          description: Current controller policy discriminator.
+          description: Current controller policy discriminator for a transition.
+          returned: for transition operations
           type: str
         to_policy_type:
-          description: Destination controller policy discriminator.
+          description: Destination controller policy discriminator for a transition.
+          returned: for transition operations
           type: str
+        changes:
+          description: Leaf-level differences for update, transition, or physical-reset operations whose reported values differ.
+          returned: when an update-like operation has reported differences
+          type: list
+          elements: dict
+          contains:
+            path:
+              description: Dot-delimited path of the changed property.
+              type: str
+            before:
+              description: Value before the operation.
+              type: raw
+            after:
+              description: Value after the operation.
+              type: raw
     changed:
       description:
       - Whether C(before) and the reported C(after) differ.
       - In check mode this is prospective; in normal mode it is actual when reconciliation succeeds.
+      - Remains V(false) when this resource is only a target of deployment for already-staged intent.
       type: bool
     planned_changed:
-      description: Whether this group had a planned transition, create, update, or delete.
+      description: Whether this group had a planned create, update, transition, physical reset, or logical delete.
       type: bool
     before:
-      description: Existing selected family configuration before execution.
+      description:
+      - Initial observed controller state for the identities explicitly listed by this group when O(resources[].state) is V(merged),
+        V(replaced), or V(deleted).
+      - For V(overridden), the complete selected-family configuration in the authoritative fabric scope.
+      - Each returned target includes C(policy_type), so a source policy owned by another eligible family remains visible.
       type: list
       elements: dict
     after:
-      description: Prospective family configuration in check mode and reconciled actual configuration after normal-mode writes.
+      description:
+      - Target-scoped prospective configuration in check mode and reconciled observed configuration after normal-mode writes.
+      - A removed logical interface is absent. A reset physical Ethernet interface remains present with C(policy_type=trunkHost) and its
+        normalized default configuration.
+      - For V(overridden), the complete selected-family configuration in the authoritative fabric scope.
       type: list
       elements: dict
     after_verified:
-      description: Whether C(after) represents observed controller state rather than an unverified plan after a reconciliation failure.
+      description:
+      - Whether C(after) represents coherent observed controller state rather than an unverified plan after reconciliation failure.
+      - V(false) also covers reconciliation that cannot establish consistent vPC state because a peer record is missing or incoherent.
       type: bool
-    diff:
-      description: An Ansible-style C(before) and C(after) dictionary, or an empty dictionary when the collections match.
-      type: dict
     proposed:
       description: Normalized user configuration validated by the standalone model.
       returned: when O(output_level) is V(info) or V(debug)
       type: list
       elements: dict
-    created:
-      description: Models planned for creation.
+    family_before:
+      description: Complete unprojected selected-family configuration before execution for diagnostic use.
+      returned: when O(output_level) is V(debug)
       type: list
       elements: dict
-    updated:
-      description: Models planned for update.
+    family_after:
+      description: Complete unprojected prospective or reconciled selected-family configuration after execution for diagnostic use.
+      returned: when O(output_level) is V(debug)
       type: list
       elements: dict
-    deleted:
-      description:
-      - Models planned for deletion.
-      - Physical Ethernet entries represent reset-to-default operations; deletable logical entries represent removals.
-      type: list
-      elements: dict
-before:
-  description: Per-resource C(before) collections retaining resource index and type.
-  returned: always
-  type: list
-  elements: dict
-after:
-  description: Per-resource prospective C(after) collections retaining resource index and type.
-  returned: always
-  type: list
-  elements: dict
-diff:
-  description: Per-resource differences retaining resource index and type.
-  returned: always
-  type: list
-  elements: dict
 request_stats:
-  description: Shared configured-interface inventory, lazy transition/delete safety inventory, vPC context, mutation, deployment, cache,
-    refresh, and overlay counters for this execution.
+  description: Shared configured-interface inventory, lazy transition/delete safety inventory, vPC context, cache, refresh, and overlay
+    counters for this execution. Write counters are reported only under C(execution).
   returned: always
   type: dict
   contains:
@@ -390,10 +445,19 @@ request_stats:
       description: Family reads served from the shared snapshot.
       type: int
     interface_inventory_refreshes:
-      description: Explicit switch refreshes.
+      description:
+      - Number of per-switch interface-inventory refresh attempts explicitly initiated during this execution.
+      - A refresh invalidates the execution-scoped local snapshot before loading it again, so the same operation also increments
+        C(interface_inventory_dirty_refetches).
+      - This is a logical per-switch count. Paginated HTTP requests are counted separately by C(interface_inventory_gets).
       type: int
     interface_inventory_dirty_refetches:
-      description: Automatic refetches caused by dirty snapshot state.
+      description:
+      - Number of switch-inventory load attempts caused by an execution-scoped local snapshot being marked stale.
+      - Local dirty state is unrelated to controller C(configSyncStatus) values such as C(outOfSync) or C(pending).
+      - The counter increments once before each dirty switch fetch, including a fetch initiated by an explicit refresh. A switch can
+        contribute more than once if it is marked stale and loaded again, and paginated HTTP requests are counted separately by
+        C(interface_inventory_gets).
       type: int
     interface_summary_switches:
       description: Number of switches fetched into the lazy transition/delete safety summary cache.
@@ -413,12 +477,6 @@ request_stats:
     vpc_pair_gets:
       description: Fabric vPC-pair inventory GETs.
       type: int
-    mutation_requests:
-      description: Interface mutation requests sent.
-      type: int
-    deploy_requests:
-      description: Consolidated deployment requests sent.
-      type: int
 execution:
   description: Execution status and write counters.
   returned: always
@@ -437,13 +495,9 @@ execution:
       description: Switch serial numbers refreshed after mutation requests.
       type: list
       elements: str
-    items:
-      description: Per-planned-mutation execution status, identity, transition source and destination policy types when applicable, and
-        controller message when available.
-      type: list
-      elements: dict
     deployment:
-      description: Consolidated deployment request, target, and partial-success details.
+      description: Consolidated deployment request, prospective or attempted exact targets, and partial-success details. A check-mode
+        deployment-only preview uses V(would_deploy) status without incrementing C(deployments_sent).
       type: dict
     errors:
       description: Execution and reconciliation errors collected for the failed result.

--- a/plugins/modules/nd_interfaces_workflow.py
+++ b/plugins/modules/nd_interfaces_workflow.py
@@ -1,0 +1,443 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: nd_interfaces_workflow
+version_added: "2.0.0"
+short_description: Manage multiple Cisco Nexus Dashboard interface families with one shared snapshot
+description:
+- Coordinates several interface resource families in one module execution.
+- Validates and plans every resource group before the first possible mutation.
+- Fetches the complete configured-interface inventory once per targeted switch and shares it across all requested families.
+- Each O(resources[].config) uses the authoritative input contract and validation logic of the standalone module selected by
+  O(resources[].type).
+- Check mode returns the complete multi-family plan, aggregate diff, conflicts, and request statistics without sending mutation or
+  deployment requests.
+- Normal mode executes the complete validated plan in dependency-safe order, consolidates deferred remove and deploy actions, and
+  refetches affected switches to report actual controller state.
+author:
+- Mike Wiebe (@mikewiebe)
+options:
+  fabric_name:
+    description:
+    - Name of the Nexus Dashboard fabric containing the interfaces.
+    type: str
+    required: true
+  resources:
+    description:
+    - Ordered interface resource groups to validate and plan together.
+    - Repeated values of O(resources[].type) are supported; results retain C(resource_index) so groups are not collapsed.
+    - The coordinator rejects ownership, policy-transition, delete/write, override, and physical-member conflicts across groups.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      type:
+        description:
+        - Selects the standalone interface contract used to validate O(resources[].config).
+        - V(ethernet_access) uses M(cisco.nd.nd_interface_ethernet_access).
+        - V(ethernet_trunk_host) uses M(cisco.nd.nd_interface_ethernet_trunk_host).
+        - V(loopback) uses M(cisco.nd.nd_interface_loopback).
+        - V(port_channel_access) uses M(cisco.nd.nd_interface_port_channel_access).
+        - V(port_channel_trunk_host) uses M(cisco.nd.nd_interface_port_channel_trunk_host).
+        - V(subinterface_managed) uses M(cisco.nd.nd_interface_subinterface_managed).
+        - V(subinterface_unmanaged) uses M(cisco.nd.nd_interface_subinterface_unmanaged).
+        - V(svi) uses M(cisco.nd.nd_interface_svi).
+        - V(vpc_access) uses M(cisco.nd.nd_interface_vpc_access).
+        - V(vpc_trunk_host) uses M(cisco.nd.nd_interface_vpc_trunk_host).
+        type: str
+        required: true
+        choices:
+        - ethernet_access
+        - ethernet_trunk_host
+        - loopback
+        - port_channel_access
+        - port_channel_trunk_host
+        - subinterface_managed
+        - subinterface_unmanaged
+        - svi
+        - vpc_access
+        - vpc_trunk_host
+      state:
+        description:
+        - Desired state for this resource group.
+        - V(merged) creates missing resources and merges supplied fields into existing resources.
+        - V(replaced) replaces the fields of the explicitly listed resources according to the selected standalone model.
+        - V(overridden) treats this family's configuration as authoritative and expands interface inventory scope to the complete fabric.
+        - V(deleted) removes the listed resources that currently exist.
+        - All ten initial interface adapters support all four values.
+        type: str
+        choices: [ merged, replaced, overridden, deleted ]
+        default: merged
+      config:
+        description:
+        - Interface configuration using the same list-of-dictionaries shape accepted by the standalone module selected by
+          O(resources[].type).
+        - Interface-specific fields, constraints, defaults, and examples intentionally remain documented by that standalone module.
+        - Validation errors identify the resource index, selected type, model, state, and standalone module.
+        type: list
+        elements: dict
+        required: true
+  config_actions:
+    description:
+    - Controls actions coordinated after all interface mutation groups complete.
+    - Deployment is attempted only after every planned interface mutation succeeds. A mutation failure stops later writes and deployment.
+    type: dict
+    suboptions:
+      deploy:
+        description:
+        - Whether changed interfaces should be deployed in one consolidated action after successful mutation groups.
+        - Has no side effect in check mode.
+        type: bool
+        default: true
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is supported only on Cisco Nexus Dashboard.
+- C(cisco.nd.nd_interface_flow_rules) is intentionally outside this workflow and is not a valid O(resources[].type).
+- A non-overridden workflow reads only the union of switches named by its resource groups. Any V(overridden) group expands the shared
+  inventory scope to all switches in the fabric.
+- vPC groups load authoritative fabric vPC-pair inventory in the same execution and reject a configured switch that is not paired.
+- Sibling policy-type transitions are rejected unless an explicit, tested transition sequence is added; they are never inferred as an
+  independent create.
+- The shared snapshot is execution-scoped and is never accepted from arbitrary caller input or persisted across Ansible tasks.
+- Normal-mode execution uses the interface model and orchestrator contracts currently present in the develop branch. Outstanding interface
+  pull-request behavior is intentionally deferred until those pull requests merge.
+- Deletes run before updates and creates. Deferred logical removes, Ethernet normalize/reset operations, and deployments are consolidated
+  across compatible resource groups.
+- The executor stops after the first failed mutation phase, does not replay mixed-success requests, reports succeeded, failed, uncertain,
+  skipped, and not-attempted items, and refreshes affected switches after any mutation request.
+"""
+
+EXAMPLES = r"""
+- name: Configure several interface families with one shared snapshot
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: FABRIC1
+    resources:
+      - type: loopback
+        state: merged
+        config:
+          - switch_ip: 192.168.1.11
+            interface_name: loopback10
+            config_data:
+              network_os:
+                policy:
+                  ip: 192.0.2.10
+                  description: Router ID
+      - type: ethernet_access
+        state: merged
+        config:
+          - switch_ip: 192.168.1.11
+            interface_names:
+              - Ethernet1/10
+              - Ethernet1/11
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  access_vlan: 100
+                  description: Application servers
+      - type: port_channel_trunk_host
+        state: replaced
+        config:
+          - switch_ip: 192.168.1.12
+            interface_name: port-channel20
+            config_data:
+              network_os:
+                policy:
+                  allowed_vlans: "100-200"
+                  ports:
+                    - Ethernet1/20
+                    - Ethernet1/21
+                  port_channel_mode: active
+    config_actions:
+      deploy: true
+  register: interface_result
+
+- name: Preview a fabric-wide authoritative SVI group
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: FABRIC1
+    resources:
+      - type: svi
+        state: overridden
+        config:
+          - switch_ip: 192.168.1.11
+            interface_name: vlan100
+            config_data:
+              network_os:
+                policy:
+                  ip: 192.0.2.1
+                  prefix: 24
+  check_mode: true
+"""
+
+RETURN = r"""
+changed:
+  description:
+  - In check mode, whether the plan contains at least one create, update, or delete.
+  - In normal mode, whether mutation responses or the reconciled actual state show a controller change.
+  returned: always
+  type: bool
+planned_changed:
+  description: Whether the validated aggregate plan contains at least one mutation.
+  returned: always
+  type: bool
+check_mode:
+  description: Whether the module executed in Ansible check mode.
+  returned: always
+  type: bool
+output_level:
+  description: Output detail level selected for the task.
+  returned: always
+  type: str
+fabric_name:
+  description: Fabric used by the shared snapshot and every resource group.
+  returned: always
+  type: str
+config_actions:
+  description: Coordinated action settings accepted by the task.
+  returned: always
+  type: dict
+mutation_count:
+  description: Total number of planned creates, updates, and deletes across resource groups.
+  returned: always
+  type: int
+target_switch_ids:
+  description: De-duplicated switch serial numbers loaded into the shared interface snapshot.
+  returned: always
+  type: list
+  elements: str
+resources:
+  description:
+  - Ordered per-resource-group results. Repeated interface types remain separate through C(resource_index).
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    resource_index:
+      description: Zero-based position of the group in O(resources).
+      type: int
+    type:
+      description: Interface family discriminator.
+      type: str
+    module:
+      description: Standalone module that supplied the authoritative model and validation contract.
+      type: str
+    state:
+      description: State planned for this group.
+      type: str
+    changed:
+      description:
+      - Whether C(before) and the reported C(after) differ.
+      - In check mode this is prospective; in normal mode it is actual when reconciliation succeeds.
+      type: bool
+    planned_changed:
+      description: Whether this group had a planned create, update, or delete.
+      type: bool
+    before:
+      description: Existing selected family configuration before execution.
+      type: list
+      elements: dict
+    after:
+      description: Prospective family configuration in check mode and reconciled actual configuration after normal-mode writes.
+      type: list
+      elements: dict
+    after_verified:
+      description: Whether C(after) represents observed controller state rather than an unverified plan after a reconciliation failure.
+      type: bool
+    diff:
+      description: An Ansible-style C(before) and C(after) dictionary, or an empty dictionary when the collections match.
+      type: dict
+    proposed:
+      description: Normalized user configuration validated by the standalone model.
+      returned: when O(output_level) is V(info) or V(debug)
+      type: list
+      elements: dict
+    created:
+      description: Models planned for creation.
+      type: list
+      elements: dict
+    updated:
+      description: Models planned for update.
+      type: list
+      elements: dict
+    deleted:
+      description: Models planned for deletion.
+      type: list
+      elements: dict
+before:
+  description: Per-resource C(before) collections retaining resource index and type.
+  returned: always
+  type: list
+  elements: dict
+after:
+  description: Per-resource prospective C(after) collections retaining resource index and type.
+  returned: always
+  type: list
+  elements: dict
+diff:
+  description: Per-resource differences retaining resource index and type.
+  returned: always
+  type: list
+  elements: dict
+request_stats:
+  description: Shared inventory, vPC context, mutation, deployment, cache, refresh, and overlay counters for this execution.
+  returned: always
+  type: dict
+  contains:
+    switches:
+      description: Number of switches fetched into the interface snapshot.
+      type: int
+    interface_inventory_gets:
+      description: Interface inventory GET requests, including pagination.
+      type: int
+    interface_inventory_pages:
+      description: Interface inventory pages fetched.
+      type: int
+    interface_inventory_cache_hits:
+      description: Family reads served from the shared snapshot.
+      type: int
+    interface_inventory_refreshes:
+      description: Explicit switch refreshes.
+      type: int
+    interface_inventory_dirty_refetches:
+      description: Automatic refetches caused by dirty snapshot state.
+      type: int
+    snapshot_overlays:
+      description: Atomic known-success overlays applied to the snapshot.
+      type: int
+    vpc_pair_gets:
+      description: Fabric vPC-pair inventory GETs.
+      type: int
+    mutation_requests:
+      description: Interface mutation requests sent.
+      type: int
+    deploy_requests:
+      description: Consolidated deployment requests sent.
+      type: int
+execution:
+  description: Execution status and write counters.
+  returned: always
+  type: dict
+  contains:
+    status:
+      description: One of V(check_mode), V(no_change), V(completed), V(staged), V(failed), or V(partial_failure).
+      type: str
+    mutations_sent:
+      description: Number of non-GET, non-deployment mutation requests sent.
+      type: int
+    deployments_sent:
+      description: Number of consolidated deployment requests sent.
+      type: int
+    affected_switch_ids:
+      description: Switch serial numbers refreshed after mutation requests.
+      type: list
+      elements: str
+    items:
+      description: Per-planned-mutation execution status, identity, and controller message when available.
+      type: list
+      elements: dict
+    deployment:
+      description: Consolidated deployment request, target, and partial-success details.
+      type: dict
+    errors:
+      description: Execution and reconciliation errors collected for the failed result.
+      type: list
+      elements: str
+conflicts:
+  description: Structured cross-family conflicts collected before mutation.
+  returned: on conflict
+  type: list
+  elements: dict
+msg:
+  description: Human-readable validation, conflict, prerequisite, or unexpected failure.
+  returned: on failure
+  type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_family_adapters import (
+    INTERFACE_FAMILY_ADAPTERS,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_coordinator import (
+    InterfaceWorkflowCoordinator,
+    InterfaceWorkflowExecutionFailed,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planner import (
+    InterfaceWorkflowConflictError,
+    InterfaceWorkflowValidationError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import (
+    config_actions_spec,
+    nd_argument_spec,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_plan import (
+    SUPPORTED_STATES,
+)
+
+
+def interface_workflow_argument_spec():
+    """Return the workflow-only argspec while family models remain authoritative."""
+    argument_spec = nd_argument_spec()
+    argument_spec.update(
+        {
+            "fabric_name": {"type": "str", "required": True},
+            "resources": {
+                "type": "list",
+                "elements": "dict",
+                "required": True,
+                "options": {
+                    "type": {
+                        "type": "str",
+                        "required": True,
+                        "choices": list(INTERFACE_FAMILY_ADAPTERS),
+                    },
+                    "state": {
+                        "type": "str",
+                        "default": "merged",
+                        "choices": sorted(SUPPORTED_STATES),
+                    },
+                    "config": {"type": "list", "elements": "dict", "required": True},
+                },
+            },
+        }
+    )
+    argument_spec.update(config_actions_spec(include=("deploy",)))
+    return argument_spec
+
+
+def main():
+    """Run the public aggregate workflow module."""
+    module = AnsibleModule(
+        argument_spec=interface_workflow_argument_spec(), supports_check_mode=True
+    )
+    require_pydantic(module)
+    try:
+        module.exit_json(**InterfaceWorkflowCoordinator(module=module).run())
+    except InterfaceWorkflowExecutionFailed as exc:
+        module.fail_json(msg=str(exc), **exc.result)
+    except InterfaceWorkflowConflictError as exc:
+        module.fail_json(
+            msg=str(exc),
+            changed=False,
+            conflicts=[conflict.to_dict() for conflict in exc.conflicts],
+        )
+    except InterfaceWorkflowValidationError as exc:
+        module.fail_json(msg=str(exc), changed=False)
+    except Exception as exc:  # pylint: disable=broad-except
+        module.fail_json(
+            msg=f"Unexpected interface workflow error: {exc}", changed=False
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_interfaces_workflow.py
+++ b/plugins/modules/nd_interfaces_workflow.py
@@ -66,10 +66,16 @@ options:
       state:
         description:
         - Desired state for this resource group.
-        - V(merged) creates missing resources and merges supplied fields into existing resources.
-        - V(replaced) replaces the fields of the explicitly listed resources according to the selected standalone model.
+        - V(merged) creates missing resources and merges supplied fields when the current policy already belongs to the selected family.
+          If an explicitly listed interface has a different eligible policy in the same structural interface domain, it performs an
+          implicit policy transition and applies the selected family's desired configuration.
+        - V(replaced) replaces the fields of explicitly listed resources. If the current policy belongs to another eligible family in the
+          same structural interface domain, it performs the same implicit policy transition.
         - V(overridden) treats this family's configuration as authoritative and expands interface inventory scope to the complete fabric.
-        - V(deleted) removes the listed resources that currently exist.
+          It does not claim unlisted interfaces owned by other policy families.
+        - V(deleted) acts on each explicitly listed identity regardless of its current policy family, provided the current interface is in
+          the same structural domain and is safe to delete. Physical Ethernet interfaces are reset to the unconfigured fabric-default
+          policy; deletable logical interfaces are removed.
         - All ten initial interface adapters support all four values.
         type: str
         choices: [ merged, replaced, overridden, deleted ]
@@ -103,14 +109,37 @@ notes:
 - C(cisco.nd.nd_interface_flow_rules) is intentionally outside this workflow and is not a valid O(resources[].type).
 - A non-overridden workflow reads only the union of switches named by its resource groups. Any V(overridden) group expands the shared
   inventory scope to all switches in the fabric.
-- vPC groups load authoritative fabric vPC-pair inventory in the same execution and reject a configured switch that is not paired.
-- Sibling policy-type transitions are rejected unless an explicit, tested transition sequence is added; they are never inferred as an
-  independent create.
+- vPC groups load the complete intended fabric vPC-pair inventory with deterministic pagination in the same execution. They reject
+  missing, self-referential, conflicting, or inverse-inconsistent pair records.
+- vPC identity is pair-scoped. Equal vPC names on different pairs are planned independently, while both peer echoes for one pair are
+  required and treated as one resource.
+- For V(merged) and V(replaced), O(resources[].type) is the desired policy family. An explicitly listed interface using another eligible
+  policy in the same structural interface domain is changed with one destination-family replacement request; no separate transition
+  option is required.
+- A policy transition is rejected before writes when controller safety metadata, structural type, vPC peer consistency, port-channel or
+  vPC membership, or parent-child interface dependencies make the change unsafe.
+- Current and final physical members of port-channel and vPC interfaces are protected from independent Ethernet resets, transitions,
+  creates, and non-whitelisted updates, including when operational membership data is stale.
+- Ethernet and port-channel parents cannot be mutated in the same workflow as a child-subinterface mutation and cannot be changed while
+  an existing child subinterface remains. Managed and unmanaged subinterface writes require an existing routed parent configured in a
+  prior workflow; V(routedHost) for Ethernet or V(l3PortChannel) for a port-channel.
+- For V(deleted), the selected type supplies the input and execution contract, but explicit identity lookup is policy-independent within
+  that structural interface domain. A physical Ethernet delete resets the interface to the unconfigured default instead of removing the
+  physical interface.
+- An unconfigured default V(trunkHost) physical interface retains the ordinary bulk-create path and is never converted into a
+  per-interface transition, preserving the workflow's scale advantage.
+- Interface inventories and transition/delete safety data are shared for the complete workflow. They are not fetched once per resource
+  group or once per interface; pagination may require more than one GET for a switch or fabric-level safety inventory.
+- The authoritative vPC-pair map is shared with all vPC resource orchestrators, preventing repeated per-resource peer-lookup GETs.
 - The shared snapshot is execution-scoped and is never accepted from arbitrary caller input or persisted across Ansible tasks.
 - Normal-mode execution uses the same current interface model and orchestrator contracts as the standalone modules, so merged validation,
   normalization, and deployment behavior is inherited automatically.
-- Deletes run before updates and creates. Deferred logical removes, Ethernet normalize/reset operations, and deployments are consolidated
-  across compatible resource groups.
+- Deletes and deferred normalize/reset operations run before transitions, updates, and creates. Deployments are consolidated across
+  compatible resource groups.
+- The Ethernet V(routedHost) to V(accessHost) and V(accessHost) to V(trunkHost) cross-policy PUTs have been live-qualified during this
+  development effort. Destination orchestrators exist for port-channel, vPC, managed and unmanaged subinterface, SVI, loopback, and other
+  Ethernet transitions, but those source/destination combinations must be live-qualified against the intended Nexus Dashboard release
+  and fabric type before production use. Architectural support is not a claim of live qualification.
 - The executor stops after the first failed mutation phase, does not replay mixed-success requests, reports succeeded, failed, uncertain,
   skipped, and not-attempted items, and refreshes affected switches after any mutation request.
 """
@@ -175,12 +204,43 @@ EXAMPLES = r"""
                   ip: 192.0.2.1
                   prefix: 24
   check_mode: true
+
+- name: Converge a routed or dot1q-tunnel interface to the Ethernet access policy
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: FABRIC1
+    resources:
+      - type: ethernet_access
+        state: merged
+        config:
+          - switch_ip: 192.168.1.11
+            interface_names:
+              - Ethernet1/40
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  access_vlan: 3900
+    config_actions:
+      deploy: false
+
+- name: Reset an explicitly named physical interface regardless of its current policy
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: FABRIC1
+    resources:
+      - type: ethernet_access
+        state: deleted
+        config:
+          - switch_ip: 192.168.1.11
+            interface_names:
+              - Ethernet1/40
+    config_actions:
+      deploy: false
 """
 
 RETURN = r"""
 changed:
   description:
-  - In check mode, whether the plan contains at least one create, update, or delete.
+  - In check mode, whether the plan contains at least one transition, create, update, or delete.
   - In normal mode, whether mutation responses or the reconciled actual state show a controller change.
   returned: always
   type: bool
@@ -205,7 +265,7 @@ config_actions:
   returned: always
   type: dict
 mutation_count:
-  description: Total number of planned creates, updates, and deletes across resource groups.
+  description: Total number of planned transitions, creates, updates, and deletes across resource groups.
   returned: always
   type: int
 target_switch_ids:
@@ -232,13 +292,36 @@ resources:
     state:
       description: State planned for this group.
       type: str
+    transitions:
+      description: One-request implicit policy transitions planned for this group.
+      type: list
+      elements: dict
+      contains:
+        action:
+          description: Always V(transition).
+          type: str
+        switch_ip:
+          description: Management IP of the target switch.
+          type: str
+        switch_id:
+          description: Controller serial identity of the target switch.
+          type: str
+        interface_name:
+          description: Interface name.
+          type: str
+        from_policy_type:
+          description: Current controller policy discriminator.
+          type: str
+        to_policy_type:
+          description: Destination controller policy discriminator.
+          type: str
     changed:
       description:
       - Whether C(before) and the reported C(after) differ.
       - In check mode this is prospective; in normal mode it is actual when reconciliation succeeds.
       type: bool
     planned_changed:
-      description: Whether this group had a planned create, update, or delete.
+      description: Whether this group had a planned transition, create, update, or delete.
       type: bool
     before:
       description: Existing selected family configuration before execution.
@@ -268,7 +351,9 @@ resources:
       type: list
       elements: dict
     deleted:
-      description: Models planned for deletion.
+      description:
+      - Models planned for deletion.
+      - Physical Ethernet entries represent reset-to-default operations; deletable logical entries represent removals.
       type: list
       elements: dict
 before:
@@ -287,7 +372,8 @@ diff:
   type: list
   elements: dict
 request_stats:
-  description: Shared inventory, vPC context, mutation, deployment, cache, refresh, and overlay counters for this execution.
+  description: Shared configured-interface inventory, lazy transition/delete safety inventory, vPC context, mutation, deployment, cache,
+    refresh, and overlay counters for this execution.
   returned: always
   type: dict
   contains:
@@ -308,6 +394,18 @@ request_stats:
       type: int
     interface_inventory_dirty_refetches:
       description: Automatic refetches caused by dirty snapshot state.
+      type: int
+    interface_summary_switches:
+      description: Number of switches fetched into the lazy transition/delete safety summary cache.
+      type: int
+    interface_summary_gets:
+      description: Interface-summary safety GET requests, including pagination.
+      type: int
+    interface_summary_pages:
+      description: Interface-summary safety pages fetched.
+      type: int
+    interface_summary_cache_hits:
+      description: Safety lookups served from the shared interface-summary cache.
       type: int
     snapshot_overlays:
       description: Atomic known-success overlays applied to the snapshot.
@@ -340,7 +438,8 @@ execution:
       type: list
       elements: str
     items:
-      description: Per-planned-mutation execution status, identity, and controller message when available.
+      description: Per-planned-mutation execution status, identity, transition source and destination policy types when applicable, and
+        controller message when available.
       type: list
       elements: dict
     deployment:

--- a/plugins/modules/nd_interfaces_workflow.py
+++ b/plugins/modules/nd_interfaces_workflow.py
@@ -20,9 +20,10 @@ description:
   O(resources[].type).
 - Check mode returns the complete multi-family plan, aggregate diff, conflicts, prospective deployment-only targets, and request
   statistics without sending mutation or deployment requests.
-- Normal mode executes the complete validated plan in dependency-safe order, consolidates deferred remove and deploy actions, and
-  refetches switches affected by interface mutations to report actual controller state. It can also deploy previously staged intent for
-  explicitly requested interfaces when the current workflow has no interface mutations.
+- Normal mode executes the complete validated plan in dependency-safe order and consolidates deferred remove and deploy actions.
+  Successful mutations return projected intended state by default; O(verify.enabled=true) refetches affected switches to report observed
+  controller state. The module can also deploy previously staged intent for explicitly requested interfaces when the current workflow
+  has no interface mutations.
 author:
 - Mike Wiebe (@mikewiebe)
 options:
@@ -110,6 +111,21 @@ options:
         - Check mode reports a prospective deployment but sends no request.
         type: bool
         default: false
+  verify:
+    description:
+    - Controls post-mutation interface-inventory verification.
+    - Initial discovery and all planning and safety reads are always performed, regardless of this setting.
+    type: dict
+    suboptions:
+      enabled:
+        description:
+        - Whether a completely successful mutating workflow refetches affected switch inventories before returning.
+        - When V(false), successful writes return projected C(resources[].after) state with C(resources[].after_verified=false), avoiding
+          the post-write inventory GETs.
+        - No-op and deployment-only runs continue to return observed state from initial discovery. Partial or failed write execution
+          forces reconciliation even when this option is V(false).
+        type: bool
+        default: false
 extends_documentation_fragment:
 - cisco.nd.modules
 - cisco.nd.check_mode
@@ -148,6 +164,11 @@ notes:
   per-interface transition, preserving the workflow's scale advantage.
 - Interface inventories and transition/delete safety data are shared for the complete workflow. They are not fetched once per resource
   group or once per interface; pagination may require more than one GET for a switch or fabric-level safety inventory.
+- O(verify.enabled) affects only the post-write refresh for a completely successful mutating workflow. Its default V(false) avoids those
+  additional inventory GETs and reports projected state with C(resources[].after_verified=false). Initial discovery, validation, and
+  safety reads are unchanged.
+- No-op and deployment-only workflows report observed initial state. Partial or failed writes force a post-write reconciliation attempt
+  even when O(verify.enabled=false), so mixed or uncertain outcomes are diagnosed against current controller state when possible.
 - Loopback creates sharing both switch and C(policy_type) remain bulked. Different loopback policy types require one POST per switch and
   policy-type combination because Nexus Dashboard rejects mixed-policy loopback bulk requests; this does not add inventory GETs.
 - Deployment-only candidate detection reuses the fabric switch records already fetched to resolve switch identities. It sends no
@@ -187,10 +208,11 @@ notes:
   and fabric type before production use. Architectural support is not a claim of live qualification.
 - In particular, NX-OS and IOS-XE loopback policy-to-policy PUT combinations have not yet been live-qualified through this workflow.
   IOS-XE loopback integration coverage requires an explicitly declared IOS-XE test switch and is not inferred from NX-OS inventory.
-- The executor stops after the first failed mutation phase, does not replay mixed-success requests, reports succeeded, failed, uncertain,
-  skipped, and not-attempted items, and refreshes affected switches after any mutation request. For HTTP 207 responses, only an exact
-  per-item V(success) is successful; missing, warning, notexecuted, unknown, and omitted-target outcomes fail closed while identifiable
-  successes remain reported separately.
+- The executor stops after the first failed mutation phase, does not replay mixed-success requests, and reports succeeded, failed,
+  uncertain, skipped, and not-attempted items. It refreshes affected switches after successful writes only when O(verify.enabled=true),
+  but always attempts reconciliation after partial or failed writes. For HTTP 207 responses, only an exact per-item V(success) is
+  successful; missing, warning, notexecuted, unknown, and omitted-target outcomes fail closed while identifiable successes remain
+  reported separately.
 """
 
 EXAMPLES = r"""
@@ -238,6 +260,8 @@ EXAMPLES = r"""
                   port_channel_mode: active
     config_actions:
       deploy: true
+    verify:
+      enabled: true
   register: interface_result
 
 - name: Preview a fabric-wide authoritative SVI group
@@ -273,6 +297,8 @@ EXAMPLES = r"""
                   access_vlan: 3900
     config_actions:
       deploy: false
+    verify:
+      enabled: false
 
 - name: Deploy the same explicitly requested interface after staging it in an earlier task
   cisco.nd.nd_interfaces_workflow:
@@ -310,7 +336,8 @@ RETURN = r"""
 changed:
   description:
   - In check mode, whether the plan contains a mutation or an explicitly requested deployment-only target.
-  - In normal mode, whether mutation responses, reconciled actual state, or a successful deployment request show a controller action.
+  - In normal mode, whether an exact successful mutation response, reconciled actual state, or a successful deployment request shows a
+    controller action. Successful mutations remain changed when O(verify.enabled=false) skips readback.
   returned: always
   type: bool
 planned_changed:
@@ -407,7 +434,8 @@ resources:
     changed:
       description:
       - Whether C(before) and the reported C(after) differ.
-      - In check mode this is prospective; in normal mode it is actual when reconciliation succeeds.
+      - In check mode this is prospective. In normal mode it compares observed state when C(after_verified=true) and projected state when
+        C(after_verified=false).
       - Remains V(false) when this resource is only a target of deployment for already-staged intent.
       type: bool
     planned_changed:
@@ -425,7 +453,11 @@ resources:
       elements: dict
     after:
       description:
-      - Target-scoped prospective configuration in check mode and reconciled observed configuration after normal-mode writes.
+      - Target-scoped prospective configuration in check mode.
+      - After a successful normal-mode mutation, this is reconciled observed state when O(verify.enabled=true) and projected intended
+        state when O(verify.enabled=false). Consult C(after_verified) before treating it as controller-observed state.
+      - No-op and deployment-only normal-mode runs return observed state from initial discovery. Partial or failed writes force a
+        reconciliation attempt even when verification is disabled.
       - Like C(before), each target reports C(policy_type) at top level; loopback input uses the nested policy discriminator.
       - A removed logical interface is absent. A reset physical Ethernet interface remains present with C(policy_type=trunkHost) and its
         normalized default configuration.
@@ -434,8 +466,10 @@ resources:
       elements: dict
     after_verified:
       description:
-      - Whether C(after) represents coherent observed controller state rather than an unverified plan after reconciliation failure.
-      - V(false) also covers reconciliation that cannot establish consistent vPC state because a peer record is missing or incoherent.
+      - Whether C(after) represents coherent observed controller state rather than projected or unverified state.
+      - V(false) follows a successful mutation when O(verify.enabled=false), a failed reconciliation, or reconciliation that cannot
+        establish consistent vPC state because a peer record is missing or incoherent.
+      - No-op and deployment-only normal-mode runs remain V(true) because C(after) comes from initial observed discovery.
       type: bool
     proposed:
       description: Normalized user configuration validated by the standalone model.
@@ -448,7 +482,9 @@ resources:
       type: list
       elements: dict
     family_after:
-      description: Complete unprojected prospective or reconciled selected-family configuration after execution for diagnostic use.
+      description:
+      - Complete unprojected prospective, projected, or reconciled selected-family configuration after execution for diagnostic use.
+      - C(after_verified) identifies whether the result was observed after execution.
       returned: when O(output_level) is V(debug)
       type: list
       elements: dict
@@ -473,6 +509,8 @@ request_stats:
     interface_inventory_refreshes:
       description:
       - Number of per-switch interface-inventory refresh attempts explicitly initiated during this execution.
+      - A completely successful mutation increments this only when O(verify.enabled=true). Partial or failed write execution can increment
+        it even when verification is disabled because reconciliation is forced.
       - A refresh invalidates the execution-scoped local snapshot before loading it again, so the same operation also increments
         C(interface_inventory_dirty_refetches).
       - This is a logical per-switch count. Paginated HTTP requests are counted separately by C(interface_inventory_gets).
@@ -518,7 +556,10 @@ execution:
       description: Number of consolidated deployment requests sent.
       type: int
     affected_switch_ids:
-      description: Switch serial numbers refreshed after mutation requests.
+      description:
+      - Switch serial numbers in the affected scope after mutation requests.
+      - They are refreshed after a successful mutation only when O(verify.enabled=true), and are also the forced reconciliation scope for
+        partial or failed writes.
       type: list
       elements: str
     deployment:
@@ -586,6 +627,12 @@ def interface_workflow_argument_spec():
                         "choices": sorted(SUPPORTED_STATES),
                     },
                     "config": {"type": "list", "elements": "dict", "required": True},
+                },
+            },
+            "verify": {
+                "type": "dict",
+                "options": {
+                    "enabled": {"type": "bool", "default": False},
                 },
             },
         }

--- a/plugins/modules/nd_interfaces_workflow.py
+++ b/plugins/modules/nd_interfaces_workflow.py
@@ -94,7 +94,7 @@ options:
         - Whether changed interfaces should be deployed in one consolidated action after successful mutation groups.
         - Has no side effect in check mode.
         type: bool
-        default: true
+        default: false
 extends_documentation_fragment:
 - cisco.nd.modules
 - cisco.nd.check_mode
@@ -107,8 +107,8 @@ notes:
 - Sibling policy-type transitions are rejected unless an explicit, tested transition sequence is added; they are never inferred as an
   independent create.
 - The shared snapshot is execution-scoped and is never accepted from arbitrary caller input or persisted across Ansible tasks.
-- Normal-mode execution uses the interface model and orchestrator contracts currently present in the develop branch. Outstanding interface
-  pull-request behavior is intentionally deferred until those pull requests merge.
+- Normal-mode execution uses the same current interface model and orchestrator contracts as the standalone modules, so merged validation,
+  normalization, and deployment behavior is inherited automatically.
 - Deletes run before updates and creates. Deferred logical removes, Ethernet normalize/reset operations, and deployments are consolidated
   across compatible resource groups.
 - The executor stops after the first failed mutation phase, does not replay mixed-success requests, reports succeeded, failed, uncertain,
@@ -417,9 +417,7 @@ def interface_workflow_argument_spec():
 
 def main():
     """Run the public aggregate workflow module."""
-    module = AnsibleModule(
-        argument_spec=interface_workflow_argument_spec(), supports_check_mode=True
-    )
+    module = AnsibleModule(argument_spec=interface_workflow_argument_spec(), supports_check_mode=True)
     require_pydantic(module)
     try:
         module.exit_json(**InterfaceWorkflowCoordinator(module=module).run())
@@ -434,9 +432,7 @@ def main():
     except InterfaceWorkflowValidationError as exc:
         module.fail_json(msg=str(exc), changed=False)
     except Exception as exc:  # pylint: disable=broad-except
-        module.fail_json(
-            msg=f"Unexpected interface workflow error: {exc}", changed=False
-        )
+        module.fail_json(msg=f"Unexpected interface workflow error: {exc}", changed=False)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/nd_interfaces_workflow.py
+++ b/plugins/modules/nd_interfaces_workflow.py
@@ -45,6 +45,10 @@ options:
         description:
         - Selects the standalone interface contract used to validate O(resources[].config).
         - V(ethernet_access) uses M(cisco.nd.nd_interface_ethernet_access).
+        - V(ethernet_routed) uses M(cisco.nd.nd_interface_ethernet_routed).
+        - Configured V(ethernet_routed) items require C(config_data.network_os.network_os_type). The routed policy discriminator is
+          optional and is derived as V(routedHost) for V(nx-os) or V(iosXeRoutedHost) for V(ios-xe). Identifier-only V(deleted) items
+          may omit C(config_data).
         - V(ethernet_trunk_host) uses M(cisco.nd.nd_interface_ethernet_trunk_host).
         - V(loopback) uses M(cisco.nd.nd_interface_loopback).
         - Configured V(loopback) items require C(config_data.network_os.network_os_type) plus
@@ -60,6 +64,7 @@ options:
         required: true
         choices:
         - ethernet_access
+        - ethernet_routed
         - ethernet_trunk_host
         - loopback
         - port_channel_access
@@ -82,7 +87,7 @@ options:
         - V(deleted) acts on each explicitly listed identity regardless of its current policy family, provided the current interface is in
           the same structural domain and is safe to delete. Physical Ethernet interfaces are reset to the unconfigured fabric-default
           policy; deletable logical interfaces are removed.
-        - All ten initial interface adapters support all four values.
+        - All eleven interface adapters support all four values.
         type: str
         choices: [ merged, replaced, overridden, deleted ]
         default: merged
@@ -98,7 +103,8 @@ options:
   config_actions:
     description:
     - Controls actions coordinated after all interface mutation groups complete.
-    - Deployment is attempted only after every planned interface mutation succeeds. A mutation failure stops later writes and deployment.
+    - A mutation failure stops later mutation writes. When O(config_actions.deploy=true), any earlier targets backed by exact controller
+      success evidence are still deployed together in one failure-path request; failed, uncertain, and unattempted targets are excluded.
     - A zero-mutation workflow can deploy previously staged controller intent for explicitly requested interfaces when the already-fetched
       fabric switch record has an explicit out-of-sync or pending status.
     type: dict
@@ -132,6 +138,8 @@ extends_documentation_fragment:
 notes:
 - This module is supported only on Cisco Nexus Dashboard.
 - C(cisco.nd.nd_interface_flow_rules) is intentionally outside this workflow and is not a valid O(resources[].type).
+- C(cisco.nd.nd_manage_links) manages fabric-link resources rather than a host-interface family and is not a valid
+  O(resources[].type). Link-owned interfaces remain protected from host-interface transitions and resets.
 - A non-overridden workflow reads only the union of switches named by its resource groups. Any V(overridden) group expands the shared
   inventory scope to all switches in the fabric.
 - vPC groups load the complete intended fabric vPC-pair inventory with deterministic pagination in the same execution. They reject
@@ -147,6 +155,8 @@ notes:
   destination-policy transition. Changing C(network_os_type) is rejected before writes.
 - Configured V(loopback) items require both C(network_os_type) and C(policy_type); the workflow does not invent discriminator defaults.
   Identifier-only V(deleted) loopback items remain valid without C(config_data).
+- Configured V(ethernet_routed) items require C(network_os_type). The standalone model derives the matching routed policy when
+  C(policy_type) is omitted. A configured item cannot change between V(nx-os) and V(ios-xe) during an implicit transition.
 - The managed V(loopback) scope comprises NX-OS C(loopback), C(ipfmLoopback), and C(mplsLoopback), plus IOS-XE C(iosXeLoopback),
   C(iosXeLoopbackShutNoshut), C(iosXeUnderlayLoopback), C(iosXeInternalLoopback), C(csrLoopback), and C(csr1kvLoopback).
   V(overridden) is authoritative across those nine policies but excludes C(userDefined) and system-owned NX-OS C(underlayLoopback).
@@ -160,6 +170,8 @@ notes:
 - For V(deleted), the selected type supplies the input and execution contract, but explicit identity lookup is policy-independent within
   that structural interface domain. A physical Ethernet delete resets the interface to the unconfigured default instead of removing the
   physical interface.
+- For V(ethernet_routed), an NX-OS delete resets the physical port to the default V(trunkHost) policy. An IOS-XE delete keeps the physical
+  port under V(iosXeRoutedHost) but clears its configurable policy fields to the IOS-XE template defaults.
 - An unconfigured default V(trunkHost) physical interface retains the ordinary bulk-create path and is never converted into a
   per-interface transition, preserving the workflow's scale advantage.
 - Interface inventories and transition/delete safety data are shared for the complete workflow. They are not fetched once per resource
@@ -186,18 +198,19 @@ notes:
 - The authoritative vPC-pair map is shared with all vPC resource orchestrators, preventing repeated per-resource peer-lookup GETs.
 - The shared snapshot is execution-scoped and is never accepted from arbitrary caller input or persisted across Ansible tasks.
 - Normal-mode execution reuses the current standalone interface models and orchestrator contracts for validation, normalization, and
-  mutation payload construction. Final deployment orchestration is workflow-owned; pending targets are consolidated only after every mutation
-  phase succeeds. If a later mutation fails, earlier accepted mutations remain staged; no automatic failure-path deployment is performed.
+  mutation payload construction. Final deployment orchestration is workflow-owned. A successful mutation run consolidates all pending targets
+  into one deployment request. If a later mutation fails and deployment is enabled, only earlier targets with exact success evidence are
+  consolidated into one failure-path deployment request; targets whose mutations failed, are uncertain, or were not attempted are never sent.
 - For V(merged), V(replaced), and V(deleted), C(resources[].before) and C(resources[].after) contain only identities explicitly listed in
   that resource group. Aggregate-interface members remain visible inside the requested port-channel or vPC policy instead of being mixed
   into the result as unrelated Ethernet-family records.
 - Target-scoped C(before) and C(after) include C(policy_type), including when a requested identity starts in another eligible policy family.
-  A deleted logical interface is absent from C(after); a deleted physical Ethernet interface remains present with the normalized default
-  V(trunkHost) policy.
+  A deleted logical interface is absent from C(after). A deleted physical NX-OS Ethernet interface remains present with the normalized
+  default V(trunkHost) policy; a deleted IOS-XE routed interface remains present with a defaults-only V(iosXeRoutedHost) policy.
 - C(resources[].operations) is the single operation ledger. It combines create, update, transition, physical-reset, and logical-delete
   actions with their target identities and execution status; update-like actions can include leaf-level C(changes).
-- Successful output intentionally omits duplicate top-level snapshots and task-input echoes. C(request_stats) contains read, cache,
-  refresh, overlay, and vPC metrics; C(execution) exclusively owns mutation and deployment write counters.
+- Successful output intentionally omits duplicate top-level snapshots and task-input echoes. C(request_stats) contains interface and
+  fabric-link read, cache, refresh, overlay, and vPC metrics; C(execution) exclusively owns mutation and deployment write counters.
 - At O(output_level=debug), C(resources[].family_before) and C(resources[].family_after) expose the complete selected-family collections
   used for diagnostics. Result projection is in-memory and sends no additional controller GET requests.
 - Deletes and deferred normalize/reset operations run before transitions, updates, and creates. Deployments are consolidated across
@@ -245,6 +258,18 @@ EXAMPLES = r"""
                   admin_state: true
                   access_vlan: 100
                   description: Application servers
+      - type: ethernet_routed
+        state: merged
+        config:
+          - switch_ip: 192.168.1.11
+            interface_name: Ethernet1/12
+            config_data:
+              network_os:
+                network_os_type: nx-os
+                policy:
+                  ip: 198.51.100.1
+                  prefix: 30
+                  description: Routed service handoff
       - type: port_channel_trunk_host
         state: replaced
         config:
@@ -446,9 +471,9 @@ resources:
       - Initial observed controller state for the identities explicitly listed by this group when O(resources[].state) is V(merged),
         V(replaced), or V(deleted).
       - For V(overridden), the complete selected-family configuration in the authoritative fabric scope.
-      - Each returned target includes C(policy_type), so a source policy owned by another eligible family remains visible. Loopback input
-        and C(proposed) keep this discriminator nested under C(config_data.network_os.policy), while C(before) promotes it to the target
-        top level and omits the duplicate nested key.
+      - Each returned target includes C(policy_type), so a source policy owned by another eligible family remains visible. Loopback and
+        routed-Ethernet input and C(proposed) keep this discriminator nested under C(config_data.network_os.policy), while C(before)
+        promotes it to the target top level and omits the duplicate nested key.
       type: list
       elements: dict
     after:
@@ -458,9 +483,11 @@ resources:
         state when O(verify.enabled=false). Consult C(after_verified) before treating it as controller-observed state.
       - No-op and deployment-only normal-mode runs return observed state from initial discovery. Partial or failed writes force a
         reconciliation attempt even when verification is disabled.
-      - Like C(before), each target reports C(policy_type) at top level; loopback input uses the nested policy discriminator.
-      - A removed logical interface is absent. A reset physical Ethernet interface remains present with C(policy_type=trunkHost) and its
-        normalized default configuration.
+      - Like C(before), each target reports C(policy_type) at top level; loopback and routed-Ethernet input use the nested policy
+        discriminator.
+      - A removed logical interface is absent. A reset physical NX-OS Ethernet interface remains present with C(policy_type=trunkHost)
+        and its normalized default configuration. A reset IOS-XE routed interface remains present with
+        C(policy_type=iosXeRoutedHost) and defaults-only policy configuration.
       - For V(overridden), the complete selected-family configuration in the authoritative fabric scope.
       type: list
       elements: dict
@@ -489,8 +516,8 @@ resources:
       type: list
       elements: dict
 request_stats:
-  description: Shared configured-interface inventory, lazy transition/delete safety inventory, vPC context, cache, refresh, and overlay
-    counters for this execution. Write counters are reported only under C(execution).
+  description: Shared configured-interface inventory, lazy transition/delete and fabric-link safety inventory, vPC context, cache,
+    refresh, and overlay counters for this execution. Write counters are reported only under C(execution).
   returned: always
   type: dict
   contains:
@@ -537,6 +564,11 @@ request_stats:
       type: int
     snapshot_overlays:
       description: Atomic known-success overlays applied to the snapshot.
+      type: int
+    fabric_link_gets:
+      description:
+      - Fabric-link inventory GET requests used to protect IOS-XE link endpoints from host-interface transitions and resets.
+      - The lazy link cache is shared by all routed resource and platform-reset orchestrators in one workflow, including pagination.
       type: int
     vpc_pair_gets:
       description: Fabric vPC-pair inventory GETs.

--- a/tests/integration/targets/nd_interfaces_workflow/README.md
+++ b/tests/integration/targets/nd_interfaces_workflow/README.md
@@ -1,0 +1,139 @@
+<!--
+Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+-->
+
+# `nd_interfaces_workflow` network integration target
+
+This target qualifies `cisco.nd.nd_interfaces_workflow` against live Nexus Dashboard fabrics. It exercises all ten interface-family adapters, aggregate lifecycle behavior, shared snapshots, implicit policy transitions, policy-independent explicit deletion, conflicts, output controls, invalid inputs, optional property packs, and guarded cleanup.
+
+## Run the target
+
+Run this as an Ansible **network integration** target from the collection root. Do not use the generic `ansible-test integration` command.
+
+```shell
+ansible-test network-integration nd_interfaces_workflow \
+  --inventory /absolute/path/to/inventory.yaml \
+  --python 3.11 -v --truncate 0
+```
+
+Put the target variables in inventory or associated inventory/group variables. The profile selector is exactly `nd_iw_profile`; `nd_iw_test_profile` is not an alias.
+
+| `nd_iw_profile` | Check-mode coverage | Additional live behavior |
+|---|---|---|
+| `smoke` | Minimal family payloads plus batched merged-create, merged-update, and deleted previews; core aggregation, cache, output, conflict, and request-count checks | Applies the lifecycle, checks idempotency, and cleans reserved identities |
+| `full` | Maximal payloads, the replaced preview, implicit-transition metadata, mutex alternatives, invalid cases, optional packs, and all smoke checks | Attempts create/update/replace/delete, merged and replaced accessHost↔trunkHost transitions, opposite-family Ethernet deletion/reset, and prerequisite-approved optional packs when live mutation is enabled |
+| `destructive` | Full coverage plus a separately opted-in authoritative `overridden` preview | May apply the guarded fabric-wide override; deployment remains separately gated |
+
+The defaults are `nd_iw_profile: smoke`, `nd_iw_execution_mode: check`, and `nd_iw_enable_live_mutation: false`. Check mode still queries the live controller and validates plans, but it must send no mutation or deployment requests.
+
+Measured on one fabric in the current live setup:
+
+- Smoke profile: **57.56 seconds**
+- Full check profile: **306.82 seconds** (about 5 minutes 7 seconds)
+
+These are reference measurements, not timeouts; controller load, latency, and selected families can change runtime. The role is guarded with `run_once`, and selected fabrics run serially to protect the shared lab.
+### Scale and request-count invariants
+
+The target treats request counts as part of the module contract:
+
+- Configured-interface inventory is shared by every resource group and fetched per targeted switch and page, never per family or interface.
+- Any additional transition/delete safety inventory is shared for the whole workflow rather than repeated for each candidate.
+- Intended vPC-pair inventory is fetched once per deterministic page for the fabric. The resulting authoritative peer map is shared by
+  every vPC resource group, so access and trunk groups do not repeat per-primary peer-lookup GETs.
+- Equal vPC names on different pairs remain independent pair-scoped resources; reciprocal peer echoes must agree.
+- A real cross-policy transition uses one destination-family PUT per interface because Nexus Dashboard does not expose a bulk transition API.
+- Unconfigured default `trunkHost` ports continue through the established bulk-create path, so ordinary access-port provisioning remains
+  one bulk request per switch rather than one PUT per interface.
+- Compatible physical resets, logical removals, and deployments remain consolidated. The live Ethernet delete scenario asserts that two
+  opposite-family deletes on one switch share one normalize request and send no deployment when deployment is disabled.
+
+
+## Live and destructive safety gates
+
+Normal live reconciliation requires both:
+
+```yaml
+nd_iw_execution_mode: live
+nd_iw_enable_live_mutation: true
+```
+
+Selecting authoritative overridden tests, even in check mode, additionally requires:
+
+```yaml
+nd_iw_profile: destructive
+nd_iw_enable_destructive: true
+```
+
+Physical deployment is independently gated by `nd_iw_enable_deploy: true`. Leave it false unless the reserved interfaces may safely be deployed. The target cleans only its reserved identities before and after live execution; `nd_iw_cleanup_strict` defaults to true so cleanup failures fail the run.
+
+Some shared-lab inventories or wrapper tooling use a `STOP` marker as an operator safety interlock. If one is present, do not delete, bypass, or automate around it. Confirm why the marker was placed, that the fabric and reserved resources are available, and that the owner has authorized the run before clearing it. A stale marker can explain why an otherwise valid invocation does not start, but it must not be assumed stale.
+
+## Fabric and inventory mapping
+
+The supported fabric discriminators are:
+
+- `vxlanEbgp`
+- `vxlanIbgp`
+- `externalConnectivity`
+
+`aimlVxlanEbgp` and `aimlVxlanIbgp` are intentionally excluded from this target for now. `interface_flow_rules` is also outside this interface-aggregator matrix.
+
+`nd_iw_selected_fabric_types` defaults to all three supported discriminators. For a one-fabric run, set it to a one-item list. Each selected fabric must have an enabled matrix entry, an inventory host present in `hostvars`, the real fabric name, and the management IP of a reserved primary switch. The inventory host must securely supply `ansible_host`, `ansible_user`, and `ansible_password`; do not commit those credentials to this target.
+
+Use the following exact override families:
+
+| Fabric | Inventory/fabric overrides | Switch overrides |
+|---|---|---|
+| `vxlanEbgp` | `nd_iw_vxlan_ebgp_inventory_host`, `nd_iw_vxlan_ebgp_fabric_name` | `nd_iw_vxlan_ebgp_switch_primary`, plus `nd_iw_vxlan_ebgp_vpc_peer1` and `nd_iw_vxlan_ebgp_vpc_peer2` for vPC families |
+| `vxlanIbgp` | `nd_iw_vxlan_ibgp_inventory_host`, `nd_iw_vxlan_ibgp_fabric_name` | `nd_iw_vxlan_ibgp_switch_primary`, plus `nd_iw_vxlan_ibgp_vpc_peer1` and `nd_iw_vxlan_ibgp_vpc_peer2` for vPC families |
+| `externalConnectivity` | `nd_iw_external_inventory_host`, `nd_iw_external_fabric_name` | `nd_iw_external_switch_primary`, plus `nd_iw_external_vpc_peer1` and `nd_iw_external_vpc_peer2` for vPC families |
+
+The matrix also defines a `secondary` slot for future scenarios. Both vPC peer management addresses are required when vPC families are selected; independent raw verification binds the expected interface to both authoritative switch serials.
+
+The preflight reads the mapped fabric and, when `nd_iw_verify_fabric_type` is true, requires its observed discriminator to match the matrix. Empty required switch mappings are rejected before test mutation. Operators must verify that every nonempty mapping is a reserved lab resource; preflight does not infer ownership from an address value.
+
+## Interface-family capabilities
+
+Each fabric currently lists the same ten `candidate_families`:
+
+- `ethernet_access`
+- `ethernet_trunk_host`
+- `loopback`
+- `port_channel_access`
+- `port_channel_trunk_host`
+- `subinterface_managed`
+- `subinterface_unmanaged`
+- `svi`
+- `vpc_access`
+- `vpc_trunk_host`
+
+Use `nd_iw_selected_families` to restrict a run. A family is active only when it is selected, is present in the fabric `candidate_families`, is not in `unsupported_families`, is permitted by any optional `supported_families` allow-list, and supports the fabric discriminator in the property matrix. Candidate families declared unsupported are exercised as `nd_iw_unsupported_cases` and must fail in check mode without reporting a change. A per-family string or discriminator/default mapping in `unsupported_expected_error` can constrain the diagnostic.
+
+The checked-in mappings currently declare no unsupported families. Add an exclusion only after collecting controller evidence, and keep it as a subset of `candidate_families`; preflight rejects unknown or inconsistent names. Live setup and cleanup send only active, declared-supported resource types.
+
+## Lab prerequisites
+
+Before selecting a family, reserve controller-visible resources that will not collide with other tests:
+
+- Physical interfaces for Ethernet cases and physical member interfaces for port channels.
+- A valid vPC pair and per-peer member interfaces for vPC cases.
+- Routed parent interfaces for managed and unmanaged subinterfaces.
+- Test-owned loopback, port-channel, subinterface, SVI, vPC, and VLAN identifiers matching the reserved-resource overrides.
+- Existing NetFlow monitors/samplers, QoS and queuing policies, and controller/switch support for PFC or VLAN mapping when those optional packs are exercised.
+
+Subinterface writes are intentionally fail-closed in the aggregator. Their Ethernet or port-channel parent must already exist in routed
+mode from a separately completed workflow: `routedHost` for Ethernet or `l3PortChannel` for a port-channel. The aggregator rejects a
+missing, structurally incompatible, access, or trunk parent before mutation. It also rejects any workflow that mutates a parent and its
+child together, and any parent mutation while existing child subinterfaces remain.
+
+Optional live packs are gated by `nd_iw_optional_prerequisites`, a mapping of prerequisite name to boolean. Set a prerequisite true only after verifying the referenced object or hardware capability in that fabric. Check-profile previews prove model normalization and zero-write planning, but they do not prove that a named NetFlow or QoS object exists. Object existence remains a live prerequisite.
+
+The full check-only profile cannot deterministically preview a sibling-policy transition without first seeding live source state. The full live profile uses the standalone Ethernet access and trunk-host modules to establish deterministic sibling-policy sources, then verifies implicit accessHost↔trunkHost transitions under both `merged` and `replaced`, transition metadata, idempotency, and policy-independent deletion through the opposite Ethernet type. It also verifies that physical deletion resets both interfaces to the default `trunkHost` policy without physical deployment. Other structural domains and source policies remain unit-tested until each combination has a safe, model-backed live setup path; do not use fabric-owned loopbacks, SVIs, peer links, or other controller-owned interfaces merely to manufacture transition coverage.
+
+The Ethernet `routedHost → accessHost` and `accessHost → trunkHost` cross-policy PUTs now have recorded live qualification. The latter was
+verified on `nac-msd-fabric1` for `10.122.84.182/Ethernet1/40` with `state: replaced`: one staged PUT, an authoritative post-write refetch,
+and a zero-change check-mode replay. Deployment was disabled, so this qualifies controller intent mutation rather than physical switch
+deployment. The reverse trunk-to-access scenario and all port-channel, vPC, managed/unmanaged subinterface, SVI, and loopback
+cross-policy combinations remain qualification workloads, not completed qualification claims. Run them against each intended Nexus
+Dashboard release and fabric type before production use.

--- a/tests/integration/targets/nd_interfaces_workflow/README.md
+++ b/tests/integration/targets/nd_interfaces_workflow/README.md
@@ -47,7 +47,53 @@ The target treats request counts as part of the module contract:
   one bulk request per switch rather than one PUT per interface.
 - Compatible physical resets, logical removals, and deployments remain consolidated. The live Ethernet delete scenario asserts that two
   opposite-family deletes on one switch share one normalize request and send no deployment when deployment is disabled.
+- An exact `deploy: true` replay after an earlier `deploy: false` mutation can deploy already-staged intent with zero new interface
+  mutations. Candidate selection reuses the fabric switch rows already fetched for identity resolution, adds no GET, and sends all
+  qualifying explicitly requested identities in one de-duplicated deployment POST.
+- Only an explicitly normalized `outOfSync` or `pending` switch status qualifies for deployment-only execution. An `inSync`, absent, or unknown status
+  does not trigger deployment. A vPC target qualifies when either authoritative peer is explicitly out of sync or pending.
+- Switch sync status is coarser than interface sync status. Unrelated pending intent on the same switch can therefore cause a harmless
+  redeploy of a requested interface, but the request never expands to unrelated interface identities.
+- A later replay cannot recover interfaces implicitly removed because they were omitted from an earlier `overridden` resource. A future
+  deployment-only task must name each intended target explicitly.
 
+### Compact result contract
+
+The complete configured-family snapshot remains available internally for planning, conflict detection, transition safety, and authoritative
+override behavior. Successful public output has one authoritative resource-level representation and deliberately avoids repeating task
+inputs or snapshots:
+
+- The top level contains `changed`, `planned_changed`, `mutation_count`, `target_switch_ids`, `resources`, `request_stats`, and
+  `execution`. It does not echo `check_mode`, `output_level`, `fabric_name`, or `config_actions`, and it does not duplicate
+  `before`, `after`, or `diff`.
+- Each ordered resource result retains `resource_index`, `type`, `module`, `state`, `changed`, `planned_changed`, `before`,
+  `after`, and `after_verified`.
+- `resources[].operations` is the single action ledger. Each entry reports `action`, `switch_ip`, `switch_id`,
+  `interface_name`, and `status`. Transitions also report `from_policy_type` and `to_policy_type`. Update, transition, and
+  physical-reset entries can report `changes: [{path, before, after}]`; creates and logical deletes omit leaf deltas.
+- Physical Ethernet normalization is `action: reset`; logical removal is `action: delete`. Check mode reports `status: planned`.
+  Normal mode carries the matching execution outcome into the same operation entry, so `execution.items` is not duplicated.
+- `output_level: info` adds `resources[].proposed`. `output_level: debug` adds `resources[].proposed`,
+  `resources[].family_before`, and `resources[].family_after`. The selected output level is an input control and is not echoed.
+- `request_stats` contains only read, cache, refresh, overlay, and vPC metrics. `execution.mutations_sent` and
+  `execution.deployments_sent` are the sole write-request counters.
+
+Resource snapshot scope remains state-aware:
+
+- `merged`, `replaced`, and `deleted` report only identities explicitly listed in the corresponding resource group under `before`
+  and `after`.
+- `overridden` remains authoritative and reports the complete selected-family scope because omitted resources are intentional mutation
+  targets.
+- Target records include `policy_type`. Cross-policy transitions and policy-independent deletes therefore show the actual source policy
+  in `before` and the destination or normalized policy in `after`.
+- Logical deletion removes the requested identity from `after`. Physical Ethernet deletion keeps the requested identity in `after`
+  with the normalized default `trunkHost` policy.
+- Port-channel and vPC members remain nested in their requested aggregate-interface policy; unrelated Ethernet-family records are not
+  added.
+- Full-family debug projection and compact operation deltas are derived in memory and require no additional controller GETs.
+- A successful deployment-only run, and its prospective check-mode form, reports top-level `changed: true`,
+  `planned_changed: false`, and `mutation_count: 0`; each resource remains unchanged. Check mode reports deployment status
+  `would_deploy` while both write counters stay zero.
 
 ## Live and destructive safety gates
 
@@ -66,6 +112,11 @@ nd_iw_enable_destructive: true
 ```
 
 Physical deployment is independently gated by `nd_iw_enable_deploy: true`. Leave it false unless the reserved interfaces may safely be deployed. The target cleans only its reserved identities before and after live execution; `nd_iw_cleanup_strict` defaults to true so cleanup failures fail the run.
+
+With that gate enabled, `deploy_controls.yaml` stages an exact reserved configuration with deployment disabled, previews an identical
+deployment-only replay in check mode, performs the identical replay as one zero-mutation deployment, and replays it once more. The final
+no-deployment assertion is conditional on the independently observed switch status having converged to `inSync`; a shared switch can
+remain out of sync because of unrelated lab intent.
 
 Some shared-lab inventories or wrapper tooling use a `STOP` marker as an operator safety interlock. If one is present, do not delete, bypass, or automate around it. Confirm why the marker was placed, that the fabric and reserved resources are available, and that the owner has authorized the run before clearing it. A stale marker can explain why an otherwise valid invocation does not start, but it must not be assumed stale.
 

--- a/tests/integration/targets/nd_interfaces_workflow/README.md
+++ b/tests/integration/targets/nd_interfaces_workflow/README.md
@@ -78,6 +78,12 @@ inputs or snapshots:
 - `request_stats` contains only read, cache, refresh, overlay, and vPC metrics. `execution.mutations_sent` and
   `execution.deployments_sent` are the sole write-request counters.
 
+Post-mutation verification is optional and disabled by default. A successful mutating task without a `verify` mapping, or with
+`verify.enabled: false`, skips the second interface-inventory read. Its resource groups return projected intended `after` state with
+`after_verified: false`, while `interface_inventory_refreshes` and `interface_inventory_dirty_refetches` remain zero. Setting
+`verify.enabled: true` preserves explicit controller readback and returns observed `after` state with `after_verified: true`. Initial
+discovery and safety reads are never skipped, and partial or failed write execution forces reconciliation for diagnostics.
+
 Resource snapshot scope remains state-aware:
 
 - `merged`, `replaced`, and `deleted` report only identities explicitly listed in the corresponding resource group under `before`

--- a/tests/integration/targets/nd_interfaces_workflow/README.md
+++ b/tests/integration/targets/nd_interfaces_workflow/README.md
@@ -5,7 +5,7 @@ GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gp
 
 # `nd_interfaces_workflow` network integration target
 
-This target qualifies `cisco.nd.nd_interfaces_workflow` against live Nexus Dashboard fabrics. It exercises all ten interface-family adapters, aggregate lifecycle behavior, shared snapshots, implicit policy transitions, policy-independent explicit deletion, conflicts, output controls, invalid inputs, optional property packs, and guarded cleanup.
+This target qualifies `cisco.nd.nd_interfaces_workflow` against live Nexus Dashboard fabrics. It exercises all eleven interface-family adapters, aggregate lifecycle behavior, shared snapshots, implicit policy transitions, policy-independent explicit deletion, conflicts, output controls, invalid inputs, optional property packs, and guarded cleanup.
 
 ## Run the target
 
@@ -27,12 +27,14 @@ Put the target variables in inventory or associated inventory/group variables. T
 
 The defaults are `nd_iw_profile: smoke`, `nd_iw_execution_mode: check`, and `nd_iw_enable_live_mutation: false`. Check mode still queries the live controller and validates plans, but it must send no mutation or deployment requests.
 
-Measured on one fabric in the current live setup:
+Historical ten-family measurements on one fabric, before `ethernet_routed` joined the matrix, were:
 
 - Smoke profile: **57.56 seconds**
 - Full check profile: **306.82 seconds** (about 5 minutes 7 seconds)
 
-These are reference measurements, not timeouts; controller load, latency, and selected families can change runtime. The role is guarded with `run_once`, and selected fabrics run serially to protect the shared lab.
+These are reference measurements, not timeouts. An all-eleven run performs additional routed-interface planning and lifecycle requests,
+so replace these figures after collecting a comparable run. Controller load, latency, and selected families can change runtime. The role
+is guarded with `run_once`, and selected fabrics run serially to protect the shared lab.
 ### Scale and request-count invariants
 
 The target treats request counts as part of the module contract:
@@ -75,7 +77,7 @@ inputs or snapshots:
   Normal mode carries the matching execution outcome into the same operation entry, so `execution.items` is not duplicated.
 - `output_level: info` adds `resources[].proposed`. `output_level: debug` adds `resources[].proposed`,
   `resources[].family_before`, and `resources[].family_after`. The selected output level is an input control and is not echoed.
-- `request_stats` contains only read, cache, refresh, overlay, and vPC metrics. `execution.mutations_sent` and
+- `request_stats` contains only interface/fabric-link read, cache, refresh, overlay, and vPC metrics. `execution.mutations_sent` and
   `execution.deployments_sent` are the sole write-request counters.
 
 Post-mutation verification is optional and disabled by default. A successful mutating task without a `verify` mapping, or with
@@ -92,8 +94,8 @@ Resource snapshot scope remains state-aware:
   targets.
 - Target records include `policy_type`. Cross-policy transitions and policy-independent deletes therefore show the actual source policy
   in `before` and the destination or normalized policy in `after`.
-- Logical deletion removes the requested identity from `after`. Physical Ethernet deletion keeps the requested identity in `after`
-  with the normalized default `trunkHost` policy.
+- Logical deletion removes the requested identity from `after`. Physical NX-OS Ethernet deletion keeps the requested identity in
+  `after` with the normalized default `trunkHost` policy; IOS-XE routed deletion keeps it with defaults-only `iosXeRoutedHost` intent.
 - Port-channel and vPC members remain nested in their requested aggregate-interface policy; unrelated Ethernet-family records are not
   added.
 - Full-family debug projection and compact operation deltas are derived in memory and require no additional controller GETs.
@@ -117,6 +119,16 @@ nd_iw_profile: destructive
 nd_iw_enable_destructive: true
 ```
 
+The generic all-family destructive run skips `ethernet_routed` override because NX-OS routed override resets every managed
+`routedHost` omitted from the task, including a separately prepared subinterface parent. To exercise that state, use an isolated
+resource-owner fabric containing no unrelated managed routed interfaces, select only `ethernet_routed`, satisfy the normal destructive
+fabric gates, and additionally set:
+
+```yaml
+nd_iw_selected_families: [ethernet_routed]
+nd_iw_enable_ethernet_routed_override: true
+```
+
 Physical deployment is independently gated by `nd_iw_enable_deploy: true`. Leave it false unless the reserved interfaces may safely be deployed. The target cleans only its reserved identities before and after live execution; `nd_iw_cleanup_strict` defaults to true so cleanup failures fail the run.
 
 With that gate enabled, `deploy_controls.yaml` stages an exact reserved configuration with deployment disabled, previews an identical
@@ -134,7 +146,9 @@ The supported fabric discriminators are:
 - `vxlanIbgp`
 - `externalConnectivity`
 
-`aimlVxlanEbgp` and `aimlVxlanIbgp` are intentionally excluded from this target for now. `interface_flow_rules` is also outside this interface-aggregator matrix.
+`aimlVxlanEbgp` and `aimlVxlanIbgp` are intentionally excluded from this target for now. `interface_flow_rules` is also outside this
+interface-aggregator matrix. `nd_manage_links` owns fabric-link resources rather than a host-interface family and is likewise not an
+aggregator resource type; the target verifies both exclusions before mutation.
 
 `nd_iw_selected_fabric_types` defaults to all three supported discriminators. For a one-fabric run, set it to a one-item list. Each selected fabric must have an enabled matrix entry, an inventory host present in `hostvars`, the real fabric name, and the management IP of a reserved primary switch. The inventory host must securely supply `ansible_host`, `ansible_user`, and `ansible_password`; do not commit those credentials to this target.
 
@@ -152,9 +166,10 @@ The preflight reads the mapped fabric and, when `nd_iw_verify_fabric_type` is tr
 
 ## Interface-family capabilities
 
-Each fabric currently lists the same ten `candidate_families`:
+Each fabric currently lists the same eleven `candidate_families`:
 
 - `ethernet_access`
+- `ethernet_routed`
 - `ethernet_trunk_host`
 - `loopback`
 - `port_channel_access`
@@ -173,7 +188,8 @@ The checked-in mappings currently declare no unsupported families. Add an exclus
 
 Before selecting a family, reserve controller-visible resources that will not collide with other tests:
 
-- Physical interfaces for Ethernet cases and physical member interfaces for port channels.
+- Physical interfaces for Ethernet cases and physical member interfaces for port channels. The checked-in NX-OS routed cases reserve
+  `Ethernet1/52` and `Ethernet1/53` by default; override both identities when those ports are not test-owned.
 - A valid vPC pair and per-peer member interfaces for vPC cases.
 - Routed parent interfaces for managed and unmanaged subinterfaces.
 - Test-owned loopback, port-channel, subinterface, SVI, vPC, and VLAN identifiers matching the reserved-resource overrides.
@@ -192,6 +208,11 @@ of the three managed NX-OS policies (`loopback`, `ipfmLoopback`, `mplsLoopback`)
 Identifier-only loopback deletion intentionally omits both discriminators. The checked-in live property matrix covers only the classic
 NX-OS `loopback` policy today. IPFM, MPLS, and IOS-XE property packs are explicit follow-up work; IOS-XE requires an explicitly
 declared IOS-XE test inventory.
+
+Configured `ethernet_routed` cases use the standalone module's outer network-OS discriminator. The checked-in live matrix covers NX-OS
+`routedHost`, including derived `policy_type`, all controller-object-independent policy fields, guarded optional NetFlow/QoS/PFC fields,
+and reset to the default `trunkHost` policy. IOS-XE `iosXeRoutedHost` needs a separately declared IOS-XE switch and free interface and is
+not inferred from the NX-OS fabric mappings.
 
 The full check-only profile cannot deterministically preview a sibling-policy transition without first seeding live source state. The full live profile uses the standalone Ethernet access and trunk-host modules to establish deterministic sibling-policy sources, then verifies implicit accessHost↔trunkHost transitions under both `merged` and `replaced`, transition metadata, idempotency, and policy-independent deletion through the opposite Ethernet type. It also verifies that physical deletion resets both interfaces to the default `trunkHost` policy without physical deployment. Other structural domains and source policies remain unit-tested until each combination has a safe, model-backed live setup path; do not use fabric-owned loopbacks, SVIs, peer links, or other controller-owned interfaces merely to manufacture transition coverage.
 

--- a/tests/integration/targets/nd_interfaces_workflow/defaults/main.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/defaults/main.yaml
@@ -1,0 +1,39 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# A role invocation is read-only unless the caller explicitly selects live.
+nd_iw_execution_mode: check
+nd_iw_enable_live_mutation: false
+nd_iw_profile: smoke
+
+# The default scope requires an explicit, enabled mapping for every supported
+# fabric type.  Override this list to run a deliberately smaller qualification.
+nd_iw_selected_fabric_types:
+  - vxlanEbgp
+  - vxlanIbgp
+  - externalConnectivity
+nd_iw_selected_families: []
+
+# Fabric-wide deletion through state: overridden is independently guarded even
+# when nd_iw_profile is destructive.
+nd_iw_enable_destructive: false
+nd_iw_enable_deploy: false
+
+nd_iw_output_level: normal
+nd_iw_logging_config: ""
+nd_iw_verify_fabric_type: true
+nd_iw_cleanup_strict: true
+
+# These task lists each run once per fabric.  Family-specific full-profile
+# branches are dispatched separately by tasks/run_family.yaml.
+nd_iw_common_scenarios:
+  - batched_lifecycle
+  - output_levels
+  - deploy_controls
+  - shared_snapshot
+  - mixed_workflow
+  - repeated_types
+  - policy_transitions
+  - conflicts_validation
+  - unsupported_combinations

--- a/tests/integration/targets/nd_interfaces_workflow/defaults/main.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/defaults/main.yaml
@@ -18,6 +18,10 @@ nd_iw_selected_families: []
 # Fabric-wide deletion through state: overridden is independently guarded even
 # when nd_iw_profile is destructive.
 nd_iw_enable_destructive: false
+# Routed overridden state is fabric-wide for managed NX-OS routedHost intent.
+# Enable only with nd_iw_selected_families: [ethernet_routed] after confirming
+# exclusive ownership of every managed routed interface in the selected fabric.
+nd_iw_enable_ethernet_routed_override: false
 nd_iw_enable_deploy: false
 
 nd_iw_output_level: normal

--- a/tests/integration/targets/nd_interfaces_workflow/meta/main.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/meta/main.yaml
@@ -1,0 +1,5 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+dependencies: []

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/cleanup.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/cleanup.yaml
@@ -1,0 +1,33 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Interface workflow cleanup | Reset cleanup tracking
+  ansible.builtin.set_fact:
+    nd_iw_cleanup_failures: []
+
+- name: Interface workflow cleanup | Batch-delete test-owned resources per fabric
+  ansible.builtin.include_tasks:
+    file: cleanup_fabric.yaml
+    apply:
+      tags:
+        - always
+        - nd_iw_cleanup
+  vars:
+    nd_iw_cleanup_phase: always
+  loop: "{{ nd_iw_active_fabrics }}"
+  loop_control:
+    loop_var: nd_iw_current_fabric
+    label: "{{ nd_iw_current_fabric.discriminator }}:{{ nd_iw_current_fabric.fabric_name }}"
+  tags:
+    - always
+    - nd_iw_cleanup
+
+- name: Interface workflow cleanup | Report any cleanup failures
+  ansible.builtin.assert:
+    that:
+      - nd_iw_cleanup_failures | length == 0
+    fail_msg: >-
+      Test execution completed, but cleanup failed for: {{ nd_iw_cleanup_failures | join(', ') }}.
+      The listed fabrics require manual inspection before reuse.
+  when: nd_iw_cleanup_strict | bool

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/cleanup_fabric.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/cleanup_fabric.yaml
@@ -1,0 +1,54 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Interface workflow cleanup | Select reserved resources
+  ansible.builtin.set_fact:
+    nd_iw_active_switches: "{{ nd_iw_current_fabric.switches }}"
+    nd_iw_active_resources: "{{ nd_iw_reserved_resources[nd_iw_current_fabric.reserved_set] }}"
+
+- name: Interface workflow cleanup | Reset supported cleanup resources
+  ansible.builtin.set_fact:
+    nd_iw_supported_cleanup_resources: []
+
+- name: Interface workflow cleanup | Select only declared supported cleanup resources
+  ansible.builtin.set_fact:
+    nd_iw_supported_cleanup_resources: "{{ nd_iw_supported_cleanup_resources + [item] }}"
+  loop: "{{ nd_iw_cleanup_resources }}"
+  loop_control:
+    label: "{{ item.type }}"
+  when:
+    - nd_iw_selected_families | length == 0 or item.type in nd_iw_selected_families
+    - item.type in (nd_iw_current_fabric.candidate_families | default(nd_iw_property_matrix.keys() | list))
+    - item.type not in (nd_iw_current_fabric.unsupported_families | default([]))
+    - item.type in (nd_iw_current_fabric.supported_families | default(nd_iw_property_matrix.keys() | list))
+    - nd_iw_current_fabric.discriminator in (nd_iw_property_matrix[item.type].supported_fabric_types | default(nd_iw_supported_fabric_types))
+
+- name: Interface workflow cleanup | Delete all test identities in one workflow call
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources: "{{ nd_iw_supported_cleanup_resources }}"
+    config_actions:
+      deploy: >-
+        {{ nd_iw_enable_deploy | bool
+           or nd_iw_deployment_exercised | default(false) | bool }}
+    output_level: "{{ nd_iw_output_level }}"
+  register: nd_iw_cleanup_result
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+
+- name: Interface workflow cleanup | Track cleanup failures
+  ansible.builtin.set_fact:
+    nd_iw_cleanup_failures: >-
+      {{ nd_iw_cleanup_failures
+         + [nd_iw_current_fabric.discriminator ~ ':' ~ nd_iw_current_fabric.fabric_name] }}
+  when: nd_iw_cleanup_result.failed | default(false) | bool
+
+- name: Interface workflow cleanup | Require a clean setup baseline
+  ansible.builtin.assert:
+    that:
+      - not (nd_iw_cleanup_result.failed | default(false) | bool)
+    fail_msg: >-
+      Pre-test cleanup failed for {{ nd_iw_current_fabric.fabric_name }}. The suite stopped before
+      creating any new test intent: {{ nd_iw_cleanup_result.msg | default('unknown controller error') }}
+  when: nd_iw_cleanup_phase == 'setup'

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/main.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/main.yaml
@@ -1,0 +1,63 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Interface workflow | Run the target exactly once
+  run_once: true
+  block:
+    - name: Interface workflow | Load fabric mappings
+      ansible.builtin.include_vars:
+        file: "{{ role_path }}/vars/fabric_matrix.yaml"
+      tags: always
+
+    - name: Interface workflow | Load interface property matrix
+      ansible.builtin.include_vars:
+        file: "{{ role_path }}/vars/property_matrix.yaml"
+      tags: always
+
+    - name: Interface workflow | Load reserved resource identifiers
+      ansible.builtin.include_vars:
+        file: "{{ role_path }}/vars/reserved_resources.yaml"
+      tags: always
+
+    - name: Interface workflow | Validate and resolve the requested live-test scope
+      ansible.builtin.include_tasks:
+        file: preflight.yaml
+        apply:
+          tags: always
+      tags: always
+
+    - name: Interface workflow | Execute the guarded integration suite
+      block:
+        - name: Interface workflow | Remove test-owned resources before live execution
+          ansible.builtin.include_tasks: setup.yaml
+          when: not nd_iw_module_check_mode
+          tags:
+            - nd_iw_live
+            - nd_iw_cleanup
+
+        - name: Interface workflow | Run each enabled fabric qualification
+          ansible.builtin.include_tasks: run_fabric.yaml
+          loop: "{{ nd_iw_active_fabrics }}"
+          loop_control:
+            loop_var: nd_iw_current_fabric
+            label: "{{ nd_iw_current_fabric.discriminator }}:{{ nd_iw_current_fabric.fabric_name }}"
+          tags:
+            - nd_iw_smoke
+            - nd_iw_full
+            - nd_iw_destructive
+
+      always:
+        - name: Interface workflow | Remove all test-owned resources after live execution
+          ansible.builtin.include_tasks:
+            file: cleanup.yaml
+            apply:
+              tags:
+                - always
+                - nd_iw_cleanup
+          when: not nd_iw_module_check_mode
+          tags:
+            - always
+            - nd_iw_cleanup
+      environment:
+        ND_LOGGING_CONFIG: "{{ nd_iw_logging_config }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/normalize_case.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/normalize_case.yaml
@@ -1,0 +1,47 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Interface workflow fabric | Determine whether the family is a candidate
+  ansible.builtin.set_fact:
+    nd_iw_case_candidate: >-
+      {{ nd_iw_family_entry.key
+         in (nd_iw_current_fabric.candidate_families
+             | default(nd_iw_property_matrix.keys() | list)) }}
+
+- name: Interface workflow fabric | Determine declared family support
+  ansible.builtin.set_fact:
+    nd_iw_case_supported: >-
+      {{ (nd_iw_case_candidate | bool)
+         and (nd_iw_family_entry.key not in (nd_iw_current_fabric.unsupported_families | default([])))
+         and (nd_iw_family_entry.key in (nd_iw_current_fabric.supported_families
+                                         | default(nd_iw_property_matrix.keys() | list)))
+         and (nd_iw_current_fabric.discriminator
+              in (nd_iw_family_entry.value.supported_fabric_types
+                  | default(nd_iw_supported_fabric_types))) }}
+
+- name: Interface workflow fabric | Build normalized family case
+  ansible.builtin.set_fact:
+    nd_iw_normalized_case: >-
+      {{ nd_iw_family_entry.value
+         | combine({'family': nd_iw_family_entry.key,
+                    'type': nd_iw_family_entry.value.type | default(nd_iw_family_entry.key),
+                    'create_config': (nd_iw_family_entry.value.maximal
+                                      if nd_iw_run_full and nd_iw_family_entry.value.maximal is defined
+                                      else nd_iw_family_entry.value.minimal),
+                    'update_config': nd_iw_family_entry.value.alternate | default([]),
+                    'replace_config': nd_iw_family_entry.value.replacement | default([]),
+                    'delete_config': nd_iw_family_entry.value.delete | default([]),
+                    'property_assertions': nd_iw_family_entry.value.properties | default([]),
+                    'expected_supported': nd_iw_case_supported}) }}
+
+- name: Interface workflow fabric | Add normalized family case to coverage lists
+  ansible.builtin.set_fact:
+    nd_iw_selected_cases: >-
+      {{ nd_iw_selected_cases + ([nd_iw_normalized_case] if nd_iw_case_candidate | bool else []) }}
+    nd_iw_active_cases: >-
+      {{ nd_iw_active_cases + ([nd_iw_normalized_case] if nd_iw_case_supported else []) }}
+    nd_iw_unsupported_cases: >-
+      {{ nd_iw_unsupported_cases
+         + ([nd_iw_normalized_case]
+            if nd_iw_case_candidate | bool and not nd_iw_case_supported | bool else []) }}

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/preflight.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/preflight.yaml
@@ -1,0 +1,80 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Interface workflow preflight | Validate runner selectors
+  ansible.builtin.assert:
+    that:
+      - nd_iw_execution_mode in ['check', 'live']
+      - nd_iw_profile in nd_iw_profiles
+      - nd_iw_selected_fabric_types | length > 0
+      - nd_iw_selected_fabric_types | difference(nd_iw_supported_fabric_types) | length == 0
+      - nd_iw_fabric_matrix is mapping
+    fail_msg: >-
+      Invalid nd_interfaces_workflow integration-test configuration. Select check or live execution,
+      a declared profile, and only supported fabric discriminators; provide the checked-in matrix fixtures.
+
+- name: Interface workflow preflight | Require explicit live-mutation opt-in
+  ansible.builtin.assert:
+    that:
+      - nd_iw_enable_live_mutation | bool
+    fail_msg: >-
+      Live mode requires nd_iw_enable_live_mutation=true in addition to
+      nd_iw_execution_mode=live. No interface mutation was attempted.
+  when: nd_iw_execution_mode == 'live'
+
+- name: Interface workflow preflight | Require explicit destructive opt-in
+  ansible.builtin.assert:
+    that:
+      - nd_iw_enable_destructive | bool
+    fail_msg: >-
+      The destructive profile requires nd_iw_enable_destructive=true in addition to
+      nd_iw_profile=destructive. No fabric-wide override was attempted.
+  when: nd_iw_profile == 'destructive'
+
+- name: Interface workflow preflight | Derive immutable run flags
+  ansible.builtin.set_fact:
+    nd_iw_module_check_mode: "{{ nd_iw_execution_mode != 'live' }}"
+    nd_iw_run_full: "{{ nd_iw_profile in ['full', 'destructive'] }}"
+    nd_iw_run_destructive: >-
+      {{ nd_iw_profile == 'destructive' and nd_iw_enable_destructive | bool }}
+    nd_iw_profile_config: "{{ nd_iw_profiles[nd_iw_profile] }}"
+    nd_iw_active_fabrics: []
+    nd_iw_deployment_exercised: false
+
+- name: Interface workflow preflight | Resolve enabled fabric mappings
+  ansible.builtin.set_fact:
+    nd_iw_active_fabrics: >-
+      {{ nd_iw_active_fabrics
+         + [item.value | combine({'matrix_key': item.key,
+                                  'discriminator': item.value.fabric_type | default(item.key)})] }}
+  loop: "{{ nd_iw_fabric_matrix | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - item.key in nd_iw_selected_fabric_types
+    - item.value.enabled | default(false) | bool
+
+- name: Interface workflow preflight | Require every selected fabric mapping
+  ansible.builtin.assert:
+    that:
+      - nd_iw_active_fabrics | length > 0
+      - >-
+        nd_iw_selected_fabric_types
+        | difference(nd_iw_active_fabrics | map(attribute='discriminator') | list)
+        | length == 0
+    fail_msg: >-
+      Every selected discriminator must have an enabled nd_iw_fabric_matrix entry with real inventory,
+      fabric, switch, and reserved-resource values. Missing mappings: {{ nd_iw_selected_fabric_types
+      | difference(nd_iw_active_fabrics | map(attribute='discriminator') | list) | join(', ') }}.
+
+- name: Interface workflow preflight | Validate each mapped fabric without mutation
+  ansible.builtin.include_tasks:
+    file: preflight_fabric.yaml
+    apply:
+      tags: always
+  loop: "{{ nd_iw_active_fabrics }}"
+  loop_control:
+    loop_var: nd_iw_preflight_fabric
+    label: "{{ nd_iw_preflight_fabric.discriminator }}:{{ nd_iw_preflight_fabric.fabric_name }}"
+  tags: always

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/preflight.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/preflight.yaml
@@ -32,6 +32,17 @@
       nd_iw_profile=destructive. No fabric-wide override was attempted.
   when: nd_iw_profile == 'destructive'
 
+- name: Interface workflow preflight | Require exclusive scope for routed authoritative override
+  ansible.builtin.assert:
+    that:
+      - nd_iw_profile == 'destructive'
+      - nd_iw_enable_destructive | bool
+      - nd_iw_selected_families == ['ethernet_routed']
+    fail_msg: >-
+      Routed authoritative override can reset every managed NX-OS routedHost interface in the fabric.
+      Use the destructive profile, enable its normal safety gates, and select only ethernet_routed.
+  when: nd_iw_enable_ethernet_routed_override | bool
+
 - name: Interface workflow preflight | Derive immutable run flags
   ansible.builtin.set_fact:
     nd_iw_module_check_mode: "{{ nd_iw_execution_mode != 'live' }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/preflight_fabric.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/preflight_fabric.yaml
@@ -1,0 +1,100 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Interface workflow preflight | Validate explicit mapping fields
+  ansible.builtin.assert:
+    that:
+      - nd_iw_preflight_fabric.discriminator in nd_iw_supported_fabric_types
+      - nd_iw_preflight_fabric.fabric_name is string
+      - nd_iw_preflight_fabric.fabric_name | length > 0
+      - nd_iw_preflight_fabric.inventory_host is string
+      - nd_iw_preflight_fabric.inventory_host | length > 0
+      - nd_iw_preflight_fabric.inventory_host in hostvars
+      - nd_iw_preflight_fabric.reserved_set is string
+      - nd_iw_preflight_fabric.reserved_set in nd_iw_reserved_resources
+      - nd_iw_preflight_fabric.switches is mapping
+      - nd_iw_preflight_fabric.switches.primary | default('') | length > 0
+    fail_msg: >-
+      The {{ nd_iw_preflight_fabric.discriminator }} mapping is incomplete. Supply a real inventory host,
+      fabric name, nonempty primary switch IP, and a valid reserved_set; operators must verify reservation ownership.
+
+- name: Interface workflow preflight | Validate declared family capabilities
+  vars:
+    nd_iw_known_families: "{{ nd_iw_family_order }}"
+    nd_iw_candidate_families: >-
+      {{ nd_iw_preflight_fabric.candidate_families | default(nd_iw_known_families) }}
+    nd_iw_declared_unsupported_families: >-
+      {{ nd_iw_preflight_fabric.unsupported_families | default([]) }}
+    nd_iw_selected_candidate_families: >-
+      {{ (nd_iw_candidate_families | intersect(nd_iw_selected_families))
+         if nd_iw_selected_families | length > 0 else nd_iw_candidate_families }}
+    nd_iw_selected_vpc_families: >-
+      {{ nd_iw_selected_candidate_families
+         | intersect(nd_iw_preflight_fabric.vpc_families | default([]))
+         | difference(nd_iw_declared_unsupported_families) }}
+  ansible.builtin.assert:
+    that:
+      - nd_iw_preflight_fabric.capability_mode | default("declared") == "declared"
+      - nd_iw_candidate_families is sequence
+      - nd_iw_candidate_families is not string
+      - nd_iw_candidate_families | length > 0
+      - nd_iw_declared_unsupported_families is sequence
+      - nd_iw_declared_unsupported_families is not string
+      - nd_iw_candidate_families | difference(nd_iw_known_families) | length == 0
+      - nd_iw_declared_unsupported_families | difference(nd_iw_candidate_families) | length == 0
+      - >-
+        nd_iw_selected_vpc_families | length == 0
+        or (nd_iw_preflight_fabric.switches.vpc_peer1 | default("") | length > 0
+            and nd_iw_preflight_fabric.switches.vpc_peer2 | default("") | length > 0)
+    fail_msg: >-
+      The {{ nd_iw_preflight_fabric.discriminator }} family capability declaration is inconsistent.
+      Candidate and unsupported names must be known, unsupported must be a candidate subset, and selected
+      vPC families require both vpc_peer1 and vpc_peer2 switch mappings.
+
+- name: Interface workflow preflight | Validate delegated ND credentials
+  ansible.builtin.assert:
+    that:
+      - hostvars[nd_iw_preflight_fabric.inventory_host].ansible_host is defined
+      - hostvars[nd_iw_preflight_fabric.inventory_host].ansible_host | string | length > 0
+      - hostvars[nd_iw_preflight_fabric.inventory_host].ansible_user is defined
+      - hostvars[nd_iw_preflight_fabric.inventory_host].ansible_user | string | length > 0
+      - hostvars[nd_iw_preflight_fabric.inventory_host].ansible_password is defined
+      - hostvars[nd_iw_preflight_fabric.inventory_host].ansible_password | string | length > 0
+    fail_msg: >-
+      Inventory host '{{ nd_iw_preflight_fabric.inventory_host }}' must define ansible_host,
+      ansible_user, and ansible_password for the live ND connection.
+  no_log: true
+
+- name: Interface workflow preflight | Read mapped fabric
+  cisco.nd.nd_rest:
+    path: "/api/v1/manage/fabrics/{{ nd_iw_preflight_fabric.fabric_name | urlencode }}"
+    method: get
+  register: nd_iw_fabric_query
+  delegate_to: "{{ nd_iw_preflight_fabric.inventory_host }}"
+  when: nd_iw_verify_fabric_type | bool
+
+- name: Interface workflow preflight | Verify mapped fabric discriminator
+  vars:
+    nd_iw_fabric_current: "{{ nd_iw_fabric_query.current | default({}) }}"
+    nd_iw_fabric_management: "{{ nd_iw_fabric_current.get('management', {}) }}"
+    nd_iw_observed_fabric_type: >-
+      {{ nd_iw_fabric_management.get(
+           'type',
+           nd_iw_fabric_current.get(
+             'type',
+             nd_iw_fabric_current.get(
+               'fabricType',
+               nd_iw_fabric_current.get('unifiedNDFabricType', '')
+             )
+           )
+         ) }}
+  ansible.builtin.assert:
+    that:
+      - nd_iw_fabric_query.status | int == 200
+      - nd_iw_observed_fabric_type == nd_iw_preflight_fabric.discriminator
+    fail_msg: >-
+      Fabric '{{ nd_iw_preflight_fabric.fabric_name }}' was not found on
+      '{{ nd_iw_preflight_fabric.inventory_host }}' or its controller discriminator did not equal
+      '{{ nd_iw_preflight_fabric.discriminator }}'. No test mutation was attempted.
+  when: nd_iw_verify_fabric_type | bool

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/run_fabric.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/run_fabric.yaml
@@ -1,0 +1,57 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Interface workflow fabric | Select reserved switch and interface identities
+  ansible.builtin.set_fact:
+    nd_iw_active_switches: "{{ nd_iw_current_fabric.switches }}"
+    nd_iw_active_resources: "{{ nd_iw_reserved_resources[nd_iw_current_fabric.reserved_set] }}"
+    nd_iw_selected_cases: []
+    nd_iw_active_cases: []
+    nd_iw_unsupported_cases: []
+
+- name: Interface workflow fabric | Validate rendered fixture contracts
+  ansible.builtin.assert:
+    that:
+      - nd_iw_property_matrix is mapping
+      - nd_iw_reserved_resources is mapping
+      - nd_iw_active_resources is mapping
+      - nd_iw_cleanup_resources is sequence
+    fail_msg: >-
+      The property matrix, reserved resources, or cleanup payload did not render for
+      {{ nd_iw_current_fabric.discriminator }} after its runtime aliases were selected.
+
+- name: Interface workflow fabric | Normalize selected family fixtures
+  ansible.builtin.include_tasks: normalize_case.yaml
+  loop: "{{ nd_iw_property_matrix | dict2items }}"
+  loop_control:
+    loop_var: nd_iw_family_entry
+    label: "{{ nd_iw_family_entry.key }}"
+  when: >-
+    nd_iw_selected_families | length == 0
+    or nd_iw_family_entry.key in nd_iw_selected_families
+
+- name: Interface workflow fabric | Require at least one supported selected family
+  ansible.builtin.assert:
+    that:
+      - nd_iw_active_cases | length > 0
+    fail_msg: >-
+      No selected interface family is supported by the {{ nd_iw_current_fabric.discriminator }}
+      mapping. Check nd_iw_selected_families and supported_families.
+
+- name: Interface workflow fabric | Run batched and fabric-wide scenarios
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/{{ nd_iw_common_scenario }}.yaml"
+  loop: "{{ nd_iw_common_scenarios }}"
+  loop_control:
+    loop_var: nd_iw_common_scenario
+    label: "{{ nd_iw_common_scenario }}"
+  when: >-
+    nd_iw_common_scenario in ['batched_lifecycle', 'output_levels', 'shared_snapshot',
+                              'mixed_workflow', 'repeated_types'] or nd_iw_run_full
+
+- name: Interface workflow fabric | Run family-specific property branches
+  ansible.builtin.include_tasks: run_family.yaml
+  loop: "{{ nd_iw_active_cases }}"
+  loop_control:
+    loop_var: nd_iw_family_case
+    label: "{{ nd_iw_family_case.family }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/run_family.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/run_family.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: "Interface workflow family | Run {{ nd_iw_family_case.family }} property scenarios"
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/families/{{ nd_iw_family_case.family }}.yaml"
+  vars:
+    nd_iw_current_case: "{{ nd_iw_family_case }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tasks/setup.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tasks/setup.yaml
@@ -1,0 +1,16 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Interface workflow setup | Reset cleanup tracking
+  ansible.builtin.set_fact:
+    nd_iw_cleanup_failures: []
+
+- name: Interface workflow setup | Batch-delete test-owned resources per fabric
+  ansible.builtin.include_tasks: cleanup_fabric.yaml
+  vars:
+    nd_iw_cleanup_phase: setup
+  loop: "{{ nd_iw_active_fabrics }}"
+  loop_control:
+    loop_var: nd_iw_current_fabric
+    label: "{{ nd_iw_current_fabric.discriminator }}:{{ nd_iw_current_fabric.fabric_name }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_absent_config_item.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_absent_config_item.yaml
@@ -1,0 +1,26 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Normalize deleted interface identities
+  ansible.builtin.set_fact:
+    nd_iw_absent_interface_names: >-
+      {{
+        [nd_iw_absent_config_item.interface_name]
+        if nd_iw_absent_config_item.interface_name is defined
+        else nd_iw_absent_config_item.interface_names
+      }}
+
+- name: Verify deleted interfaces are absent from selected family state
+  vars:
+    nd_iw_absent_matches: >-
+      {{
+        nd_iw_assert_resource_result.after
+        | selectattr('switch_ip', 'equalto', nd_iw_absent_config_item.switch_ip)
+        | selectattr('interface_name', 'in', nd_iw_absent_interface_names)
+        | list
+      }}
+  ansible.builtin.assert:
+    that:
+      - nd_iw_absent_matches | length == 0

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_absent_config_item.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_absent_config_item.yaml
@@ -24,3 +24,27 @@
   ansible.builtin.assert:
     that:
       - nd_iw_absent_matches | length == 0
+  when: >-
+    nd_iw_assert_resource_result.state != 'deleted'
+    or (nd_iw_assert_family | default(nd_iw_current_case.family | default(''))) not in ['ethernet_access', 'ethernet_trunk_host']
+
+- name: Verify deleted physical Ethernet interfaces were reset to the default policy
+  vars:
+    nd_iw_reset_matches: >-
+      {{
+        nd_iw_assert_resource_result.after
+        | selectattr('switch_ip', 'equalto', nd_iw_absent_config_item.switch_ip)
+        | selectattr('interface_name', 'in', nd_iw_absent_interface_names)
+        | list
+      }}
+  ansible.builtin.assert:
+    that:
+      - nd_iw_reset_matches | length == nd_iw_absent_interface_names | length
+      - >-
+        nd_iw_reset_matches | rejectattr('policy_type', 'equalto', 'trunkHost') | list | length == 0
+    fail_msg: >-
+      Deleted physical Ethernet targets were not returned with the normalized default trunkHost policy.
+  when:
+    - nd_iw_assert_resource_result.state == 'deleted'
+    - >-
+      (nd_iw_assert_family | default(nd_iw_current_case.family | default(''))) in ['ethernet_access', 'ethernet_trunk_host']

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_absent_config_item.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_absent_config_item.yaml
@@ -26,7 +26,8 @@
       - nd_iw_absent_matches | length == 0
   when: >-
     nd_iw_assert_resource_result.state != 'deleted'
-    or (nd_iw_assert_family | default(nd_iw_current_case.family | default(''))) not in ['ethernet_access', 'ethernet_trunk_host']
+    or (nd_iw_assert_family | default(nd_iw_current_case.family | default('')))
+       not in ['ethernet_access', 'ethernet_routed', 'ethernet_trunk_host']
 
 - name: Verify deleted physical Ethernet interfaces were reset to the default policy
   vars:
@@ -47,4 +48,5 @@
   when:
     - nd_iw_assert_resource_result.state == 'deleted'
     - >-
-      (nd_iw_assert_family | default(nd_iw_current_case.family | default(''))) in ['ethernet_access', 'ethernet_trunk_host']
+      (nd_iw_assert_family | default(nd_iw_current_case.family | default('')))
+      in ['ethernet_access', 'ethernet_routed', 'ethernet_trunk_host']

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_absent.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_absent.yaml
@@ -1,0 +1,22 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Verify deleted resource metadata for {{ nd_iw_assert_family }}
+  ansible.builtin.assert:
+    that:
+      - nd_iw_assert_resource_result.type == nd_iw_assert_family
+      - nd_iw_assert_resource_result.state == 'deleted'
+      - nd_iw_assert_resource_result.after_verified
+
+- name: Verify configured deletion identities for {{ nd_iw_assert_family }}
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_absent_config_item.yaml"
+  loop: "{{ nd_iw_assert_absent_config }}"
+  loop_control:
+    loop_var: nd_iw_absent_config_item
+    label: >-
+      {{
+        nd_iw_absent_config_item.interface_name
+        | default(nd_iw_absent_config_item.interface_names | default(['unknown']) | first)
+      }}

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_absent.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_absent.yaml
@@ -4,11 +4,25 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: Verify deleted resource metadata for {{ nd_iw_assert_family }}
+  vars:
+    nd_iw_assert_delete_action: >-
+      {{
+        "reset"
+        if nd_iw_assert_family in ["ethernet_access", "ethernet_trunk_host"]
+        else "delete"
+      }}
   ansible.builtin.assert:
     that:
       - nd_iw_assert_resource_result.type == nd_iw_assert_family
       - nd_iw_assert_resource_result.state == 'deleted'
       - nd_iw_assert_resource_result.after_verified
+      - nd_iw_assert_resource_result.operations is sequence
+      - nd_iw_assert_resource_result.operations | length > 0
+      - >-
+        nd_iw_assert_resource_result.operations
+        | rejectattr("action", "equalto", nd_iw_assert_delete_action)
+        | list
+        | length == 0
 
 - name: Verify configured deletion identities for {{ nd_iw_assert_family }}
   ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_absent_config_item.yaml"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_absent.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_absent.yaml
@@ -8,7 +8,7 @@
     nd_iw_assert_delete_action: >-
       {{
         "reset"
-        if nd_iw_assert_family in ["ethernet_access", "ethernet_trunk_host"]
+        if nd_iw_assert_family in ["ethernet_access", "ethernet_routed", "ethernet_trunk_host"]
         else "delete"
       }}
   ansible.builtin.assert:

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_result.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_result.yaml
@@ -1,0 +1,28 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Verify indexed resource metadata for {{ nd_iw_assert_case.family | default(nd_iw_assert_case.type | default('unknown')) }}
+  ansible.builtin.assert:
+    that:
+      - nd_iw_assert_resource_result.type == (nd_iw_assert_case.family | default(nd_iw_assert_case.type | default('')))
+      - nd_iw_assert_resource_result.state == nd_iw_assert_state
+      - nd_iw_assert_resource_result.after_verified
+      - nd_iw_assert_resource_result.module == nd_iw_assert_case.module
+      - nd_iw_assert_resource_result.after is sequence
+      - nd_iw_assert_resource_result.diff is mapping
+      - nd_iw_assert_resource_result.created is sequence
+      - nd_iw_assert_resource_result.updated is sequence
+      - nd_iw_assert_resource_result.deleted is sequence
+
+- name: Verify configured items for {{ nd_iw_assert_case.family | default(nd_iw_assert_case.type | default('unknown')) }}
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_config_item.yaml"
+  loop: "{{ nd_iw_assert_expected_config }}"
+  loop_control:
+    loop_var: nd_iw_expected_config_item
+    label: >-
+      {{
+        nd_iw_expected_config_item.interface_name
+        | default(nd_iw_expected_config_item.interface_names | default(['unknown']) | first)
+      }}

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_result.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_result.yaml
@@ -11,10 +11,7 @@
       - nd_iw_assert_resource_result.after_verified
       - nd_iw_assert_resource_result.module == nd_iw_assert_case.module
       - nd_iw_assert_resource_result.after is sequence
-      - nd_iw_assert_resource_result.diff is mapping
-      - nd_iw_assert_resource_result.created is sequence
-      - nd_iw_assert_resource_result.updated is sequence
-      - nd_iw_assert_resource_result.deleted is sequence
+      - nd_iw_assert_resource_result.operations is sequence
 
 - name: Verify configured items for {{ nd_iw_assert_case.family | default(nd_iw_assert_case.type | default('unknown')) }}
   ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_config_item.yaml"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_result.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_case_result.yaml
@@ -8,7 +8,9 @@
     that:
       - nd_iw_assert_resource_result.type == (nd_iw_assert_case.family | default(nd_iw_assert_case.type | default('')))
       - nd_iw_assert_resource_result.state == nd_iw_assert_state
-      - nd_iw_assert_resource_result.after_verified
+      - >-
+        nd_iw_assert_resource_result.after_verified
+        == (nd_iw_assert_after_verified | default(true) | bool)
       - nd_iw_assert_resource_result.module == nd_iw_assert_case.module
       - nd_iw_assert_resource_result.after is sequence
       - nd_iw_assert_resource_result.operations is sequence

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_config_item.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_config_item.yaml
@@ -1,0 +1,20 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Normalize expected interface identities
+  ansible.builtin.set_fact:
+    nd_iw_expected_interface_names: >-
+      {{
+        [nd_iw_expected_config_item.interface_name]
+        if nd_iw_expected_config_item.interface_name is defined
+        else nd_iw_expected_config_item.interface_names
+      }}
+
+- name: Verify each normalized interface and all supplied properties
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_interface_item.yaml"
+  loop: "{{ nd_iw_expected_interface_names }}"
+  loop_control:
+    loop_var: nd_iw_expected_interface_name
+    label: "{{ nd_iw_expected_interface_name }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_interface_item.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_interface_item.yaml
@@ -1,0 +1,46 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Select planned or reconciled state for {{ nd_iw_expected_interface_name }}
+  vars:
+    nd_iw_observed_interface_items: >-
+      {{ nd_iw_assert_observed_items | default(nd_iw_assert_resource_result.after) }}
+  ansible.builtin.set_fact:
+    nd_iw_matching_proposed_items: >-
+      {{
+        nd_iw_assert_resource_result.proposed
+        | selectattr('switch_ip', 'equalto', nd_iw_expected_config_item.switch_ip)
+        | selectattr('interface_name', 'equalto', nd_iw_expected_interface_name)
+        | list
+      }}
+    nd_iw_matching_after_items: >-
+      {{
+        nd_iw_observed_interface_items
+        | selectattr('switch_ip', 'equalto', nd_iw_expected_config_item.switch_ip)
+        | selectattr('interface_name', 'equalto', nd_iw_expected_interface_name)
+        | list
+      }}
+
+- name: Verify {{ nd_iw_expected_interface_name }} and its supplied property subset
+  vars:
+    nd_iw_observed_interface_item: "{{ nd_iw_matching_after_items | first | default({}) }}"
+    nd_iw_expected_config_data: >-
+      {{
+        (nd_iw_matching_proposed_items | first).config_data
+        if nd_iw_assert_resource_result.after_verified | default(false) | bool
+        and nd_iw_matching_proposed_items | length == 1
+        else nd_iw_expected_config_item.config_data | default({})
+      }}
+  ansible.builtin.assert:
+    that:
+      - nd_iw_matching_after_items | length == 1
+      - nd_iw_observed_interface_item.config_data is defined
+      - >-
+        nd_iw_observed_interface_item.config_data
+        | combine(nd_iw_expected_config_data, recursive=true)
+        == nd_iw_observed_interface_item.config_data
+    fail_msg: >-
+      Planned or reconciled {{ nd_iw_assert_resource_result.type }} state did not contain the expected
+      {{ nd_iw_expected_config_item.switch_ip }}/{{ nd_iw_expected_interface_name }} property subset.

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_interface_item.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/assert_interface_item.yaml
@@ -29,8 +29,7 @@
     nd_iw_expected_config_data: >-
       {{
         (nd_iw_matching_proposed_items | first).config_data
-        if nd_iw_assert_resource_result.after_verified | default(false) | bool
-        and nd_iw_matching_proposed_items | length == 1
+        if nd_iw_matching_proposed_items | length == 1
         else nd_iw_expected_config_item.config_data | default({})
       }}
     nd_iw_expected_network_os: "{{ nd_iw_expected_config_data.get('network_os', {}) }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/batched_lifecycle.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/batched_lifecycle.yaml
@@ -82,6 +82,8 @@
         resources: "{{ nd_iw_batch_cleanup_resources }}"
         config_actions:
           deploy: false
+        verify:
+          enabled: true
         output_level: normal
       check_mode: "{{ nd_iw_module_check_mode }}"
       register: nd_iw_batch_precleanup
@@ -124,7 +126,7 @@
             nd_iw_batch_create_preview.request_stats.vpc_pair_gets
             == (1 if (nd_iw_batch_create_resources | selectattr('type', 'in', ['vpc_access', 'vpc_trunk_host']) | list | length > 0) else 0)
 
-    - name: Apply the batched merged create
+    - name: Apply the batched merged create with verification disabled by default
       cisco.nd.nd_interfaces_workflow:
         fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
         resources: "{{ nd_iw_batch_create_resources }}"
@@ -145,7 +147,9 @@
           - nd_iw_batch_create.execution.mutations_sent > 0
           - nd_iw_batch_create.execution.deployments_sent == 0
           - nd_iw_batch_create.resources | length == nd_iw_active_cases | length
-          - nd_iw_batch_create.resources | selectattr('after_verified', 'equalto', true) | list | length == nd_iw_active_cases | length
+          - nd_iw_batch_create.resources | selectattr('after_verified', 'equalto', false) | list | length == nd_iw_active_cases | length
+          - nd_iw_batch_create.request_stats.interface_inventory_refreshes == 0
+          - nd_iw_batch_create.request_stats.interface_inventory_dirty_refetches == 0
       when: not nd_iw_module_check_mode
 
     - name: Verify every created family and configured property
@@ -159,6 +163,7 @@
           }}
         nd_iw_assert_resource_result: "{{ nd_iw_batch_create.resources[nd_iw_assert_case_index] }}"
         nd_iw_assert_state: merged
+        nd_iw_assert_after_verified: false
       loop: "{{ nd_iw_active_cases }}"
       loop_control:
         loop_var: nd_iw_assert_case_item
@@ -222,10 +227,20 @@
         resources: "{{ nd_iw_batch_update_resources }}"
         config_actions:
           deploy: false
+        verify:
+          enabled: true
         output_level: info
       check_mode: "{{ nd_iw_module_check_mode }}"
       register: nd_iw_batch_update
       delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Verify explicit post-mutation readback refreshed affected inventories
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_update.request_stats.interface_inventory_refreshes > 0
+          - nd_iw_batch_update.request_stats.interface_inventory_dirty_refetches > 0
+          - nd_iw_batch_update.resources | selectattr('after_verified', 'equalto', true) | list | length == nd_iw_active_cases | length
       when: not nd_iw_module_check_mode
 
     - name: Verify every updated family and configured property
@@ -292,6 +307,8 @@
         resources: "{{ nd_iw_batch_replace_resources }}"
         config_actions:
           deploy: false
+        verify:
+          enabled: true
         output_level: info
       check_mode: "{{ nd_iw_module_check_mode }}"
       register: nd_iw_batch_replace
@@ -368,6 +385,8 @@
         resources: "{{ nd_iw_batch_delete_resources }}"
         config_actions:
           deploy: false
+        verify:
+          enabled: true
         output_level: normal
       check_mode: "{{ nd_iw_module_check_mode }}"
       register: nd_iw_batch_delete
@@ -426,6 +445,8 @@
         resources: "{{ nd_iw_batch_cleanup_resources }}"
         config_actions:
           deploy: false
+        verify:
+          enabled: true
         output_level: normal
       check_mode: "{{ nd_iw_module_check_mode }}"
       register: nd_iw_batch_cleanup

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/batched_lifecycle.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/batched_lifecycle.yaml
@@ -1,0 +1,436 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Reset batched interface workflow lifecycle inputs
+  ansible.builtin.set_fact:
+    nd_iw_batch_create_resources: []
+    nd_iw_batch_update_resources: []
+    nd_iw_batch_replace_resources: []
+    nd_iw_batch_delete_resources: []
+    nd_iw_batch_cleanup_resources: []
+
+- name: Build batched interface workflow lifecycle inputs
+  ansible.builtin.set_fact:
+    nd_iw_batch_create_resources: >-
+      {{
+        nd_iw_batch_create_resources
+        + [
+          {
+            'type': item.family | default(item.type | default('')),
+            'state': 'merged',
+            'config': item.create_config | default(item.maximal | default(item.minimal | default([])))
+          }
+        ]
+      }}
+    nd_iw_batch_update_resources: >-
+      {{
+        nd_iw_batch_update_resources
+        + [
+          {
+            'type': item.family | default(item.type | default('')),
+            'state': 'merged',
+            'config': item.update_config | default(item.alternate | default([]))
+          }
+        ]
+      }}
+    nd_iw_batch_replace_resources: >-
+      {{
+        nd_iw_batch_replace_resources
+        + [
+          {
+            'type': item.family | default(item.type | default('')),
+            'state': 'replaced',
+            'config': item.replace_config | default(item.replacement | default([]))
+          }
+        ]
+      }}
+    nd_iw_batch_delete_resources: >-
+      {{
+        nd_iw_batch_delete_resources
+        + [
+          {
+            'type': item.family | default(item.type | default('')),
+            'state': 'deleted',
+            'config': item.delete_config | default(item.delete | default([]))
+          }
+        ]
+      }}
+    nd_iw_batch_cleanup_resources: >-
+      {{
+        nd_iw_batch_cleanup_resources
+        + [
+          {
+            'type': item.family | default(item.type | default('')),
+            'state': 'deleted',
+            'config': item.delete_all_config
+              | default(item.delete_all | default(item.delete_config | default(item.delete | default([]))))
+          }
+        ]
+      }}
+  loop: "{{ nd_iw_active_cases }}"
+  loop_control:
+    label: "{{ item.family | default(item.type | default('unknown')) }}"
+
+- name: Exercise the batched interface workflow lifecycle
+  when: nd_iw_active_cases | length > 0
+  block:
+    - name: Remove only reserved lifecycle resources before the live run
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_cleanup_resources }}"
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_precleanup
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Preview the batched merged create
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_create_resources }}"
+        config_actions:
+          deploy: true
+        output_level: info
+      check_mode: true
+      register: nd_iw_batch_create_preview
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+    - name: Verify the complete create plan has no side effects
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_create_preview.check_mode
+          - nd_iw_batch_create_preview.execution.status == 'check_mode'
+          - nd_iw_batch_create_preview.execution.mutations_sent == 0
+          - nd_iw_batch_create_preview.execution.deployments_sent == 0
+          - nd_iw_batch_create_preview.request_stats.mutation_requests == 0
+          - nd_iw_batch_create_preview.request_stats.deploy_requests == 0
+          - nd_iw_batch_create_preview.resources | length == nd_iw_active_cases | length
+          - nd_iw_batch_create_preview.resources | map(attribute='resource_index') | list == range(0, nd_iw_active_cases | length) | list
+          - nd_iw_batch_create_preview.resources | map(attribute='state') | unique | list == ['merged']
+          - nd_iw_batch_create_preview.resources | selectattr('after_verified', 'equalto', false) | list | length == nd_iw_active_cases | length
+          - nd_iw_batch_create_preview.resources | selectattr('proposed', 'defined') | list | length == nd_iw_active_cases | length
+          - not nd_iw_module_check_mode or nd_iw_batch_create_preview.planned_changed
+
+    - name: Verify shared inventory reads tolerate pagination and avoid family refetches
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_create_preview.request_stats.switches == nd_iw_batch_create_preview.target_switch_ids | length
+          - nd_iw_batch_create_preview.request_stats.interface_inventory_gets == nd_iw_batch_create_preview.request_stats.interface_inventory_pages
+          - nd_iw_batch_create_preview.request_stats.interface_inventory_gets >= nd_iw_batch_create_preview.request_stats.switches
+          - nd_iw_batch_create_preview.request_stats.interface_inventory_cache_hits >= nd_iw_active_cases | length
+          - nd_iw_batch_create_preview.request_stats.interface_inventory_cache_hits > 0
+          - >-
+            nd_iw_batch_create_preview.request_stats.vpc_pair_gets
+            == (1 if (nd_iw_batch_create_resources | selectattr('type', 'in', ['vpc_access', 'vpc_trunk_host']) | list | length > 0) else 0)
+
+    - name: Apply the batched merged create
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_create_resources }}"
+        config_actions:
+          deploy: false
+        output_level: info
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_create
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Verify the live batched create result
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_create is changed
+          - nd_iw_batch_create.planned_changed
+          - nd_iw_batch_create.execution.status == 'staged'
+          - nd_iw_batch_create.execution.mutations_sent > 0
+          - nd_iw_batch_create.execution.deployments_sent == 0
+          - nd_iw_batch_create.resources | length == nd_iw_active_cases | length
+          - nd_iw_batch_create.resources | selectattr('after_verified', 'equalto', true) | list | length == nd_iw_active_cases | length
+      when: not nd_iw_module_check_mode
+
+    - name: Verify every created family and configured property
+      ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_case_result.yaml"
+      vars:
+        nd_iw_assert_case: "{{ nd_iw_assert_case_item }}"
+        nd_iw_assert_expected_config: >-
+          {{
+            nd_iw_assert_case_item.create_config
+            | default(nd_iw_assert_case_item.maximal | default(nd_iw_assert_case_item.minimal | default([])))
+          }}
+        nd_iw_assert_resource_result: "{{ nd_iw_batch_create.resources[nd_iw_assert_case_index] }}"
+        nd_iw_assert_state: merged
+      loop: "{{ nd_iw_active_cases }}"
+      loop_control:
+        loop_var: nd_iw_assert_case_item
+        index_var: nd_iw_assert_case_index
+        label: "{{ nd_iw_assert_case_item.family | default(nd_iw_assert_case_item.type | default('unknown')) }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Independently verify created intent through raw controller inventory
+      ansible.builtin.include_tasks: "{{ role_path }}/tests/common/controller_verify_inventory.yaml"
+      vars:
+        nd_iw_raw_verify_mode: present
+        nd_iw_raw_workflow_result: "{{ nd_iw_batch_create }}"
+        nd_iw_raw_identity_resources: "{{ nd_iw_batch_create_resources }}"
+        nd_iw_raw_fingerprint_resources: "{{ nd_iw_batch_create_resources }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Reapply the batched create for idempotency
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_create_resources }}"
+        config_actions:
+          deploy: "{{ nd_iw_enable_deploy | bool }}"
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_create_idempotent
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Verify merged create idempotency performs no write or deployment
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_create_idempotent is not changed
+          - not nd_iw_batch_create_idempotent.planned_changed
+          - nd_iw_batch_create_idempotent.execution.status == 'no_change'
+          - nd_iw_batch_create_idempotent.request_stats.mutation_requests == 0
+          - nd_iw_batch_create_idempotent.request_stats.deploy_requests == 0
+      when: not nd_iw_module_check_mode
+
+    - name: Preview the batched merged update
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_update_resources }}"
+        config_actions:
+          deploy: true
+        output_level: normal
+      check_mode: true
+      register: nd_iw_batch_update_preview
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+    - name: Verify the merged update preview performs no writes
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_update_preview is changed
+          - nd_iw_batch_update_preview.execution.status == 'check_mode'
+          - nd_iw_batch_update_preview.request_stats.mutation_requests == 0
+          - nd_iw_batch_update_preview.request_stats.deploy_requests == 0
+
+    - name: Apply the batched merged update
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_update_resources }}"
+        config_actions:
+          deploy: false
+        output_level: info
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_update
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Verify every updated family and configured property
+      ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_case_result.yaml"
+      vars:
+        nd_iw_assert_case: "{{ nd_iw_assert_case_item }}"
+        nd_iw_assert_expected_config: >-
+          {{ nd_iw_assert_case_item.update_config | default(nd_iw_assert_case_item.alternate | default([])) }}
+        nd_iw_assert_resource_result: "{{ nd_iw_batch_update.resources[nd_iw_assert_case_index] }}"
+        nd_iw_assert_state: merged
+      loop: "{{ nd_iw_active_cases }}"
+      loop_control:
+        loop_var: nd_iw_assert_case_item
+        index_var: nd_iw_assert_case_index
+        label: "{{ nd_iw_assert_case_item.family | default(nd_iw_assert_case_item.type | default('unknown')) }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Reapply the batched merged update for idempotency
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_update_resources }}"
+        config_actions:
+          deploy: "{{ nd_iw_enable_deploy | bool }}"
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_update_idempotent
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Verify merged update idempotency performs no write or deployment
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_update_idempotent is not changed
+          - not nd_iw_batch_update_idempotent.planned_changed
+          - nd_iw_batch_update_idempotent.request_stats.mutation_requests == 0
+          - nd_iw_batch_update_idempotent.request_stats.deploy_requests == 0
+      when: not nd_iw_module_check_mode
+
+    - name: Preview the batched replaced state
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_replace_resources }}"
+        config_actions:
+          deploy: true
+        output_level: normal
+      check_mode: true
+      register: nd_iw_batch_replace_preview
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: nd_iw_run_full | bool
+
+    - name: Verify the replaced preview performs no writes
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_replace_preview is changed
+          - nd_iw_batch_replace_preview.execution.status == 'check_mode'
+          - nd_iw_batch_replace_preview.resources | map(attribute='state') | unique | list == ['replaced']
+          - nd_iw_batch_replace_preview.request_stats.mutation_requests == 0
+          - nd_iw_batch_replace_preview.request_stats.deploy_requests == 0
+      when: nd_iw_run_full | bool
+
+    - name: Apply the batched replaced state
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_replace_resources }}"
+        config_actions:
+          deploy: false
+        output_level: info
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_replace
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when:
+        - nd_iw_run_full | bool
+        - not nd_iw_module_check_mode
+
+    - name: Verify every replaced family and configured property
+      ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_case_result.yaml"
+      vars:
+        nd_iw_assert_case: "{{ nd_iw_assert_case_item }}"
+        nd_iw_assert_expected_config: >-
+          {{ nd_iw_assert_case_item.replace_config | default(nd_iw_assert_case_item.replacement | default([])) }}
+        nd_iw_assert_resource_result: "{{ nd_iw_batch_replace.resources[nd_iw_assert_case_index] }}"
+        nd_iw_assert_state: replaced
+      loop: "{{ nd_iw_active_cases }}"
+      loop_control:
+        loop_var: nd_iw_assert_case_item
+        index_var: nd_iw_assert_case_index
+        label: "{{ nd_iw_assert_case_item.family | default(nd_iw_assert_case_item.type | default('unknown')) }}"
+      when:
+        - nd_iw_run_full | bool
+        - not nd_iw_module_check_mode
+
+    - name: Reapply the batched replaced state for idempotency
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_replace_resources }}"
+        config_actions:
+          deploy: "{{ nd_iw_enable_deploy | bool }}"
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_replace_idempotent
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when:
+        - nd_iw_run_full | bool
+        - not nd_iw_module_check_mode
+
+    - name: Verify replaced idempotency performs no write or deployment
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_replace_idempotent is not changed
+          - not nd_iw_batch_replace_idempotent.planned_changed
+          - nd_iw_batch_replace_idempotent.request_stats.mutation_requests == 0
+          - nd_iw_batch_replace_idempotent.request_stats.deploy_requests == 0
+      when:
+        - nd_iw_run_full | bool
+        - not nd_iw_module_check_mode
+
+    - name: Preview the batched deleted state
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_delete_resources }}"
+        config_actions:
+          deploy: true
+        output_level: normal
+      check_mode: true
+      register: nd_iw_batch_delete_preview
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+    - name: Verify the deleted preview performs no writes
+      ansible.builtin.assert:
+        that:
+          - nd_iw_module_check_mode or nd_iw_batch_delete_preview is changed
+          - nd_iw_batch_delete_preview.execution.status == 'check_mode'
+          - nd_iw_batch_delete_preview.resources | map(attribute='state') | unique | list == ['deleted']
+          - nd_iw_batch_delete_preview.request_stats.mutation_requests == 0
+          - nd_iw_batch_delete_preview.request_stats.deploy_requests == 0
+
+    - name: Apply the batched deleted state
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_delete_resources }}"
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_delete
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Verify every deleted family is absent from reconciled state
+      ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_case_absent.yaml"
+      vars:
+        nd_iw_assert_absent_config: >-
+          {{ nd_iw_assert_case_item.delete_config | default(nd_iw_assert_case_item.delete | default([])) }}
+        nd_iw_assert_resource_result: "{{ nd_iw_batch_delete.resources[nd_iw_assert_case_index] }}"
+        nd_iw_assert_family: "{{ nd_iw_assert_case_item.family | default(nd_iw_assert_case_item.type | default('')) }}"
+      loop: "{{ nd_iw_active_cases }}"
+      loop_control:
+        loop_var: nd_iw_assert_case_item
+        index_var: nd_iw_assert_case_index
+        label: "{{ nd_iw_assert_case_item.family | default(nd_iw_assert_case_item.type | default('unknown')) }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Independently verify deleted intent through raw controller inventory
+      ansible.builtin.include_tasks: "{{ role_path }}/tests/common/controller_verify_inventory.yaml"
+      vars:
+        nd_iw_raw_verify_mode: absent
+        nd_iw_raw_workflow_result: "{{ nd_iw_batch_delete }}"
+        nd_iw_raw_identity_resources: "{{ nd_iw_batch_delete_resources }}"
+        nd_iw_raw_fingerprint_resources: "{{ nd_iw_batch_replace_resources }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Reapply the batched deleted state for idempotency
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_delete_resources }}"
+        config_actions:
+          deploy: "{{ nd_iw_enable_deploy | bool }}"
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_delete_idempotent
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Verify deleted idempotency performs no write or deployment
+      ansible.builtin.assert:
+        that:
+          - nd_iw_batch_delete_idempotent is not changed
+          - not nd_iw_batch_delete_idempotent.planned_changed
+          - nd_iw_batch_delete_idempotent.execution.status == 'no_change'
+          - nd_iw_batch_delete_idempotent.request_stats.mutation_requests == 0
+          - nd_iw_batch_delete_idempotent.request_stats.deploy_requests == 0
+      when: not nd_iw_module_check_mode
+
+  always:
+    - name: Remove only reserved lifecycle resources after the live run
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources: "{{ nd_iw_batch_cleanup_resources }}"
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_batch_cleanup
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/batched_lifecycle.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/batched_lifecycle.yaml
@@ -102,12 +102,9 @@
     - name: Verify the complete create plan has no side effects
       ansible.builtin.assert:
         that:
-          - nd_iw_batch_create_preview.check_mode
           - nd_iw_batch_create_preview.execution.status == 'check_mode'
           - nd_iw_batch_create_preview.execution.mutations_sent == 0
           - nd_iw_batch_create_preview.execution.deployments_sent == 0
-          - nd_iw_batch_create_preview.request_stats.mutation_requests == 0
-          - nd_iw_batch_create_preview.request_stats.deploy_requests == 0
           - nd_iw_batch_create_preview.resources | length == nd_iw_active_cases | length
           - nd_iw_batch_create_preview.resources | map(attribute='resource_index') | list == range(0, nd_iw_active_cases | length) | list
           - nd_iw_batch_create_preview.resources | map(attribute='state') | unique | list == ['merged']
@@ -196,8 +193,8 @@
           - nd_iw_batch_create_idempotent is not changed
           - not nd_iw_batch_create_idempotent.planned_changed
           - nd_iw_batch_create_idempotent.execution.status == 'no_change'
-          - nd_iw_batch_create_idempotent.request_stats.mutation_requests == 0
-          - nd_iw_batch_create_idempotent.request_stats.deploy_requests == 0
+          - nd_iw_batch_create_idempotent.execution.mutations_sent == 0
+          - nd_iw_batch_create_idempotent.execution.deployments_sent == 0
       when: not nd_iw_module_check_mode
 
     - name: Preview the batched merged update
@@ -216,8 +213,8 @@
         that:
           - nd_iw_batch_update_preview is changed
           - nd_iw_batch_update_preview.execution.status == 'check_mode'
-          - nd_iw_batch_update_preview.request_stats.mutation_requests == 0
-          - nd_iw_batch_update_preview.request_stats.deploy_requests == 0
+          - nd_iw_batch_update_preview.execution.mutations_sent == 0
+          - nd_iw_batch_update_preview.execution.deployments_sent == 0
 
     - name: Apply the batched merged update
       cisco.nd.nd_interfaces_workflow:
@@ -263,8 +260,8 @@
         that:
           - nd_iw_batch_update_idempotent is not changed
           - not nd_iw_batch_update_idempotent.planned_changed
-          - nd_iw_batch_update_idempotent.request_stats.mutation_requests == 0
-          - nd_iw_batch_update_idempotent.request_stats.deploy_requests == 0
+          - nd_iw_batch_update_idempotent.execution.mutations_sent == 0
+          - nd_iw_batch_update_idempotent.execution.deployments_sent == 0
       when: not nd_iw_module_check_mode
 
     - name: Preview the batched replaced state
@@ -285,8 +282,8 @@
           - nd_iw_batch_replace_preview is changed
           - nd_iw_batch_replace_preview.execution.status == 'check_mode'
           - nd_iw_batch_replace_preview.resources | map(attribute='state') | unique | list == ['replaced']
-          - nd_iw_batch_replace_preview.request_stats.mutation_requests == 0
-          - nd_iw_batch_replace_preview.request_stats.deploy_requests == 0
+          - nd_iw_batch_replace_preview.execution.mutations_sent == 0
+          - nd_iw_batch_replace_preview.execution.deployments_sent == 0
       when: nd_iw_run_full | bool
 
     - name: Apply the batched replaced state
@@ -339,8 +336,8 @@
         that:
           - nd_iw_batch_replace_idempotent is not changed
           - not nd_iw_batch_replace_idempotent.planned_changed
-          - nd_iw_batch_replace_idempotent.request_stats.mutation_requests == 0
-          - nd_iw_batch_replace_idempotent.request_stats.deploy_requests == 0
+          - nd_iw_batch_replace_idempotent.execution.mutations_sent == 0
+          - nd_iw_batch_replace_idempotent.execution.deployments_sent == 0
       when:
         - nd_iw_run_full | bool
         - not nd_iw_module_check_mode
@@ -362,8 +359,8 @@
           - nd_iw_module_check_mode or nd_iw_batch_delete_preview is changed
           - nd_iw_batch_delete_preview.execution.status == 'check_mode'
           - nd_iw_batch_delete_preview.resources | map(attribute='state') | unique | list == ['deleted']
-          - nd_iw_batch_delete_preview.request_stats.mutation_requests == 0
-          - nd_iw_batch_delete_preview.request_stats.deploy_requests == 0
+          - nd_iw_batch_delete_preview.execution.mutations_sent == 0
+          - nd_iw_batch_delete_preview.execution.deployments_sent == 0
 
     - name: Apply the batched deleted state
       cisco.nd.nd_interfaces_workflow:
@@ -418,8 +415,8 @@
           - nd_iw_batch_delete_idempotent is not changed
           - not nd_iw_batch_delete_idempotent.planned_changed
           - nd_iw_batch_delete_idempotent.execution.status == 'no_change'
-          - nd_iw_batch_delete_idempotent.request_stats.mutation_requests == 0
-          - nd_iw_batch_delete_idempotent.request_stats.deploy_requests == 0
+          - nd_iw_batch_delete_idempotent.execution.mutations_sent == 0
+          - nd_iw_batch_delete_idempotent.execution.deployments_sent == 0
       when: not nd_iw_module_check_mode
 
   always:

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/conflicts_validation.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/conflicts_validation.yaml
@@ -1,0 +1,224 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Reject an excluded interface workflow resource type
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: interface_flow_rules
+        state: merged
+        config: []
+    config_actions:
+      deploy: true
+    output_level: normal
+  check_mode: true
+  register: nd_iw_excluded_type_result
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+
+- name: Verify excluded-type validation fails before planning or writes
+  ansible.builtin.assert:
+    that:
+      - nd_iw_excluded_type_result.failed | default(false) | bool
+      - not (nd_iw_excluded_type_result.changed | default(false) | bool)
+      - nd_iw_excluded_type_result.msg is search('interface_flow_rules')
+
+- name: Select a supported family for duplicate-ownership validation
+  ansible.builtin.set_fact:
+    nd_iw_conflict_case: "{{ nd_iw_active_cases | first }}"
+
+- name: Plan duplicate ownership of one interface identity
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_conflict_case.family }}"
+        state: merged
+        config: "{{ nd_iw_conflict_case.create_config }}"
+      - type: "{{ nd_iw_conflict_case.family }}"
+        state: merged
+        config: "{{ nd_iw_conflict_case.create_config }}"
+    config_actions:
+      deploy: true
+    output_level: debug
+  check_mode: true
+  register: nd_iw_duplicate_conflict
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+
+- name: Verify duplicate ownership is a structured pre-mutation conflict
+  ansible.builtin.assert:
+    that:
+      - nd_iw_duplicate_conflict.failed | default(false) | bool
+      - not (nd_iw_duplicate_conflict.changed | default(false) | bool)
+      - nd_iw_duplicate_conflict.conflicts is defined
+      - nd_iw_duplicate_conflict.conflicts | selectattr('code', 'equalto', 'duplicate_ownership') | list | length >= 1
+      - nd_iw_duplicate_conflict.conflicts[0].resource_indices == [0, 1]
+
+- name: Select Ethernet sibling-policy fixtures
+  ansible.builtin.set_fact:
+    nd_iw_conflict_access_cases: "{{ nd_iw_active_cases | selectattr('family', 'equalto', 'ethernet_access') | list }}"
+    nd_iw_conflict_trunk_cases: "{{ nd_iw_active_cases | selectattr('family', 'equalto', 'ethernet_trunk_host') | list }}"
+
+- name: Plan access and trunk ownership of the same Ethernet interface
+  vars:
+    nd_iw_conflict_access_case: "{{ nd_iw_conflict_access_cases | first }}"
+    nd_iw_conflict_trunk_case: "{{ nd_iw_conflict_trunk_cases | first }}"
+    nd_iw_conflict_access_item: "{{ nd_iw_conflict_access_case.create_config | first }}"
+    nd_iw_conflict_trunk_item: >-
+      {{
+        (nd_iw_conflict_trunk_case.create_config | first)
+        | combine(
+            {
+              'switch_ip': nd_iw_conflict_access_item.switch_ip,
+              'interface_names': nd_iw_conflict_access_item.interface_names
+            },
+            recursive=true
+          )
+      }}
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: ethernet_access
+        state: merged
+        config:
+          - "{{ nd_iw_conflict_access_item }}"
+      - type: ethernet_trunk_host
+        state: merged
+        config:
+          - "{{ nd_iw_conflict_trunk_item }}"
+    config_actions:
+      deploy: true
+    output_level: normal
+  check_mode: true
+  register: nd_iw_ethernet_sibling_conflict
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+  when:
+    - nd_iw_conflict_access_cases | length > 0
+    - nd_iw_conflict_trunk_cases | length > 0
+
+- name: Verify Ethernet sibling policies cannot claim one identity
+  ansible.builtin.assert:
+    that:
+      - nd_iw_ethernet_sibling_conflict.failed | default(false) | bool
+      - not (nd_iw_ethernet_sibling_conflict.changed | default(false) | bool)
+      - nd_iw_ethernet_sibling_conflict.conflicts | selectattr('code', 'equalto', 'duplicate_ownership') | list | length >= 1
+  when:
+    - nd_iw_conflict_access_cases | length > 0
+    - nd_iw_conflict_trunk_cases | length > 0
+
+- name: Select physical-port and port-channel fixtures
+  ansible.builtin.set_fact:
+    nd_iw_conflict_port_channel_cases: "{{ nd_iw_active_cases | selectattr('family', 'equalto', 'port_channel_access') | list }}"
+
+- name: Plan independent Ethernet intent on a new port-channel member
+  vars:
+    nd_iw_conflict_access_case: "{{ nd_iw_conflict_access_cases | first }}"
+    nd_iw_conflict_port_channel_case: "{{ nd_iw_conflict_port_channel_cases | first }}"
+    nd_iw_conflict_port_channel_item: "{{ nd_iw_conflict_port_channel_case.create_config | first }}"
+    nd_iw_conflict_member: "{{ nd_iw_conflict_port_channel_item.config_data.network_os.policy.ports | first }}"
+    nd_iw_conflict_member_item: >-
+      {{
+        (nd_iw_conflict_access_case.create_config | first)
+        | combine(
+            {
+              'switch_ip': nd_iw_conflict_port_channel_item.switch_ip,
+              'interface_names': [nd_iw_conflict_member]
+            },
+            recursive=true
+          )
+      }}
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: ethernet_access
+        state: merged
+        config:
+          - "{{ nd_iw_conflict_member_item }}"
+      - type: port_channel_access
+        state: merged
+        config:
+          - "{{ nd_iw_conflict_port_channel_item }}"
+    config_actions:
+      deploy: true
+    output_level: normal
+  check_mode: true
+  register: nd_iw_member_conflict
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+  when:
+    - nd_iw_conflict_access_cases | length > 0
+    - nd_iw_conflict_port_channel_cases | length > 0
+
+- name: Verify Ethernet and port-channel member ownership cannot race
+  ansible.builtin.assert:
+    that:
+      - nd_iw_member_conflict.failed | default(false) | bool
+      - not (nd_iw_member_conflict.changed | default(false) | bool)
+      - nd_iw_member_conflict.conflicts | selectattr('code', 'equalto', 'ethernet_member_collision') | list | length >= 1
+  when:
+    - nd_iw_conflict_access_cases | length > 0
+    - nd_iw_conflict_port_channel_cases | length > 0
+
+- name: Select vPC sibling-policy fixtures
+  ansible.builtin.set_fact:
+    nd_iw_conflict_vpc_access_cases: "{{ nd_iw_active_cases | selectattr('family', 'equalto', 'vpc_access') | list }}"
+    nd_iw_conflict_vpc_trunk_cases: "{{ nd_iw_active_cases | selectattr('family', 'equalto', 'vpc_trunk_host') | list }}"
+
+- name: Plan access and trunk ownership of the same vPC identity
+  vars:
+    nd_iw_conflict_vpc_access_case: "{{ nd_iw_conflict_vpc_access_cases | first }}"
+    nd_iw_conflict_vpc_trunk_case: "{{ nd_iw_conflict_vpc_trunk_cases | first }}"
+    nd_iw_conflict_vpc_access_item: "{{ nd_iw_conflict_vpc_access_case.create_config | first }}"
+    nd_iw_conflict_vpc_trunk_item: >-
+      {{
+        (nd_iw_conflict_vpc_trunk_case.create_config | first)
+        | combine(
+            {
+              'switch_ip': nd_iw_conflict_vpc_access_item.switch_ip,
+              'interface_name': nd_iw_conflict_vpc_access_item.interface_name
+            },
+            recursive=true
+          )
+      }}
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: vpc_access
+        state: merged
+        config:
+          - "{{ nd_iw_conflict_vpc_access_item }}"
+      - type: vpc_trunk_host
+        state: merged
+        config:
+          - "{{ nd_iw_conflict_vpc_trunk_item }}"
+    config_actions:
+      deploy: true
+    output_level: normal
+  check_mode: true
+  register: nd_iw_vpc_sibling_conflict
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+  when:
+    - nd_iw_conflict_vpc_access_cases | length > 0
+    - nd_iw_conflict_vpc_trunk_cases | length > 0
+
+- name: Verify vPC sibling policies cannot claim one pair-scoped identity
+  ansible.builtin.assert:
+    that:
+      - nd_iw_vpc_sibling_conflict.failed | default(false) | bool
+      - not (nd_iw_vpc_sibling_conflict.changed | default(false) | bool)
+      - nd_iw_vpc_sibling_conflict.conflicts | selectattr('code', 'equalto', 'duplicate_ownership') | list | length >= 1
+  when:
+    - nd_iw_conflict_vpc_access_cases | length > 0
+    - nd_iw_conflict_vpc_trunk_cases | length > 0
+
+- name: Run family-model invalid property cases
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/invalid_family_cases.yaml"
+  loop: "{{ nd_iw_active_cases }}"
+  loop_control:
+    loop_var: nd_iw_invalid_family_case
+    label: "{{ nd_iw_invalid_family_case.family }}"
+  when: nd_iw_profile_config.run_invalid | bool

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/conflicts_validation.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/conflicts_validation.yaml
@@ -25,6 +25,28 @@
       - not (nd_iw_excluded_type_result.changed | default(false) | bool)
       - nd_iw_excluded_type_result.msg is search('interface_flow_rules')
 
+- name: Reject link management as an interface workflow resource type
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: manage_links
+        state: merged
+        config: []
+    config_actions:
+      deploy: true
+    output_level: normal
+  check_mode: true
+  register: nd_iw_excluded_links_result
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+
+- name: Verify link-resource validation fails before planning or writes
+  ansible.builtin.assert:
+    that:
+      - nd_iw_excluded_links_result.failed | default(false) | bool
+      - not (nd_iw_excluded_links_result.changed | default(false) | bool)
+      - nd_iw_excluded_links_result.msg is search('manage_links')
+
 - name: Select a supported family for duplicate-ownership validation
   ansible.builtin.set_fact:
     nd_iw_conflict_case: "{{ nd_iw_active_cases | first }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/controller_verify_inventory.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/controller_verify_inventory.yaml
@@ -1,0 +1,232 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Reset independent controller inventory evidence
+  ansible.builtin.set_fact:
+    nd_iw_raw_expected_policy_keys: []
+    nd_iw_raw_expected_fingerprint_keys: []
+    nd_iw_raw_switch_id_by_ip: {}
+    nd_iw_raw_interfaces: []
+    nd_iw_raw_observed_policy_keys: []
+    nd_iw_raw_observed_fingerprint_keys: []
+    nd_iw_raw_policy_type_by_family:
+      ethernet_access: accessHost
+      ethernet_trunk_host: trunkHost
+      loopback: loopback
+      port_channel_access: accessPoHost
+      port_channel_trunk_host: trunkPoHost
+      subinterface_managed: subinterface
+      subinterface_unmanaged: monitorSubinterface
+      svi: svi
+      vpc_access: accessVpcHost
+      vpc_trunk_host: trunkVpcHost
+
+- name: Read authoritative fabric switch identities
+  cisco.nd.nd_rest:
+    path: >-
+      /api/v1/manage/fabrics/{{ nd_iw_current_fabric.fabric_name | urlencode }}/switches?max=500&offset=0
+    method: get
+  register: nd_iw_raw_switch_inventory
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+- name: Verify authoritative fabric switch inventory response
+  ansible.builtin.assert:
+    that:
+      - nd_iw_raw_switch_inventory.status | int == 200
+      - nd_iw_raw_switch_inventory.current.switches is sequence
+    fail_msg: >-
+      Independent raw verification could not read the fabric switch identity map.
+
+- name: Build authoritative management-IP-to-serial map
+  ansible.builtin.set_fact:
+    nd_iw_raw_switch_id_by_ip: >-
+      {{ nd_iw_raw_switch_id_by_ip
+         | combine({item.fabricManagementIp: item.switchId
+                    | default(item.serialNumber | default(''), true)}) }}
+  loop: "{{ nd_iw_raw_switch_inventory.current.switches }}"
+  loop_control:
+    label: "{{ item.fabricManagementIp | default('unaddressed') }}"
+  when:
+    - item.fabricManagementIp | default('') | length > 0
+    - item.switchId | default(item.serialNumber | default(''), true) | length > 0
+
+- name: Verify workflow target serials belong to the mapped fabric
+  ansible.builtin.assert:
+    that:
+      - >-
+        nd_iw_raw_workflow_result.target_switch_ids
+        | difference(nd_iw_raw_switch_id_by_ip.values() | list)
+        | length == 0
+    fail_msg: >-
+      Workflow target serials were absent from the independent fabric switch inventory.
+
+- name: Build expected raw policy identities
+  vars:
+    nd_iw_raw_expected_names: >-
+      {{
+        [item.1.interface_name]
+        if item.1.interface_name is defined
+        else item.1.interface_names
+      }}
+    nd_iw_raw_expected_switch_ips: >-
+      {{ [nd_iw_active_switches.vpc_peer1, nd_iw_active_switches.vpc_peer2]
+         if item.0.type in ['vpc_access', 'vpc_trunk_host']
+         else [item.1.switch_ip] }}
+    nd_iw_raw_expected_switch_ids: >-
+      {{ nd_iw_raw_expected_switch_ips
+         | map('extract', nd_iw_raw_switch_id_by_ip)
+         | unique
+         | list }}
+    nd_iw_raw_expected_policy: "{{ nd_iw_raw_policy_type_by_family[item.0.type] }}"
+  ansible.builtin.set_fact:
+    nd_iw_raw_expected_policy_keys: >-
+      {{
+        nd_iw_raw_expected_policy_keys
+        + (
+          nd_iw_raw_expected_switch_ids
+          | product(nd_iw_raw_expected_names | map('lower') | list)
+          | map('join', '|')
+          | product([nd_iw_raw_expected_policy])
+          | map('join', '|')
+          | list
+        )
+      }}
+  loop: "{{ nd_iw_raw_identity_resources | subelements('config') }}"
+  loop_control:
+    label: "{{ item.0.type }}"
+
+- name: Build expected raw description fingerprints
+  vars:
+    nd_iw_raw_expected_names: >-
+      {{
+        [item.1.interface_name]
+        if item.1.interface_name is defined
+        else item.1.interface_names
+      }}
+    nd_iw_raw_expected_switch_ips: >-
+      {{ [nd_iw_active_switches.vpc_peer1, nd_iw_active_switches.vpc_peer2]
+         if item.0.type in ['vpc_access', 'vpc_trunk_host']
+         else [item.1.switch_ip] }}
+    nd_iw_raw_expected_switch_ids: >-
+      {{ nd_iw_raw_expected_switch_ips
+         | map('extract', nd_iw_raw_switch_id_by_ip)
+         | unique
+         | list }}
+    nd_iw_raw_expected_policy: "{{ nd_iw_raw_policy_type_by_family[item.0.type] }}"
+    nd_iw_raw_expected_description: "{{ item.1.config_data.network_os.policy.description }}"
+  ansible.builtin.set_fact:
+    nd_iw_raw_expected_fingerprint_keys: >-
+      {{
+        nd_iw_raw_expected_fingerprint_keys
+        + (
+          nd_iw_raw_expected_switch_ids
+          | product(nd_iw_raw_expected_names | map('lower') | list)
+          | map('join', '|')
+          | product([nd_iw_raw_expected_policy])
+          | map('join', '|')
+          | product([nd_iw_raw_expected_description])
+          | map('join', '|')
+          | list
+        )
+      }}
+  loop: "{{ nd_iw_raw_fingerprint_resources | subelements('config') }}"
+  loop_control:
+    label: "{{ item.0.type }}"
+  when: item.1.config_data.network_os.policy.description is defined
+
+- name: Read raw interface inventory once per targeted switch
+  cisco.nd.nd_rest:
+    path: >-
+      /api/v1/manage/fabrics/{{ nd_iw_current_fabric.fabric_name | urlencode
+      }}/switches/{{ item | urlencode }}/interfaces?max=500&offset=0
+    method: get
+  register: nd_iw_raw_inventory
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  loop: "{{ nd_iw_raw_workflow_result.target_switch_ids }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Verify every raw interface inventory response
+  ansible.builtin.assert:
+    that:
+      - item.status | int == 200
+      - item.current.interfaces is sequence
+    fail_msg: >-
+      Independent raw verification could not read interface inventory for switch {{ item.item }}.
+  loop: "{{ nd_iw_raw_inventory.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Combine raw controller interface records
+  ansible.builtin.set_fact:
+    nd_iw_raw_interfaces: >-
+      {{ nd_iw_raw_interfaces
+         + (item.current.interfaces
+            | default([])
+            | map('combine', {'nd_iw_raw_switch_id': item.item})
+            | list) }}
+  loop: "{{ nd_iw_raw_inventory.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Build independently observed policy and description signatures
+  vars:
+    nd_iw_raw_observed_name: "{{ item.interfaceName | default('') | lower }}"
+    nd_iw_raw_observed_policy: >-
+      {{ item.get('configData', {}).get('networkOS', {}).get('policy', {}).get('policyType', '') }}
+    nd_iw_raw_observed_description: >-
+      {{ item.get('configData', {}).get('networkOS', {}).get('policy', {}).get('description', '') }}
+  ansible.builtin.set_fact:
+    nd_iw_raw_observed_policy_keys: >-
+      {{
+        nd_iw_raw_observed_policy_keys
+        + [item.nd_iw_raw_switch_id ~ '|' ~ nd_iw_raw_observed_name
+           ~ '|' ~ nd_iw_raw_observed_policy]
+      }}
+    nd_iw_raw_observed_fingerprint_keys: >-
+      {{
+        nd_iw_raw_observed_fingerprint_keys
+        + [
+          item.nd_iw_raw_switch_id
+          ~ '|' ~ nd_iw_raw_observed_name
+          ~ '|' ~ nd_iw_raw_observed_policy
+          ~ '|' ~ nd_iw_raw_observed_description
+        ]
+      }}
+  loop: "{{ nd_iw_raw_interfaces }}"
+  loop_control:
+    label: >-
+      {{ item.nd_iw_raw_switch_id ~ ':' ~ (item.interfaceName | default('unnamed')) }}
+
+- name: Verify raw controller inventory contains created managed intent
+  ansible.builtin.assert:
+    that:
+      - nd_iw_raw_expected_policy_keys | difference(nd_iw_raw_observed_policy_keys) | length == 0
+      - nd_iw_raw_expected_fingerprint_keys | difference(nd_iw_raw_observed_fingerprint_keys) | length == 0
+    fail_msg: >-
+      Independent ND inventory did not contain all created interface policy signatures.
+      Missing policies={{ nd_iw_raw_expected_policy_keys | difference(nd_iw_raw_observed_policy_keys) }};
+      missing fingerprints={{
+        nd_iw_raw_expected_fingerprint_keys | difference(nd_iw_raw_observed_fingerprint_keys)
+      }}.
+  when: nd_iw_raw_verify_mode == 'present'
+
+- name: Verify raw controller inventory no longer contains deleted managed intent
+  vars:
+    # Physical trunk interfaces remain in inventory as normalized trunkHost
+    # records. Their test description fingerprint must disappear instead.
+    nd_iw_raw_absence_policy_keys: >-
+      {{ nd_iw_raw_expected_policy_keys | reject('search', '\\|trunkHost$') | list }}
+  ansible.builtin.assert:
+    that:
+      - nd_iw_raw_absence_policy_keys | intersect(nd_iw_raw_observed_policy_keys) | length == 0
+      - nd_iw_raw_expected_fingerprint_keys | intersect(nd_iw_raw_observed_fingerprint_keys) | length == 0
+    fail_msg: >-
+      Independent ND inventory still contains deleted test intent.
+      Policy matches={{ nd_iw_raw_absence_policy_keys | intersect(nd_iw_raw_observed_policy_keys) }};
+      fingerprint matches={{
+        nd_iw_raw_expected_fingerprint_keys | intersect(nd_iw_raw_observed_fingerprint_keys)
+      }}.
+  when: nd_iw_raw_verify_mode == 'absent'

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/controller_verify_inventory.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/controller_verify_inventory.yaml
@@ -13,6 +13,7 @@
     nd_iw_raw_observed_fingerprint_keys: []
     nd_iw_raw_policy_type_by_family:
       ethernet_access: accessHost
+      ethernet_routed: routedHost
       ethernet_trunk_host: trunkHost
       loopback: loopback
       port_channel_access: accessPoHost

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/deploy_controls.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/deploy_controls.yaml
@@ -10,6 +10,15 @@
     nd_iw_deploy_case: >-
       {{ nd_iw_ethernet_deploy_cases | first if nd_iw_ethernet_deploy_cases | length > 0 else nd_iw_active_cases | first }}
 
+- name: Build the explicitly requested deployment target set
+  ansible.builtin.set_fact:
+    nd_iw_deploy_target_names: >-
+      {{
+        (nd_iw_deploy_case.create_config | map(attribute='interface_names') | flatten | list)
+        if nd_iw_deploy_case.create_config[0].interface_names is defined
+        else (nd_iw_deploy_case.create_config | map(attribute='interface_name') | list)
+      }}
+
 - name: Preview a change with deployment requested
   cisco.nd.nd_interfaces_workflow:
     fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
@@ -24,19 +33,16 @@
   register: nd_iw_deploy_preview
   delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
 
-- name: Verify check mode never mutates or deploys
+- name: Verify check mode never sends a mutation or deployment
   ansible.builtin.assert:
     that:
-      - nd_iw_deploy_preview.check_mode
       - nd_iw_deploy_preview.execution.status == 'check_mode'
       - nd_iw_deploy_preview.execution.deployment.requested
-      - nd_iw_deploy_preview.execution.deployment.status == 'not_needed'
+      - nd_iw_deploy_preview.execution.deployment.status in ['not_needed', 'would_deploy']
       - nd_iw_deploy_preview.execution.mutations_sent == 0
       - nd_iw_deploy_preview.execution.deployments_sent == 0
-      - nd_iw_deploy_preview.request_stats.mutation_requests == 0
-      - nd_iw_deploy_preview.request_stats.deploy_requests == 0
 
-- name: Exercise live deployment controls on one reserved identity
+- name: Exercise live deployment controls on explicitly requested reserved identities
   when: not nd_iw_module_check_mode
   block:
     - name: Remove the reserved deployment-control identity
@@ -45,11 +51,7 @@
         resources:
           - type: "{{ nd_iw_deploy_case.family }}"
             state: deleted
-            config: >-
-              {{
-                nd_iw_deploy_case.delete_all
-                | default(nd_iw_deploy_case.delete_config | default(nd_iw_deploy_case.delete))
-              }}
+            config: "{{ nd_iw_deploy_case.delete_config }}"
         config_actions:
           deploy: false
         output_level: normal
@@ -80,15 +82,47 @@
           - nd_iw_deploy_disabled.execution.deployment.status in ['disabled', 'not_needed']
           - nd_iw_deploy_disabled.execution.mutations_sent > 0
           - nd_iw_deploy_disabled.execution.deployments_sent == 0
-          - nd_iw_deploy_disabled.request_stats.deploy_requests == 0
 
-    - name: Update and deploy the reserved interface once
+    - name: Preview staged intent with an identical zero-mutation replay
       cisco.nd.nd_interfaces_workflow:
         fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
         resources:
           - type: "{{ nd_iw_deploy_case.family }}"
             state: merged
-            config: "{{ nd_iw_deploy_case.update_config }}"
+            config: "{{ nd_iw_deploy_case.create_config }}"
+        config_actions:
+          deploy: true
+        output_level: normal
+      check_mode: true
+      register: nd_iw_deploy_only_preview
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      retries: 10
+      delay: 2
+      until: nd_iw_deploy_only_preview.execution.deployment.status == 'would_deploy'
+      when: nd_iw_enable_deploy | bool
+
+    - name: Verify the deployment-only preview is changed but sends no writes
+      ansible.builtin.assert:
+        that:
+          - nd_iw_deploy_only_preview is changed
+          - not nd_iw_deploy_only_preview.planned_changed
+          - nd_iw_deploy_only_preview.mutation_count == 0
+          - nd_iw_deploy_only_preview.resources | selectattr('changed', 'equalto', true) | list | length == 0
+          - nd_iw_deploy_only_preview.execution.status == 'check_mode'
+          - nd_iw_deploy_only_preview.execution.deployment.requested
+          - nd_iw_deploy_only_preview.execution.deployment.status == 'would_deploy'
+          - nd_iw_deploy_only_preview.execution.mutations_sent == 0
+          - nd_iw_deploy_only_preview.execution.deployments_sent == 0
+          - nd_iw_deploy_only_preview.execution.deployment.targets | map(attribute='interface_name') | list | sort == nd_iw_deploy_target_names | unique | sort
+      when: nd_iw_enable_deploy | bool
+
+    - name: Deploy the already-staged exact configuration with zero mutations
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_deploy_case.family }}"
+            state: merged
+            config: "{{ nd_iw_deploy_case.create_config }}"
         config_actions:
           deploy: true
         output_level: normal
@@ -97,16 +131,23 @@
       delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
       when: nd_iw_enable_deploy | bool
 
-    - name: Verify all successful mutations produce exactly one consolidated deployment
+    - name: Verify staged intent used one exact-target deployment and zero mutations
       ansible.builtin.assert:
         that:
           - nd_iw_deploy_enabled is changed
+          - not nd_iw_deploy_enabled.planned_changed
+          - nd_iw_deploy_enabled.mutation_count == 0
+          - nd_iw_deploy_enabled.resources | selectattr('changed', 'equalto', true) | list | length == 0
           - nd_iw_deploy_enabled.execution.status == 'completed'
           - nd_iw_deploy_enabled.execution.deployment.requested
           - nd_iw_deploy_enabled.execution.deployment.status == 'succeeded'
-          - nd_iw_deploy_enabled.execution.mutations_sent > 0
+          - nd_iw_deploy_enabled.execution.mutations_sent == 0
           - nd_iw_deploy_enabled.execution.deployments_sent == 1
-          - nd_iw_deploy_enabled.request_stats.deploy_requests == 1
+          - nd_iw_deploy_enabled.execution.deployment.targets | map(attribute='interface_name') | list | sort == nd_iw_deploy_target_names | unique | sort
+          - >-
+            nd_iw_deploy_enabled.execution.deployment.targets
+            | selectattr('status', 'equalto', 'succeeded') | list | length
+            == nd_iw_deploy_target_names | unique | length
       when: nd_iw_enable_deploy | bool
 
     - name: Record that physical deployment cleanup is required
@@ -116,13 +157,57 @@
         - nd_iw_enable_deploy | bool
         - nd_iw_deploy_enabled.execution.deployment.status == 'succeeded'
 
-    - name: Reapply deployed intent to prove no-change suppresses deployment
+    - name: Read fabric switch sync status after deployment
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ nd_iw_current_fabric.fabric_name | urlencode }}/switches?max=500&offset=0
+        method: get
+      register: nd_iw_deploy_sync_query
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: nd_iw_enable_deploy | bool
+
+    - name: Verify the independent switch-status read succeeded
+      ansible.builtin.assert:
+        that:
+          - nd_iw_deploy_sync_query.status | int == 200
+          - nd_iw_deploy_sync_query.current.switches | default([]) is sequence
+      when: nd_iw_enable_deploy | bool
+
+    - name: Reset independently observed target-switch sync statuses
+      ansible.builtin.set_fact:
+        nd_iw_deploy_observed_sync_statuses: []
+      when: nd_iw_enable_deploy | bool
+
+    - name: Record sync status for every workflow target switch
+      vars:
+        nd_iw_deploy_sync_switch_id: >-
+          {{ item.get('switchId', item.get('serialNumber', '')) }}
+        nd_iw_deploy_sync_additional: "{{ item.get('additionalData', {}) }}"
+        nd_iw_deploy_sync_status: >-
+          {{
+            nd_iw_deploy_sync_additional.get(
+              'configSyncStatus',
+              item.get('configSyncStatus', '')
+            )
+            | string | lower | regex_replace('[^a-z0-9]', '')
+          }}
+      ansible.builtin.set_fact:
+        nd_iw_deploy_observed_sync_statuses: >-
+          {{ nd_iw_deploy_observed_sync_statuses + [nd_iw_deploy_sync_status] }}
+      loop: "{{ nd_iw_deploy_sync_query.current.switches | default([]) }}"
+      loop_control:
+        label: "{{ nd_iw_deploy_sync_switch_id | default('unidentified') }}"
+      when:
+        - nd_iw_enable_deploy | bool
+        - nd_iw_deploy_sync_switch_id in nd_iw_deploy_enabled.target_switch_ids
+
+    - name: Reapply the exact deployed intent once
       cisco.nd.nd_interfaces_workflow:
         fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
         resources:
           - type: "{{ nd_iw_deploy_case.family }}"
             state: merged
-            config: "{{ nd_iw_deploy_case.update_config }}"
+            config: "{{ nd_iw_deploy_case.create_config }}"
         config_actions:
           deploy: true
         output_level: normal
@@ -131,16 +216,44 @@
       delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
       when: nd_iw_enable_deploy | bool
 
-    - name: Verify idempotency sends no mutation or deployment
+    - name: Verify the exact replay remains mutation-free
+      ansible.builtin.assert:
+        that:
+          - not nd_iw_deploy_idempotent.planned_changed
+          - nd_iw_deploy_idempotent.mutation_count == 0
+          - nd_iw_deploy_idempotent.resources | selectattr('changed', 'equalto', true) | list | length == 0
+          - nd_iw_deploy_idempotent.execution.mutations_sent == 0
+          - nd_iw_deploy_idempotent.execution.deployments_sent in [0, 1]
+      when: nd_iw_enable_deploy | bool
+
+    - name: Verify a controller-confirmed in-sync replay sends no deployment
       ansible.builtin.assert:
         that:
           - nd_iw_deploy_idempotent is not changed
           - nd_iw_deploy_idempotent.execution.status == 'no_change'
-          - nd_iw_deploy_idempotent.execution.mutations_sent == 0
+          - nd_iw_deploy_idempotent.execution.deployment.status == 'not_needed'
           - nd_iw_deploy_idempotent.execution.deployments_sent == 0
-          - nd_iw_deploy_idempotent.request_stats.mutation_requests == 0
-          - nd_iw_deploy_idempotent.request_stats.deploy_requests == 0
-      when: nd_iw_enable_deploy | bool
+      when:
+        - nd_iw_enable_deploy | bool
+        - nd_iw_deploy_observed_sync_statuses | length == nd_iw_deploy_enabled.target_switch_ids | length
+        - nd_iw_deploy_observed_sync_statuses | reject('equalto', 'insync') | list | length == 0
+
+    - name: Verify any shared-lab redeploy remains consolidated and exact-target scoped
+      ansible.builtin.assert:
+        that:
+          - nd_iw_deploy_idempotent is changed
+          - nd_iw_deploy_idempotent.execution.status == 'completed'
+          - nd_iw_deploy_idempotent.execution.deployment.requested
+          - nd_iw_deploy_idempotent.execution.deployment.status == 'succeeded'
+          - nd_iw_deploy_idempotent.execution.deployments_sent == 1
+          - nd_iw_deploy_idempotent.execution.deployment.targets | map(attribute='interface_name') | list | sort == nd_iw_deploy_target_names | unique | sort
+          - >-
+            nd_iw_deploy_idempotent.execution.deployment.targets
+            | selectattr('status', 'equalto', 'succeeded') | list | length
+            == nd_iw_deploy_target_names | unique | length
+      when:
+        - nd_iw_enable_deploy | bool
+        - nd_iw_deploy_idempotent.execution.deployments_sent == 1
 
   always:
     - name: Remove only the reserved deployment-control identity
@@ -149,11 +262,7 @@
         resources:
           - type: "{{ nd_iw_deploy_case.family }}"
             state: deleted
-            config: >-
-              {{
-                nd_iw_deploy_case.delete_all
-                | default(nd_iw_deploy_case.delete_config | default(nd_iw_deploy_case.delete))
-              }}
+            config: "{{ nd_iw_deploy_case.delete_config }}"
         config_actions:
           deploy: "{{ (nd_iw_enable_deploy | bool) or (nd_iw_deployment_exercised | default(false) | bool) }}"
         output_level: normal

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/deploy_controls.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/deploy_controls.yaml
@@ -1,0 +1,162 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Select a stable family for deployment-control coverage
+  vars:
+    nd_iw_ethernet_deploy_cases: "{{ nd_iw_active_cases | selectattr('family', 'equalto', 'ethernet_access') | list }}"
+  ansible.builtin.set_fact:
+    nd_iw_deploy_case: >-
+      {{ nd_iw_ethernet_deploy_cases | first if nd_iw_ethernet_deploy_cases | length > 0 else nd_iw_active_cases | first }}
+
+- name: Preview a change with deployment requested
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_deploy_case.family }}"
+        state: merged
+        config: "{{ nd_iw_deploy_case.create_config }}"
+    config_actions:
+      deploy: true
+    output_level: normal
+  check_mode: true
+  register: nd_iw_deploy_preview
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+- name: Verify check mode never mutates or deploys
+  ansible.builtin.assert:
+    that:
+      - nd_iw_deploy_preview.check_mode
+      - nd_iw_deploy_preview.execution.status == 'check_mode'
+      - nd_iw_deploy_preview.execution.deployment.requested
+      - nd_iw_deploy_preview.execution.deployment.status == 'not_needed'
+      - nd_iw_deploy_preview.execution.mutations_sent == 0
+      - nd_iw_deploy_preview.execution.deployments_sent == 0
+      - nd_iw_deploy_preview.request_stats.mutation_requests == 0
+      - nd_iw_deploy_preview.request_stats.deploy_requests == 0
+
+- name: Exercise live deployment controls on one reserved identity
+  when: not nd_iw_module_check_mode
+  block:
+    - name: Remove the reserved deployment-control identity
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_deploy_case.family }}"
+            state: deleted
+            config: >-
+              {{
+                nd_iw_deploy_case.delete_all
+                | default(nd_iw_deploy_case.delete_config | default(nd_iw_deploy_case.delete))
+              }}
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_deploy_precleanup
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+    - name: Stage a reserved interface without deployment
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_deploy_case.family }}"
+            state: merged
+            config: "{{ nd_iw_deploy_case.create_config }}"
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_deploy_disabled
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+    - name: Verify deploy false stages intent without a deployment request
+      ansible.builtin.assert:
+        that:
+          - nd_iw_deploy_disabled is changed
+          - nd_iw_deploy_disabled.execution.status == 'staged'
+          - not nd_iw_deploy_disabled.execution.deployment.requested
+          - nd_iw_deploy_disabled.execution.deployment.status in ['disabled', 'not_needed']
+          - nd_iw_deploy_disabled.execution.mutations_sent > 0
+          - nd_iw_deploy_disabled.execution.deployments_sent == 0
+          - nd_iw_deploy_disabled.request_stats.deploy_requests == 0
+
+    - name: Update and deploy the reserved interface once
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_deploy_case.family }}"
+            state: merged
+            config: "{{ nd_iw_deploy_case.update_config }}"
+        config_actions:
+          deploy: true
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_deploy_enabled
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: nd_iw_enable_deploy | bool
+
+    - name: Verify all successful mutations produce exactly one consolidated deployment
+      ansible.builtin.assert:
+        that:
+          - nd_iw_deploy_enabled is changed
+          - nd_iw_deploy_enabled.execution.status == 'completed'
+          - nd_iw_deploy_enabled.execution.deployment.requested
+          - nd_iw_deploy_enabled.execution.deployment.status == 'succeeded'
+          - nd_iw_deploy_enabled.execution.mutations_sent > 0
+          - nd_iw_deploy_enabled.execution.deployments_sent == 1
+          - nd_iw_deploy_enabled.request_stats.deploy_requests == 1
+      when: nd_iw_enable_deploy | bool
+
+    - name: Record that physical deployment cleanup is required
+      ansible.builtin.set_fact:
+        nd_iw_deployment_exercised: true
+      when:
+        - nd_iw_enable_deploy | bool
+        - nd_iw_deploy_enabled.execution.deployment.status == 'succeeded'
+
+    - name: Reapply deployed intent to prove no-change suppresses deployment
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_deploy_case.family }}"
+            state: merged
+            config: "{{ nd_iw_deploy_case.update_config }}"
+        config_actions:
+          deploy: true
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_deploy_idempotent
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: nd_iw_enable_deploy | bool
+
+    - name: Verify idempotency sends no mutation or deployment
+      ansible.builtin.assert:
+        that:
+          - nd_iw_deploy_idempotent is not changed
+          - nd_iw_deploy_idempotent.execution.status == 'no_change'
+          - nd_iw_deploy_idempotent.execution.mutations_sent == 0
+          - nd_iw_deploy_idempotent.execution.deployments_sent == 0
+          - nd_iw_deploy_idempotent.request_stats.mutation_requests == 0
+          - nd_iw_deploy_idempotent.request_stats.deploy_requests == 0
+      when: nd_iw_enable_deploy | bool
+
+  always:
+    - name: Remove only the reserved deployment-control identity
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_deploy_case.family }}"
+            state: deleted
+            config: >-
+              {{
+                nd_iw_deploy_case.delete_all
+                | default(nd_iw_deploy_case.delete_config | default(nd_iw_deploy_case.delete))
+              }}
+        config_actions:
+          deploy: "{{ (nd_iw_enable_deploy | bool) or (nd_iw_deployment_exercised | default(false) | bool) }}"
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_deploy_cleanup
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/family_property_branches.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/family_property_branches.yaml
@@ -1,0 +1,29 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Verify {{ nd_iw_expected_family }} matrix metadata
+  ansible.builtin.assert:
+    that:
+      - nd_iw_current_case.family == nd_iw_expected_family
+      - nd_iw_current_case.module is string
+      - nd_iw_current_case.create_config is sequence
+      - nd_iw_current_case.update_config is sequence
+      - nd_iw_current_case.replace_config is sequence
+      - nd_iw_current_case.delete_config is sequence
+      - nd_iw_current_case.property_assertions is sequence
+      - nd_iw_current_case.property_assertions | length > 0
+      - nd_iw_current_case.expected_supported | bool
+
+- name: Exercise {{ nd_iw_expected_family }} mutually exclusive and alternate branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/mutex_variants.yaml"
+  when: nd_iw_profile_config.run_mutex | bool
+
+- name: Validate {{ nd_iw_expected_family }} controller-object-dependent property packs
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/optional_packs.yaml"
+  when: nd_iw_profile_config.run_optional | bool
+
+- name: Exercise guarded {{ nd_iw_expected_family }} authoritative override
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/overridden.yaml"
+  when: nd_iw_run_destructive | bool

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/family_property_branches.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/family_property_branches.yaml
@@ -26,4 +26,19 @@
 
 - name: Exercise guarded {{ nd_iw_expected_family }} authoritative override
   ansible.builtin.include_tasks: "{{ role_path }}/tests/common/overridden.yaml"
-  when: nd_iw_run_destructive | bool
+  when:
+    - nd_iw_run_destructive | bool
+    - >-
+      nd_iw_current_case.generic_override_safe | default(true) | bool
+      or nd_iw_enable_ethernet_routed_override | bool
+
+- name: Report skipped generic authoritative override for {{ nd_iw_expected_family }}
+  ansible.builtin.debug:
+    msg: >-
+      The generic authoritative override is disabled for {{ nd_iw_expected_family }} because it can reset
+      unrelated managed routed interfaces. Select only ethernet_routed and explicitly enable its dedicated
+      override gate after confirming exclusive ownership of every managed routedHost interface in the fabric.
+  when:
+    - nd_iw_run_destructive | bool
+    - not (nd_iw_current_case.generic_override_safe | default(true) | bool)
+    - not (nd_iw_enable_ethernet_routed_override | bool)

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/invalid_case.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/invalid_case.yaml
@@ -1,0 +1,27 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Reject {{ nd_iw_invalid_family_case.family }} invalid case {{ nd_iw_invalid_case.name }}
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_invalid_family_case.family }}"
+        state: merged
+        config: "{{ nd_iw_invalid_case.config }}"
+    config_actions:
+      deploy: true
+    output_level: debug
+  check_mode: true
+  register: nd_iw_invalid_result
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+
+- name: Verify {{ nd_iw_invalid_case.name }} fails without a mutation
+  ansible.builtin.assert:
+    that:
+      - nd_iw_invalid_result.failed | default(false) | bool
+      - not (nd_iw_invalid_result.changed | default(false) | bool)
+      - nd_iw_invalid_result.msg is string
+      - nd_iw_invalid_result.msg is search(nd_iw_invalid_case.expected_error)

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/invalid_family_cases.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/invalid_family_cases.yaml
@@ -1,0 +1,11 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run invalid cases for {{ nd_iw_invalid_family_case.family }}
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/invalid_case.yaml"
+  loop: "{{ nd_iw_invalid_family_case.invalid | default([]) }}"
+  loop_control:
+    loop_var: nd_iw_invalid_case
+    label: "{{ nd_iw_invalid_case.name }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/mixed_workflow.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/mixed_workflow.yaml
@@ -24,8 +24,8 @@
       - nd_iw_observed_mixed_families | difference(nd_iw_expected_ten_families) | length == 0
       - nd_iw_expected_ten_families | difference(nd_iw_observed_mixed_families) | length == 0
       - nd_iw_batch_create_preview.resources | map(attribute='resource_index') | list == range(0, 10) | list
-      - nd_iw_batch_create_preview.request_stats.mutation_requests == 0
-      - nd_iw_batch_create_preview.request_stats.deploy_requests == 0
+      - nd_iw_batch_create_preview.execution.mutations_sent == 0
+      - nd_iw_batch_create_preview.execution.deployments_sent == 0
   when: nd_iw_active_cases | length == 10
 
 - name: Record why ten-family coverage is unavailable on this fabric

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/mixed_workflow.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/mixed_workflow.yaml
@@ -1,0 +1,36 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Verify one workflow planned all ten interface families
+  vars:
+    nd_iw_expected_ten_families:
+      - ethernet_access
+      - ethernet_trunk_host
+      - loopback
+      - port_channel_access
+      - port_channel_trunk_host
+      - subinterface_managed
+      - subinterface_unmanaged
+      - svi
+      - vpc_access
+      - vpc_trunk_host
+    nd_iw_observed_mixed_families: "{{ nd_iw_batch_create_preview.resources | map(attribute='type') | list }}"
+  ansible.builtin.assert:
+    that:
+      - nd_iw_batch_create_preview.resources | length == 10
+      - nd_iw_observed_mixed_families | unique | length == 10
+      - nd_iw_observed_mixed_families | difference(nd_iw_expected_ten_families) | length == 0
+      - nd_iw_expected_ten_families | difference(nd_iw_observed_mixed_families) | length == 0
+      - nd_iw_batch_create_preview.resources | map(attribute='resource_index') | list == range(0, 10) | list
+      - nd_iw_batch_create_preview.request_stats.mutation_requests == 0
+      - nd_iw_batch_create_preview.request_stats.deploy_requests == 0
+  when: nd_iw_active_cases | length == 10
+
+- name: Record why ten-family coverage is unavailable on this fabric
+  ansible.builtin.debug:
+    msg: >-
+      {{ nd_iw_current_fabric.discriminator }} exposes {{ nd_iw_active_cases | length }} supported
+      interface families; the all-ten assertion is covered on a fabric where all ten are supported.
+  when: nd_iw_active_cases | length != 10

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/mixed_workflow.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/mixed_workflow.yaml
@@ -3,10 +3,11 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: Verify one workflow planned all ten interface families
+- name: Verify one workflow planned all eleven interface families
   vars:
-    nd_iw_expected_ten_families:
+    nd_iw_expected_eleven_families:
       - ethernet_access
+      - ethernet_routed
       - ethernet_trunk_host
       - loopback
       - port_channel_access
@@ -19,18 +20,18 @@
     nd_iw_observed_mixed_families: "{{ nd_iw_batch_create_preview.resources | map(attribute='type') | list }}"
   ansible.builtin.assert:
     that:
-      - nd_iw_batch_create_preview.resources | length == 10
-      - nd_iw_observed_mixed_families | unique | length == 10
-      - nd_iw_observed_mixed_families | difference(nd_iw_expected_ten_families) | length == 0
-      - nd_iw_expected_ten_families | difference(nd_iw_observed_mixed_families) | length == 0
-      - nd_iw_batch_create_preview.resources | map(attribute='resource_index') | list == range(0, 10) | list
+      - nd_iw_batch_create_preview.resources | length == 11
+      - nd_iw_observed_mixed_families | unique | length == 11
+      - nd_iw_observed_mixed_families | difference(nd_iw_expected_eleven_families) | length == 0
+      - nd_iw_expected_eleven_families | difference(nd_iw_observed_mixed_families) | length == 0
+      - nd_iw_batch_create_preview.resources | map(attribute='resource_index') | list == range(0, 11) | list
       - nd_iw_batch_create_preview.execution.mutations_sent == 0
       - nd_iw_batch_create_preview.execution.deployments_sent == 0
-  when: nd_iw_active_cases | length == 10
+  when: nd_iw_active_cases | length == 11
 
-- name: Record why ten-family coverage is unavailable on this fabric
+- name: Record why eleven-family coverage is unavailable on this fabric
   ansible.builtin.debug:
     msg: >-
       {{ nd_iw_current_fabric.discriminator }} exposes {{ nd_iw_active_cases | length }} supported
-      interface families; the all-ten assertion is covered on a fabric where all ten are supported.
-  when: nd_iw_active_cases | length != 10
+      interface families; the all-eleven assertion is covered on a fabric where all eleven are supported.
+  when: nd_iw_active_cases | length != 11

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/mutex_variant.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/mutex_variant.yaml
@@ -1,0 +1,98 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Preview {{ nd_iw_current_case.family }} variant {{ nd_iw_mutex_variant.name }}
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_current_case.family }}"
+        state: merged
+        config: "{{ nd_iw_mutex_variant.config }}"
+    config_actions:
+      deploy: true
+    output_level: debug
+  check_mode: true
+  register: nd_iw_mutex_preview
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+
+- name: Verify valid {{ nd_iw_mutex_variant.name }} preview has no side effects
+  ansible.builtin.assert:
+    that:
+      - not (nd_iw_mutex_preview.failed | default(false) | bool)
+      - nd_iw_mutex_preview.execution.status == 'check_mode'
+      - nd_iw_mutex_preview.execution.mutations_sent == 0
+      - nd_iw_mutex_preview.execution.deployments_sent == 0
+      - nd_iw_mutex_preview.request_stats.mutation_requests == 0
+      - nd_iw_mutex_preview.request_stats.deploy_requests == 0
+  when: nd_iw_mutex_variant.valid | bool
+
+- name: Verify every valid {{ nd_iw_mutex_variant.name }} property value survived normalization
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_config_item.yaml"
+  vars:
+    nd_iw_expected_config_item: "{{ item }}"
+    nd_iw_assert_resource_result: "{{ nd_iw_mutex_preview.resources[0] }}"
+    nd_iw_assert_observed_items: "{{ nd_iw_mutex_preview.resources[0].proposed }}"
+  loop: "{{ nd_iw_mutex_variant.config }}"
+  loop_control:
+    label: >-
+      {{ item.interface_name | default(item.interface_names | default(["unknown"]) | first) }}
+  when:
+    - nd_iw_mutex_variant.valid | bool
+    - not (nd_iw_mutex_preview.failed | default(false) | bool)
+
+- name: Verify invalid {{ nd_iw_mutex_variant.name }} branch is rejected
+  ansible.builtin.assert:
+    that:
+      - nd_iw_mutex_preview.failed | default(false) | bool
+      - not (nd_iw_mutex_preview.changed | default(false) | bool)
+      - nd_iw_mutex_preview.msg is search(nd_iw_mutex_variant.expected_error)
+  when: not (nd_iw_mutex_variant.valid | bool)
+
+- name: Apply valid {{ nd_iw_mutex_variant.name }} branch on its reserved identity
+  when:
+    - nd_iw_mutex_variant.valid | bool
+    - not nd_iw_module_check_mode
+  block:
+    - name: Apply {{ nd_iw_current_case.family }} variant {{ nd_iw_mutex_variant.name }}
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: merged
+            config: "{{ nd_iw_mutex_variant.config }}"
+        config_actions:
+          deploy: false
+        output_level: info
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_mutex_apply
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+    - name: Verify {{ nd_iw_mutex_variant.name }} reached reconciled controller state
+      ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_case_result.yaml"
+      vars:
+        nd_iw_assert_case: "{{ nd_iw_current_case }}"
+        nd_iw_assert_expected_config: "{{ nd_iw_mutex_variant.config }}"
+        nd_iw_assert_resource_result: "{{ nd_iw_mutex_apply.resources[0] }}"
+        nd_iw_assert_state: merged
+
+  always:
+    - name: Remove only {{ nd_iw_current_case.family }} reserved variant identities
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: deleted
+            config: >-
+              {{
+                nd_iw_current_case.delete_all
+                | default(nd_iw_current_case.delete_config | default(nd_iw_current_case.delete))
+              }}
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_mutex_cleanup
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/mutex_variant.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/mutex_variant.yaml
@@ -25,8 +25,6 @@
       - nd_iw_mutex_preview.execution.status == 'check_mode'
       - nd_iw_mutex_preview.execution.mutations_sent == 0
       - nd_iw_mutex_preview.execution.deployments_sent == 0
-      - nd_iw_mutex_preview.request_stats.mutation_requests == 0
-      - nd_iw_mutex_preview.request_stats.deploy_requests == 0
   when: nd_iw_mutex_variant.valid | bool
 
 - name: Verify every valid {{ nd_iw_mutex_variant.name }} property value survived normalization

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/mutex_variants.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/mutex_variants.yaml
@@ -1,0 +1,11 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run {{ nd_iw_current_case.family }} mutually exclusive variants
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/mutex_variant.yaml"
+  loop: "{{ nd_iw_current_case.mutex_variants | default([]) }}"
+  loop_control:
+    loop_var: nd_iw_mutex_variant
+    label: "{{ nd_iw_mutex_variant.name }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/optional_packs.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/optional_packs.yaml
@@ -1,0 +1,133 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Preview controller-object-dependent property packs for {{ nd_iw_current_case.family }}
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_current_case.family }}"
+        state: merged
+        config: "{{ item.config }}"
+    config_actions:
+      deploy: true
+    output_level: info
+  check_mode: true
+  register: nd_iw_optional_pack_previews
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+  loop: "{{ nd_iw_current_case.optional_packs | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Verify optional property packs validate and never write
+  ansible.builtin.assert:
+    that:
+      - not (item.failed | default(false) | bool)
+      - item.resources | length == 1
+      - item.resources[0].proposed is defined
+      - item.resources[0].proposed | length >= item.item.config | length
+      - item.execution.status == 'check_mode'
+      - item.execution.mutations_sent == 0
+      - item.execution.deployments_sent == 0
+      - item.request_stats.mutation_requests == 0
+      - item.request_stats.deploy_requests == 0
+    fail_msg: >-
+      Optional pack {{ item.item.name }} for {{ nd_iw_current_case.family }} did not validate.
+      Requirements={{ item.item.requirements | default([]) }}; error={{ item.msg | default('none') }}.
+  loop: "{{ nd_iw_optional_pack_previews.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+
+- name: Verify every optional property value survived normalization
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_config_item.yaml"
+  vars:
+    nd_iw_optional_result: "{{ item.0 }}"
+    nd_iw_expected_config_item: "{{ item.1 }}"
+    nd_iw_assert_resource_result: "{{ item.0.resources[0] }}"
+    nd_iw_assert_observed_items: "{{ item.0.resources[0].proposed }}"
+  loop: "{{ nd_iw_optional_pack_previews.results | default([]) | subelements('item.config') }}"
+  loop_control:
+    label: >-
+      {{ item.0.item.name ~ ':' ~ (item.1.interface_name | default(item.1.interface_names | default(["unknown"]) | first)) }}
+  when: not (item.0.failed | default(false) | bool)
+
+- name: Reset live-eligible optional packs
+  ansible.builtin.set_fact:
+    nd_iw_optional_live_packs: []
+    nd_iw_confirmed_optional_prerequisites: >-
+      {{
+        nd_iw_optional_prerequisites
+        | default({})
+        | dict2items
+        | selectattr('value', 'equalto', true)
+        | map(attribute='key')
+        | list
+      }}
+
+- name: Select live-safe or explicitly satisfied optional packs
+  ansible.builtin.set_fact:
+    nd_iw_optional_live_packs: "{{ nd_iw_optional_live_packs + [item] }}"
+  loop: "{{ nd_iw_current_case.optional_packs | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: >-
+    item.live_safe | default(false) | bool
+    or (
+      item.requirements | default([])
+      | difference(nd_iw_confirmed_optional_prerequisites)
+      | length == 0
+    )
+
+- name: Apply live-eligible optional packs for {{ nd_iw_current_case.family }}
+  when:
+    - not nd_iw_module_check_mode
+    - nd_iw_optional_live_packs | length > 0
+  block:
+    - name: Apply optional property pack to its reserved identity
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: merged
+            config: "{{ item.config }}"
+        config_actions:
+          deploy: false
+        output_level: info
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_optional_pack_live_results
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      loop: "{{ nd_iw_optional_live_packs }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Verify optional pack properties reached reconciled controller state
+      ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_case_result.yaml"
+      vars:
+        nd_iw_assert_case: "{{ nd_iw_current_case }}"
+        nd_iw_assert_expected_config: "{{ item.item.config }}"
+        nd_iw_assert_resource_result: "{{ item.resources[0] }}"
+        nd_iw_assert_state: merged
+      loop: "{{ nd_iw_optional_pack_live_results.results }}"
+      loop_control:
+        label: "{{ item.item.name }}"
+
+  always:
+    - name: Remove only reserved optional-pack identities
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: deleted
+            config: >-
+              {{
+                nd_iw_current_case.delete_all
+                | default(nd_iw_current_case.delete_config | default(nd_iw_current_case.delete))
+              }}
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_optional_pack_cleanup
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/optional_packs.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/optional_packs.yaml
@@ -31,8 +31,6 @@
       - item.execution.status == 'check_mode'
       - item.execution.mutations_sent == 0
       - item.execution.deployments_sent == 0
-      - item.request_stats.mutation_requests == 0
-      - item.request_stats.deploy_requests == 0
     fail_msg: >-
       Optional pack {{ item.item.name }} for {{ nd_iw_current_case.family }} did not validate.
       Requirements={{ item.item.requirements | default([]) }}; error={{ item.msg | default('none') }}.

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/output_levels.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/output_levels.yaml
@@ -1,0 +1,67 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Select a supported family for output-level coverage
+  ansible.builtin.set_fact:
+    nd_iw_output_case: "{{ nd_iw_active_cases | first }}"
+
+- name: Read a normal-level workflow plan
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_output_case.family }}"
+        state: merged
+        config: "{{ nd_iw_output_case.create_config }}"
+    config_actions:
+      deploy: false
+    output_level: normal
+  check_mode: true
+  register: nd_iw_output_normal
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+- name: Read an info-level workflow plan
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_output_case.family }}"
+        state: merged
+        config: "{{ nd_iw_output_case.create_config }}"
+    config_actions:
+      deploy: false
+    output_level: info
+  check_mode: true
+  register: nd_iw_output_info
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+- name: Read a debug-level workflow plan
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_output_case.family }}"
+        state: merged
+        config: "{{ nd_iw_output_case.create_config }}"
+    config_actions:
+      deploy: false
+    output_level: debug
+  check_mode: true
+  register: nd_iw_output_debug
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+- name: Verify normal, info, and debug output contracts
+  ansible.builtin.assert:
+    that:
+      - nd_iw_output_normal.output_level == 'normal'
+      - nd_iw_output_info.output_level == 'info'
+      - nd_iw_output_debug.output_level == 'debug'
+      - nd_iw_output_normal.resources | rejectattr('proposed', 'defined') | list | length == 1
+      - nd_iw_output_info.resources | selectattr('proposed', 'defined') | list | length == 1
+      - nd_iw_output_debug.resources | selectattr('proposed', 'defined') | list | length == 1
+      - nd_iw_output_info.resources[0].proposed == nd_iw_output_debug.resources[0].proposed
+      - nd_iw_output_normal.execution.mutations_sent == 0
+      - nd_iw_output_info.execution.mutations_sent == 0
+      - nd_iw_output_debug.execution.mutations_sent == 0
+      - nd_iw_output_normal.execution.deployments_sent == 0
+      - nd_iw_output_info.execution.deployments_sent == 0
+      - nd_iw_output_debug.execution.deployments_sent == 0

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/output_levels.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/output_levels.yaml
@@ -49,19 +49,119 @@
   register: nd_iw_output_debug
   delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
 
-- name: Verify normal, info, and debug output contracts
+- name: Verify compact successful-result contract at every output level
   ansible.builtin.assert:
     that:
-      - nd_iw_output_normal.output_level == 'normal'
-      - nd_iw_output_info.output_level == 'info'
-      - nd_iw_output_debug.output_level == 'debug'
+      - nd_iw_output_result.changed is defined
+      - nd_iw_output_result.planned_changed is defined
+      - nd_iw_output_result.mutation_count is defined
+      - nd_iw_output_result.target_switch_ids is sequence
+      - nd_iw_output_result.resources is sequence
+      - nd_iw_output_result.resources | length == 1
+      - nd_iw_output_result.request_stats is mapping
+      - nd_iw_output_result.execution is mapping
+      - nd_iw_output_result.before is not defined
+      - nd_iw_output_result.after is not defined
+      - nd_iw_output_result.diff is not defined
+      - nd_iw_output_result.check_mode is not defined
+      - nd_iw_output_result.output_level is not defined
+      - nd_iw_output_result.fabric_name is not defined
+      - nd_iw_output_result.config_actions is not defined
+      - nd_iw_output_result.resources[0].resource_index is defined
+      - nd_iw_output_result.resources[0].type is defined
+      - nd_iw_output_result.resources[0].module is defined
+      - nd_iw_output_result.resources[0].state is defined
+      - nd_iw_output_result.resources[0].changed is defined
+      - nd_iw_output_result.resources[0].planned_changed is defined
+      - nd_iw_output_result.resources[0].before is sequence
+      - nd_iw_output_result.resources[0].after is sequence
+      - nd_iw_output_result.resources[0].after_verified is defined
+      - nd_iw_output_result.resources[0].operations is sequence
+      - nd_iw_output_result.resources[0].diff is not defined
+      - nd_iw_output_result.resources[0].family_diff is not defined
+      - nd_iw_output_result.resources[0].transitions is not defined
+      - nd_iw_output_result.resources[0].created is not defined
+      - nd_iw_output_result.resources[0].updated is not defined
+      - nd_iw_output_result.resources[0].deleted is not defined
+      - nd_iw_output_result.request_stats.switches is defined
+      - nd_iw_output_result.request_stats.interface_inventory_gets is defined
+      - nd_iw_output_result.request_stats.interface_inventory_pages is defined
+      - nd_iw_output_result.request_stats.interface_inventory_cache_hits is defined
+      - nd_iw_output_result.request_stats.interface_inventory_refreshes is defined
+      - nd_iw_output_result.request_stats.interface_inventory_dirty_refetches is defined
+      - nd_iw_output_result.request_stats.interface_summary_switches is defined
+      - nd_iw_output_result.request_stats.interface_summary_gets is defined
+      - nd_iw_output_result.request_stats.interface_summary_pages is defined
+      - nd_iw_output_result.request_stats.interface_summary_cache_hits is defined
+      - nd_iw_output_result.request_stats.snapshot_overlays is defined
+      - nd_iw_output_result.request_stats.vpc_pair_gets is defined
+      - nd_iw_output_result.request_stats.mutation_requests is not defined
+      - nd_iw_output_result.request_stats.deploy_requests is not defined
+      - nd_iw_output_result.execution.mutations_sent == 0
+      - nd_iw_output_result.execution.deployments_sent == 0
+      - nd_iw_output_result.execution.items is not defined
+  loop:
+    - "{{ nd_iw_output_normal }}"
+    - "{{ nd_iw_output_info }}"
+    - "{{ nd_iw_output_debug }}"
+  loop_control:
+    loop_var: nd_iw_output_result
+    label: "{{ nd_iw_output_result.resources[0].type }}"
+
+- name: Verify normal, info, and debug resource projections
+  ansible.builtin.assert:
+    that:
       - nd_iw_output_normal.resources | rejectattr('proposed', 'defined') | list | length == 1
       - nd_iw_output_info.resources | selectattr('proposed', 'defined') | list | length == 1
       - nd_iw_output_debug.resources | selectattr('proposed', 'defined') | list | length == 1
       - nd_iw_output_info.resources[0].proposed == nd_iw_output_debug.resources[0].proposed
-      - nd_iw_output_normal.execution.mutations_sent == 0
-      - nd_iw_output_info.execution.mutations_sent == 0
-      - nd_iw_output_debug.execution.mutations_sent == 0
-      - nd_iw_output_normal.execution.deployments_sent == 0
-      - nd_iw_output_info.execution.deployments_sent == 0
-      - nd_iw_output_debug.execution.deployments_sent == 0
+      - nd_iw_output_normal.resources[0].family_before is not defined
+      - nd_iw_output_normal.resources[0].family_after is not defined
+      - nd_iw_output_info.resources[0].family_before is not defined
+      - nd_iw_output_info.resources[0].family_after is not defined
+      - nd_iw_output_debug.resources[0].family_before is sequence
+      - nd_iw_output_debug.resources[0].family_after is sequence
+      - nd_iw_output_normal.resources[0].before == nd_iw_output_info.resources[0].before
+      - nd_iw_output_info.resources[0].before == nd_iw_output_debug.resources[0].before
+      - nd_iw_output_normal.resources[0].after == nd_iw_output_info.resources[0].after
+      - nd_iw_output_info.resources[0].after == nd_iw_output_debug.resources[0].after
+      - nd_iw_output_normal.resources[0].operations == nd_iw_output_info.resources[0].operations
+      - nd_iw_output_info.resources[0].operations == nd_iw_output_debug.resources[0].operations
+      - nd_iw_output_normal.resources[0].after | length == nd_iw_output_info.resources[0].proposed | length
+      - nd_iw_output_debug.resources[0].family_before | length >= nd_iw_output_debug.resources[0].before | length
+      - nd_iw_output_debug.resources[0].family_after | length >= nd_iw_output_debug.resources[0].after | length
+
+- name: Verify compact operation identities and check-mode status
+  ansible.builtin.assert:
+    that:
+      - nd_iw_operation.action in ['create', 'update', 'transition', 'reset', 'delete']
+      - nd_iw_operation.switch_ip is defined
+      - nd_iw_operation.switch_id is defined
+      - nd_iw_operation.interface_name is defined
+      - nd_iw_operation.status == 'planned'
+      - nd_iw_operation.changes is not defined or nd_iw_operation.changes is sequence
+      - nd_iw_operation.action != 'transition' or nd_iw_operation.from_policy_type is defined
+      - nd_iw_operation.action != 'transition' or nd_iw_operation.to_policy_type is defined
+      - nd_iw_operation.action != 'create' or nd_iw_operation.changes is not defined
+      - nd_iw_operation.action != 'delete' or nd_iw_operation.changes is not defined
+  loop: "{{ nd_iw_output_normal.resources[0].operations }}"
+  loop_control:
+    loop_var: nd_iw_operation
+    label: "{{ nd_iw_operation.action }} {{ nd_iw_operation.switch_ip }}/{{ nd_iw_operation.interface_name }}"
+
+- name: Verify optional operation leaf-delta shape
+  ansible.builtin.assert:
+    that:
+      - nd_iw_operation_change.path is string
+      - nd_iw_operation_change.before is defined
+      - nd_iw_operation_change.after is defined
+  loop: >-
+    {{
+      nd_iw_output_normal.resources[0].operations
+      | selectattr('changes', 'defined')
+      | map(attribute='changes')
+      | flatten
+    }}
+  loop_control:
+    loop_var: nd_iw_operation_change
+    label: "{{ nd_iw_operation_change.path }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/output_levels.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/output_levels.yaml
@@ -94,12 +94,13 @@
       - nd_iw_output_result.request_stats.interface_summary_pages is defined
       - nd_iw_output_result.request_stats.interface_summary_cache_hits is defined
       - nd_iw_output_result.request_stats.snapshot_overlays is defined
+      - nd_iw_output_result.request_stats.fabric_link_gets is defined
       - nd_iw_output_result.request_stats.vpc_pair_gets is defined
       - nd_iw_output_result.request_stats.mutation_requests is not defined
       - nd_iw_output_result.request_stats.deploy_requests is not defined
       - nd_iw_output_result.execution.mutations_sent == 0
       - nd_iw_output_result.execution.deployments_sent == 0
-      - nd_iw_output_result.execution.items is not defined
+      - "'items' not in nd_iw_output_result.execution"
   loop:
     - "{{ nd_iw_output_normal }}"
     - "{{ nd_iw_output_info }}"
@@ -128,7 +129,7 @@
       - nd_iw_output_normal.resources[0].operations == nd_iw_output_info.resources[0].operations
       - nd_iw_output_info.resources[0].operations == nd_iw_output_debug.resources[0].operations
       - nd_iw_output_normal.resources[0].after | length == nd_iw_output_info.resources[0].proposed | length
-      - nd_iw_output_debug.resources[0].family_before | length >= nd_iw_output_debug.resources[0].before | length
+      # A transition's targeted before state can belong to a different source family.
       - nd_iw_output_debug.resources[0].family_after | length >= nd_iw_output_debug.resources[0].after | length
 
 - name: Verify compact operation identities and check-mode status

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/overridden.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/overridden.yaml
@@ -1,0 +1,166 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Require explicit isolation approval for {{ nd_iw_current_case.family }} override
+  ansible.builtin.assert:
+    that:
+      - nd_iw_enable_destructive | bool
+      - nd_iw_run_destructive | bool
+      - nd_iw_current_fabric.isolated_resource_owner | default(false) | bool
+      - nd_iw_current_fabric.fabric_name in (nd_iw_destructive_fabrics | default([]))
+      - nd_iw_override_scope_confirmed | default(false) | bool
+      - nd_iw_current_case.secondary is defined
+      - nd_iw_current_case.override is defined
+      - nd_iw_current_case.delete_all is defined
+    fail_msg: >-
+      Authoritative override is intentionally blocked. Mark this exact fabric as an isolated
+      resource owner, add its name to nd_iw_destructive_fabrics, and set
+      nd_iw_override_scope_confirmed=true only after verifying no non-test interface intent exists.
+
+- name: Build guarded override seed for {{ nd_iw_current_case.family }}
+  ansible.builtin.set_fact:
+    nd_iw_override_seed_config: "{{ nd_iw_current_case.create_config + nd_iw_current_case.secondary }}"
+
+- name: Exercise authoritative override for {{ nd_iw_current_case.family }}
+  block:
+    - name: Remove only the reserved override identities before setup
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: deleted
+            config: "{{ nd_iw_current_case.delete_all }}"
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_override_precleanup
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Seed two reserved identities for authoritative deletion coverage
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: merged
+            config: "{{ nd_iw_override_seed_config }}"
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_override_seed
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Preview authoritative retention of only the primary identity
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: overridden
+            config: "{{ nd_iw_current_case.override }}"
+        config_actions:
+          deploy: true
+        output_level: info
+      check_mode: true
+      register: nd_iw_override_preview
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+    - name: Verify override preview expands scope without writing
+      ansible.builtin.assert:
+        that:
+          - nd_iw_override_preview.execution.status == 'check_mode'
+          - nd_iw_override_preview.resources[0].state == 'overridden'
+          - nd_iw_override_preview.target_switch_ids | length >= nd_iw_active_switches.values() | reject('equalto', '') | unique | list | length
+          - nd_iw_override_preview.execution.mutations_sent == 0
+          - nd_iw_override_preview.execution.deployments_sent == 0
+          - nd_iw_override_preview.request_stats.mutation_requests == 0
+          - nd_iw_override_preview.request_stats.deploy_requests == 0
+
+    - name: Verify override preview plans removal of the secondary identity
+      ansible.builtin.assert:
+        that:
+          - nd_iw_override_preview is changed
+          - nd_iw_override_preview.resources[0].deleted | length > 0
+      when: not nd_iw_module_check_mode
+
+    - name: Apply authoritative retention of only the primary identity
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: overridden
+            config: "{{ nd_iw_current_case.override }}"
+        config_actions:
+          deploy: false
+        output_level: info
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_override_apply
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Verify overridden state retained primary and removed secondary intent
+      ansible.builtin.assert:
+        that:
+          - nd_iw_override_apply is changed
+          - nd_iw_override_apply.resources[0].state == 'overridden'
+          - nd_iw_override_apply.resources[0].after_verified
+          - nd_iw_override_apply.resources[0].deleted | length > 0
+      when: not nd_iw_module_check_mode
+
+    - name: Verify secondary override identities are absent
+      ansible.builtin.include_tasks: "{{ role_path }}/tests/common/assert_absent_config_item.yaml"
+      vars:
+        nd_iw_assert_resource_result: "{{ nd_iw_override_apply.resources[0] }}"
+      loop: "{{ nd_iw_current_case.secondary }}"
+      loop_control:
+        loop_var: nd_iw_absent_config_item
+        label: >-
+          {{
+            nd_iw_absent_config_item.interface_name
+            | default(nd_iw_absent_config_item.interface_names | default(['unknown']) | first)
+          }}
+      when: not nd_iw_module_check_mode
+
+    - name: Reapply authoritative state for idempotency
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: overridden
+            config: "{{ nd_iw_current_case.override }}"
+        config_actions:
+          deploy: "{{ nd_iw_enable_deploy | bool }}"
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_override_idempotent
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode
+
+    - name: Verify overridden idempotency sends no write or deployment
+      ansible.builtin.assert:
+        that:
+          - nd_iw_override_idempotent is not changed
+          - nd_iw_override_idempotent.execution.status == 'no_change'
+          - nd_iw_override_idempotent.request_stats.mutation_requests == 0
+          - nd_iw_override_idempotent.request_stats.deploy_requests == 0
+      when: not nd_iw_module_check_mode
+
+  always:
+    - name: Remove only reserved {{ nd_iw_current_case.family }} override identities
+      cisco.nd.nd_interfaces_workflow:
+        fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+        resources:
+          - type: "{{ nd_iw_current_case.family }}"
+            state: deleted
+            config: "{{ nd_iw_current_case.delete_all }}"
+        config_actions:
+          deploy: false
+        output_level: normal
+      check_mode: "{{ nd_iw_module_check_mode }}"
+      register: nd_iw_override_cleanup
+      delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+      when: not nd_iw_module_check_mode

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/overridden.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/overridden.yaml
@@ -105,6 +105,8 @@
             config: "{{ nd_iw_current_case.override }}"
         config_actions:
           deploy: false
+        verify:
+          enabled: true
         output_level: info
       check_mode: "{{ nd_iw_module_check_mode }}"
       register: nd_iw_override_apply

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/overridden.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/overridden.yaml
@@ -77,14 +77,23 @@
           - nd_iw_override_preview.target_switch_ids | length >= nd_iw_active_switches.values() | reject('equalto', '') | unique | list | length
           - nd_iw_override_preview.execution.mutations_sent == 0
           - nd_iw_override_preview.execution.deployments_sent == 0
-          - nd_iw_override_preview.request_stats.mutation_requests == 0
-          - nd_iw_override_preview.request_stats.deploy_requests == 0
 
     - name: Verify override preview plans removal of the secondary identity
+      vars:
+        nd_iw_override_removal_action: >-
+          {{
+            "reset"
+            if nd_iw_current_case.family in ["ethernet_access", "ethernet_trunk_host"]
+            else "delete"
+          }}
       ansible.builtin.assert:
         that:
           - nd_iw_override_preview is changed
-          - nd_iw_override_preview.resources[0].deleted | length > 0
+          - >-
+            nd_iw_override_preview.resources[0].operations
+            | selectattr("action", "equalto", nd_iw_override_removal_action)
+            | list
+            | length > 0
       when: not nd_iw_module_check_mode
 
     - name: Apply authoritative retention of only the primary identity
@@ -103,12 +112,23 @@
       when: not nd_iw_module_check_mode
 
     - name: Verify overridden state retained primary and removed secondary intent
+      vars:
+        nd_iw_override_removal_action: >-
+          {{
+            "reset"
+            if nd_iw_current_case.family in ["ethernet_access", "ethernet_trunk_host"]
+            else "delete"
+          }}
       ansible.builtin.assert:
         that:
           - nd_iw_override_apply is changed
           - nd_iw_override_apply.resources[0].state == 'overridden'
           - nd_iw_override_apply.resources[0].after_verified
-          - nd_iw_override_apply.resources[0].deleted | length > 0
+          - >-
+            nd_iw_override_apply.resources[0].operations
+            | selectattr("action", "equalto", nd_iw_override_removal_action)
+            | list
+            | length > 0
       when: not nd_iw_module_check_mode
 
     - name: Verify secondary override identities are absent
@@ -145,8 +165,8 @@
         that:
           - nd_iw_override_idempotent is not changed
           - nd_iw_override_idempotent.execution.status == 'no_change'
-          - nd_iw_override_idempotent.request_stats.mutation_requests == 0
-          - nd_iw_override_idempotent.request_stats.deploy_requests == 0
+          - nd_iw_override_idempotent.execution.mutations_sent == 0
+          - nd_iw_override_idempotent.execution.deployments_sent == 0
       when: not nd_iw_module_check_mode
 
   always:

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/overridden.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/overridden.yaml
@@ -83,7 +83,7 @@
         nd_iw_override_removal_action: >-
           {{
             "reset"
-            if nd_iw_current_case.family in ["ethernet_access", "ethernet_trunk_host"]
+            if nd_iw_current_case.family in ["ethernet_access", "ethernet_routed", "ethernet_trunk_host"]
             else "delete"
           }}
       ansible.builtin.assert:
@@ -118,7 +118,7 @@
         nd_iw_override_removal_action: >-
           {{
             "reset"
-            if nd_iw_current_case.family in ["ethernet_access", "ethernet_trunk_host"]
+            if nd_iw_current_case.family in ["ethernet_access", "ethernet_routed", "ethernet_trunk_host"]
             else "delete"
           }}
       ansible.builtin.assert:

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/policy_transitions.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/policy_transitions.yaml
@@ -154,6 +154,8 @@
                 config: "{{ nd_iw_transition_to_trunk }}"
             config_actions:
               deploy: false
+            verify:
+              enabled: true
             output_level: info
           register: nd_iw_transition_apply
           delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/policy_transitions.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/policy_transitions.yaml
@@ -110,24 +110,37 @@
             that:
               - nd_iw_transition_preview is changed
               - nd_iw_transition_preview.planned_changed
-              - nd_iw_transition_preview.check_mode
               - nd_iw_transition_preview.mutation_count == 2
               - nd_iw_transition_preview.execution.status == 'check_mode'
               - nd_iw_transition_preview.execution.mutations_sent == 0
               - nd_iw_transition_preview.execution.deployments_sent == 0
-              - nd_iw_transition_preview.request_stats.mutation_requests == 0
-              - nd_iw_transition_preview.request_stats.deploy_requests == 0
               - nd_iw_transition_preview.resources | length == 2
               - nd_iw_transition_preview.resources[0].state == 'merged'
               - nd_iw_transition_preview.resources[1].state == 'replaced'
-              - nd_iw_transition_preview.resources[0].created | length == 0
-              - nd_iw_transition_preview.resources[1].created | length == 0
-              - nd_iw_transition_preview.resources[0].transitions | length == 1
-              - nd_iw_transition_preview.resources[1].transitions | length == 1
-              - nd_iw_transition_preview.resources[0].transitions[0].from_policy_type == 'trunkHost'
-              - nd_iw_transition_preview.resources[0].transitions[0].to_policy_type == 'accessHost'
-              - nd_iw_transition_preview.resources[1].transitions[0].from_policy_type == 'accessHost'
-              - nd_iw_transition_preview.resources[1].transitions[0].to_policy_type == 'trunkHost'
+              - nd_iw_transition_preview.resources[0].operations | selectattr('action', 'equalto', 'create') | list | length == 0
+              - nd_iw_transition_preview.resources[1].operations | selectattr('action', 'equalto', 'create') | list | length == 0
+              - nd_iw_transition_preview.resources[0].operations | selectattr('action', 'equalto', 'transition') | list | length == 1
+              - nd_iw_transition_preview.resources[1].operations | selectattr('action', 'equalto', 'transition') | list | length == 1
+              - >-
+                nd_iw_transition_preview.resources[0].operations
+                | selectattr("action", "equalto", "transition")
+                | map(attribute="from_policy_type")
+                | list == ["trunkHost"]
+              - >-
+                nd_iw_transition_preview.resources[0].operations
+                | selectattr("action", "equalto", "transition")
+                | map(attribute="to_policy_type")
+                | list == ["accessHost"]
+              - >-
+                nd_iw_transition_preview.resources[1].operations
+                | selectattr("action", "equalto", "transition")
+                | map(attribute="from_policy_type")
+                | list == ["accessHost"]
+              - >-
+                nd_iw_transition_preview.resources[1].operations
+                | selectattr("action", "equalto", "transition")
+                | map(attribute="to_policy_type")
+                | list == ["trunkHost"]
 
         - name: Apply both implicit physical Ethernet policy transitions
           cisco.nd.nd_interfaces_workflow:
@@ -154,12 +167,20 @@
               - nd_iw_transition_apply.execution.status == 'staged'
               - nd_iw_transition_apply.execution.mutations_sent == 2
               - nd_iw_transition_apply.execution.deployments_sent == 0
-              - nd_iw_transition_apply.request_stats.mutation_requests == 2
-              - nd_iw_transition_apply.request_stats.deploy_requests == 0
               - nd_iw_transition_apply.resources | selectattr('after_verified', 'equalto', true) | list | length == 2
-              - nd_iw_transition_apply.execution.items | length == 2
-              - nd_iw_transition_apply.execution.items | selectattr('action', 'equalto', 'transition') | list | length == 2
-              - nd_iw_transition_apply.execution.items | selectattr('status', 'equalto', 'succeeded') | list | length == 2
+              - >-
+                nd_iw_transition_apply.resources
+                | map(attribute="operations")
+                | flatten
+                | length == 2
+              - >-
+                nd_iw_transition_apply.resources
+                | map(attribute="operations")
+                | flatten
+                | selectattr("action", "equalto", "transition")
+                | selectattr("status", "equalto", "succeeded")
+                | list
+                | length == 2
 
         - name: Independently verify transitioned policy and description fingerprints
           ansible.builtin.include_tasks: "{{ role_path }}/tests/common/controller_verify_inventory.yaml"
@@ -200,10 +221,10 @@
               - not nd_iw_transition_idempotent.planned_changed
               - nd_iw_transition_idempotent.mutation_count == 0
               - nd_iw_transition_idempotent.execution.status == 'no_change'
-              - nd_iw_transition_idempotent.request_stats.mutation_requests == 0
-              - nd_iw_transition_idempotent.request_stats.deploy_requests == 0
-              - nd_iw_transition_idempotent.resources[0].transitions | length == 0
-              - nd_iw_transition_idempotent.resources[1].transitions | length == 0
+              - nd_iw_transition_idempotent.execution.mutations_sent == 0
+              - nd_iw_transition_idempotent.execution.deployments_sent == 0
+              - nd_iw_transition_idempotent.resources[0].operations | selectattr('action', 'equalto', 'transition') | list | length == 0
+              - nd_iw_transition_idempotent.resources[1].operations | selectattr('action', 'equalto', 'transition') | list | length == 0
 
         - name: Preview policy-independent deletion through the opposite Ethernet types
           cisco.nd.nd_interfaces_workflow:
@@ -227,16 +248,15 @@
             that:
               - nd_iw_transition_delete_preview is changed
               - nd_iw_transition_delete_preview.planned_changed
-              - nd_iw_transition_delete_preview.check_mode
               - nd_iw_transition_delete_preview.mutation_count == 2
               - nd_iw_transition_delete_preview.execution.status == 'check_mode'
-              - nd_iw_transition_delete_preview.request_stats.mutation_requests == 0
-              - nd_iw_transition_delete_preview.request_stats.deploy_requests == 0
+              - nd_iw_transition_delete_preview.execution.mutations_sent == 0
+              - nd_iw_transition_delete_preview.execution.deployments_sent == 0
               - nd_iw_transition_delete_preview.resources | length == 2
-              - nd_iw_transition_delete_preview.resources[0].deleted | length == 1
-              - nd_iw_transition_delete_preview.resources[1].deleted | length == 1
-              - nd_iw_transition_delete_preview.resources[0].transitions | length == 0
-              - nd_iw_transition_delete_preview.resources[1].transitions | length == 0
+              - nd_iw_transition_delete_preview.resources[0].operations | selectattr('action', 'equalto', 'reset') | list | length == 1
+              - nd_iw_transition_delete_preview.resources[1].operations | selectattr('action', 'equalto', 'reset') | list | length == 1
+              - nd_iw_transition_delete_preview.resources[0].operations | selectattr('action', 'equalto', 'transition') | list | length == 0
+              - nd_iw_transition_delete_preview.resources[1].operations | selectattr('action', 'equalto', 'transition') | list | length == 0
 
         - name: Apply policy-independent deletion through the opposite Ethernet types
           cisco.nd.nd_interfaces_workflow:
@@ -263,13 +283,17 @@
               - nd_iw_transition_delete_apply.execution.status == 'staged'
               - nd_iw_transition_delete_apply.execution.mutations_sent == 1
               - nd_iw_transition_delete_apply.execution.deployments_sent == 0
-              - nd_iw_transition_delete_apply.request_stats.mutation_requests == 1
-              - nd_iw_transition_delete_apply.request_stats.deploy_requests == 0
-              - nd_iw_transition_delete_apply.execution.items | length == 2
               - >-
-                nd_iw_transition_delete_apply.execution.items
-                | selectattr('action', 'equalto', 'delete')
-                | selectattr('status', 'equalto', 'succeeded')
+                nd_iw_transition_delete_apply.resources
+                | map(attribute="operations")
+                | flatten
+                | length == 2
+              - >-
+                nd_iw_transition_delete_apply.resources
+                | map(attribute="operations")
+                | flatten
+                | selectattr("action", "equalto", "reset")
+                | selectattr("status", "equalto", "succeeded")
                 | list
                 | length == 2
 
@@ -330,8 +354,8 @@
               - not nd_iw_transition_delete_idempotent.planned_changed
               - nd_iw_transition_delete_idempotent.mutation_count == 0
               - nd_iw_transition_delete_idempotent.execution.status == 'no_change'
-              - nd_iw_transition_delete_idempotent.request_stats.mutation_requests == 0
-              - nd_iw_transition_delete_idempotent.request_stats.deploy_requests == 0
+              - nd_iw_transition_delete_idempotent.execution.mutations_sent == 0
+              - nd_iw_transition_delete_idempotent.execution.deployments_sent == 0
 
 
       always:

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/policy_transitions.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/policy_transitions.yaml
@@ -1,0 +1,378 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Select physical Ethernet cases for policy-transition coverage
+  ansible.builtin.set_fact:
+    nd_iw_transition_access_cases: >-
+      {{ nd_iw_active_cases | selectattr('family', 'equalto', 'ethernet_access') | list }}
+    nd_iw_transition_trunk_cases: >-
+      {{ nd_iw_active_cases | selectattr('family', 'equalto', 'ethernet_trunk_host') | list }}
+
+- name: Exercise implicit physical Ethernet policy transitions and policy-independent deletion
+  when:
+    - nd_iw_transition_access_cases | length > 0
+    - nd_iw_transition_trunk_cases | length > 0
+  block:
+    - name: Build deterministic policy-transition fixtures
+      ansible.builtin.set_fact:
+        nd_iw_transition_access_source:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names:
+              - "{{ nd_iw_active_resources.ethernet_trunk_host.primary | first }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+                  description: IW transition source access
+        nd_iw_transition_trunk_source:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names:
+              - "{{ nd_iw_active_resources.ethernet_access.primary | first }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+                  native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+                  description: IW transition source trunk
+        nd_iw_transition_to_access:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names:
+              - "{{ nd_iw_active_resources.ethernet_access.primary | first }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  access_vlan: "{{ nd_iw_active_resources.vlans.access_alternate }}"
+                  description: IW transition target access
+        nd_iw_transition_to_trunk:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names:
+              - "{{ nd_iw_active_resources.ethernet_trunk_host.primary | first }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  allowed_vlans: all
+                  native_vlan: "{{ nd_iw_active_resources.vlans.native_alternate }}"
+                  description: IW transition target trunk
+        nd_iw_transition_delete_access_via_trunk:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names:
+              - "{{ nd_iw_active_resources.ethernet_access.primary | first }}"
+        nd_iw_transition_delete_trunk_via_access:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names:
+              - "{{ nd_iw_active_resources.ethernet_trunk_host.primary | first }}"
+
+    - name: Exercise live cross-policy replacement in both directions
+      when: not nd_iw_module_check_mode
+      block:
+        - name: Configure a trunkHost source on the access transition port
+          cisco.nd.nd_interface_ethernet_trunk_host:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            state: merged
+            config: "{{ nd_iw_transition_trunk_source }}"
+            config_actions:
+              deploy: false
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+        - name: Configure an accessHost source on the trunk transition port
+          cisco.nd.nd_interface_ethernet_access:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            state: merged
+            config: "{{ nd_iw_transition_access_source }}"
+            config_actions:
+              deploy: false
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+        - name: Preview implicit merged and replaced physical Ethernet policy transitions
+          cisco.nd.nd_interfaces_workflow:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            resources:
+              - type: ethernet_access
+                state: merged
+                config: "{{ nd_iw_transition_to_access }}"
+              - type: ethernet_trunk_host
+                state: replaced
+                config: "{{ nd_iw_transition_to_trunk }}"
+            config_actions:
+              deploy: true
+            output_level: info
+          check_mode: true
+          register: nd_iw_transition_preview
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+        - name: Verify transition preview metadata and zero-write behavior
+          ansible.builtin.assert:
+            that:
+              - nd_iw_transition_preview is changed
+              - nd_iw_transition_preview.planned_changed
+              - nd_iw_transition_preview.check_mode
+              - nd_iw_transition_preview.mutation_count == 2
+              - nd_iw_transition_preview.execution.status == 'check_mode'
+              - nd_iw_transition_preview.execution.mutations_sent == 0
+              - nd_iw_transition_preview.execution.deployments_sent == 0
+              - nd_iw_transition_preview.request_stats.mutation_requests == 0
+              - nd_iw_transition_preview.request_stats.deploy_requests == 0
+              - nd_iw_transition_preview.resources | length == 2
+              - nd_iw_transition_preview.resources[0].state == 'merged'
+              - nd_iw_transition_preview.resources[1].state == 'replaced'
+              - nd_iw_transition_preview.resources[0].created | length == 0
+              - nd_iw_transition_preview.resources[1].created | length == 0
+              - nd_iw_transition_preview.resources[0].transitions | length == 1
+              - nd_iw_transition_preview.resources[1].transitions | length == 1
+              - nd_iw_transition_preview.resources[0].transitions[0].from_policy_type == 'trunkHost'
+              - nd_iw_transition_preview.resources[0].transitions[0].to_policy_type == 'accessHost'
+              - nd_iw_transition_preview.resources[1].transitions[0].from_policy_type == 'accessHost'
+              - nd_iw_transition_preview.resources[1].transitions[0].to_policy_type == 'trunkHost'
+
+        - name: Apply both implicit physical Ethernet policy transitions
+          cisco.nd.nd_interfaces_workflow:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            resources:
+              - type: ethernet_access
+                state: merged
+                config: "{{ nd_iw_transition_to_access }}"
+              - type: ethernet_trunk_host
+                state: replaced
+                config: "{{ nd_iw_transition_to_trunk }}"
+            config_actions:
+              deploy: false
+            output_level: info
+          register: nd_iw_transition_apply
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+        - name: Verify each transition used one successful mutation and no deployment
+          ansible.builtin.assert:
+            that:
+              - nd_iw_transition_apply is changed
+              - nd_iw_transition_apply.planned_changed
+              - nd_iw_transition_apply.mutation_count == 2
+              - nd_iw_transition_apply.execution.status == 'staged'
+              - nd_iw_transition_apply.execution.mutations_sent == 2
+              - nd_iw_transition_apply.execution.deployments_sent == 0
+              - nd_iw_transition_apply.request_stats.mutation_requests == 2
+              - nd_iw_transition_apply.request_stats.deploy_requests == 0
+              - nd_iw_transition_apply.resources | selectattr('after_verified', 'equalto', true) | list | length == 2
+              - nd_iw_transition_apply.execution.items | length == 2
+              - nd_iw_transition_apply.execution.items | selectattr('action', 'equalto', 'transition') | list | length == 2
+              - nd_iw_transition_apply.execution.items | selectattr('status', 'equalto', 'succeeded') | list | length == 2
+
+        - name: Independently verify transitioned policy and description fingerprints
+          ansible.builtin.include_tasks: "{{ role_path }}/tests/common/controller_verify_inventory.yaml"
+          vars:
+            nd_iw_raw_verify_mode: present
+            nd_iw_raw_workflow_result: "{{ nd_iw_transition_apply }}"
+            nd_iw_raw_identity_resources:
+              - type: ethernet_access
+                config: "{{ nd_iw_transition_to_access }}"
+              - type: ethernet_trunk_host
+                config: "{{ nd_iw_transition_to_trunk }}"
+            nd_iw_raw_fingerprint_resources:
+              - type: ethernet_access
+                config: "{{ nd_iw_transition_to_access }}"
+              - type: ethernet_trunk_host
+                config: "{{ nd_iw_transition_to_trunk }}"
+
+        - name: Reapply transitioned intent for idempotency
+          cisco.nd.nd_interfaces_workflow:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            resources:
+              - type: ethernet_access
+                state: merged
+                config: "{{ nd_iw_transition_to_access }}"
+              - type: ethernet_trunk_host
+                state: replaced
+                config: "{{ nd_iw_transition_to_trunk }}"
+            config_actions:
+              deploy: "{{ nd_iw_enable_deploy | bool }}"
+            output_level: normal
+          register: nd_iw_transition_idempotent
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+        - name: Verify transitioned intent is idempotent without writes or deployment
+          ansible.builtin.assert:
+            that:
+              - nd_iw_transition_idempotent is not changed
+              - not nd_iw_transition_idempotent.planned_changed
+              - nd_iw_transition_idempotent.mutation_count == 0
+              - nd_iw_transition_idempotent.execution.status == 'no_change'
+              - nd_iw_transition_idempotent.request_stats.mutation_requests == 0
+              - nd_iw_transition_idempotent.request_stats.deploy_requests == 0
+              - nd_iw_transition_idempotent.resources[0].transitions | length == 0
+              - nd_iw_transition_idempotent.resources[1].transitions | length == 0
+
+        - name: Preview policy-independent deletion through the opposite Ethernet types
+          cisco.nd.nd_interfaces_workflow:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            resources:
+              - type: ethernet_trunk_host
+                state: deleted
+                config: "{{ nd_iw_transition_delete_access_via_trunk }}"
+              - type: ethernet_access
+                state: deleted
+                config: "{{ nd_iw_transition_delete_trunk_via_access }}"
+            config_actions:
+              deploy: true
+            output_level: info
+          check_mode: true
+          register: nd_iw_transition_delete_preview
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+        - name: Verify policy-independent delete preview and zero-write behavior
+          ansible.builtin.assert:
+            that:
+              - nd_iw_transition_delete_preview is changed
+              - nd_iw_transition_delete_preview.planned_changed
+              - nd_iw_transition_delete_preview.check_mode
+              - nd_iw_transition_delete_preview.mutation_count == 2
+              - nd_iw_transition_delete_preview.execution.status == 'check_mode'
+              - nd_iw_transition_delete_preview.request_stats.mutation_requests == 0
+              - nd_iw_transition_delete_preview.request_stats.deploy_requests == 0
+              - nd_iw_transition_delete_preview.resources | length == 2
+              - nd_iw_transition_delete_preview.resources[0].deleted | length == 1
+              - nd_iw_transition_delete_preview.resources[1].deleted | length == 1
+              - nd_iw_transition_delete_preview.resources[0].transitions | length == 0
+              - nd_iw_transition_delete_preview.resources[1].transitions | length == 0
+
+        - name: Apply policy-independent deletion through the opposite Ethernet types
+          cisco.nd.nd_interfaces_workflow:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            resources:
+              - type: ethernet_trunk_host
+                state: deleted
+                config: "{{ nd_iw_transition_delete_access_via_trunk }}"
+              - type: ethernet_access
+                state: deleted
+                config: "{{ nd_iw_transition_delete_trunk_via_access }}"
+            config_actions:
+              deploy: false
+            output_level: info
+          register: nd_iw_transition_delete_apply
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+        - name: Verify both physical deletes shared one normalize request
+          ansible.builtin.assert:
+            that:
+              - nd_iw_transition_delete_apply is changed
+              - nd_iw_transition_delete_apply.planned_changed
+              - nd_iw_transition_delete_apply.mutation_count == 2
+              - nd_iw_transition_delete_apply.execution.status == 'staged'
+              - nd_iw_transition_delete_apply.execution.mutations_sent == 1
+              - nd_iw_transition_delete_apply.execution.deployments_sent == 0
+              - nd_iw_transition_delete_apply.request_stats.mutation_requests == 1
+              - nd_iw_transition_delete_apply.request_stats.deploy_requests == 0
+              - nd_iw_transition_delete_apply.execution.items | length == 2
+              - >-
+                nd_iw_transition_delete_apply.execution.items
+                | selectattr('action', 'equalto', 'delete')
+                | selectattr('status', 'equalto', 'succeeded')
+                | list
+                | length == 2
+
+        - name: Independently verify transitioned intent was reset
+          ansible.builtin.include_tasks: "{{ role_path }}/tests/common/controller_verify_inventory.yaml"
+          vars:
+            nd_iw_raw_verify_mode: absent
+            nd_iw_raw_workflow_result: "{{ nd_iw_transition_delete_apply }}"
+            nd_iw_raw_identity_resources:
+              - type: ethernet_access
+                config: "{{ nd_iw_transition_to_access }}"
+              - type: ethernet_trunk_host
+                config: "{{ nd_iw_transition_to_trunk }}"
+            nd_iw_raw_fingerprint_resources:
+              - type: ethernet_access
+                config: "{{ nd_iw_transition_to_access }}"
+              - type: ethernet_trunk_host
+                config: "{{ nd_iw_transition_to_trunk }}"
+
+        - name: Verify both physical interfaces now use the default trunk policy
+          vars:
+            nd_iw_transition_default_policy_keys:
+              - >-
+                {{ nd_iw_raw_switch_id_by_ip[nd_iw_active_switches.primary]
+                   ~ '|' ~ (nd_iw_active_resources.ethernet_access.primary | first | lower)
+                   ~ '|trunkHost' }}
+              - >-
+                {{ nd_iw_raw_switch_id_by_ip[nd_iw_active_switches.primary]
+                   ~ '|' ~ (nd_iw_active_resources.ethernet_trunk_host.primary | first | lower)
+                   ~ '|trunkHost' }}
+          ansible.builtin.assert:
+            that:
+              - >-
+                nd_iw_transition_default_policy_keys
+                | difference(nd_iw_raw_observed_policy_keys)
+                | length == 0
+
+        - name: Reapply policy-independent deletion for idempotency
+          cisco.nd.nd_interfaces_workflow:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            resources:
+              - type: ethernet_trunk_host
+                state: deleted
+                config: "{{ nd_iw_transition_delete_access_via_trunk }}"
+              - type: ethernet_access
+                state: deleted
+                config: "{{ nd_iw_transition_delete_trunk_via_access }}"
+            config_actions:
+              deploy: "{{ nd_iw_enable_deploy | bool }}"
+            output_level: normal
+          register: nd_iw_transition_delete_idempotent
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+
+        - name: Verify policy-independent deletion is idempotent
+          ansible.builtin.assert:
+            that:
+              - nd_iw_transition_delete_idempotent is not changed
+              - not nd_iw_transition_delete_idempotent.planned_changed
+              - nd_iw_transition_delete_idempotent.mutation_count == 0
+              - nd_iw_transition_delete_idempotent.execution.status == 'no_change'
+              - nd_iw_transition_delete_idempotent.request_stats.mutation_requests == 0
+              - nd_iw_transition_delete_idempotent.request_stats.deploy_requests == 0
+
+
+      always:
+        - name: Remove accessHost intent from both transition ports
+          cisco.nd.nd_interface_ethernet_access:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            state: deleted
+            config:
+              - switch_ip: "{{ nd_iw_active_switches.primary }}"
+                interface_names:
+                  - "{{ nd_iw_active_resources.ethernet_access.primary | first }}"
+                  - "{{ nd_iw_active_resources.ethernet_trunk_host.primary | first }}"
+            config_actions:
+              deploy: false
+          register: nd_iw_transition_access_cleanup
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+          ignore_errors: true
+          when: not nd_iw_module_check_mode
+
+        - name: Remove trunkHost intent from both transition ports
+          cisco.nd.nd_interface_ethernet_trunk_host:
+            fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+            state: deleted
+            config:
+              - switch_ip: "{{ nd_iw_active_switches.primary }}"
+                interface_names:
+                  - "{{ nd_iw_active_resources.ethernet_access.primary | first }}"
+                  - "{{ nd_iw_active_resources.ethernet_trunk_host.primary | first }}"
+            config_actions:
+              deploy: false
+          register: nd_iw_transition_trunk_cleanup
+          delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+          ignore_errors: true
+          when: not nd_iw_module_check_mode
+
+        - name: Require successful cleanup of both transition source families
+          ansible.builtin.assert:
+            that:
+              - not (nd_iw_transition_access_cleanup.failed | default(false) | bool)
+              - not (nd_iw_transition_trunk_cleanup.failed | default(false) | bool)
+            fail_msg: >-
+              Policy-transition cleanup failed. access={{ nd_iw_transition_access_cleanup.msg | default('ok') }};
+              trunk={{ nd_iw_transition_trunk_cleanup.msg | default('ok') }}.
+          when: not nd_iw_module_check_mode

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/repeated_types.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/repeated_types.yaml
@@ -1,0 +1,48 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Select a family with a distinct secondary identity
+  ansible.builtin.set_fact:
+    nd_iw_repeated_case_candidates: "{{ nd_iw_active_cases | selectattr('secondary', 'defined') | list }}"
+
+- name: Plan two groups of the same interface type
+  vars:
+    nd_iw_repeated_case: "{{ nd_iw_repeated_case_candidates | first }}"
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_repeated_case.family }}"
+        state: merged
+        config: "{{ nd_iw_repeated_case.create_config }}"
+      - type: "{{ nd_iw_repeated_case.family }}"
+        state: merged
+        config: "{{ nd_iw_repeated_case.secondary }}"
+    config_actions:
+      deploy: true
+    output_level: info
+  check_mode: true
+  register: nd_iw_repeated_result
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  when: nd_iw_repeated_case_candidates | length > 0
+
+- name: Verify repeated types retain distinct resource indices
+  ansible.builtin.assert:
+    that:
+      - nd_iw_repeated_result.resources | length == 2
+      - nd_iw_repeated_result.resources | map(attribute='resource_index') | list == [0, 1]
+      - nd_iw_repeated_result.resources | map(attribute='type') | unique | list | length == 1
+      - nd_iw_repeated_result.resources[0].proposed != nd_iw_repeated_result.resources[1].proposed
+      - nd_iw_repeated_result.execution.status == 'check_mode'
+      - nd_iw_repeated_result.execution.mutations_sent == 0
+      - nd_iw_repeated_result.execution.deployments_sent == 0
+      - nd_iw_repeated_result.request_stats.mutation_requests == 0
+      - nd_iw_repeated_result.request_stats.deploy_requests == 0
+  when: nd_iw_repeated_case_candidates | length > 0
+
+- name: Require a secondary fixture for repeated-type coverage
+  ansible.builtin.assert:
+    that:
+      - nd_iw_repeated_case_candidates | length > 0
+    fail_msg: The property matrix must define at least one distinct secondary config.

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/repeated_types.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/repeated_types.yaml
@@ -37,8 +37,6 @@
       - nd_iw_repeated_result.execution.status == 'check_mode'
       - nd_iw_repeated_result.execution.mutations_sent == 0
       - nd_iw_repeated_result.execution.deployments_sent == 0
-      - nd_iw_repeated_result.request_stats.mutation_requests == 0
-      - nd_iw_repeated_result.request_stats.deploy_requests == 0
   when: nd_iw_repeated_case_candidates | length > 0
 
 - name: Require a secondary fixture for repeated-type coverage

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/shared_snapshot.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/shared_snapshot.yaml
@@ -1,0 +1,30 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Require the batched preview before checking shared snapshot statistics
+  ansible.builtin.assert:
+    that:
+      - nd_iw_batch_create_preview is defined
+      - nd_iw_batch_create_preview.request_stats is mapping
+      - nd_iw_batch_create_preview.resources | length == nd_iw_active_cases | length
+
+- name: Verify one paginated inventory sequence is shared across all resource groups
+  vars:
+    nd_iw_snapshot_stats: "{{ nd_iw_batch_create_preview.request_stats }}"
+  ansible.builtin.assert:
+    that:
+      - nd_iw_snapshot_stats.switches == nd_iw_batch_create_preview.target_switch_ids | unique | list | length
+      - nd_iw_snapshot_stats.interface_inventory_pages == nd_iw_snapshot_stats.interface_inventory_gets
+      - nd_iw_snapshot_stats.interface_inventory_gets >= nd_iw_snapshot_stats.switches
+      - nd_iw_snapshot_stats.interface_inventory_cache_hits >= nd_iw_active_cases | length
+      - nd_iw_snapshot_stats.interface_inventory_cache_hits > 0
+      - nd_iw_snapshot_stats.interface_inventory_refreshes == 0
+      - nd_iw_snapshot_stats.interface_inventory_dirty_refetches == 0
+      - nd_iw_snapshot_stats.snapshot_overlays == 0
+      - nd_iw_snapshot_stats.mutation_requests == 0
+      - nd_iw_snapshot_stats.deploy_requests == 0
+    fail_msg: >-
+      The batched plan did not demonstrate snapshot reuse. Pagination may increase GET/page counts,
+      but each family must hit the execution-scoped cache instead of starting its own inventory fetch.

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/shared_snapshot.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/shared_snapshot.yaml
@@ -23,8 +23,10 @@
       - nd_iw_snapshot_stats.interface_inventory_refreshes == 0
       - nd_iw_snapshot_stats.interface_inventory_dirty_refetches == 0
       - nd_iw_snapshot_stats.snapshot_overlays == 0
-      - nd_iw_snapshot_stats.mutation_requests == 0
-      - nd_iw_snapshot_stats.deploy_requests == 0
+      - nd_iw_snapshot_stats.fabric_link_gets is defined
+      - nd_iw_snapshot_stats.fabric_link_gets >= 0
+      - "'mutation_requests' not in nd_iw_snapshot_stats"
+      - "'deploy_requests' not in nd_iw_snapshot_stats"
     fail_msg: >-
       The batched plan did not demonstrate snapshot reuse. Pagination may increase GET/page counts,
       but each family must hit the execution-scoped cache instead of starting its own inventory fetch.

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/unsupported_case.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/unsupported_case.yaml
@@ -1,0 +1,54 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Require the expected unsupported combination to reject in check mode
+  cisco.nd.nd_interfaces_workflow:
+    fabric_name: "{{ nd_iw_current_fabric.fabric_name }}"
+    resources:
+      - type: "{{ nd_iw_unsupported_case.family }}"
+        state: merged
+        config: "{{ nd_iw_unsupported_case.create_config }}"
+    config_actions:
+      deploy: true
+    output_level: debug
+  check_mode: true
+  register: nd_iw_unsupported_result
+  delegate_to: "{{ nd_iw_current_fabric.inventory_host }}"
+  ignore_errors: true
+
+- name: Verify unsupported combination failed before mutation
+  vars:
+    nd_iw_fabric_error_spec: >-
+      {{ (nd_iw_current_fabric.unsupported_expected_error | default({})).get(
+           nd_iw_unsupported_case.family, {}
+         ) }}
+    nd_iw_family_error_spec: >-
+      {{ nd_iw_unsupported_case.unsupported_expected_error | default({}) }}
+    nd_iw_unsupported_error_spec: >-
+      {{ nd_iw_fabric_error_spec
+         if ((nd_iw_fabric_error_spec is string and nd_iw_fabric_error_spec | length > 0)
+             or (nd_iw_fabric_error_spec is mapping and nd_iw_fabric_error_spec | length > 0))
+         else nd_iw_family_error_spec }}
+    nd_iw_unsupported_expected_error: >-
+      {% if nd_iw_unsupported_error_spec is string %}
+      {{ nd_iw_unsupported_error_spec }}
+      {% elif nd_iw_unsupported_error_spec is mapping %}
+      {{ nd_iw_unsupported_error_spec.get(
+           nd_iw_current_fabric.discriminator,
+           nd_iw_unsupported_error_spec.get('default', '')
+         ) }}
+      {% else %}
+      {{ '' }}
+      {% endif %}
+  ansible.builtin.assert:
+    that:
+      - nd_iw_unsupported_result.failed | default(false) | bool
+      - not (nd_iw_unsupported_result.changed | default(false) | bool)
+      - nd_iw_unsupported_result.msg is string
+      - nd_iw_unsupported_expected_error | length == 0 or nd_iw_unsupported_result.msg is search(nd_iw_unsupported_expected_error)
+    fail_msg: >-
+      {{ nd_iw_unsupported_case.family }} unexpectedly planned successfully on
+      {{ nd_iw_current_fabric.discriminator }}. Update the capability matrix only after confirming
+      that this controller and switch role now support the combination.

--- a/tests/integration/targets/nd_interfaces_workflow/tests/common/unsupported_combinations.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/common/unsupported_combinations.yaml
@@ -1,0 +1,18 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Check every expected unsupported fabric and interface combination
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/unsupported_case.yaml"
+  loop: "{{ nd_iw_unsupported_cases }}"
+  loop_control:
+    loop_var: nd_iw_unsupported_case
+    label: "{{ nd_iw_current_fabric.discriminator }}:{{ nd_iw_unsupported_case.family }}"
+
+- name: Report a fabric with no expected unsupported combinations
+  ansible.builtin.debug:
+    msg: >-
+      Every selected interface family is expected to be supported on
+      {{ nd_iw_current_fabric.discriminator }}.
+  when: nd_iw_unsupported_cases | length == 0

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/ethernet_access.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/ethernet_access.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run Ethernet access property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: ethernet_access

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/ethernet_routed.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/ethernet_routed.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run Ethernet routed property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: ethernet_routed

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/ethernet_trunk_host.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/ethernet_trunk_host.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run Ethernet trunk-host property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: ethernet_trunk_host

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/loopback.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/loopback.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run loopback property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: loopback

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/port_channel_access.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/port_channel_access.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run port-channel access property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: port_channel_access

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/port_channel_trunk_host.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/port_channel_trunk_host.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run port-channel trunk-host property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: port_channel_trunk_host

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/subinterface_managed.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/subinterface_managed.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run managed subinterface property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: subinterface_managed

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/subinterface_unmanaged.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/subinterface_unmanaged.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run unmanaged subinterface property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: subinterface_unmanaged

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/svi.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/svi.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run SVI property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: svi

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/vpc_access.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/vpc_access.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run vPC access property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: vpc_access

--- a/tests/integration/targets/nd_interfaces_workflow/tests/families/vpc_trunk_host.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/tests/families/vpc_trunk_host.yaml
@@ -1,0 +1,8 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Run vPC trunk-host property branches
+  ansible.builtin.include_tasks: "{{ role_path }}/tests/common/family_property_branches.yaml"
+  vars:
+    nd_iw_expected_family: vpc_trunk_host

--- a/tests/integration/targets/nd_interfaces_workflow/vars/fabric_matrix.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/vars/fabric_matrix.yaml
@@ -1,0 +1,79 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Switch values intentionally default to empty strings. Preflight discovers them
+# from the named fabric or requires explicit nd_iw_*_switch_* overrides; the test
+# suite never falls back to a plausible-looking management address.
+nd_iw_fabric_matrix:
+  vxlanEbgp:
+    fabric_type: vxlanEbgp
+    inventory_host: "{{ nd_iw_vxlan_ebgp_inventory_host | default('nac-fabric-ebgp-vxlan', true) }}"
+    fabric_name: >-
+      {{ nd_iw_vxlan_ebgp_fabric_name |
+         default(nd_iw_vxlan_ebgp_inventory_host | default('nac-fabric-ebgp-vxlan', true), true) }}
+    enabled: "{{ nd_iw_enable_vxlan_ebgp | default(true) | bool }}"
+    switches:
+      primary: "{{ nd_iw_vxlan_ebgp_switch_primary | default('', true) }}"
+      secondary: "{{ nd_iw_vxlan_ebgp_switch_secondary | default('', true) }}"
+      vpc_peer1: "{{ nd_iw_vxlan_ebgp_vpc_peer1 | default('', true) }}"
+      vpc_peer2: "{{ nd_iw_vxlan_ebgp_vpc_peer2 | default('', true) }}"
+    reserved_set: default
+    capability_mode: declared
+    candidate_families: &all_interface_families
+      - ethernet_access
+      - ethernet_trunk_host
+      - loopback
+      - port_channel_access
+      - port_channel_trunk_host
+      - subinterface_managed
+      - subinterface_unmanaged
+      - svi
+      - vpc_access
+      - vpc_trunk_host
+    vpc_families: &vpc_interface_families
+      - vpc_access
+      - vpc_trunk_host
+    unsupported_families: []
+    unsupported_expected_error: {}
+
+  vxlanIbgp:
+    fabric_type: vxlanIbgp
+    inventory_host: "{{ nd_iw_vxlan_ibgp_inventory_host | default('nac-fabric-ibgp-vxlan', true) }}"
+    fabric_name: >-
+      {{ nd_iw_vxlan_ibgp_fabric_name |
+         default(nd_iw_vxlan_ibgp_inventory_host | default('nac-fabric-ibgp-vxlan', true), true) }}
+    enabled: "{{ nd_iw_enable_vxlan_ibgp | default(true) | bool }}"
+    switches:
+      primary: "{{ nd_iw_vxlan_ibgp_switch_primary | default('', true) }}"
+      secondary: "{{ nd_iw_vxlan_ibgp_switch_secondary | default('', true) }}"
+      vpc_peer1: "{{ nd_iw_vxlan_ibgp_vpc_peer1 | default('', true) }}"
+      vpc_peer2: "{{ nd_iw_vxlan_ibgp_vpc_peer2 | default('', true) }}"
+    reserved_set: default
+    capability_mode: declared
+    candidate_families: *all_interface_families
+    vpc_families: *vpc_interface_families
+    unsupported_families: []
+    unsupported_expected_error: {}
+
+  externalConnectivity:
+    fabric_type: externalConnectivity
+    inventory_host: "{{ nd_iw_external_inventory_host | default('nac-msd-external', true) }}"
+    fabric_name: >-
+      {{ nd_iw_external_fabric_name |
+         default(nd_iw_external_inventory_host | default('nac-msd-external', true), true) }}
+    enabled: "{{ nd_iw_enable_external | default(true) | bool }}"
+    switches:
+      primary: "{{ nd_iw_external_switch_primary | default('', true) }}"
+      secondary: "{{ nd_iw_external_switch_secondary | default('', true) }}"
+      vpc_peer1: "{{ nd_iw_external_vpc_peer1 | default('', true) }}"
+      vpc_peer2: "{{ nd_iw_external_vpc_peer2 | default('', true) }}"
+    reserved_set: default
+    capability_mode: declared
+    candidate_families: *all_interface_families
+    vpc_families: *vpc_interface_families
+    # External-fabric support varies with controller release, switch role, and
+    # actual vPC-pair inventory. Declare verified exceptions in unsupported_families;
+    # the target does not infer capabilities from a failed mutation.
+    unsupported_families: []
+    unsupported_expected_error: {}

--- a/tests/integration/targets/nd_interfaces_workflow/vars/fabric_matrix.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/vars/fabric_matrix.yaml
@@ -22,6 +22,7 @@ nd_iw_fabric_matrix:
     capability_mode: declared
     candidate_families: &all_interface_families
       - ethernet_access
+      - ethernet_routed
       - ethernet_trunk_host
       - loopback
       - port_channel_access

--- a/tests/integration/targets/nd_interfaces_workflow/vars/main.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/vars/main.yaml
@@ -1,0 +1,42 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Profile selection lives in defaults/main.yaml so inventory can override it.
+nd_iw_profiles:
+  smoke:
+    run_mutex: false
+    run_invalid: false
+    run_optional: false
+  full:
+    run_mutex: true
+    run_invalid: true
+    run_optional: true
+  destructive:
+    run_mutex: true
+    run_invalid: true
+    run_optional: true
+
+nd_iw_supported_fabric_types:
+  - vxlanEbgp
+  - vxlanIbgp
+  - externalConnectivity
+
+# This catalog is used by preflight before the templated property matrix can be
+# rendered, and preserves deterministic dependency-safe family order.
+nd_iw_family_order:
+  - subinterface_managed
+  - subinterface_unmanaged
+  - svi
+  - loopback
+  - vpc_access
+  - vpc_trunk_host
+  - port_channel_access
+  - port_channel_trunk_host
+  - ethernet_access
+  - ethernet_trunk_host
+
+# The runner must set these aliases for the currently selected fabric before it
+# renders property or cleanup payloads.
+nd_iw_active_switches: "{{ nd_iw_runtime_switches | default({}) }}"
+nd_iw_active_resources: "{{ nd_iw_runtime_resources | default({}) }}"

--- a/tests/integration/targets/nd_interfaces_workflow/vars/main.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/vars/main.yaml
@@ -34,6 +34,7 @@ nd_iw_family_order:
   - port_channel_access
   - port_channel_trunk_host
   - ethernet_access
+  - ethernet_routed
   - ethernet_trunk_host
 
 # The runner must set these aliases for the currently selected fabric before it

--- a/tests/integration/targets/nd_interfaces_workflow/vars/property_matrix.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/vars/property_matrix.yaml
@@ -1,0 +1,1996 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Scenario payloads are complete config lists and can be assigned directly to
+# resources[].config. "maximal" combines every controller-object-independent
+# field that can coexist. Feature packs carry explicit live prerequisites.
+nd_iw_property_matrix:
+  ethernet_access:
+    module: cisco.nd.nd_interface_ethernet_access
+    ownership_domain: ethernet
+    identity_fields: [switch_ip, interface_names]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: [physical_interfaces]
+    unsupported_expected_error: {}
+    minimal: &nd_iw_ea_minimal
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+              description: IW ethernet access minimal
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+              bandwidth: 100000
+              bpdu_filter: enable
+              bpdu_guard: enable
+              cdp: true
+              debounce_timer: 100
+              debounce_linkup_timer: 1000
+              description: IW ethernet access maximal
+              duplex_mode: auto
+              error_detection_acl: true
+              extra_config: load-interval counter 1 30
+              fec: auto
+              inherit_bandwidth: 100000
+              link_type: auto
+              monitor: false
+              mtu: jumbo
+              negotiate_auto: true
+              netflow: false
+              orphan_port: false
+              pfc: false
+              port_type_edge_trunk: true
+              qos: false
+              speed: auto
+              storm_control: true
+              storm_control_action: trap
+              storm_control_broadcast_level: 10.5
+              storm_control_multicast_level: 20.5
+              storm_control_unicast_level: 30.5
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              access_vlan: "{{ nd_iw_active_resources.vlans.access_alternate }}"
+              bandwidth: 200000
+              bpdu_filter: disable
+              bpdu_guard: default
+              cdp: false
+              debounce_timer: 200
+              debounce_linkup_timer: 2000
+              description: IW ethernet access alternate
+              duplex_mode: full
+              error_detection_acl: false
+              extra_config: load-interval counter 1 60
+              fec: "off"
+              inherit_bandwidth: 200000
+              link_type: pointToPoint
+              monitor: true
+              mtu: default
+              negotiate_auto: false
+              netflow: false
+              orphan_port: true
+              pfc: true
+              port_type_edge_trunk: false
+              qos: false
+              speed: 1Gb
+              storm_control: true
+              storm_control_action: shutdown
+              storm_control_broadcast_level_pps: 1000
+              storm_control_multicast_level_pps: 2000
+              storm_control_unicast_level_pps: 3000
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access_alternate }}"
+              description: IW ethernet access replaced
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_access.secondary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+              description: IW ethernet access override victim
+    override: *nd_iw_ea_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_access.primary + nd_iw_active_resources.ethernet_access.secondary }}"
+    mutex_variants:
+      - name: percentage_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+            config_data:
+              network_os:
+                policy:
+                  storm_control_broadcast_level: 42.5
+                  storm_control_multicast_level: 43.5
+                  storm_control_unicast_level: 44.5
+      - name: pps_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+            config_data:
+              network_os:
+                policy:
+                  storm_control_broadcast_level_pps: 4200
+                  storm_control_multicast_level_pps: 4300
+                  storm_control_unicast_level_pps: 4400
+      - name: percentage_and_pps_rejected
+        valid: false
+        expected_error: storm-control percentage and pps levels are mutually exclusive
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+            config_data:
+              network_os:
+                policy:
+                  storm_control_broadcast_level: 42.5
+                  storm_control_broadcast_level_pps: 4200
+    optional_packs:
+      - name: referenced_netflow_qos_pfc
+        live_safe: false
+        requirements:
+          - l2_netflow_monitor_exists
+          - netflow_sampler_supported
+          - qos_policy_exists
+          - queuing_policy_exists
+          - pfc_supported
+        properties:
+          - config_data.network_os.policy.netflow
+          - config_data.network_os.policy.netflow_monitor
+          - config_data.network_os.policy.netflow_sampler
+          - config_data.network_os.policy.pfc
+          - config_data.network_os.policy.qos
+          - config_data.network_os.policy.qos_policy
+          - config_data.network_os.policy.queuing_policy
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+            config_data:
+              network_os:
+                policy:
+                  netflow: true
+                  netflow_monitor: "{{ nd_iw_active_resources.references.l2_netflow_monitor }}"
+                  netflow_sampler: "{{ nd_iw_active_resources.references.netflow_sampler }}"
+                  pfc: true
+                  qos: true
+                  qos_policy: "{{ nd_iw_active_resources.references.qos_policy }}"
+                  queuing_policy: "{{ nd_iw_active_resources.references.queuing_policy }}"
+    invalid:
+      - name: vlan_below_minimum
+        expected_error: greater than or equal to 1
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+            config_data: {network_os: {policy: {access_vlan: 0}}}
+      - name: bandwidth_above_maximum
+        expected_error: less than or equal to 100000000
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+            config_data: {network_os: {policy: {bandwidth: 100000001}}}
+      - name: non_ascii_description
+        expected_error: ASCII
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_access.primary }}"
+            config_data: {network_os: {policy: {description: "IW café"}}}
+    properties:
+      - switch_ip
+      - interface_names
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.access_vlan
+      - config_data.network_os.policy.bandwidth
+      - config_data.network_os.policy.bpdu_filter
+      - config_data.network_os.policy.bpdu_guard
+      - config_data.network_os.policy.cdp
+      - config_data.network_os.policy.debounce_timer
+      - config_data.network_os.policy.debounce_linkup_timer
+      - config_data.network_os.policy.description
+      - config_data.network_os.policy.duplex_mode
+      - config_data.network_os.policy.error_detection_acl
+      - config_data.network_os.policy.extra_config
+      - config_data.network_os.policy.fec
+      - config_data.network_os.policy.inherit_bandwidth
+      - config_data.network_os.policy.link_type
+      - config_data.network_os.policy.monitor
+      - config_data.network_os.policy.mtu
+      - config_data.network_os.policy.negotiate_auto
+      - config_data.network_os.policy.netflow
+      - config_data.network_os.policy.netflow_monitor
+      - config_data.network_os.policy.netflow_sampler
+      - config_data.network_os.policy.orphan_port
+      - config_data.network_os.policy.pfc
+      - config_data.network_os.policy.port_type_edge_trunk
+      - config_data.network_os.policy.qos
+      - config_data.network_os.policy.qos_policy
+      - config_data.network_os.policy.queuing_policy
+      - config_data.network_os.policy.speed
+      - config_data.network_os.policy.storm_control
+      - config_data.network_os.policy.storm_control_action
+      - config_data.network_os.policy.storm_control_broadcast_level
+      - config_data.network_os.policy.storm_control_broadcast_level_pps
+      - config_data.network_os.policy.storm_control_multicast_level
+      - config_data.network_os.policy.storm_control_multicast_level_pps
+      - config_data.network_os.policy.storm_control_unicast_level
+      - config_data.network_os.policy.storm_control_unicast_level_pps
+
+  ethernet_trunk_host:
+    module: cisco.nd.nd_interface_ethernet_trunk_host
+    ownership_domain: ethernet
+    identity_fields: [switch_ip, interface_names]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: [physical_interfaces]
+    unsupported_expected_error: {}
+    minimal: &nd_iw_eth_minimal
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+              native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+              description: IW ethernet trunk minimal
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+              bandwidth: 100000
+              bpdu_filter: enable
+              bpdu_guard: enable
+              cdp: true
+              debounce_timer: 100
+              debounce_linkup_timer: 1000
+              description: IW ethernet trunk maximal
+              duplex_mode: auto
+              error_detection_acl: true
+              extra_config: load-interval counter 1 30
+              fec: auto
+              inherit_bandwidth: 100000
+              link_type: auto
+              monitor: false
+              mtu: jumbo
+              native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+              negotiate_auto: true
+              netflow: false
+              orphan_port: false
+              pfc: false
+              port_type_edge_trunk: true
+              qos: false
+              speed: auto
+              storm_control: true
+              storm_control_action: trap
+              storm_control_broadcast_level: 10.5
+              storm_control_multicast_level: 20.5
+              storm_control_unicast_level: 30.5
+              vlan_mapping: false
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed_alternate }}"
+              bandwidth: 200000
+              bpdu_filter: disable
+              bpdu_guard: default
+              cdp: false
+              debounce_timer: 200
+              debounce_linkup_timer: 2000
+              description: IW ethernet trunk alternate
+              duplex_mode: full
+              error_detection_acl: false
+              extra_config: load-interval counter 1 60
+              fec: "off"
+              inherit_bandwidth: 200000
+              link_type: pointToPoint
+              monitor: true
+              mtu: default
+              native_vlan: "{{ nd_iw_active_resources.vlans.native_alternate }}"
+              negotiate_auto: false
+              netflow: false
+              orphan_port: true
+              pfc: true
+              port_type_edge_trunk: false
+              qos: false
+              speed: 1Gb
+              storm_control: true
+              storm_control_action: shutdown
+              storm_control_broadcast_level_pps: 1000
+              storm_control_multicast_level_pps: 2000
+              storm_control_unicast_level_pps: 3000
+              vlan_mapping: false
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: all
+              native_vlan: "{{ nd_iw_active_resources.vlans.native_alternate }}"
+              description: IW ethernet trunk replaced
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.secondary }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+              native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+              description: IW ethernet trunk override victim
+    override: *nd_iw_eth_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary + nd_iw_active_resources.ethernet_trunk_host.secondary }}"
+    mutex_variants:
+      - name: percentage_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level: 42.5}}}
+      - name: pps_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level_pps: 4200}}}
+      - name: percentage_and_pps_rejected
+        valid: false
+        expected_error: storm-control percentage and pps levels are mutually exclusive
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+            config_data:
+              network_os:
+                policy:
+                  storm_control_broadcast_level: 42.5
+                  storm_control_broadcast_level_pps: 4200
+    optional_packs:
+      - name: referenced_netflow_qos_pfc
+        live_safe: false
+        requirements: [l2_netflow_monitor_exists, netflow_sampler_supported, qos_policy_exists, queuing_policy_exists, pfc_supported]
+        properties:
+          - config_data.network_os.policy.netflow
+          - config_data.network_os.policy.netflow_monitor
+          - config_data.network_os.policy.netflow_sampler
+          - config_data.network_os.policy.pfc
+          - config_data.network_os.policy.qos
+          - config_data.network_os.policy.qos_policy
+          - config_data.network_os.policy.queuing_policy
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+            config_data:
+              network_os:
+                policy:
+                  netflow: true
+                  netflow_monitor: "{{ nd_iw_active_resources.references.l2_netflow_monitor }}"
+                  netflow_sampler: "{{ nd_iw_active_resources.references.netflow_sampler }}"
+                  pfc: true
+                  qos: true
+                  qos_policy: "{{ nd_iw_active_resources.references.qos_policy }}"
+                  queuing_policy: "{{ nd_iw_active_resources.references.queuing_policy }}"
+      - name: vlan_mapping
+        live_safe: false
+        requirements: [vlan_mapping_supported]
+        properties:
+          - config_data.network_os.policy.vlan_mapping
+          - config_data.network_os.policy.vlan_mapping_entries[].customer_inner_vlan_id
+          - config_data.network_os.policy.vlan_mapping_entries[].customer_vlan_id
+          - config_data.network_os.policy.vlan_mapping_entries[].dot1q_tunnel
+          - config_data.network_os.policy.vlan_mapping_entries[].provider_vlan_id
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+            config_data:
+              network_os:
+                policy:
+                  vlan_mapping: true
+                  vlan_mapping_entries: >-
+                    {{
+                      [{
+                        'customer_inner_vlan_id': nd_iw_active_resources.vlans.customer_inner | int,
+                        'customer_vlan_id': nd_iw_active_resources.vlans.customer,
+                        'dot1q_tunnel': true,
+                        'provider_vlan_id': nd_iw_active_resources.vlans.provider | int
+                      }]
+                    }}
+    invalid:
+      - name: malformed_allowed_vlans
+        expected_error: allowed_vlans must be
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+            config_data: {network_os: {policy: {allowed_vlans: "10-bad"}}}
+      - name: reversed_vlan_range
+        expected_error: start greater than end
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+            config_data: {network_os: {policy: {allowed_vlans: "200-100"}}}
+      - name: mapping_without_entries
+        expected_error: vlan_mapping_entries must be provided
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary }}"
+            config_data: {network_os: {policy: {vlan_mapping: true}}}
+    properties:
+      - switch_ip
+      - interface_names
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.allowed_vlans
+      - config_data.network_os.policy.bandwidth
+      - config_data.network_os.policy.bpdu_filter
+      - config_data.network_os.policy.bpdu_guard
+      - config_data.network_os.policy.cdp
+      - config_data.network_os.policy.debounce_timer
+      - config_data.network_os.policy.debounce_linkup_timer
+      - config_data.network_os.policy.description
+      - config_data.network_os.policy.duplex_mode
+      - config_data.network_os.policy.error_detection_acl
+      - config_data.network_os.policy.extra_config
+      - config_data.network_os.policy.fec
+      - config_data.network_os.policy.inherit_bandwidth
+      - config_data.network_os.policy.link_type
+      - config_data.network_os.policy.monitor
+      - config_data.network_os.policy.mtu
+      - config_data.network_os.policy.native_vlan
+      - config_data.network_os.policy.negotiate_auto
+      - config_data.network_os.policy.netflow
+      - config_data.network_os.policy.netflow_monitor
+      - config_data.network_os.policy.netflow_sampler
+      - config_data.network_os.policy.orphan_port
+      - config_data.network_os.policy.pfc
+      - config_data.network_os.policy.port_type_edge_trunk
+      - config_data.network_os.policy.qos
+      - config_data.network_os.policy.qos_policy
+      - config_data.network_os.policy.queuing_policy
+      - config_data.network_os.policy.speed
+      - config_data.network_os.policy.storm_control
+      - config_data.network_os.policy.storm_control_action
+      - config_data.network_os.policy.storm_control_broadcast_level
+      - config_data.network_os.policy.storm_control_broadcast_level_pps
+      - config_data.network_os.policy.storm_control_multicast_level
+      - config_data.network_os.policy.storm_control_multicast_level_pps
+      - config_data.network_os.policy.storm_control_unicast_level
+      - config_data.network_os.policy.storm_control_unicast_level_pps
+      - config_data.network_os.policy.vlan_mapping
+      - config_data.network_os.policy.vlan_mapping_entries[].customer_inner_vlan_id
+      - config_data.network_os.policy.vlan_mapping_entries[].customer_vlan_id
+      - config_data.network_os.policy.vlan_mapping_entries[].dot1q_tunnel
+      - config_data.network_os.policy.vlan_mapping_entries[].provider_vlan_id
+
+  loopback:
+    module: cisco.nd.nd_interface_loopback
+    ownership_domain: loopback
+    identity_fields: [switch_ip, interface_name]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: []
+    unsupported_expected_error: {}
+    minimal: &nd_iw_loopback_minimal
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: "{{ nd_iw_active_resources.loopback.primary_ipv4 }}"
+              description: IW loopback minimal
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: "{{ nd_iw_active_resources.loopback.primary_ipv4 }}"
+              # TODO: Re-enable loopback IPv6 after nd_interface_loopback normalizes CIDR input
+              # to the bare host value required by NDFC; the int_loopback template appends /128.
+              # ipv6: "{{ nd_iw_active_resources.loopback.primary_ipv6 }}"
+              vrf: "{{ nd_iw_active_resources.references.vrf }}"
+              route_map_tag: "{{ nd_iw_active_resources.references.route_map_tag }}"
+              description: IW loopback maximal
+              extra_config: no ip redirects
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              ip: "{{ nd_iw_active_resources.loopback.alternate_ipv4 }}"
+              # ipv6: "{{ nd_iw_active_resources.loopback.alternate_ipv6 }}"
+              vrf: "{{ nd_iw_active_resources.references.vrf }}"
+              route_map_tag: "902"
+              description: IW loopback alternate
+              extra_config: no ipv6 redirects
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: "{{ nd_iw_active_resources.loopback.alternate_ipv4 }}"
+              description: IW loopback replaced
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.secondary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 198.18.90.3
+              description: IW loopback override victim
+    override: *nd_iw_loopback_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.primary_name }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.secondary_name }}"
+    mutex_variants: []
+    optional_packs: []
+    invalid:
+      - name: non_ascii_description
+        expected_error: ASCII
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.loopback.primary_name }}"
+            config_data: {network_os: {policy: {description: "IW café"}}}
+      - name: empty_vrf
+        expected_error: at least 1 character
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.loopback.primary_name }}"
+            config_data: {network_os: {policy: {vrf: ""}}}
+    properties:
+      - switch_ip
+      - interface_name
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.ip
+      # - config_data.network_os.policy.ipv6  # Disabled with the loopback IPv6 TODO above.
+      - config_data.network_os.policy.vrf
+      - config_data.network_os.policy.route_map_tag
+      - config_data.network_os.policy.description
+      - config_data.network_os.policy.extra_config
+
+  port_channel_access:
+    module: cisco.nd.nd_interface_port_channel_access
+    ownership_domain: port_channel
+    identity_fields: [switch_ip, interface_name]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: [physical_member_interfaces]
+    unsupported_expected_error: {}
+    minimal: &nd_iw_pca_minimal
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+              ports: "{{ nd_iw_active_resources.port_channel_access.primary_ports }}"
+              port_channel_mode: active
+              description: IW port-channel access minimal
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+              bpdu_filter: enable
+              bpdu_guard: enable
+              cdp: true
+              copy_description: true
+              description: IW port-channel access maximal
+              duplex_mode: auto
+              extra_config: load-interval counter 1 30
+              lacp_port_priority: 32768
+              lacp_rate: fast
+              lacp_suspend: true
+              monitor: false
+              mtu: jumbo
+              netflow: false
+              port_channel_mode: active
+              ports: "{{ nd_iw_active_resources.port_channel_access.primary_ports }}"
+              qos: false
+              speed: auto
+              storm_control: true
+              storm_control_action: trap
+              storm_control_broadcast_level: 10.5
+              storm_control_multicast_level: 20.5
+              storm_control_unicast_level: 30.5
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              access_vlan: "{{ nd_iw_active_resources.vlans.access_alternate }}"
+              bpdu_filter: disable
+              bpdu_guard: default
+              cdp: false
+              copy_description: false
+              description: IW port-channel access alternate
+              duplex_mode: full
+              extra_config: load-interval counter 1 60
+              lacp_port_priority: 4096
+              lacp_rate: normal
+              lacp_suspend: false
+              monitor: true
+              mtu: default
+              netflow: false
+              port_channel_mode: passive
+              ports: "{{ nd_iw_active_resources.port_channel_access.alternate_ports }}"
+              qos: false
+              speed: 1Gb
+              storm_control: true
+              storm_control_action: shutdown
+              storm_control_broadcast_level_pps: 1000
+              storm_control_multicast_level_pps: 2000
+              storm_control_unicast_level_pps: 3000
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access_alternate }}"
+              ports: "{{ nd_iw_active_resources.port_channel_access.alternate_ports }}"
+              port_channel_mode: active
+              description: IW port-channel access replaced
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.secondary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+              ports: "{{ nd_iw_active_resources.port_channel_access.secondary_ports }}"
+              port_channel_mode: active
+              description: IW port-channel access override victim
+    override: *nd_iw_pca_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.secondary_name }}"
+    mutex_variants:
+      - name: percentage_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level: 42.5}}}
+      - name: pps_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level_pps: 4200}}}
+      - name: percentage_and_pps_rejected
+        valid: false
+        expected_error: storm-control percentage and pps levels are mutually exclusive
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  storm_control_broadcast_level: 42.5
+                  storm_control_broadcast_level_pps: 4200
+    optional_packs:
+      - name: referenced_netflow_qos
+        live_safe: false
+        requirements: [l2_netflow_monitor_exists, netflow_sampler_supported, qos_policy_exists, queuing_policy_exists]
+        properties:
+          - config_data.network_os.policy.netflow
+          - config_data.network_os.policy.netflow_monitor
+          - config_data.network_os.policy.netflow_sampler
+          - config_data.network_os.policy.qos
+          - config_data.network_os.policy.qos_policy
+          - config_data.network_os.policy.queuing_policy
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  netflow: true
+                  netflow_monitor: "{{ nd_iw_active_resources.references.l2_netflow_monitor }}"
+                  netflow_sampler: "{{ nd_iw_active_resources.references.netflow_sampler }}"
+                  qos: true
+                  qos_policy: "{{ nd_iw_active_resources.references.qos_policy }}"
+                  queuing_policy: "{{ nd_iw_active_resources.references.queuing_policy }}"
+    invalid:
+      - name: netflow_without_monitor
+        expected_error: netflow_monitor must be provided
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+            config_data: {network_os: {policy: {netflow: true}}}
+      - name: lacp_priority_below_minimum
+        expected_error: greater than or equal to 1
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+            config_data: {network_os: {policy: {lacp_port_priority: 0}}}
+    properties:
+      - switch_ip
+      - interface_name
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.access_vlan
+      - config_data.network_os.policy.bpdu_filter
+      - config_data.network_os.policy.bpdu_guard
+      - config_data.network_os.policy.cdp
+      - config_data.network_os.policy.copy_description
+      - config_data.network_os.policy.description
+      - config_data.network_os.policy.duplex_mode
+      - config_data.network_os.policy.extra_config
+      - config_data.network_os.policy.lacp_port_priority
+      - config_data.network_os.policy.lacp_rate
+      - config_data.network_os.policy.lacp_suspend
+      - config_data.network_os.policy.monitor
+      - config_data.network_os.policy.mtu
+      - config_data.network_os.policy.netflow
+      - config_data.network_os.policy.netflow_monitor
+      - config_data.network_os.policy.netflow_sampler
+      - config_data.network_os.policy.port_channel_mode
+      - config_data.network_os.policy.ports
+      - config_data.network_os.policy.qos
+      - config_data.network_os.policy.qos_policy
+      - config_data.network_os.policy.queuing_policy
+      - config_data.network_os.policy.speed
+      - config_data.network_os.policy.storm_control
+      - config_data.network_os.policy.storm_control_action
+      - config_data.network_os.policy.storm_control_broadcast_level
+      - config_data.network_os.policy.storm_control_broadcast_level_pps
+      - config_data.network_os.policy.storm_control_multicast_level
+      - config_data.network_os.policy.storm_control_multicast_level_pps
+      - config_data.network_os.policy.storm_control_unicast_level
+      - config_data.network_os.policy.storm_control_unicast_level_pps
+
+  port_channel_trunk_host:
+    module: cisco.nd.nd_interface_port_channel_trunk_host
+    ownership_domain: port_channel
+    identity_fields: [switch_ip, interface_name]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: [physical_member_interfaces]
+    unsupported_expected_error: {}
+    minimal: &nd_iw_pcth_minimal
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+              native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+              ports: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_ports }}"
+              port_channel_mode: active
+              description: IW port-channel trunk minimal
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+              bandwidth: 100000
+              bpdu_filter: enable
+              bpdu_guard: enable
+              cdp: true
+              copy_description: true
+              description: IW port-channel trunk maximal
+              duplex_mode: auto
+              extra_config: load-interval counter 1 30
+              inherit_bandwidth: 100000
+              lacp_port_priority: 32768
+              lacp_rate: fast
+              lacp_suspend: true
+              link_type: auto
+              monitor: false
+              mtu: jumbo
+              native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+              negotiate_auto: true
+              netflow: false
+              orphan_port: false
+              pfc: false
+              port_channel_mode: active
+              port_type_edge_trunk: true
+              ports: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_ports }}"
+              ptp: false
+              qos: false
+              speed: auto
+              storm_control: true
+              storm_control_action: trap
+              storm_control_broadcast_level: 10.5
+              storm_control_multicast_level: 20.5
+              storm_control_unicast_level: 30.5
+              vlan_mapping: false
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed_alternate }}"
+              native_vlan: "{{ nd_iw_active_resources.vlans.native_alternate }}"
+              ports: "{{ nd_iw_active_resources.port_channel_trunk_host.alternate_ports }}"
+              port_channel_mode: passive
+              lacp_rate: normal
+              ptp: true
+              description: IW port-channel trunk alternate
+              storm_control_broadcast_level_pps: 1000
+              storm_control_multicast_level_pps: 2000
+              storm_control_unicast_level_pps: 3000
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: all
+              native_vlan: "{{ nd_iw_active_resources.vlans.native_alternate }}"
+              ports: "{{ nd_iw_active_resources.port_channel_trunk_host.alternate_ports }}"
+              port_channel_mode: active
+              description: IW port-channel trunk replaced
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.secondary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+              native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+              ports: "{{ nd_iw_active_resources.port_channel_trunk_host.secondary_ports }}"
+              port_channel_mode: active
+              description: IW port-channel trunk override victim
+    override: *nd_iw_pcth_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.secondary_name }}"
+    mutex_variants:
+      - name: percentage_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level: 42.5}}}
+      - name: pps_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level_pps: 4200}}}
+      - name: percentage_and_pps_rejected
+        valid: false
+        expected_error: storm-control percentage and pps levels are mutually exclusive
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  storm_control_broadcast_level: 42.5
+                  storm_control_broadcast_level_pps: 4200
+    optional_packs:
+      - name: referenced_netflow_qos_pfc
+        live_safe: false
+        requirements: [l2_netflow_monitor_exists, netflow_sampler_supported, qos_policy_exists, queuing_policy_exists, pfc_supported]
+        properties:
+          - config_data.network_os.policy.netflow
+          - config_data.network_os.policy.netflow_monitor
+          - config_data.network_os.policy.netflow_sampler
+          - config_data.network_os.policy.pfc
+          - config_data.network_os.policy.qos
+          - config_data.network_os.policy.qos_policy
+          - config_data.network_os.policy.queuing_policy
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  netflow: true
+                  netflow_monitor: "{{ nd_iw_active_resources.references.l2_netflow_monitor }}"
+                  netflow_sampler: "{{ nd_iw_active_resources.references.netflow_sampler }}"
+                  pfc: true
+                  qos: true
+                  qos_policy: "{{ nd_iw_active_resources.references.qos_policy }}"
+                  queuing_policy: "{{ nd_iw_active_resources.references.queuing_policy }}"
+      - name: vlan_mapping
+        live_safe: false
+        requirements: [vlan_mapping_supported]
+        properties:
+          - config_data.network_os.policy.vlan_mapping
+          - config_data.network_os.policy.vlan_mapping_entries[].customer_inner_vlan_id
+          - config_data.network_os.policy.vlan_mapping_entries[].customer_vlan_id
+          - config_data.network_os.policy.vlan_mapping_entries[].dot1q_tunnel
+          - config_data.network_os.policy.vlan_mapping_entries[].provider_vlan_id
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  vlan_mapping: true
+                  vlan_mapping_entries: >-
+                    {{
+                      [{
+                        'customer_inner_vlan_id': nd_iw_active_resources.vlans.customer_inner | int,
+                        'customer_vlan_id': nd_iw_active_resources.vlans.customer,
+                        'dot1q_tunnel': true,
+                        'provider_vlan_id': nd_iw_active_resources.vlans.provider | int
+                      }]
+                    }}
+    invalid:
+      - name: netflow_without_monitor
+        expected_error: netflow_monitor must be provided
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+            config_data: {network_os: {policy: {netflow: true}}}
+      - name: malformed_allowed_vlans
+        expected_error: allowed_vlans must be
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+            config_data: {network_os: {policy: {allowed_vlans: bad}}}
+    properties:
+      - switch_ip
+      - interface_name
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.allowed_vlans
+      - config_data.network_os.policy.bandwidth
+      - config_data.network_os.policy.bpdu_filter
+      - config_data.network_os.policy.bpdu_guard
+      - config_data.network_os.policy.cdp
+      - config_data.network_os.policy.copy_description
+      - config_data.network_os.policy.description
+      - config_data.network_os.policy.duplex_mode
+      - config_data.network_os.policy.extra_config
+      - config_data.network_os.policy.inherit_bandwidth
+      - config_data.network_os.policy.lacp_port_priority
+      - config_data.network_os.policy.lacp_rate
+      - config_data.network_os.policy.lacp_suspend
+      - config_data.network_os.policy.link_type
+      - config_data.network_os.policy.monitor
+      - config_data.network_os.policy.mtu
+      - config_data.network_os.policy.native_vlan
+      - config_data.network_os.policy.negotiate_auto
+      - config_data.network_os.policy.netflow
+      - config_data.network_os.policy.netflow_monitor
+      - config_data.network_os.policy.netflow_sampler
+      - config_data.network_os.policy.orphan_port
+      - config_data.network_os.policy.pfc
+      - config_data.network_os.policy.port_channel_mode
+      - config_data.network_os.policy.port_type_edge_trunk
+      - config_data.network_os.policy.ports
+      - config_data.network_os.policy.ptp
+      - config_data.network_os.policy.qos
+      - config_data.network_os.policy.qos_policy
+      - config_data.network_os.policy.queuing_policy
+      - config_data.network_os.policy.speed
+      - config_data.network_os.policy.storm_control
+      - config_data.network_os.policy.storm_control_action
+      - config_data.network_os.policy.storm_control_broadcast_level
+      - config_data.network_os.policy.storm_control_broadcast_level_pps
+      - config_data.network_os.policy.storm_control_multicast_level
+      - config_data.network_os.policy.storm_control_multicast_level_pps
+      - config_data.network_os.policy.storm_control_unicast_level
+      - config_data.network_os.policy.storm_control_unicast_level_pps
+      - config_data.network_os.policy.vlan_mapping
+      - config_data.network_os.policy.vlan_mapping_entries[].customer_inner_vlan_id
+      - config_data.network_os.policy.vlan_mapping_entries[].customer_vlan_id
+      - config_data.network_os.policy.vlan_mapping_entries[].dot1q_tunnel
+      - config_data.network_os.policy.vlan_mapping_entries[].provider_vlan_id
+
+  vpc_access:
+    module: cisco.nd.nd_interface_vpc_access
+    ownership_domain: vpc
+    identity_fields: [interface_name]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: [vpc_pair, paired_switches, per_peer_member_interfaces]
+    unsupported_expected_error:
+      default: switch is not part of an authoritative vPC pair
+    minimal: &nd_iw_vpca_minimal
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_access.primary_port_channel_id }}"
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_access.peer1_primary_ports }}"
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_access.primary_port_channel_id }}"
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_access.peer2_primary_ports }}"
+              port_channel_mode: active
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+              bandwidth: 100000
+              bpdu_filter: enable
+              bpdu_guard: enable
+              cdp: true
+              copy_description: true
+              duplex_mode: auto
+              inherit_bandwidth: 100000
+              lacp_port_priority: 32768
+              lacp_rate: fast
+              lacp_suspend: true
+              lacp_vpc_convergence: true
+              link_type: auto
+              mirror_config: true
+              mtu: jumbo
+              negotiate_auto: true
+              netflow: false
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_access.peer1_primary_ports }}"
+              peer1_port_channel_configuration: load-interval counter 1 30
+              peer1_port_channel_description: IW vPC access peer1
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_access.primary_port_channel_id }}"
+              # With mirror_config true, ND requires Peer-2 config/description to be
+              # present and identical to Peer-1. The alternate fixture covers asymmetry.
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_access.peer2_primary_ports }}"
+              peer2_port_channel_configuration: load-interval counter 1 30
+              peer2_port_channel_description: IW vPC access peer1
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_access.primary_port_channel_id }}"
+              pfc: false
+              port_channel_mode: active
+              port_type_edge_trunk: true
+              qos: false
+              speed: auto
+              storm_control: true
+              storm_control_action: trap
+              storm_control_broadcast_level: 10.5
+              storm_control_multicast_level: 20.5
+              storm_control_unicast_level: 30.5
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              access_vlan: "{{ nd_iw_active_resources.vlans.access_alternate }}"
+              bpdu_filter: disable
+              bpdu_guard: default
+              cdp: false
+              copy_description: false
+              lacp_rate: normal
+              lacp_suspend: false
+              lacp_vpc_convergence: false
+              mirror_config: false
+              mtu: default
+              negotiate_auto: false
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_access.peer1_primary_ports }}"
+              peer1_port_channel_description: IW vPC access peer1 alternate
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_access.primary_port_channel_id }}"
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_access.peer2_primary_ports }}"
+              peer2_port_channel_description: IW vPC access peer2 alternate
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_access.primary_port_channel_id }}"
+              port_channel_mode: passive
+              speed: 1Gb
+              storm_control_broadcast_level_pps: 1000
+              storm_control_multicast_level_pps: 2000
+              storm_control_unicast_level_pps: 3000
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access_alternate }}"
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_access.primary_port_channel_id }}"
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_access.peer1_primary_ports }}"
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_access.primary_port_channel_id }}"
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_access.peer2_primary_ports }}"
+              port_channel_mode: active
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.secondary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              access_vlan: "{{ nd_iw_active_resources.vlans.access }}"
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_access.secondary_port_channel_id }}"
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_access.peer1_secondary_ports }}"
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_access.secondary_port_channel_id }}"
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_access.peer2_secondary_ports }}"
+              port_channel_mode: active
+    override: *nd_iw_vpca_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.secondary_name }}"
+    mutex_variants:
+      - name: percentage_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level: 42.5}}}
+      - name: pps_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level_pps: 4200}}}
+      - name: percentage_and_pps_rejected
+        valid: false
+        expected_error: storm-control percentage and pps levels are mutually exclusive
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  storm_control_broadcast_level: 42.5
+                  storm_control_broadcast_level_pps: 4200
+    optional_packs:
+      - name: referenced_netflow_qos_pfc
+        live_safe: false
+        requirements: [l2_netflow_monitor_exists, netflow_sampler_supported, qos_policy_exists, queuing_policy_exists, pfc_supported]
+        properties:
+          - config_data.network_os.policy.netflow
+          - config_data.network_os.policy.netflow_monitor
+          - config_data.network_os.policy.netflow_sampler
+          - config_data.network_os.policy.pfc
+          - config_data.network_os.policy.qos
+          - config_data.network_os.policy.qos_policy
+          - config_data.network_os.policy.queuing_policy
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  netflow: true
+                  netflow_monitor: "{{ nd_iw_active_resources.references.l2_netflow_monitor }}"
+                  netflow_sampler: "{{ nd_iw_active_resources.references.netflow_sampler }}"
+                  pfc: true
+                  qos: true
+                  qos_policy: "{{ nd_iw_active_resources.references.qos_policy }}"
+                  queuing_policy: "{{ nd_iw_active_resources.references.queuing_policy }}"
+    invalid:
+      - name: peer_port_channel_id_below_minimum
+        expected_error: greater than or equal to 1
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+            config_data: {network_os: {policy: {peer1_port_channel_id: 0}}}
+      - name: non_ascii_peer_description
+        expected_error: ASCII
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+            config_data: {network_os: {policy: {peer1_port_channel_description: "IW café"}}}
+    properties:
+      - switch_ip
+      - interface_name
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.bandwidth
+      - config_data.network_os.policy.bpdu_filter
+      - config_data.network_os.policy.bpdu_guard
+      - config_data.network_os.policy.cdp
+      - config_data.network_os.policy.copy_description
+      - config_data.network_os.policy.duplex_mode
+      - config_data.network_os.policy.inherit_bandwidth
+      - config_data.network_os.policy.lacp_port_priority
+      - config_data.network_os.policy.lacp_rate
+      - config_data.network_os.policy.lacp_suspend
+      - config_data.network_os.policy.lacp_vpc_convergence
+      - config_data.network_os.policy.link_type
+      - config_data.network_os.policy.mirror_config
+      - config_data.network_os.policy.mtu
+      - config_data.network_os.policy.negotiate_auto
+      - config_data.network_os.policy.netflow
+      - config_data.network_os.policy.netflow_monitor
+      - config_data.network_os.policy.netflow_sampler
+      - config_data.network_os.policy.access_vlan
+      - config_data.network_os.policy.peer1_member_ports
+      - config_data.network_os.policy.peer1_port_channel_configuration
+      - config_data.network_os.policy.peer1_port_channel_description
+      - config_data.network_os.policy.peer1_port_channel_id
+      - config_data.network_os.policy.peer2_member_ports
+      - config_data.network_os.policy.peer2_port_channel_configuration
+      - config_data.network_os.policy.peer2_port_channel_description
+      - config_data.network_os.policy.peer2_port_channel_id
+      - config_data.network_os.policy.pfc
+      - config_data.network_os.policy.port_channel_mode
+      - config_data.network_os.policy.port_type_edge_trunk
+      - config_data.network_os.policy.qos
+      - config_data.network_os.policy.qos_policy
+      - config_data.network_os.policy.queuing_policy
+      - config_data.network_os.policy.speed
+      - config_data.network_os.policy.storm_control
+      - config_data.network_os.policy.storm_control_action
+      - config_data.network_os.policy.storm_control_broadcast_level
+      - config_data.network_os.policy.storm_control_broadcast_level_pps
+      - config_data.network_os.policy.storm_control_multicast_level
+      - config_data.network_os.policy.storm_control_multicast_level_pps
+      - config_data.network_os.policy.storm_control_unicast_level
+      - config_data.network_os.policy.storm_control_unicast_level_pps
+
+  vpc_trunk_host:
+    module: cisco.nd.nd_interface_vpc_trunk_host
+    ownership_domain: vpc
+    identity_fields: [interface_name]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: [vpc_pair, paired_switches, per_peer_member_interfaces]
+    unsupported_expected_error:
+      default: switch is not part of an authoritative vPC pair
+    minimal: &nd_iw_vpcth_minimal
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+              native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.primary_port_channel_id }}"
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer1_primary_ports }}"
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.primary_port_channel_id }}"
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer2_primary_ports }}"
+              port_channel_mode: active
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+              bandwidth: 100000
+              bpdu_filter: enable
+              bpdu_guard: enable
+              cdp: true
+              copy_description: true
+              duplex_mode: auto
+              inherit_bandwidth: 100000
+              lacp_port_priority: 32768
+              lacp_rate: fast
+              lacp_suspend: true
+              lacp_vpc_convergence: true
+              link_type: auto
+              mirror_config: true
+              mtu: jumbo
+              native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+              negotiate_auto: true
+              netflow: false
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer1_primary_ports }}"
+              peer1_port_channel_configuration: load-interval counter 1 30
+              peer1_port_channel_description: IW vPC trunk peer1
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.primary_port_channel_id }}"
+              # With mirror_config true, ND requires Peer-2 config/description to be
+              # present and identical to Peer-1. The alternate fixture covers asymmetry.
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer2_primary_ports }}"
+              peer2_port_channel_configuration: load-interval counter 1 30
+              peer2_port_channel_description: IW vPC trunk peer1
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.primary_port_channel_id }}"
+              pfc: false
+              port_channel_mode: active
+              port_type_edge_trunk: true
+              qos: false
+              speed: auto
+              storm_control: true
+              storm_control_action: trap
+              storm_control_broadcast_level: 10.5
+              storm_control_multicast_level: 20.5
+              storm_control_unicast_level: 30.5
+              vlan_mapping: false
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed_alternate }}"
+              native_vlan: "{{ nd_iw_active_resources.vlans.native_alternate }}"
+              lacp_rate: normal
+              lacp_suspend: false
+              lacp_vpc_convergence: false
+              mirror_config: false
+              mtu: default
+              negotiate_auto: false
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer1_primary_ports }}"
+              peer1_port_channel_description: IW vPC trunk peer1 alternate
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.primary_port_channel_id }}"
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer2_primary_ports }}"
+              peer2_port_channel_description: IW vPC trunk peer2 alternate
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.primary_port_channel_id }}"
+              port_channel_mode: passive
+              speed: 1Gb
+              storm_control_broadcast_level_pps: 1000
+              storm_control_multicast_level_pps: 2000
+              storm_control_unicast_level_pps: 3000
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: all
+              native_vlan: "{{ nd_iw_active_resources.vlans.native_alternate }}"
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.primary_port_channel_id }}"
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer1_primary_ports }}"
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.primary_port_channel_id }}"
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer2_primary_ports }}"
+              port_channel_mode: active
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.secondary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              allowed_vlans: "{{ nd_iw_active_resources.vlans.allowed }}"
+              native_vlan: "{{ nd_iw_active_resources.vlans.native }}"
+              peer1_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.secondary_port_channel_id }}"
+              peer1_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer1_secondary_ports }}"
+              peer2_port_channel_id: "{{ nd_iw_active_resources.vpc_trunk_host.secondary_port_channel_id }}"
+              peer2_member_ports: "{{ nd_iw_active_resources.vpc_trunk_host.peer2_secondary_ports }}"
+              port_channel_mode: active
+    override: *nd_iw_vpcth_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.secondary_name }}"
+    mutex_variants:
+      - name: percentage_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level: 42.5}}}
+      - name: pps_levels
+        valid: true
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+            config_data: {network_os: {policy: {storm_control_broadcast_level_pps: 4200}}}
+      - name: percentage_and_pps_rejected
+        valid: false
+        expected_error: storm-control percentage and pps levels are mutually exclusive
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  storm_control_broadcast_level: 42.5
+                  storm_control_broadcast_level_pps: 4200
+    optional_packs:
+      - name: referenced_netflow_qos_pfc
+        live_safe: false
+        requirements: [l2_netflow_monitor_exists, netflow_sampler_supported, qos_policy_exists, queuing_policy_exists, pfc_supported]
+        properties:
+          - config_data.network_os.policy.netflow
+          - config_data.network_os.policy.netflow_monitor
+          - config_data.network_os.policy.netflow_sampler
+          - config_data.network_os.policy.pfc
+          - config_data.network_os.policy.qos
+          - config_data.network_os.policy.qos_policy
+          - config_data.network_os.policy.queuing_policy
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  netflow: true
+                  netflow_monitor: "{{ nd_iw_active_resources.references.l2_netflow_monitor }}"
+                  netflow_sampler: "{{ nd_iw_active_resources.references.netflow_sampler }}"
+                  pfc: true
+                  qos: true
+                  qos_policy: "{{ nd_iw_active_resources.references.qos_policy }}"
+                  queuing_policy: "{{ nd_iw_active_resources.references.queuing_policy }}"
+      - name: vlan_mapping
+        live_safe: false
+        requirements: [vlan_mapping_supported]
+        properties:
+          - config_data.network_os.policy.vlan_mapping
+          - config_data.network_os.policy.vlan_mapping_entries[].customer_inner_vlan_id
+          - config_data.network_os.policy.vlan_mapping_entries[].customer_vlan_id
+          - config_data.network_os.policy.vlan_mapping_entries[].dot1q_tunnel
+          - config_data.network_os.policy.vlan_mapping_entries[].provider_vlan_id
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  vlan_mapping: true
+                  vlan_mapping_entries: >-
+                    {{
+                      [{
+                        'customer_inner_vlan_id': nd_iw_active_resources.vlans.customer_inner | int,
+                        'customer_vlan_id': nd_iw_active_resources.vlans.customer,
+                        'dot1q_tunnel': true,
+                        'provider_vlan_id': nd_iw_active_resources.vlans.provider | int
+                      }]
+                    }}
+    invalid:
+      - name: malformed_allowed_vlans
+        expected_error: allowed_vlans must be
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+            config_data: {network_os: {policy: {allowed_vlans: bad}}}
+      - name: peer_port_channel_id_above_maximum
+        expected_error: less than or equal to 4096
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+            interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+            config_data: {network_os: {policy: {peer2_port_channel_id: 4097}}}
+    properties:
+      - switch_ip
+      - interface_name
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.allowed_vlans
+      - config_data.network_os.policy.bandwidth
+      - config_data.network_os.policy.bpdu_filter
+      - config_data.network_os.policy.bpdu_guard
+      - config_data.network_os.policy.cdp
+      - config_data.network_os.policy.copy_description
+      - config_data.network_os.policy.duplex_mode
+      - config_data.network_os.policy.inherit_bandwidth
+      - config_data.network_os.policy.lacp_port_priority
+      - config_data.network_os.policy.lacp_rate
+      - config_data.network_os.policy.lacp_suspend
+      - config_data.network_os.policy.lacp_vpc_convergence
+      - config_data.network_os.policy.link_type
+      - config_data.network_os.policy.mirror_config
+      - config_data.network_os.policy.mtu
+      - config_data.network_os.policy.native_vlan
+      - config_data.network_os.policy.negotiate_auto
+      - config_data.network_os.policy.netflow
+      - config_data.network_os.policy.netflow_monitor
+      - config_data.network_os.policy.netflow_sampler
+      - config_data.network_os.policy.peer1_member_ports
+      - config_data.network_os.policy.peer1_port_channel_configuration
+      - config_data.network_os.policy.peer1_port_channel_description
+      - config_data.network_os.policy.peer1_port_channel_id
+      - config_data.network_os.policy.peer2_member_ports
+      - config_data.network_os.policy.peer2_port_channel_configuration
+      - config_data.network_os.policy.peer2_port_channel_description
+      - config_data.network_os.policy.peer2_port_channel_id
+      - config_data.network_os.policy.pfc
+      - config_data.network_os.policy.port_channel_mode
+      - config_data.network_os.policy.port_type_edge_trunk
+      - config_data.network_os.policy.qos
+      - config_data.network_os.policy.qos_policy
+      - config_data.network_os.policy.queuing_policy
+      - config_data.network_os.policy.speed
+      - config_data.network_os.policy.storm_control
+      - config_data.network_os.policy.storm_control_action
+      - config_data.network_os.policy.storm_control_broadcast_level
+      - config_data.network_os.policy.storm_control_broadcast_level_pps
+      - config_data.network_os.policy.storm_control_multicast_level
+      - config_data.network_os.policy.storm_control_multicast_level_pps
+      - config_data.network_os.policy.storm_control_unicast_level
+      - config_data.network_os.policy.storm_control_unicast_level_pps
+      - config_data.network_os.policy.vlan_mapping
+      - config_data.network_os.policy.vlan_mapping_entries[].customer_inner_vlan_id
+      - config_data.network_os.policy.vlan_mapping_entries[].customer_vlan_id
+      - config_data.network_os.policy.vlan_mapping_entries[].dot1q_tunnel
+      - config_data.network_os.policy.vlan_mapping_entries[].provider_vlan_id
+  subinterface_managed:
+    module: cisco.nd.nd_interface_subinterface_managed
+    ownership_domain: subinterface
+    identity_fields: [switch_ip, interface_name]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: [routed_parent_interfaces]
+    unsupported_expected_error: {}
+    minimal: &nd_iw_sub_managed_minimal
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: "{{ nd_iw_active_resources.subinterface.managed_primary_id | int }}"
+              ip: "{{ nd_iw_active_resources.subinterface.primary_ipv4 }}"
+              prefix: 24
+              description: IW managed subinterface minimal
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: IW managed subinterface maximal
+              extra_config: no ip redirects
+              mtu: 9216
+              vlan_id: "{{ nd_iw_active_resources.subinterface.managed_primary_id | int }}"
+              vrf_interface: "{{ nd_iw_active_resources.references.vrf }}"
+              ip: "{{ nd_iw_active_resources.subinterface.primary_ipv4 }}"
+              prefix: 24
+              ipv6: "{{ nd_iw_active_resources.subinterface.primary_ipv6 | regex_replace('/.*$', '') }}"
+              ipv6_prefix: 64
+              routing_tag: "{{ nd_iw_active_resources.references.routing_tag }}"
+              ip_redirects: true
+              pim_sparse: true
+              pim_dr_priority: 901
+              netflow: false
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              description: IW managed subinterface alternate
+              extra_config: no ipv6 redirects
+              mtu: 1500
+              vlan_id: "{{ nd_iw_active_resources.subinterface.managed_primary_id | int }}"
+              vrf_interface: "{{ nd_iw_active_resources.references.vrf }}"
+              ip: "{{ nd_iw_active_resources.subinterface.alternate_ipv4 }}"
+              prefix: 25
+              ipv6: "{{ nd_iw_active_resources.subinterface.alternate_ipv6 | regex_replace('/.*$', '') }}"
+              ipv6_prefix: 96
+              routing_tag: "902"
+              ip_redirects: false
+              pim_sparse: false
+              pim_dr_priority: 902
+              netflow: false
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: "{{ nd_iw_active_resources.subinterface.managed_primary_id | int }}"
+              ip: "{{ nd_iw_active_resources.subinterface.alternate_ipv4 }}"
+              prefix: 24
+              description: IW managed subinterface replaced
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_secondary_id }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              vlan_id: "{{ nd_iw_active_resources.subinterface.managed_secondary_id }}"
+              ip: 198.18.91.3
+              prefix: 24
+              description: IW managed subinterface override victim
+    override: *nd_iw_sub_managed_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_secondary_id }}"
+    mutex_variants: []
+    optional_packs:
+      - name: referenced_netflow
+        live_safe: false
+        requirements:
+          - l3_netflow_monitor_exists
+          - netflow_sampler_supported
+        properties:
+          - config_data.network_os.policy.netflow
+          - config_data.network_os.policy.netflow_monitor
+          - config_data.network_os.policy.netflow_sampler
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+            config_data:
+              network_os:
+                policy: >-
+                  {{
+                    {
+                      'admin_state': true,
+                      'vlan_id': nd_iw_active_resources.subinterface.managed_primary_id | int,
+                      'ip': nd_iw_active_resources.subinterface.primary_ipv4,
+                      'prefix': 24,
+                      'netflow': true,
+                      'netflow_monitor': nd_iw_active_resources.references.l3_netflow_monitor,
+                      'netflow_sampler': nd_iw_active_resources.references.netflow_sampler
+                    }
+                  }}
+    invalid:
+      - name: vlan_below_minimum
+        expected_error: greater than or equal to 2
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+            config_data: {network_os: {policy: {vlan_id: 1}}}
+      - name: mtu_below_minimum
+        expected_error: greater than or equal to 576
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+            config_data: {network_os: {policy: {mtu: 575}}}
+      - name: ipv4_without_prefix
+        expected_error: ip and prefix are required together
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+            config_data: {network_os: {policy: {ip: 198.18.91.4}}}
+      - name: ipv6_without_prefix
+        expected_error: ipv6 and ipv6_prefix are required together
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+            config_data: {network_os: {policy: {ipv6: "2001:db8:91::4"}}}
+      - name: netflow_without_monitor
+        expected_error: netflow_monitor must be provided
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+            config_data: {network_os: {policy: {netflow: true}}}
+      - name: non_ascii_description
+        expected_error: ASCII
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+            config_data: {network_os: {policy: {description: "IW café"}}}
+    properties:
+      - switch_ip
+      - interface_name
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.description
+      - config_data.network_os.policy.extra_config
+      - config_data.network_os.policy.mtu
+      - config_data.network_os.policy.vlan_id
+      - config_data.network_os.policy.vrf_interface
+      - config_data.network_os.policy.ip
+      - config_data.network_os.policy.prefix
+      - config_data.network_os.policy.ipv6
+      - config_data.network_os.policy.ipv6_prefix
+      - config_data.network_os.policy.routing_tag
+      - config_data.network_os.policy.ip_redirects
+      - config_data.network_os.policy.pim_sparse
+      - config_data.network_os.policy.pim_dr_priority
+      - config_data.network_os.policy.netflow
+      - config_data.network_os.policy.netflow_monitor
+      - config_data.network_os.policy.netflow_sampler
+
+  subinterface_unmanaged:
+    module: cisco.nd.nd_interface_subinterface_unmanaged
+    ownership_domain: subinterface
+    identity_fields: [switch_ip, interface_name]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: [routed_parent_interfaces]
+    unsupported_expected_error: {}
+    minimal: &nd_iw_sub_unmanaged_minimal
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_primary_id }}"
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_primary_id }}"
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_primary_id }}"
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_primary_id }}"
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_secondary_id }}"
+    override: *nd_iw_sub_unmanaged_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_primary_id }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_primary_id }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_secondary_id }}"
+    mutex_variants: []
+    optional_packs: []
+    invalid:
+      - name: missing_subinterface_id
+        expected_error: dot-separated subinterface id
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}"
+      - name: non_numeric_subinterface_id
+        expected_error: must be a number
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.abc"
+    properties:
+      - switch_ip
+      - interface_name
+
+  svi:
+    module: cisco.nd.nd_interface_svi
+    ownership_domain: svi
+    identity_fields: [switch_ip, interface_name]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: []
+    unsupported_expected_error: {}
+    minimal: &nd_iw_svi_minimal
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: "{{ nd_iw_active_resources.svi.primary_ipv4 }}"
+              prefix: 24
+              description: IW SVI minimal
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: IW SVI maximal
+              extra_config: no ip redirects
+              mtu: 9216
+              ip: "{{ nd_iw_active_resources.svi.primary_ipv4 }}"
+              prefix: 24
+              ipv6: "{{ nd_iw_active_resources.svi.primary_ipv6 | regex_replace('/.*$', '') }}"
+              prefixv6: 64
+              ip_redirects: true
+              vrf_interface: "{{ nd_iw_active_resources.references.vrf }}"
+              routing_tag: "{{ nd_iw_active_resources.references.routing_tag }}"
+              pim_sparse: true
+              pim_dr_priority: 901
+              hsrp: true
+              hsrp_vip: "{{ nd_iw_active_resources.svi.hsrp_vip }}"
+              hsrp_vipv6: "{{ nd_iw_active_resources.svi.hsrp_vipv6 }}"
+              hsrp_group: 901
+              hsrp_groupv6: 1901
+              hsrp_version: 2
+              hsrp_priority: 110
+              preempt: true
+              mac: "0000.0c07.ac05"
+              dhcp_server_address1: "{{ nd_iw_active_resources.references.dhcp_servers[0] }}"
+              dhcp_server_address2: "{{ nd_iw_active_resources.references.dhcp_servers[1] }}"
+              dhcp_server_address3: "{{ nd_iw_active_resources.references.dhcp_servers[2] }}"
+              vrf_dhcp1: "{{ nd_iw_active_resources.references.vrf }}"
+              vrf_dhcp2: "{{ nd_iw_active_resources.references.vrf }}"
+              vrf_dhcp3: "{{ nd_iw_active_resources.references.vrf }}"
+              advertise_subnet_in_underlay: true
+              netflow: false
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: false
+              description: IW SVI alternate
+              extra_config: no ipv6 redirects
+              mtu: 1500
+              ip: "{{ nd_iw_active_resources.svi.alternate_ipv4 }}"
+              prefix: 25
+              ipv6: "{{ nd_iw_active_resources.svi.alternate_ipv6 | regex_replace('/.*$', '') }}"
+              prefixv6: 96
+              ip_redirects: false
+              vrf_interface: "{{ nd_iw_active_resources.references.vrf }}"
+              routing_tag: "902"
+              pim_sparse: false
+              pim_dr_priority: 902
+              hsrp: true
+              hsrp_vip: "{{ nd_iw_active_resources.svi.alternate_hsrp_vip }}"
+              hsrp_vipv6: "{{ nd_iw_active_resources.svi.hsrp_vipv6 }}"
+              hsrp_group: 902
+              hsrp_groupv6: 1902
+              hsrp_version: 2
+              hsrp_priority: 120
+              preempt: false
+              mac: "0000.0c07.ac06"
+              dhcp_server_address1: "{{ nd_iw_active_resources.references.dhcp_servers[2] }}"
+              dhcp_server_address2: "{{ nd_iw_active_resources.references.dhcp_servers[1] }}"
+              dhcp_server_address3: "{{ nd_iw_active_resources.references.dhcp_servers[0] }}"
+              vrf_dhcp1: "{{ nd_iw_active_resources.references.vrf }}"
+              vrf_dhcp2: "{{ nd_iw_active_resources.references.vrf }}"
+              vrf_dhcp3: "{{ nd_iw_active_resources.references.vrf }}"
+              advertise_subnet_in_underlay: false
+              netflow: false
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: "{{ nd_iw_active_resources.svi.alternate_ipv4 }}"
+              prefix: 24
+              description: IW SVI replaced
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.secondary_name }}"
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              ip: 198.18.92.3
+              prefix: 24
+              description: IW SVI override victim
+    override: *nd_iw_svi_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.secondary_name }}"
+    mutex_variants: []
+    optional_packs:
+      - name: referenced_netflow
+        live_safe: false
+        requirements:
+          - l3_netflow_monitor_exists
+          - netflow_sampler_supported
+        properties:
+          - config_data.network_os.policy.netflow
+          - config_data.network_os.policy.netflow_monitor
+          - config_data.network_os.policy.netflow_sampler
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  ip: "{{ nd_iw_active_resources.svi.primary_ipv4 }}"
+                  prefix: 24
+                  netflow: true
+                  netflow_monitor: "{{ nd_iw_active_resources.references.l3_netflow_monitor }}"
+                  netflow_sampler: "{{ nd_iw_active_resources.references.netflow_sampler }}"
+    invalid:
+      - name: vlan_above_maximum
+        expected_error: range 1-4094
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: vlan4095
+      - name: mtu_below_minimum
+        expected_error: greater than or equal to 68
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+            config_data: {network_os: {policy: {mtu: 67}}}
+      - name: ipv4_without_prefix
+        expected_error: ip and prefix are required together
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+            config_data: {network_os: {policy: {ip: 198.18.92.4}}}
+      - name: ipv6_without_prefix
+        expected_error: ipv6 and prefixv6 are required together
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+            config_data: {network_os: {policy: {ipv6: "2001:db8:92::4"}}}
+      - name: invalid_hsrp_version
+        expected_error: Input should be 1 or 2
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+            config_data: {network_os: {policy: {hsrp_version: 3}}}
+      - name: netflow_without_monitor
+        expected_error: netflow_monitor must be provided
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+            config_data: {network_os: {policy: {netflow: true}}}
+      - name: non_ascii_description
+        expected_error: ASCII
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+            config_data: {network_os: {policy: {description: "IW café"}}}
+    properties:
+      - switch_ip
+      - interface_name
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.description
+      - config_data.network_os.policy.extra_config
+      - config_data.network_os.policy.mtu
+      - config_data.network_os.policy.ip
+      - config_data.network_os.policy.prefix
+      - config_data.network_os.policy.ipv6
+      - config_data.network_os.policy.prefixv6
+      - config_data.network_os.policy.ip_redirects
+      - config_data.network_os.policy.vrf_interface
+      - config_data.network_os.policy.routing_tag
+      - config_data.network_os.policy.pim_sparse
+      - config_data.network_os.policy.pim_dr_priority
+      - config_data.network_os.policy.hsrp
+      - config_data.network_os.policy.hsrp_vip
+      - config_data.network_os.policy.hsrp_vipv6
+      - config_data.network_os.policy.hsrp_group
+      - config_data.network_os.policy.hsrp_groupv6
+      - config_data.network_os.policy.hsrp_version
+      - config_data.network_os.policy.hsrp_priority
+      - config_data.network_os.policy.preempt
+      - config_data.network_os.policy.mac
+      - config_data.network_os.policy.dhcp_server_address1
+      - config_data.network_os.policy.dhcp_server_address2
+      - config_data.network_os.policy.dhcp_server_address3
+      - config_data.network_os.policy.vrf_dhcp1
+      - config_data.network_os.policy.vrf_dhcp2
+      - config_data.network_os.policy.vrf_dhcp3
+      - config_data.network_os.policy.advertise_subnet_in_underlay
+      - config_data.network_os.policy.netflow
+      - config_data.network_os.policy.netflow_monitor
+      - config_data.network_os.policy.netflow_sampler

--- a/tests/integration/targets/nd_interfaces_workflow/vars/property_matrix.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/vars/property_matrix.yaml
@@ -240,6 +240,220 @@ nd_iw_property_matrix:
       - config_data.network_os.policy.storm_control_unicast_level
       - config_data.network_os.policy.storm_control_unicast_level_pps
 
+  ethernet_routed:
+    module: cisco.nd.nd_interface_ethernet_routed
+    ownership_domain: ethernet
+    identity_fields: [switch_ip, interface_name]
+    supported_states: [merged, replaced, overridden, deleted]
+    requires: [physical_interfaces]
+    unsupported_expected_error: {}
+    # A generic routed override would reset every managed NX-OS routedHost in
+    # the fabric, including a parent reserved for subinterface tests. Its live
+    # branch therefore requires the dedicated, single-family isolation gate.
+    generic_override_safe: false
+    minimal: &nd_iw_er_minimal
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+        config_data:
+          network_os:
+            network_os_type: nx-os
+            policy:
+              # policy_type intentionally omitted to verify derivation from
+              # network_os_type through the standalone routed model.
+              admin_state: true
+              ip: "{{ nd_iw_active_resources.ethernet_routed.primary_ipv4 }}"
+              prefix: 30
+              description: IW Ethernet routed minimal
+    maximal:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+        config_data:
+          network_os:
+            network_os_type: nx-os
+            policy:
+              policy_type: routedHost
+              admin_state: true
+              description: IW Ethernet routed maximal
+              extra_config: load-interval counter 1 30
+              fec: auto
+              ip: "{{ nd_iw_active_resources.ethernet_routed.primary_ipv4 }}"
+              ip_redirects: false
+              mtu: 9216
+              netflow: false
+              pfc: false
+              pim_dr_priority: 901
+              pim_sparse: false
+              prefix: 30
+              qos: false
+              routing_tag: "903"
+              speed: auto
+              vrf: "{{ nd_iw_active_resources.references.vrf }}"
+    alternate:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+        config_data:
+          network_os:
+            network_os_type: nx-os
+            policy:
+              policy_type: routedHost
+              admin_state: false
+              description: IW Ethernet routed alternate
+              extra_config: load-interval counter 1 60
+              fec: "off"
+              ip: "{{ nd_iw_active_resources.ethernet_routed.alternate_ipv4 }}"
+              ip_redirects: true
+              mtu: 1500
+              netflow: false
+              pfc: false
+              pim_dr_priority: 902
+              pim_sparse: true
+              prefix: 30
+              qos: false
+              routing_tag: "904"
+              speed: auto
+              vrf: "{{ nd_iw_active_resources.references.vrf }}"
+    replacement:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+        config_data:
+          network_os:
+            network_os_type: nx-os
+            policy:
+              policy_type: routedHost
+              admin_state: true
+              ip: "{{ nd_iw_active_resources.ethernet_routed.alternate_ipv4 }}"
+              prefix: 30
+              description: IW Ethernet routed replaced
+    secondary:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.secondary_name }}"
+        config_data:
+          network_os:
+            network_os_type: nx-os
+            policy:
+              policy_type: routedHost
+              admin_state: true
+              ip: "{{ nd_iw_active_resources.ethernet_routed.secondary_ipv4 }}"
+              prefix: 30
+              description: IW Ethernet routed override victim
+    override: *nd_iw_er_minimal
+    delete:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+    delete_all:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.secondary_name }}"
+    mutex_variants: []
+    optional_packs:
+      - name: referenced_netflow_qos_pfc
+        live_safe: false
+        requirements:
+          - l3_netflow_monitor_exists
+          - netflow_sampler_supported
+          - qos_policy_exists
+          - queuing_policy_exists
+          - pfc_supported
+        properties:
+          - config_data.network_os.policy.netflow
+          - config_data.network_os.policy.netflow_monitor
+          - config_data.network_os.policy.netflow_sampler
+          - config_data.network_os.policy.pfc
+          - config_data.network_os.policy.qos
+          - config_data.network_os.policy.qos_policy
+          - config_data.network_os.policy.queuing_policy
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+            config_data:
+              network_os:
+                network_os_type: nx-os
+                policy:
+                  policy_type: routedHost
+                  netflow: true
+                  netflow_monitor: "{{ nd_iw_active_resources.references.l3_netflow_monitor }}"
+                  netflow_sampler: "{{ nd_iw_active_resources.references.netflow_sampler }}"
+                  pfc: true
+                  qos: true
+                  qos_policy: "{{ nd_iw_active_resources.references.qos_policy }}"
+                  queuing_policy: "{{ nd_iw_active_resources.references.queuing_policy }}"
+    invalid:
+      - name: missing_network_os_type
+        expected_error: network_os_type
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+            config_data:
+              network_os:
+                policy:
+                  policy_type: routedHost
+      - name: wrong_policy_for_nx_os
+        expected_error: routedHost
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+            config_data:
+              network_os:
+                network_os_type: nx-os
+                policy:
+                  policy_type: iosXeRoutedHost
+      - name: mtu_below_nx_os_minimum
+        expected_error: greater than or equal to 576
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+            config_data:
+              network_os:
+                network_os_type: nx-os
+                policy:
+                  mtu: 575
+      - name: prefix_above_maximum
+        expected_error: less than or equal to 31
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+            config_data:
+              network_os:
+                network_os_type: nx-os
+                policy:
+                  prefix: 32
+      - name: non_ascii_description
+        expected_error: ASCII
+        config:
+          - switch_ip: "{{ nd_iw_active_switches.primary }}"
+            interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+            config_data:
+              network_os:
+                network_os_type: nx-os
+                policy:
+                  description: "IW café"
+    properties:
+      - switch_ip
+      - interface_name
+      - config_data.network_os.network_os_type
+      - config_data.network_os.policy.policy_type
+      - config_data.network_os.policy.admin_state
+      - config_data.network_os.policy.description
+      - config_data.network_os.policy.extra_config
+      - config_data.network_os.policy.fec
+      - config_data.network_os.policy.ip
+      - config_data.network_os.policy.ip_redirects
+      - config_data.network_os.policy.mtu
+      - config_data.network_os.policy.netflow
+      - config_data.network_os.policy.netflow_monitor
+      - config_data.network_os.policy.netflow_sampler
+      - config_data.network_os.policy.pfc
+      - config_data.network_os.policy.pim_dr_priority
+      - config_data.network_os.policy.pim_sparse
+      - config_data.network_os.policy.prefix
+      - config_data.network_os.policy.qos
+      - config_data.network_os.policy.qos_policy
+      - config_data.network_os.policy.queuing_policy
+      - config_data.network_os.policy.routing_tag
+      - config_data.network_os.policy.speed
+      - config_data.network_os.policy.vrf
+
   ethernet_trunk_host:
     module: cisco.nd.nd_interface_ethernet_trunk_host
     ownership_domain: ethernet

--- a/tests/integration/targets/nd_interfaces_workflow/vars/reserved_resources.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/vars/reserved_resources.yaml
@@ -1,0 +1,187 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# All values are test-owned identifiers, never credentials. Override the complete
+# set (nd_iw_reserved_resources) when these ports/IDs are not reserved in a lab.
+nd_iw_reserved_resources:
+  default:
+    ethernet_access:
+      primary:
+        - "{{ nd_iw_ethernet_access_primary | default('Ethernet1/41', true) }}"
+        - "{{ nd_iw_ethernet_access_fanout | default('Ethernet1/42', true) }}"
+      secondary:
+        - "{{ nd_iw_ethernet_access_secondary | default('Ethernet1/43', true) }}"
+    ethernet_trunk_host:
+      primary:
+        - "{{ nd_iw_ethernet_trunk_primary | default('Ethernet1/44', true) }}"
+      secondary:
+        - "{{ nd_iw_ethernet_trunk_secondary | default('Ethernet1/45', true) }}"
+    port_channel_access:
+      primary_name: "port-channel{{ nd_iw_port_channel_access_primary_id | default(901) }}"
+      secondary_name: "port-channel{{ nd_iw_port_channel_access_secondary_id | default(902) }}"
+      primary_ports:
+        - "{{ nd_iw_port_channel_access_member1 | default('Ethernet1/46', true) }}"
+        - "{{ nd_iw_port_channel_access_member2 | default('Ethernet1/47', true) }}"
+      alternate_ports:
+        - "{{ nd_iw_port_channel_access_member1 | default('Ethernet1/46', true) }}"
+      secondary_ports:
+        - "{{ nd_iw_port_channel_access_member3 | default('Ethernet1/48', true) }}"
+    port_channel_trunk_host:
+      primary_name: "port-channel{{ nd_iw_port_channel_trunk_primary_id | default(911) }}"
+      secondary_name: "port-channel{{ nd_iw_port_channel_trunk_secondary_id | default(912) }}"
+      primary_ports:
+        - "{{ nd_iw_port_channel_trunk_member1 | default('Ethernet1/49', true) }}"
+        - "{{ nd_iw_port_channel_trunk_member2 | default('Ethernet1/50', true) }}"
+      alternate_ports:
+        - "{{ nd_iw_port_channel_trunk_member1 | default('Ethernet1/49', true) }}"
+      secondary_ports:
+        - "{{ nd_iw_port_channel_trunk_member3 | default('Ethernet1/51', true) }}"
+    loopback:
+      primary_name: "loopback{{ nd_iw_loopback_primary_id | default(901) }}"
+      secondary_name: "loopback{{ nd_iw_loopback_secondary_id | default(902) }}"
+      primary_ipv4: "{{ nd_iw_loopback_primary_ipv4 | default('198.18.90.1', true) }}"
+      alternate_ipv4: "{{ nd_iw_loopback_alternate_ipv4 | default('198.18.90.2', true) }}"
+      primary_ipv6: "{{ nd_iw_loopback_primary_ipv6 | default('2001:db8:90::1/128', true) }}"
+      alternate_ipv6: "{{ nd_iw_loopback_alternate_ipv6 | default('2001:db8:90::2/128', true) }}"
+    subinterface:
+      ethernet_parent: "{{ nd_iw_subinterface_ethernet_parent | default('Ethernet1/3', true) }}"
+      port_channel_parent: "{{ nd_iw_subinterface_port_channel_parent | default('port-channel10', true) }}"
+      managed_primary_id: "{{ nd_iw_subinterface_managed_primary_id | default(901) }}"
+      managed_secondary_id: "{{ nd_iw_subinterface_managed_secondary_id | default(902) }}"
+      unmanaged_primary_id: "{{ nd_iw_subinterface_unmanaged_primary_id | default(911) }}"
+      unmanaged_secondary_id: "{{ nd_iw_subinterface_unmanaged_secondary_id | default(912) }}"
+      primary_ipv4: "{{ nd_iw_subinterface_primary_ipv4 | default('198.18.91.1', true) }}"
+      alternate_ipv4: "{{ nd_iw_subinterface_alternate_ipv4 | default('198.18.91.2', true) }}"
+      primary_ipv6: "{{ nd_iw_subinterface_primary_ipv6 | default('2001:db8:91::1', true) }}"
+      alternate_ipv6: "{{ nd_iw_subinterface_alternate_ipv6 | default('2001:db8:91::2', true) }}"
+    svi:
+      primary_name: "vlan{{ nd_iw_svi_primary_id | default(3901) }}"
+      secondary_name: "vlan{{ nd_iw_svi_secondary_id | default(3902) }}"
+      primary_ipv4: "{{ nd_iw_svi_primary_ipv4 | default('198.18.92.1', true) }}"
+      alternate_ipv4: "{{ nd_iw_svi_alternate_ipv4 | default('198.18.92.2', true) }}"
+      hsrp_vip: "{{ nd_iw_svi_hsrp_vip | default('198.18.92.254', true) }}"
+      alternate_hsrp_vip: "{{ nd_iw_svi_alternate_hsrp_vip | default('198.18.92.126', true) }}"
+      primary_ipv6: "{{ nd_iw_svi_primary_ipv6 | default('2001:db8:92::1', true) }}"
+      alternate_ipv6: "{{ nd_iw_svi_alternate_ipv6 | default('2001:db8:92::2', true) }}"
+      hsrp_vipv6: "{{ nd_iw_svi_hsrp_vipv6 | default('2001:db8:92::fe', true) }}"
+    vpc_access:
+      primary_name: "vpc{{ nd_iw_vpc_access_primary_id | default(951) }}"
+      secondary_name: "vpc{{ nd_iw_vpc_access_secondary_id | default(952) }}"
+      primary_port_channel_id: "{{ nd_iw_vpc_access_primary_id | default(951) }}"
+      secondary_port_channel_id: "{{ nd_iw_vpc_access_secondary_id | default(952) }}"
+      peer1_primary_ports:
+        - "{{ nd_iw_vpc_access_peer1_member1 | default('Ethernet1/5', true) }}"
+      peer2_primary_ports:
+        - "{{ nd_iw_vpc_access_peer2_member1 | default('Ethernet1/5', true) }}"
+      peer1_secondary_ports:
+        - "{{ nd_iw_vpc_access_peer1_member2 | default('Ethernet1/6', true) }}"
+      peer2_secondary_ports:
+        - "{{ nd_iw_vpc_access_peer2_member2 | default('Ethernet1/6', true) }}"
+    vpc_trunk_host:
+      primary_name: "vpc{{ nd_iw_vpc_trunk_primary_id | default(961) }}"
+      secondary_name: "vpc{{ nd_iw_vpc_trunk_secondary_id | default(962) }}"
+      primary_port_channel_id: "{{ nd_iw_vpc_trunk_primary_id | default(961) }}"
+      secondary_port_channel_id: "{{ nd_iw_vpc_trunk_secondary_id | default(962) }}"
+      peer1_primary_ports:
+        - "{{ nd_iw_vpc_trunk_peer1_member1 | default('Ethernet1/8', true) }}"
+      peer2_primary_ports:
+        - "{{ nd_iw_vpc_trunk_peer2_member1 | default('Ethernet1/8', true) }}"
+      peer1_secondary_ports:
+        - "{{ nd_iw_vpc_trunk_peer1_member2 | default('Ethernet1/9', true) }}"
+      peer2_secondary_ports:
+        - "{{ nd_iw_vpc_trunk_peer2_member2 | default('Ethernet1/9', true) }}"
+    vlans:
+      access: "{{ nd_iw_access_vlan | default(3101) }}"
+      access_alternate: "{{ nd_iw_access_vlan_alternate | default(3102) }}"
+      native: "{{ nd_iw_native_vlan | default(3103) }}"
+      native_alternate: "{{ nd_iw_native_vlan_alternate | default(3104) }}"
+      allowed: "{{ nd_iw_allowed_vlans | default('3101-3110', true) }}"
+      allowed_alternate: "{{ nd_iw_allowed_vlans_alternate | default('3105-3115', true) }}"
+      provider: "{{ nd_iw_provider_vlan | default(3120) }}"
+      customer_inner: "{{ nd_iw_customer_inner_vlan | default(3121) }}"
+      customer:
+        - "{{ nd_iw_customer_vlan | default('3122-3123', true) }}"
+    references:
+      vrf: "{{ nd_iw_test_vrf | default('default', true) }}"
+      route_map_tag: "{{ nd_iw_route_map_tag | default('901') }}"
+      routing_tag: "{{ nd_iw_routing_tag | default('901') }}"
+      l2_netflow_monitor: "{{ nd_iw_l2_netflow_monitor | default('IW_L2_MONITOR', true) }}"
+      l3_netflow_monitor: "{{ nd_iw_l3_netflow_monitor | default('IW_L3_MONITOR', true) }}"
+      netflow_sampler: "{{ nd_iw_netflow_sampler | default('IW_SAMPLER', true) }}"
+      qos_policy: "{{ nd_iw_qos_policy | default('IW_QOS_POLICY', true) }}"
+      queuing_policy: "{{ nd_iw_queuing_policy | default('IW_QUEUING_POLICY', true) }}"
+      dhcp_servers:
+        - "{{ nd_iw_dhcp_server1 | default('192.0.2.11', true) }}"
+        - "{{ nd_iw_dhcp_server2 | default('192.0.2.12', true) }}"
+        - "{{ nd_iw_dhcp_server3 | default('192.0.2.13', true) }}"
+
+# Ready-to-use aggregate cleanup. The runner selects a reserved set and publishes
+# it as nd_iw_active_resources before rendering this variable.
+nd_iw_cleanup_resources:
+  - type: subinterface_managed
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_primary_id }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.managed_secondary_id }}"
+  - type: subinterface_unmanaged
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_primary_id }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.subinterface.ethernet_parent }}.{{ nd_iw_active_resources.subinterface.unmanaged_secondary_id }}"
+  - type: svi
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.svi.secondary_name }}"
+  - type: loopback
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.loopback.secondary_name }}"
+  - type: vpc_access
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_access.secondary_name }}"
+  - type: vpc_trunk_host
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.vpc_peer1 }}"
+        interface_name: "{{ nd_iw_active_resources.vpc_trunk_host.secondary_name }}"
+  - type: port_channel_access
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_access.secondary_name }}"
+  - type: port_channel_trunk_host
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.port_channel_trunk_host.secondary_name }}"
+  - type: ethernet_access
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_access.primary + nd_iw_active_resources.ethernet_access.secondary }}"
+  - type: ethernet_trunk_host
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_names: "{{ nd_iw_active_resources.ethernet_trunk_host.primary + nd_iw_active_resources.ethernet_trunk_host.secondary }}"

--- a/tests/integration/targets/nd_interfaces_workflow/vars/reserved_resources.yaml
+++ b/tests/integration/targets/nd_interfaces_workflow/vars/reserved_resources.yaml
@@ -12,6 +12,12 @@ nd_iw_reserved_resources:
         - "{{ nd_iw_ethernet_access_fanout | default('Ethernet1/42', true) }}"
       secondary:
         - "{{ nd_iw_ethernet_access_secondary | default('Ethernet1/43', true) }}"
+    ethernet_routed:
+      primary_name: "{{ nd_iw_ethernet_routed_primary | default('Ethernet1/52', true) }}"
+      secondary_name: "{{ nd_iw_ethernet_routed_secondary | default('Ethernet1/53', true) }}"
+      primary_ipv4: "{{ nd_iw_ethernet_routed_primary_ipv4 | default('198.18.93.1', true) }}"
+      alternate_ipv4: "{{ nd_iw_ethernet_routed_alternate_ipv4 | default('198.18.93.5', true) }}"
+      secondary_ipv4: "{{ nd_iw_ethernet_routed_secondary_ipv4 | default('198.18.93.9', true) }}"
     ethernet_trunk_host:
       primary:
         - "{{ nd_iw_ethernet_trunk_primary | default('Ethernet1/44', true) }}"
@@ -180,6 +186,13 @@ nd_iw_cleanup_resources:
     config:
       - switch_ip: "{{ nd_iw_active_switches.primary }}"
         interface_names: "{{ nd_iw_active_resources.ethernet_access.primary + nd_iw_active_resources.ethernet_access.secondary }}"
+  - type: ethernet_routed
+    state: deleted
+    config:
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.primary_name }}"
+      - switch_ip: "{{ nd_iw_active_switches.primary }}"
+        interface_name: "{{ nd_iw_active_resources.ethernet_routed.secondary_name }}"
   - type: ethernet_trunk_host
     state: deleted
     config:

--- a/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
+++ b/tests/unit/module_utils/endpoints/test_endpoints_api_v1_manage_interfaces.py
@@ -28,7 +28,9 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesPost,
     EpManageInterfacesPut,
     EpManageInterfacesRemove,
+    EpManageInterfacesSummaryGet,
     ManageInterfacesListEndpointParams,
+    ManageInterfacesSummaryEndpointParams,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 
@@ -327,6 +329,48 @@ def test_ep_manage_interfaces_00140():
         "sort=ifName%3Aasc",
         "configOnly=true",
     }
+
+
+def test_ep_manage_interfaces_00150():
+    """Verify the interface-summary endpoint defaults and GET verb."""
+    with does_not_raise():
+        instance = EpManageInterfacesSummaryGet()
+    assert instance.class_name == "EpManageInterfacesSummaryGet"
+    assert instance.verb == HttpVerbEnum.GET
+    assert instance.fabric_name is None
+    assert isinstance(instance.endpoint_params, ManageInterfacesSummaryEndpointParams)
+
+
+def test_ep_manage_interfaces_00160():
+    """Verify the interface-summary path and supported query parameters."""
+    instance = EpManageInterfacesSummaryGet()
+    instance.fabric_name = "fab/one"
+    instance.endpoint_params.cluster_name = "cluster-a"
+    instance.endpoint_params.filter = "interfaceName:Ethernet1/1"
+    instance.endpoint_params.max = 500
+    instance.endpoint_params.offset = 0
+    instance.endpoint_params.sort = "interfaceName:asc"
+    instance.endpoint_params.switch_id = "SN123"
+
+    path, query = instance.path.split("?", 1)
+
+    assert path == "/api/v1/manage/fabrics/fab%2Fone/interfacesSummary"
+    assert set(query.split("&")) == {
+        "clusterName=cluster-a",
+        "filter=interfaceName%3AEthernet1%2F1",
+        "max=500",
+        "offset=0",
+        "sort=interfaceName%3Aasc",
+        "switchId=SN123",
+    }
+
+
+def test_ep_manage_interfaces_00170():
+    """Verify the interface-summary endpoint requires a fabric name."""
+    instance = EpManageInterfacesSummaryGet()
+
+    with pytest.raises(ValueError, match="fabric_name must be set"):
+        result = instance.path  # pylint: disable=unused-variable
 
 
 # =============================================================================

--- a/tests/unit/module_utils/fixtures/fixture_data/test_rest_send.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_rest_send.json
@@ -147,6 +147,14 @@
             "error": "Invalid request data"
         }
     },
+    "test_rest_send_00510b": {
+        "TEST_NOTES": ["Sentinel success. Must NOT be consumed after the terminal 400 response."],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/test/badrequest",
+        "MESSAGE": "OK",
+        "DATA": {"status": "unexpected retry"}
+    },
     "test_rest_send_00520a": {
         "TEST_NOTES": ["500 Internal Server Error response"],
         "RETURN_CODE": 500,

--- a/tests/unit/module_utils/models/test_netflow.py
+++ b/tests/unit/module_utils/models/test_netflow.py
@@ -1,0 +1,47 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Regression tests for atomic NetFlow policy merging."""
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_access_interface import (
+    PortChannelAccessPolicyModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostPolicyModel,
+)
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    (PortChannelAccessPolicyModel, PortChannelTrunkHostPolicyModel),
+)
+def test_netflow_and_monitor_merge_as_one_valid_change(model_class) -> None:
+    """A valid two-field proposal must not fail on the intermediate state."""
+    existing = model_class(netflow=False)
+    proposed = model_class(netflow=True, netflow_monitor="MONITOR-1")
+
+    merged = existing.merge(proposed)
+
+    assert merged is existing
+    assert merged.netflow is True
+    assert merged.netflow_monitor == "MONITOR-1"
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    (PortChannelAccessPolicyModel, PortChannelTrunkHostPolicyModel),
+)
+def test_netflow_merge_rejects_invalid_final_pair_before_mutation(model_class) -> None:
+    """An invalid monitor-only change leaves the existing policy untouched."""
+    existing = model_class(netflow=True, netflow_monitor="MONITOR-1")
+    proposed = model_class(netflow_monitor="")
+
+    with pytest.raises(ValueError, match="netflow_monitor must be provided when netflow is true"):
+        existing.merge(proposed)
+
+    assert existing.netflow is True
+    assert existing.netflow_monitor == "MONITOR-1"

--- a/tests/unit/module_utils/models/test_subinterface_managed_interface.py
+++ b/tests/unit/module_utils/models/test_subinterface_managed_interface.py
@@ -424,6 +424,54 @@ def test_subinterface_managed_interface_00260():
         SubinterfaceManagedPolicyModel()
 
 
+def test_subinterface_managed_interface_00270():
+    """
+    # Summary
+
+    Verify merge atomically adds a complete IPv6 address/prefix pair to a policy that has neither field set.
+    """
+    current = SubinterfaceManagedPolicyModel()
+    proposed = SubinterfaceManagedPolicyModel(ipv6="2001:db8::2", ipv6_prefix=96)
+
+    merged = current.merge(proposed)
+
+    assert merged is current
+    assert merged.ipv6 == "2001:db8::2"
+    assert merged.ipv6_prefix == 96
+
+
+def test_subinterface_managed_interface_00280():
+    """
+    # Summary
+
+    Verify merge atomically adds a complete IPv4 address/prefix pair to a policy that has neither field set.
+    """
+    current = SubinterfaceManagedPolicyModel()
+    proposed = SubinterfaceManagedPolicyModel(ip="192.0.2.2", prefix=25)
+
+    merged = current.merge(proposed)
+
+    assert merged is current
+    assert merged.ip == "192.0.2.2"
+    assert merged.prefix == 25
+
+
+def test_subinterface_managed_interface_00290():
+    """
+    # Summary
+
+    Verify merge atomically enables NetFlow with its required monitor.
+    """
+    current = SubinterfaceManagedPolicyModel()
+    proposed = SubinterfaceManagedPolicyModel(netflow=True, netflow_monitor="MONITOR-1")
+
+    merged = current.merge(proposed)
+
+    assert merged is current
+    assert merged.netflow is True
+    assert merged.netflow_monitor == "MONITOR-1"
+
+
 # =============================================================================
 # Test: SubinterfaceManagedPolicyModel — payload / config serialization
 # =============================================================================

--- a/tests/unit/module_utils/models/test_svi_interface.py
+++ b/tests/unit/module_utils/models/test_svi_interface.py
@@ -424,6 +424,84 @@ def test_svi_interface_00250():
         SviPolicyModel()
 
 
+def test_svi_interface_00260():
+    """
+    # Summary
+
+    Verify `merge` atomically adds a complete IPv6 address/prefix pair to a policy that has neither field set.
+
+    ## Test
+
+    - Build current policy without `ipv6` or `prefixv6`
+    - Merge a proposed policy containing both fields
+    - Both values are set without triggering transient assignment validation
+
+    ## Classes and Methods
+
+    - SviPolicyModel.merge()
+    """
+    current = SviPolicyModel()
+    proposed = SviPolicyModel(ipv6="2001:db8::2", prefixv6=96)
+
+    merged = current.merge(proposed)
+
+    assert merged is current
+    assert merged.ipv6 == "2001:db8::2"
+    assert merged.prefixv6 == 96
+
+
+def test_svi_interface_00270():
+    """
+    # Summary
+
+    Verify `merge` atomically adds a complete IPv4 address/prefix pair to a policy that has neither field set.
+
+    ## Test
+
+    - Build current policy without `ip` or `prefix`
+    - Merge a proposed policy containing both fields
+    - Both values are set without triggering transient assignment validation
+
+    ## Classes and Methods
+
+    - SviPolicyModel.merge()
+    """
+    current = SviPolicyModel()
+    proposed = SviPolicyModel(ip="192.0.2.2", prefix=25)
+
+    merged = current.merge(proposed)
+
+    assert merged is current
+    assert merged.ip == "192.0.2.2"
+    assert merged.prefix == 25
+
+
+def test_svi_interface_00280():
+    """
+    # Summary
+
+    Verify `merge` atomically enables NetFlow with its required monitor on a policy that has neither field set.
+
+    ## Test
+
+    - Build current policy without `netflow` or `netflow_monitor`
+    - Merge a proposed policy enabling NetFlow and supplying its monitor
+    - Both values are set without triggering transient assignment validation
+
+    ## Classes and Methods
+
+    - SviPolicyModel.merge()
+    """
+    current = SviPolicyModel()
+    proposed = SviPolicyModel(netflow=True, netflow_monitor="MONITOR-1")
+
+    merged = current.merge(proposed)
+
+    assert merged is current
+    assert merged.netflow is True
+    assert merged.netflow_monitor == "MONITOR-1"
+
+
 # =============================================================================
 # Test: SviPolicyModel — payload / config serialization
 # =============================================================================

--- a/tests/unit/module_utils/models/test_vpc_access_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_access_interface.py
@@ -376,26 +376,25 @@ def test_vpc_access_interface_00300_identifier():
     """
     # Summary
 
-    Verify the identifier is `interface_name` only (single strategy). A vPC interface is one fabric-level resource;
-    ND echoes it from both peers but it must collapse to one identity for diff/override-deletion correctness.
+    Verify the identifier is the composite (`switch_ip`, `interface_name`), matching the other interface modules. Two vPC pairs in one
+    fabric may legally reuse the same vPC id (ND's `vpcId` resource pool is devicePair-scoped; issue #356), so name-only identity cannot
+    represent them. Consumers must dedupe the dual-peer GET echo by authoritative peer-pair identity before collection construction.
 
     ## Test
 
-    - Identifier is `["interface_name"]`
-    - Identifier strategy is `"single"`
-    - get_identifier_value returns the interface name string
-    - `switch_ip` is excluded from the diff dict (routing-only field)
+    - identifiers is ["switch_ip", "interface_name"]
+    - identifier_strategy is "composite"
+    - get_identifier_value returns the (switch_ip, interface_name) tuple
+    - switchIp stays excluded from the diff (exclude_from_diff)
 
     ## Classes and Methods
 
     - AccessVpcHostInterfaceModel.get_identifier_value()
-    - AccessVpcHostInterfaceModel.to_diff_dict()
     """
     instance = AccessVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc100")
-    assert instance.identifiers == ["interface_name"]
-    assert instance.identifier_strategy == "single"
-    assert instance.get_identifier_value() == "vpc100"
-    # switch_ip is for routing only; it must not appear in the diff dict so two peers' echoes diff-equal.
+    assert instance.identifiers == ["switch_ip", "interface_name"]
+    assert instance.identifier_strategy == "composite"
+    assert instance.get_identifier_value() == (instance.switch_ip, "vpc100")
     assert "switchIp" not in instance.to_diff_dict()
 
 

--- a/tests/unit/module_utils/models/test_vpc_trunk_host_interface.py
+++ b/tests/unit/module_utils/models/test_vpc_trunk_host_interface.py
@@ -551,26 +551,25 @@ def test_vpc_trunk_host_interface_00300_identifier():
     """
     # Summary
 
-    Verify the identifier is `interface_name` only (single strategy). A vPC interface is one fabric-level resource;
-    ND echoes it from both peers but it must collapse to one identity for diff/override-deletion correctness.
+    Verify the identifier is the composite (`switch_ip`, `interface_name`), matching the other interface modules. Two vPC pairs in one
+    fabric may legally reuse the same vPC id (ND's `vpcId` resource pool is devicePair-scoped; issue #356), so name-only identity cannot
+    represent them. Consumers must dedupe the dual-peer GET echo by authoritative peer-pair identity before collection construction.
 
     ## Test
 
-    - Identifier is `["interface_name"]`
-    - Identifier strategy is `"single"`
-    - get_identifier_value returns the interface name string
-    - `switch_ip` is excluded from the diff dict (routing-only field)
+    - identifiers is ["switch_ip", "interface_name"]
+    - identifier_strategy is "composite"
+    - get_identifier_value returns the (switch_ip, interface_name) tuple
+    - switchIp stays excluded from the diff (exclude_from_diff)
 
     ## Classes and Methods
 
     - TrunkVpcHostInterfaceModel.get_identifier_value()
-    - TrunkVpcHostInterfaceModel.to_diff_dict()
     """
     instance = TrunkVpcHostInterfaceModel(switch_ip="192.168.1.1", interface_name="vpc500")
-    assert instance.identifiers == ["interface_name"]
-    assert instance.identifier_strategy == "single"
-    assert instance.get_identifier_value() == "vpc500"
-    # switch_ip is for routing only; it must not appear in the diff dict so two peers' echoes diff-equal.
+    assert instance.identifiers == ["switch_ip", "interface_name"]
+    assert instance.identifier_strategy == "composite"
+    assert instance.get_identifier_value() == (instance.switch_ip, "vpc500")
     assert "switchIp" not in instance.to_diff_dict()
 
 

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -529,6 +529,22 @@ def test_base_interface_00530() -> None:
     assert instance._pending_removes == [("loopback10", "FDO12345ABC")]
 
 
+def test_base_interface_00540() -> None:
+    """Verify public queue transfer APIs de-duplicate targets and expose immutable views."""
+
+    def responses():
+        yield {}
+
+    instance = _StubInterfaceOrchestrator(rest_send=_build_rest_send(ResponseGenerator(responses())))
+    targets = [("loopback10", "FDO12345ABC"), ("loopback20", "FDO12345ABD")]
+
+    instance.queue_deploy_targets([*targets, targets[0]])
+    instance.queue_remove_targets([*targets, targets[0]])
+
+    assert instance.pending_deploys == tuple(targets)
+    assert instance.pending_removes == tuple(targets)
+
+
 # =============================================================================
 # Test: deploy_pending
 # =============================================================================

--- a/tests/unit/module_utils/orchestrators/test_ethernet_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_ethernet_access_interface.py
@@ -912,6 +912,23 @@ def test_ethernet_access_orchestrator_00610() -> None:
     assert instance._pending_deploys == []
 
 
+def test_ethernet_access_orchestrator_00590() -> None:
+    """Verify public Ethernet queue transfer APIs de-duplicate targets and expose immutable views."""
+
+    def responses():
+        yield {}
+
+    instance = EthernetAccessInterfaceOrchestrator(rest_send=_build_rest_send(ResponseGenerator(responses())))
+    normalize_targets = [("Ethernet1/1", "FDO11111AAA"), ("Ethernet1/2", "FDO22222BBB")]
+    reset_targets = [("Ethernet1/3", "FDO11111AAA")]
+
+    instance.queue_normalize_targets([*normalize_targets, normalize_targets[0]])
+    instance.queue_reset_targets([*reset_targets, reset_targets[0]])
+
+    assert instance.pending_normalizes == tuple(normalize_targets)
+    assert instance.pending_resets == tuple(reset_targets)
+
+
 def test_ethernet_access_orchestrator_00595() -> None:
     """
     # Summary

--- a/tests/unit/module_utils/orchestrators/test_ethernet_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_ethernet_access_interface.py
@@ -501,6 +501,65 @@ def test_ethernet_access_orchestrator_00520() -> None:
     assert instance._pending_deploys == [("Ethernet1/1", "FDO11111AAA")]
 
 
+def test_ethernet_access_orchestrator_00525(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    # Summary
+
+    Verify update accepts a routed-host wire record supplied by the workflow and sends one exact
+    access-host replacement PUT without first normalizing or creating the interface.
+
+    ## Test
+
+    - Existing data has policyType=routedHost and is not a port-channel member
+    - The destination model requests policyType=accessHost, VLAN 100, and a description
+    - Exactly one request is issued to the encoded per-interface PUT endpoint
+    - The body is exactly the destination model payload plus the resolved switch ID
+    - One deployment target is queued for the workflow's consolidated deploy phase
+
+    ## Classes and Methods
+
+    - EthernetBaseOrchestrator.update()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    instance = _build_orchestrator(gen_responses)
+    model = _build_access_model({"access_vlan": 100, "description": "workflow transition"})
+    current = {
+        "interfaceName": "Ethernet1/1",
+        "interfaceType": "ethernet",
+        "configData": {
+            "mode": "routed",
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {"policyType": "routedHost", "ip": "198.51.100.1", "prefix": 31},
+            },
+        },
+        "operData": {"portChannelId": -1},
+    }
+    requests = []
+
+    monkeypatch.setattr(instance, "_resolve_switch_id", lambda _switch_ip: "FDO11111AAA")
+    monkeypatch.setattr(instance, "_request", lambda **kwargs: requests.append(kwargs) or {"ok": True})
+
+    result = instance.update(model, existing_data=current)
+
+    expected_payload = model.to_payload()
+    expected_payload["switchId"] = "FDO11111AAA"
+    assert result == {"ok": True}
+    assert requests == [
+        {
+            "path": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces/Ethernet1%2F1",
+            "verb": HttpVerbEnum.PUT,
+            "data": expected_payload,
+        }
+    ]
+    assert requests[0]["data"]["configData"]["networkOS"]["policy"]["policyType"] == "accessHost"
+    assert instance._pending_deploys == [("Ethernet1/1", "FDO11111AAA")]
+
+
 def test_ethernet_access_orchestrator_00530() -> None:
     """
     # Summary

--- a/tests/unit/module_utils/orchestrators/test_ethernet_routed_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_ethernet_routed_interface.py
@@ -929,6 +929,59 @@ def test_ethernet_routed_orchestrator_00800() -> None:
     assert orchestrator._pending_deploys == []
 
 
+def test_ethernet_routed_orchestrator_00810(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    # Summary
+
+    Verify a second same-name bulk create that fails before response cannot reuse the first switch's successful HTTP 207.
+
+    ## Test
+
+    - Ethernet1/7 is submitted in separate per-switch POST groups and the first returns an all-success HTTP 207
+    - The second request raises from sender.commit() before recording a response
+    - Only the first switch target is queued and deployed; the unsent second target is never inferred from stale response state
+
+    ## Classes and Methods
+
+    - EthernetBaseOrchestrator.create_bulk()
+    - EthernetBaseOrchestrator._post_bulk_group()
+    - NDBaseInterfaceOrchestrator._accepted_multistatus_names()
+    """
+
+    def responses():
+        yield responses_ethernet_routed("test_remove_pending_00360a")
+        yield responses_ethernet_routed("test_remove_pending_00360b")
+        yield responses_ethernet_routed("test_remove_pending_00360d")
+
+    orchestrator = _build_orchestrator(ResponseGenerator(responses()), params={"state": "merged"})
+    orchestrator.deploy = True
+    assert orchestrator.fabric_context.get_switch_id("192.168.1.1") == "FDO11111AAA"
+    sender = orchestrator.rest_send.sender
+    original_commit = sender.commit
+    commit_count = 0
+
+    def fail_second_commit() -> None:
+        nonlocal commit_count
+        commit_count += 1
+        if commit_count == 2:
+            raise ValueError("second bulk create failed before response")
+        original_commit()
+
+    monkeypatch.setattr(sender, "commit", fail_second_commit)
+    models = [
+        _user_nx_model({"ip": "10.10.7.1", "prefix": 30}, switch_ip="192.168.1.1"),
+        _user_nx_model({"ip": "10.10.8.1", "prefix": 30}, switch_ip="192.168.1.2"),
+    ]
+    with pytest.raises(RuntimeError, match=r"Bulk create failed: .*second bulk create failed before response") as exc_info:
+        orchestrator.create_bulk(models, existing_data={"interfaceName": "probe"})
+
+    assert "The controller accepted" not in str(exc_info.value)
+    assert orchestrator._pending_deploys == [("Ethernet1/7", "FDO11111AAA")]
+    monkeypatch.setattr(sender, "commit", original_commit)
+    assert orchestrator.deploy_accepted_mutations() == [("Ethernet1/7", "FDO11111AAA")]
+    assert orchestrator._pending_deploys == []
+
+
 def test_ethernet_routed_orchestrator_00430() -> None:
     """
     # Summary
@@ -1165,6 +1218,58 @@ def test_ethernet_routed_orchestrator_00360() -> None:
     with does_not_raise():
         deployed = orchestrator.deploy_accepted_mutations()
     assert deployed == [("Ethernet1/31", "FDO11111AAA")]
+    assert orchestrator._pending_deploys == [("Ethernet1/31", "FDO22222BBB")]
+
+
+def test_ethernet_routed_orchestrator_00370(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    # Summary
+
+    Verify a second same-name normalize that fails before receiving a response cannot reuse the first switch's successful HTTP 207.
+
+    ## Test
+
+    - Ethernet1/31 is queued on two switches and the first per-switch normalize returns an all-success HTTP 207
+    - The second request raises from sender.commit() before recording a response
+    - Only the first pair is accepted/deployable; the second pair remains pending and is never inferred from stale response state
+
+    ## Classes and Methods
+
+    - EthernetBaseOrchestrator._normalize_interfaces()
+    - NDBaseInterfaceOrchestrator._accepted_multistatus_names()
+    - NDBaseInterfaceOrchestrator.deploy_accepted_mutations()
+    """
+
+    def responses():
+        yield responses_ethernet_routed("test_remove_pending_00360a")
+        yield responses_ethernet_routed("test_remove_pending_00360b")
+        yield responses_ethernet_routed("test_remove_pending_00360d")
+
+    orchestrator = _build_orchestrator(ResponseGenerator(responses()), params={"state": "deleted"})
+    orchestrator.deploy = True
+    orchestrator.delete_bulk(
+        [_nx_model("Ethernet1/31", switch_ip="192.168.1.1"), _nx_model("Ethernet1/31", switch_ip="192.168.1.2")],
+        existing_data={"interfaceName": "probe"},
+    )
+    sender = orchestrator.rest_send.sender
+    original_commit = sender.commit
+    commit_count = 0
+
+    def fail_second_commit() -> None:
+        nonlocal commit_count
+        commit_count += 1
+        if commit_count == 2:
+            raise ValueError("second normalize failed before response")
+        original_commit()
+
+    monkeypatch.setattr(sender, "commit", fail_second_commit)
+    with pytest.raises(RuntimeError, match=r"Bulk normalize failed for \['Ethernet1/31'\].*None of these interfaces were reset"):
+        orchestrator.remove_pending()
+
+    assert orchestrator._accepted_multistatus_names(None) == set()
+    assert orchestrator._pending_normalizes == [("Ethernet1/31", "FDO22222BBB")]
+    monkeypatch.setattr(sender, "commit", original_commit)
+    assert orchestrator.deploy_accepted_mutations() == [("Ethernet1/31", "FDO11111AAA")]
     assert orchestrator._pending_deploys == [("Ethernet1/31", "FDO22222BBB")]
 
 

--- a/tests/unit/module_utils/orchestrators/test_ethernet_trunk_host_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_ethernet_trunk_host_interface.py
@@ -288,6 +288,85 @@ def test_ethernet_trunk_host_orchestrator_00110() -> None:
             },
             False,
         ),
+        (
+            {
+                "configData": {
+                    "networkOS": {
+                        "policy": {
+                            "stormControl": False,
+                            "stormControlAction": "default",
+                            "stormControlBroadcastLevel": "0.0",
+                            "stormControlBroadcastLevelPps": "0",
+                        },
+                    },
+                },
+            },
+            True,
+        ),
+        (
+            {
+                "configData": {
+                    "networkOS": {"policy": {"stormControlBroadcastLevel": "42.5"}},
+                },
+            },
+            False,
+        ),
+        (
+            {
+                "configData": {
+                    "networkOS": {"policy": {"stormControlBroadcastLevelPps": "4200"}},
+                },
+            },
+            False,
+        ),
+        (
+            {
+                "configData": {
+                    "networkOS": {"policy": {"stormControl": True}},
+                },
+            },
+            False,
+        ),
+        (
+            {
+                "configData": {
+                    "networkOS": {"policy": {"stormControlAction": "trap"}},
+                },
+            },
+            False,
+        ),
+        (
+            {
+                "configData": {
+                    "networkOS": {"policy": {"qos": True}},
+                },
+            },
+            False,
+        ),
+        (
+            {
+                "configData": {
+                    "networkOS": {"policy": {"adminState": False}},
+                },
+            },
+            False,
+        ),
+        (
+            {
+                "configData": {
+                    "networkOS": {"policy": {"vlanMappingEntries": [{"providerVlanId": 100}]}},
+                },
+            },
+            False,
+        ),
+        (
+            {
+                "configData": {
+                    "networkOS": {"policy": {"ptp": False}},
+                },
+            },
+            True,
+        ),
     ],
     ids=[
         "empty",
@@ -302,6 +381,15 @@ def test_ethernet_trunk_host_orchestrator_00110() -> None:
         "class_c_bandwidth",
         "class_c_debounce_linkup",
         "class_c_inherit_bandwidth",
+        "storm_defaults_numeric_strings",
+        "storm_percentage_configured",
+        "storm_pps_configured",
+        "storm_enabled",
+        "storm_action_configured",
+        "qos_configured",
+        "admin_state_configured",
+        "vlan_mapping_entries_configured",
+        "unknown_wire_field_ignored",
     ],
 )
 def test_ethernet_trunk_host_orchestrator_00200(iface, expected) -> None:

--- a/tests/unit/module_utils/test_fabric_context.py
+++ b/tests/unit/module_utils/test_fabric_context.py
@@ -430,6 +430,58 @@ def test_fabric_context_00210() -> None:
         instance.get_switch_ip("FDO99999XYZ")
 
 
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    (
+        ("inSync", True),
+        ("In-Sync", True),
+        ("SYNCHRONIZED", True),
+        ("outOfSync", False),
+        ("Out-of-Sync", False),
+        ("not_synchronized", False),
+        ("pending", False),
+        ("Pending", False),
+        ("NA", None),
+        (None, None),
+    ),
+)
+def test_fabric_context_00211(status, expected) -> None:
+    """Verify in-sync, deploy-needed, and unknown controller synchronization spellings normalize safely."""
+    assert FabricContext._normalize_config_sync_status(status) is expected
+
+
+def test_fabric_context_00212() -> None:
+    """Verify nested and top-level switch status reuse the switch-list cache without another GET."""
+    method_name = "test_fabric_context_00200"
+
+    def responses():
+        yield responses_fabric_context(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = FabricContext(rest_send=rest_send, fabric_name="fabric_1")
+
+    assert instance.switch_map["192.168.12.151"] == "FDO12345ABC"
+    assert instance.switch_config_in_sync("FDO12345ABC") is None
+
+    instance._switch_records_by_id = {
+        "FDO12345ABC": {"switchId": "FDO12345ABC", "additionalData": {"configSyncStatus": "Out-of-Sync"}},
+        "FDO12345ABD": {"switchId": "FDO12345ABD", "configSyncStatus": "In_Sync"},
+        "FDO12345ABE": {
+            "switchId": "FDO12345ABE",
+            "additionalData": {"configSyncStatus": "NA"},
+            "configSyncStatus": "outOfSync",
+        },
+        "FDO12345ABF": {"switchId": "FDO12345ABF", "additionalData": {"configSyncStatus": "Pending"}},
+    }
+
+    assert instance.switch_config_in_sync("FDO12345ABC") is False
+    assert instance.switch_config_in_sync("FDO12345ABD") is True
+    assert instance.switch_config_in_sync("FDO12345ABE") is False
+    assert instance.switch_config_in_sync("FDO12345ABF") is False
+    assert instance.switch_config_in_sync("UNKNOWN") is None
+
+
 def test_fabric_context_00220() -> None:
     """
     # Summary

--- a/tests/unit/module_utils/test_interface_state_snapshot.py
+++ b/tests/unit/module_utils/test_interface_state_snapshot.py
@@ -73,6 +73,17 @@ def _interface(name: str, interface_type: str, policy_type: str) -> dict:
     }
 
 
+def _summary(name: str, switch_id: str, interface_type: str, policy_type: str) -> dict:
+    return {
+        "interfaceName": name,
+        "switchId": switch_id,
+        "interfaceType": interface_type,
+        "policyType": policy_type,
+        "editAllowed": True,
+        "policyChangeSupported": True,
+    }
+
+
 def test_load_switch_caches_indexes_and_isolates_callers() -> None:
     """A second family sees one cached GET and an unmodified shared record."""
     recorder = _RequestRecorder(
@@ -104,10 +115,239 @@ def test_load_switch_caches_indexes_and_isolates_callers() -> None:
         "interface_inventory_gets": 1,
         "interface_inventory_pages": 1,
         "interface_inventory_cache_hits": 1,
+        "interface_summary_switches": 0,
+        "interface_summary_gets": 0,
+        "interface_summary_pages": 0,
+        "interface_summary_cache_hits": 0,
         "interface_inventory_refreshes": 0,
         "interface_inventory_dirty_refetches": 0,
         "snapshot_overlays": 0,
     }
+
+
+def test_interface_summaries_are_lazy_batched_cached_and_isolated() -> None:
+    """Requested identities share one full summary fetch per switch and isolated cached rows."""
+    recorder = _RequestRecorder(
+        [
+            {
+                "interfaces": [
+                    _summary("Ethernet1/1", "SERIAL1", "ethernet", "accessHost"),
+                    _summary("Ethernet1/2", "SERIAL1", "ethernet", "trunkHost"),
+                ]
+            },
+            {"interfaces": [_summary("loopback10", "SERIAL2", "loopback", "loopback")]},
+        ]
+    )
+    snapshot = _snapshot(recorder)
+
+    assert snapshot.interface_summaries_by_identity == {}
+    assert recorder.calls == []
+
+    result = snapshot.load_interface_summaries(
+        [
+            ("SERIAL1", "Ethernet1/1"),
+            ("SERIAL1", "ETHERNET1/1"),
+            ("SERIAL1", "Ethernet1/99"),
+            ("SERIAL2", "loopback10"),
+        ]
+    )
+
+    assert set(result) == {("SERIAL1", "ethernet1/1"), ("SERIAL2", "loopback10")}
+    assert len(recorder.calls) == 2
+    assert "switchId=SERIAL1" in recorder.calls[0]["path"]
+    assert "switchId=SERIAL2" in recorder.calls[1]["path"]
+    assert "max=500" in recorder.calls[0]["path"]
+    assert "offset=0" in recorder.calls[0]["path"]
+
+    result[("SERIAL1", "ethernet1/1")]["policyType"] = "mutated"
+    assert snapshot.interface_summaries_by_identity[("SERIAL1", "ethernet1/1")]["policyType"] == "accessHost"
+
+    cached = snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/2")])
+    assert cached[("SERIAL1", "ethernet1/2")]["policyType"] == "trunkHost"
+    assert len(recorder.calls) == 2
+    assert snapshot.request_stats["interface_summary_switches"] == 2
+    assert snapshot.request_stats["interface_summary_gets"] == 2
+    assert snapshot.request_stats["interface_summary_pages"] == 2
+    assert snapshot.request_stats["interface_summary_cache_hits"] == 1
+
+
+def test_interface_summary_pagination_fetches_full_switch_then_exactly_filters() -> None:
+    """Summary pagination caches the switch while returning only requested identities."""
+    recorder = _RequestRecorder(
+        [
+            {
+                "interfaces": [
+                    _summary("Ethernet1/1", "SERIAL1", "ethernet", "accessHost"),
+                    _summary("Ethernet1/2", "SERIAL1", "ethernet", "trunkHost"),
+                ]
+            },
+            {"interfaces": [_summary("loopback10", "SERIAL1", "loopback", "loopback")]},
+        ]
+    )
+    snapshot = _snapshot(recorder, page_size=2)
+
+    result = snapshot.load_interface_summaries([("SERIAL1", "LOOPBACK10")])
+
+    assert set(result) == {("SERIAL1", "loopback10")}
+    assert set(snapshot.interface_summaries_by_identity) == {
+        ("SERIAL1", "ethernet1/1"),
+        ("SERIAL1", "ethernet1/2"),
+        ("SERIAL1", "loopback10"),
+    }
+    assert "offset=0" in recorder.calls[0]["path"]
+    assert "offset=2" in recorder.calls[1]["path"]
+    assert snapshot.request_stats["interface_summary_pages"] == 2
+
+
+def test_interface_summary_rejects_case_insensitive_duplicate_within_page() -> None:
+    recorder = _RequestRecorder(
+        [
+            {
+                "interfaces": [
+                    _summary("Ethernet1/1", "SERIAL1", "ethernet", "accessHost"),
+                    _summary("ethernet1/1", "SERIAL1", "ethernet", "trunkHost"),
+                ]
+            }
+        ]
+    )
+    snapshot = _snapshot(recorder)
+
+    with pytest.raises(RuntimeError, match=r"duplicate.*case-insensitive.*ethernet1/1.*SERIAL1"):
+        snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/1")])
+
+
+def test_interface_summary_rejects_case_insensitive_duplicate_across_pages() -> None:
+    recorder = _RequestRecorder(
+        [
+            {
+                "interfaces": [
+                    _summary("Ethernet1/1", "SERIAL1", "ethernet", "accessHost"),
+                    _summary("Ethernet1/2", "SERIAL1", "ethernet", "trunkHost"),
+                ]
+            },
+            {"interfaces": [_summary("ETHERNET1/1", "SERIAL1", "ethernet", "accessHost")]},
+        ]
+    )
+    snapshot = _snapshot(recorder, page_size=2)
+
+    with pytest.raises(RuntimeError, match=r"duplicate.*case-insensitive.*ethernet1/1.*SERIAL1"):
+        snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/1")])
+
+
+@pytest.mark.parametrize("returned_switch_id", [None, "", 123])
+def test_interface_summary_rejects_malformed_switch_id(returned_switch_id: Any) -> None:
+    summary = _summary("Ethernet1/1", "SERIAL1", "ethernet", "accessHost")
+    if returned_switch_id is None:
+        summary.pop("switchId")
+    else:
+        summary["switchId"] = returned_switch_id
+    recorder = _RequestRecorder([{"interfaces": [summary]}])
+    snapshot = _snapshot(recorder)
+
+    with pytest.raises(RuntimeError, match=r"summary.*switchId.*SERIAL1"):
+        snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/1")])
+
+
+def test_interface_summary_ignores_rows_for_other_switches() -> None:
+    """ND may return fabric-wide rows even when switchId is supplied."""
+    recorder = _RequestRecorder(
+        [
+            {
+                "interfaces": [
+                    _summary("Ethernet1/40", "SERIAL2", "ethernet", "accessHost"),
+                    _summary("Ethernet1/40", "SERIAL1", "ethernet", "trunkHost"),
+                    _summary("Ethernet1/41", "SERIAL2", "ethernet", "routedHost"),
+                ]
+            }
+        ]
+    )
+    snapshot = _snapshot(recorder)
+
+    result = snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/40")])
+
+    assert result == {
+        ("SERIAL1", "ethernet1/40"): _summary("Ethernet1/40", "SERIAL1", "ethernet", "trunkHost")
+    }
+    assert snapshot.interface_summaries_by_identity == result
+    assert len(recorder.calls) == 1
+    assert "switchId=SERIAL1" in recorder.calls[0]["path"]
+    assert "filter=switchId%3ASERIAL1" in recorder.calls[0]["path"]
+
+
+def test_interface_summary_foreign_only_page_returns_no_requested_identity() -> None:
+    """Unrelated fabric rows do not poison a requested switch's summary cache."""
+    recorder = _RequestRecorder(
+        [{"interfaces": [_summary("Ethernet1/40", "SERIAL2", "ethernet", "accessHost")]}]
+    )
+    snapshot = _snapshot(recorder)
+
+    assert snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/40")]) == {}
+    assert snapshot.interface_summaries_by_identity == {}
+    assert snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/40")]) == {}
+    assert len(recorder.calls) == 1
+    assert snapshot.request_stats["interface_summary_cache_hits"] == 1
+
+
+def test_interface_summary_mixed_pagination_advances_by_raw_page_length() -> None:
+    """Foreign rows count toward pagination and a target on the final page is retained."""
+    recorder = _RequestRecorder(
+        [
+            {
+                "interfaces": [
+                    _summary("Ethernet1/1", "SERIAL2", "ethernet", "accessHost"),
+                    _summary("Ethernet1/2", "SERIAL2", "ethernet", "trunkHost"),
+                ]
+            },
+            {"interfaces": [_summary("Ethernet1/40", "SERIAL1", "ethernet", "trunkHost")]},
+        ]
+    )
+    snapshot = _snapshot(recorder, page_size=2)
+
+    result = snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/40")])
+
+    assert result == {
+        ("SERIAL1", "ethernet1/40"): _summary("Ethernet1/40", "SERIAL1", "ethernet", "trunkHost")
+    }
+    assert len(recorder.calls) == 2
+    assert "offset=0" in recorder.calls[0]["path"]
+    assert "offset=2" in recorder.calls[1]["path"]
+    assert "filter=switchId%3ASERIAL1" in recorder.calls[0]["path"]
+    assert "filter=switchId%3ASERIAL1" in recorder.calls[1]["path"]
+    assert snapshot.request_stats["interface_summary_pages"] == 2
+
+
+def test_interface_summary_rejects_repeated_full_mixed_switch_page() -> None:
+    """Fabric-wide rows still detect a controller that ignores the summary offset."""
+    page = {
+        "interfaces": [
+            _summary("Ethernet1/1", "SERIAL2", "ethernet", "accessHost"),
+            _summary("Ethernet1/2", "SERIAL3", "ethernet", "trunkHost"),
+        ]
+    }
+    recorder = _RequestRecorder([page, page])
+    snapshot = _snapshot(recorder, page_size=2)
+
+    with pytest.raises(RuntimeError, match=r"summary pagination repeated a full page.*SERIAL1.*offset 2"):
+        snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/40")])
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        "SERIAL1/Ethernet1/1",
+        ("", "Ethernet1/1"),
+        ("SERIAL1", ""),
+    ],
+)
+def test_interface_summary_identity_validation_is_lazy(identity: Any) -> None:
+    """Invalid identities fail before a summary endpoint request."""
+    recorder = _RequestRecorder([])
+    snapshot = _snapshot(recorder)
+
+    with pytest.raises(ValueError, match="Interface summary identities"):
+        snapshot.load_interface_summaries([identity])
+
+    assert recorder.calls == []
 
 
 def test_load_switches_deduplicates_switch_ids() -> None:
@@ -137,8 +377,10 @@ def test_paginated_fetch_uses_offset_and_stops_on_short_page() -> None:
     assert set(result) == {"ethernet1/1", "ethernet1/2", "loopback10"}
     assert "max=2" in recorder.calls[0]["path"]
     assert "offset=0" in recorder.calls[0]["path"]
+    assert "sort=interfaceName%3Aasc" in recorder.calls[0]["path"]
     assert "max=2" in recorder.calls[1]["path"]
     assert "offset=2" in recorder.calls[1]["path"]
+    assert "sort=interfaceName%3Aasc" in recorder.calls[1]["path"]
     assert snapshot.request_stats["interface_inventory_pages"] == 2
 
 

--- a/tests/unit/module_utils/test_interface_state_snapshot.py
+++ b/tests/unit/module_utils/test_interface_state_snapshot.py
@@ -125,6 +125,32 @@ def test_load_switch_caches_indexes_and_isolates_callers() -> None:
     }
 
 
+def test_cached_interface_is_read_only_case_insensitive_and_never_fetches():
+    """Target projection can read current/original rows without adding inventory GETs."""
+    original = _interface("Ethernet1/1", "ethernet", "accessHost")
+    recorder = _RequestRecorder([{"interfaces": [original]}])
+    snapshot = _snapshot(recorder)
+
+    assert snapshot.cached_interface("SERIAL1", "Ethernet1/1") is None
+    assert recorder.calls == []
+
+    snapshot.load_switch("SERIAL1")
+    cached = snapshot.cached_interface("SERIAL1", "ETHERNET1/1")
+    cached["configData"]["networkOS"]["policy"]["policyType"] = "callerMutation"
+    assert snapshot.policy_type(snapshot.cached_interface("SERIAL1", "ethernet1/1")) == "accessHost"
+
+    snapshot.apply_overlay(
+        "SERIAL1",
+        upserts=[_interface("Ethernet1/1", "ethernet", "trunkHost")],
+    )
+
+    assert snapshot.policy_type(snapshot.cached_interface("SERIAL1", "Ethernet1/1")) == "trunkHost"
+    assert snapshot.policy_type(snapshot.cached_interface("SERIAL1", "Ethernet1/1", original=True)) == "accessHost"
+    assert snapshot.cached_interface("SERIAL1", "Ethernet1/99") is None
+    assert len(recorder.calls) == 1
+    assert snapshot.request_stats["interface_inventory_gets"] == 1
+
+
 def test_interface_summaries_are_lazy_batched_cached_and_isolated() -> None:
     """Requested identities share one full summary fetch per switch and isolated cached rows."""
     recorder = _RequestRecorder(
@@ -265,9 +291,7 @@ def test_interface_summary_ignores_rows_for_other_switches() -> None:
 
     result = snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/40")])
 
-    assert result == {
-        ("SERIAL1", "ethernet1/40"): _summary("Ethernet1/40", "SERIAL1", "ethernet", "trunkHost")
-    }
+    assert result == {("SERIAL1", "ethernet1/40"): _summary("Ethernet1/40", "SERIAL1", "ethernet", "trunkHost")}
     assert snapshot.interface_summaries_by_identity == result
     assert len(recorder.calls) == 1
     assert "switchId=SERIAL1" in recorder.calls[0]["path"]
@@ -276,9 +300,7 @@ def test_interface_summary_ignores_rows_for_other_switches() -> None:
 
 def test_interface_summary_foreign_only_page_returns_no_requested_identity() -> None:
     """Unrelated fabric rows do not poison a requested switch's summary cache."""
-    recorder = _RequestRecorder(
-        [{"interfaces": [_summary("Ethernet1/40", "SERIAL2", "ethernet", "accessHost")]}]
-    )
+    recorder = _RequestRecorder([{"interfaces": [_summary("Ethernet1/40", "SERIAL2", "ethernet", "accessHost")]}])
     snapshot = _snapshot(recorder)
 
     assert snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/40")]) == {}
@@ -305,9 +327,7 @@ def test_interface_summary_mixed_pagination_advances_by_raw_page_length() -> Non
 
     result = snapshot.load_interface_summaries([("SERIAL1", "Ethernet1/40")])
 
-    assert result == {
-        ("SERIAL1", "ethernet1/40"): _summary("Ethernet1/40", "SERIAL1", "ethernet", "trunkHost")
-    }
+    assert result == {("SERIAL1", "ethernet1/40"): _summary("Ethernet1/40", "SERIAL1", "ethernet", "trunkHost")}
     assert len(recorder.calls) == 2
     assert "offset=0" in recorder.calls[0]["path"]
     assert "offset=2" in recorder.calls[1]["path"]

--- a/tests/unit/module_utils/test_interface_state_snapshot.py
+++ b/tests/unit/module_utils/test_interface_state_snapshot.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the execution-scoped interface state snapshot provider."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import (
+    EthernetAccessInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import (
+    EthernetTrunkHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_access_interface import (
+    PortChannelAccessInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_managed_interface import (
+    SubinterfaceManagedInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_unmanaged_interface import (
+    SubinterfaceUnmanagedInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.svi_interface import SviInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_access_interface import AccessVpcHostInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_trunk_host_interface import TrunkVpcHostInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+
+
+class _RequestRecorder:
+    """Return queued DATA bodies while recording request arguments."""
+
+    def __init__(self, responses: list[Any]) -> None:
+        self._responses: Iterator[Any] = iter(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs) -> Any:
+        self.calls.append(kwargs)
+        return next(self._responses)
+
+
+def _snapshot(recorder: _RequestRecorder, *, fabric_name: str = "fabric_1", page_size: int | None = 500) -> InterfaceStateSnapshot:
+    context = FabricContext(rest_send=RestSend({"fabric_name": fabric_name, "check_mode": False}), fabric_name=fabric_name)
+    context._switch_map = {"192.0.2.1": "SERIAL1", "192.0.2.2": "SERIAL2"}
+    context._switch_map_by_id = {"SERIAL1": "192.0.2.1", "SERIAL2": "192.0.2.2"}
+    return InterfaceStateSnapshot(
+        fabric_name=fabric_name,
+        fabric_context=context,
+        request=recorder,
+        page_size=page_size,
+    )
+
+
+def _interface(name: str, interface_type: str, policy_type: str) -> dict:
+    return {
+        "interfaceName": name,
+        "interfaceType": interface_type,
+        "configData": {"networkOS": {"policy": {"policyType": policy_type}}},
+    }
+
+
+def test_load_switch_caches_indexes_and_isolates_callers() -> None:
+    """A second family sees one cached GET and an unmodified shared record."""
+    recorder = _RequestRecorder(
+        [
+            {
+                "interfaces": [
+                    _interface("Ethernet1/1", "ethernet", "accessHost"),
+                    _interface("loopback10", "loopback", "loopback"),
+                    {"interfaceType": "ethernet"},
+                ]
+            }
+        ]
+    )
+    snapshot = _snapshot(recorder)
+
+    first = snapshot.load_switch("SERIAL1")
+    first["ethernet1/1"]["switchIp"] = "192.0.2.10"
+    second = snapshot.load_switch("SERIAL1")
+
+    assert len(recorder.calls) == 1
+    assert "switchIp" not in second["ethernet1/1"]
+    assert set(second) == {"ethernet1/1", "loopback10"}
+    assert ("SERIAL1", "ethernet1/1") in snapshot.interfaces_by_identity
+    assert "ethernet1/1" in snapshot.interfaces_by_switch_ip["192.0.2.1"]
+    assert ("SERIAL1", "loopback10") in snapshot.interfaces_by_type["loopback"]
+    assert ("SERIAL1", "ethernet1/1") in snapshot.interfaces_by_policy_type["accessHost"]
+    assert snapshot.request_stats == {
+        "switches": 1,
+        "interface_inventory_gets": 1,
+        "interface_inventory_pages": 1,
+        "interface_inventory_cache_hits": 1,
+        "interface_inventory_refreshes": 0,
+        "interface_inventory_dirty_refetches": 0,
+        "snapshot_overlays": 0,
+    }
+
+
+def test_load_switches_deduplicates_switch_ids() -> None:
+    """Duplicate requested switch IDs do not create duplicate inventory GETs."""
+    recorder = _RequestRecorder([{"interfaces": []}, {"interfaces": []}])
+    snapshot = _snapshot(recorder)
+
+    result = snapshot.load_switches(["SERIAL1", "SERIAL1", "SERIAL2"])
+
+    assert set(result) == {"SERIAL1", "SERIAL2"}
+    assert len(recorder.calls) == 2
+    assert snapshot.request_stats["switches"] == 2
+
+
+def test_paginated_fetch_uses_offset_and_stops_on_short_page() -> None:
+    """All pages are combined and the next offset advances by returned rows."""
+    recorder = _RequestRecorder(
+        [
+            {"interfaces": [_interface("Ethernet1/1", "ethernet", "accessHost"), _interface("Ethernet1/2", "ethernet", "accessHost")]},
+            {"interfaces": [_interface("loopback10", "loopback", "loopback")]},
+        ]
+    )
+    snapshot = _snapshot(recorder, page_size=2)
+
+    result = snapshot.load_switch("SERIAL1")
+
+    assert set(result) == {"ethernet1/1", "ethernet1/2", "loopback10"}
+    assert "max=2" in recorder.calls[0]["path"]
+    assert "offset=0" in recorder.calls[0]["path"]
+    assert "max=2" in recorder.calls[1]["path"]
+    assert "offset=2" in recorder.calls[1]["path"]
+    assert snapshot.request_stats["interface_inventory_pages"] == 2
+
+
+def test_paginated_fetch_stops_on_empty_page() -> None:
+    """An exact-sized final data page is followed by one terminating empty page."""
+    recorder = _RequestRecorder(
+        [
+            {"interfaces": [_interface("Ethernet1/1", "ethernet", "accessHost")]},
+            {"interfaces": []},
+        ]
+    )
+    snapshot = _snapshot(recorder, page_size=1)
+
+    result = snapshot.load_switch("SERIAL1")
+
+    assert set(result) == {"ethernet1/1"}
+    assert len(recorder.calls) == 2
+    assert "offset=1" in recorder.calls[1]["path"]
+
+
+def test_paginated_fetch_rejects_a_repeated_full_page() -> None:
+    """A controller that ignores offset fails safely instead of looping."""
+    page = {"interfaces": [_interface("Ethernet1/1", "ethernet", "accessHost")]}
+    recorder = _RequestRecorder([page, page])
+    snapshot = _snapshot(recorder, page_size=1)
+
+    with pytest.raises(RuntimeError, match="repeated a full page"):
+        snapshot.load_switch("SERIAL1")
+
+
+def test_invalidate_refresh_and_original_snapshot_lifecycle() -> None:
+    """Refresh replaces current state, preserves the original diagnostic copy, and clears dirty state."""
+    recorder = _RequestRecorder(
+        [
+            {"interfaces": [_interface("loopback10", "loopback", "loopback")]},
+            {"interfaces": [_interface("loopback20", "loopback", "loopback")]},
+        ]
+    )
+    snapshot = _snapshot(recorder)
+    snapshot.load_switch("SERIAL1")
+    snapshot.mark_dirty("SERIAL1")
+
+    assert snapshot.dirty_switches == {"SERIAL1"}
+    refreshed = snapshot.refresh("SERIAL1")
+
+    assert set(refreshed["SERIAL1"]) == {"loopback20"}
+    assert snapshot.dirty_switches == set()
+    assert set(snapshot.original_interfaces_by_switch["SERIAL1"]) == {"loopback10"}
+    assert snapshot.request_stats["interface_inventory_gets"] == 2
+
+
+def test_two_interface_families_share_one_switch_get() -> None:
+    """Injected snapshot sharing reduces two family reads to one switch GET."""
+    recorder = _RequestRecorder(
+        [
+            {
+                "interfaces": [
+                    _interface("Ethernet1/1", "ethernet", "accessHost"),
+                    _interface("loopback10", "loopback", "loopback"),
+                ]
+            }
+        ]
+    )
+    snapshot = _snapshot(recorder)
+    params = {"fabric_name": "fabric_1", "state": "merged", "config": [], "check_mode": False}
+    ethernet = EthernetAccessInterfaceOrchestrator(rest_send=RestSend(params), interface_state_snapshot=snapshot)
+    loopback = LoopbackInterfaceOrchestrator(rest_send=RestSend(params), interface_state_snapshot=snapshot)
+
+    ethernet_state = ethernet._switch_interfaces("SERIAL1")
+    ethernet_state["ethernet1/1"]["switchIp"] = "192.0.2.10"
+    loopback_state = loopback._switch_interfaces("SERIAL1")
+
+    assert len(recorder.calls) == 1
+    assert "switchIp" not in loopback_state["ethernet1/1"]
+    assert ethernet.fabric_context is loopback.fabric_context
+    assert ethernet.state_snapshot is loopback.state_snapshot
+
+
+def test_ten_interface_families_share_one_switch_get() -> None:
+    """Ten family orchestrators reduce ten inventory reads to one shared GET."""
+    recorder = _RequestRecorder([{"interfaces": [_interface("Ethernet1/1", "ethernet", "accessHost")]}])
+    snapshot = _snapshot(recorder)
+    params = {"fabric_name": "fabric_1", "state": "merged", "config": [], "check_mode": False}
+    orchestrator_classes = [
+        EthernetAccessInterfaceOrchestrator,
+        EthernetTrunkHostInterfaceOrchestrator,
+        LoopbackInterfaceOrchestrator,
+        PortChannelAccessInterfaceOrchestrator,
+        PortChannelTrunkHostInterfaceOrchestrator,
+        SubinterfaceManagedInterfaceOrchestrator,
+        SubinterfaceUnmanagedInterfaceOrchestrator,
+        SviInterfaceOrchestrator,
+        AccessVpcHostInterfaceOrchestrator,
+        TrunkVpcHostInterfaceOrchestrator,
+    ]
+
+    for orchestrator_class in orchestrator_classes:
+        orchestrator = orchestrator_class(rest_send=RestSend(dict(params)), interface_state_snapshot=snapshot)
+        assert "ethernet1/1" in orchestrator._switch_interfaces("SERIAL1")
+
+    assert len(recorder.calls) == 1
+    assert snapshot.request_stats["interface_inventory_cache_hits"] == 9
+
+
+def test_orchestrator_rejects_snapshot_from_another_fabric() -> None:
+    """Injection cannot cross the snapshot's fabric validity boundary."""
+    recorder = _RequestRecorder([])
+    snapshot = _snapshot(recorder, fabric_name="fabric_1")
+    params = {"fabric_name": "fabric_2", "state": "merged", "config": [], "check_mode": False}
+
+    with pytest.raises(ValueError, match="does not match orchestrator fabric"):
+        EthernetAccessInterfaceOrchestrator(rest_send=RestSend(params), interface_state_snapshot=snapshot)
+
+
+def test_apply_overlay_atomically_updates_current_but_not_original_state() -> None:
+    """Known successful upserts/deletes update only the current snapshot."""
+    recorder = _RequestRecorder([{"interfaces": [_interface("Ethernet1/1", "ethernet", "accessHost"), _interface("loopback10", "loopback", "loopback")]}])
+    snapshot = _snapshot(recorder)
+    snapshot.load_switch("SERIAL1")
+
+    updated_ethernet = _interface("Ethernet1/1", "ethernet", "trunkHost")
+    result = snapshot.apply_overlay(
+        "SERIAL1",
+        upserts=[updated_ethernet, _interface("loopback20", "loopback", "loopback")],
+        deletes=["LOOPBACK10"],
+    )
+
+    assert set(result) == {"ethernet1/1", "loopback20"}
+    assert snapshot.policy_type(result["ethernet1/1"]) == "trunkHost"
+    assert set(snapshot.original_interfaces_by_switch["SERIAL1"]) == {"ethernet1/1", "loopback10"}
+    assert snapshot.policy_type(snapshot.original_interfaces_by_switch["SERIAL1"]["ethernet1/1"]) == "accessHost"
+    assert snapshot.request_stats["snapshot_overlays"] == 1
+
+
+def test_apply_overlay_validation_is_atomic_and_rejects_dirty_state() -> None:
+    """An invalid or dirty overlay cannot partially alter cached state."""
+    recorder = _RequestRecorder([{"interfaces": [_interface("Ethernet1/1", "ethernet", "accessHost")]}])
+    snapshot = _snapshot(recorder)
+    before = snapshot.load_switch("SERIAL1")
+
+    with pytest.raises(ValueError, match="non-empty interfaceName"):
+        snapshot.apply_overlay("SERIAL1", upserts=[{"interfaceType": "loopback"}], deletes=["Ethernet1/1"])
+    assert snapshot.load_switch("SERIAL1") == before
+
+    snapshot.mark_dirty("SERIAL1")
+    with pytest.raises(RuntimeError, match="dirty switch"):
+        snapshot.apply_overlay("SERIAL1", upserts=[_interface("loopback10", "loopback", "loopback")])
+
+
+def test_dirty_switch_is_refetched_automatically_on_next_read() -> None:
+    """A stale marker prevents a later family from consuming cached pre-mutation state."""
+    recorder = _RequestRecorder(
+        [
+            {"interfaces": [_interface("loopback10", "loopback", "loopback")]},
+            {"interfaces": [_interface("loopback20", "loopback", "loopback")]},
+        ]
+    )
+    snapshot = _snapshot(recorder)
+    snapshot.load_switch("SERIAL1")
+    snapshot.mark_dirty("SERIAL1")
+
+    result = snapshot.load_switch("SERIAL1")

--- a/tests/unit/module_utils/test_interface_workflow_coordinator.py
+++ b/tests/unit/module_utils/test_interface_workflow_coordinator.py
@@ -9,14 +9,17 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
 from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_coordinator import (
     InterfaceWorkflowCoordinator,
     InterfaceWorkflowExecutionFailed,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planner import (
+    InterfaceWorkflowPlanner,
     InterfaceWorkflowValidationError,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 
 
 class FakeCollection:
@@ -42,6 +45,20 @@ class FakeModel:
         return self.value
 
 
+class FakeTransition:
+    """Small transition serializer that keeps raw desired/current state internal."""
+
+    def to_dict(self):
+        return {
+            "action": "transition",
+            "switch_ip": "192.0.2.1",
+            "switch_id": "SERIAL1",
+            "interface_name": "Ethernet1/1",
+            "from_policy_type": "routedHost",
+            "to_policy_type": "accessHost",
+        }
+
+
 class FakeModule:
     """Module shape needed by the coordinator."""
 
@@ -55,7 +72,7 @@ class FakeModule:
         }
 
 
-def resource(index, *, changed=True):
+def resource(index, *, changed=True, transition=False):
     """Return one InterfaceResourcePlan-shaped object."""
     before_config = [{"interface_name": f"Ethernet1/{index + 1}", "value": "old"}]
     after_config = [{"interface_name": f"Ethernet1/{index + 1}", "value": "new"}] if changed else before_config
@@ -63,7 +80,7 @@ def resource(index, *, changed=True):
     after = FakeCollection(after_config)
     operations = SimpleNamespace(
         after=after,
-        creates=((FakeModel({"interface_name": f"Ethernet1/{index + 1}"}),) if changed else ()),
+        creates=(() if transition or not changed else (FakeModel({"interface_name": f"Ethernet1/{index + 1}"}),)),
         updates=(),
         deletes=(),
     )
@@ -73,15 +90,16 @@ def resource(index, *, changed=True):
         adapter=SimpleNamespace(module_name="cisco.nd.nd_interface_ethernet_access"),
         state="merged",
         changed=changed,
+        transitions=((FakeTransition(),) if transition else ()),
         before=before,
         proposed=FakeCollection(after_config),
         operations=operations,
     )
 
 
-def plan(*, changed=True):
+def plan(*, changed=True, transition=False):
     """Return one InterfaceWorkflowPlan-shaped object with repeated family types."""
-    resources = (resource(0, changed=changed), resource(1, changed=False))
+    resources = (resource(0, changed=changed, transition=transition), resource(1, changed=False))
     return SimpleNamespace(
         changed=changed,
         fabric_name="FABRIC1",
@@ -154,6 +172,26 @@ def test_check_mode_result_retains_repeated_groups_and_reports_planned_change():
     assert result["request_stats"]["interface_inventory_gets"] == 2
     assert result["request_stats"]["mutation_requests"] == 0
     assert result["request_stats"]["deploy_requests"] == 0
+
+
+def test_check_mode_result_exposes_transition_metadata_without_raw_state():
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+
+    result = coordinator._format_result(plan(transition=True))
+
+    resource_result = result["resources"][0]
+    assert "allow_policy_transition" not in resource_result
+    assert resource_result["created"] == []
+    assert resource_result["transitions"] == [
+        {
+            "action": "transition",
+            "switch_ip": "192.0.2.1",
+            "switch_id": "SERIAL1",
+            "interface_name": "Ethernet1/1",
+            "from_policy_type": "routedHost",
+            "to_policy_type": "accessHost",
+        }
+    ]
 
 
 def test_info_output_includes_normalized_proposed_config():
@@ -249,7 +287,12 @@ def test_normal_execution_failure_preserves_structured_result(monkeypatch):
 class FakeFabricContext:
     fabric_name = "FABRIC1"
 
-    switch_ip_by_id = {"SERIAL1": "192.0.2.1", "SERIAL2": "192.0.2.2"}
+    switch_ip_by_id = {
+        "SERIAL1": "192.0.2.1",
+        "SERIAL2": "192.0.2.2",
+        "SERIAL3": "192.0.2.3",
+        "SERIAL4": "192.0.2.4",
+    }
 
     def get_switch_ip(self, switch_id):
         try:
@@ -270,6 +313,127 @@ def test_vpc_pair_map_is_authoritative_and_bidirectional(monkeypatch):
     pair_map = coordinator._vpc_pair_map(resources=resources, fabric_context=FakeFabricContext(), rest_send=object())
     assert pair_map == {"192.0.2.1": "SERIAL2", "192.0.2.2": "SERIAL1"}
     assert coordinator._vpc_pair_gets == 1
+
+
+def test_vpc_pair_map_accepts_consistent_duplicate_and_inverse_records(monkeypatch):
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    monkeypatch.setattr(
+        coordinator,
+        "_request",
+        lambda *_args, **_kwargs: {
+            "vpcPairs": [
+                {"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"},
+                {"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"},
+                {"switchId": "SERIAL2", "peerSwitchId": "SERIAL1"},
+            ]
+        },
+    )
+
+    pair_map = coordinator._vpc_pair_map(
+        resources=[{"type": "vpc_access", "config": []}], fabric_context=FakeFabricContext(), rest_send=object()
+    )
+    assert pair_map == {"192.0.2.1": "SERIAL2", "192.0.2.2": "SERIAL1"}
+
+
+def test_vpc_pair_map_paginates_intended_pairs_and_counts_actual_gets(monkeypatch):
+    responses = iter(
+        [
+            {
+                "vpcPairs": [{"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"}],
+                "meta": {"counts": {"remaining": 1, "total": 2}},
+            },
+            {
+                "vpcPairs": [{"switchId": "SERIAL3", "peerSwitchId": "SERIAL4"}],
+                "meta": {"counts": {"remaining": 0, "total": 2}},
+            },
+        ]
+    )
+    requested_paths = []
+
+    def request(*_args, **kwargs):
+        requested_paths.append(kwargs["path"])
+        return next(responses)
+
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    monkeypatch.setattr(coordinator, "_request", request)
+
+    pair_map = coordinator._vpc_pair_map(
+        resources=[{"type": "vpc_access", "config": [{"switch_ip": "192.0.2.1"}]}],
+        fabric_context=FakeFabricContext(),
+        rest_send=object(),
+    )
+
+    assert pair_map == {
+        "192.0.2.1": "SERIAL2",
+        "192.0.2.2": "SERIAL1",
+        "192.0.2.3": "SERIAL4",
+        "192.0.2.4": "SERIAL3",
+    }
+    assert len(requested_paths) == 2
+    assert all("view=intendedPairs" in path for path in requested_paths)
+    assert all("max=500" in path for path in requested_paths)
+    assert all("sort=switchId%3Aasc" in path for path in requested_paths)
+    assert "offset=0" in requested_paths[0]
+    assert "offset=1" in requested_paths[1]
+    assert coordinator._vpc_pair_gets == 2
+
+
+def test_vpc_pair_map_rejects_self_pair(monkeypatch):
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    monkeypatch.setattr(
+        coordinator,
+        "_request",
+        lambda *_args, **_kwargs: {"vpcPairs": [{"switchId": "SERIAL1", "peerSwitchId": "SERIAL1"}]},
+    )
+
+    with pytest.raises(InterfaceWorkflowValidationError, match=r"self-pair.*SERIAL1"):
+        coordinator._vpc_pair_map(
+            resources=[{"type": "vpc_access", "config": []}],
+            fabric_context=FakeFabricContext(),
+            rest_send=object(),
+        )
+
+
+def test_vpc_pair_map_rejects_conflicting_duplicate_mapping(monkeypatch):
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    monkeypatch.setattr(
+        coordinator,
+        "_request",
+        lambda *_args, **_kwargs: {
+            "vpcPairs": [
+                {"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"},
+                {"switchId": "SERIAL1", "peerSwitchId": "SERIAL3"},
+            ]
+        },
+    )
+
+    with pytest.raises(InterfaceWorkflowValidationError, match=r"conflicting.*SERIAL1.*SERIAL2.*SERIAL3"):
+        coordinator._vpc_pair_map(
+            resources=[{"type": "vpc_access", "config": []}],
+            fabric_context=FakeFabricContext(),
+            rest_send=object(),
+        )
+
+
+def test_vpc_pair_map_rejects_inverse_inconsistent_records(monkeypatch):
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    monkeypatch.setattr(
+        coordinator,
+        "_request",
+        lambda *_args, **_kwargs: {
+            "vpcPairs": [
+                {"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"},
+                {"switchId": "SERIAL2", "peerSwitchId": "SERIAL3"},
+            ]
+        },
+    )
+
+    with pytest.raises(InterfaceWorkflowValidationError, match=r"inverse-inconsistent.*SERIAL2.*SERIAL3.*SERIAL1"):
+        coordinator._vpc_pair_map(
+            resources=[{"type": "vpc_access", "config": []}],
+            fabric_context=FakeFabricContext(),
+            rest_send=object(),
+        )
 
 
 def test_vpc_group_rejects_switch_missing_from_authoritative_pair_inventory(
@@ -304,3 +468,69 @@ def test_non_vpc_workflow_skips_pair_inventory(monkeypatch):
     )
     assert pair_map == {}
     assert coordinator._vpc_pair_gets == 0
+
+
+def test_vpc_pair_inventory_count_remains_visible_in_request_stats():
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    coordinator._snapshot = SimpleNamespace(request_stats={"switches": 2, "interface_inventory_gets": 2})
+    coordinator._vpc_pair_gets = 1
+
+    result = coordinator._format_result(plan())
+
+    assert result["request_stats"]["vpc_pair_gets"] == 1
+
+
+def test_authoritative_pair_inventory_seeds_one_cache_shared_by_all_vpc_orchestrators():
+    rest_send = RestSend({"fabric_name": "FABRIC1", "check_mode": True})
+    fabric_context = FabricContext(rest_send=rest_send, fabric_name="FABRIC1")
+    fabric_context._fabric_summary = {"local": True, "fabricStatus": "default"}
+    fabric_context._switch_map = {"192.0.2.1": "SERIAL1", "192.0.2.2": "SERIAL2"}
+    fabric_context._switch_map_by_id = {"SERIAL1": "192.0.2.1", "SERIAL2": "192.0.2.2"}
+    requests = []
+    snapshot = InterfaceStateSnapshot(
+        fabric_name="FABRIC1",
+        fabric_context=fabric_context,
+        request=lambda **kwargs: requests.append(kwargs) or {"interfaces": []},
+    )
+    planner = InterfaceWorkflowPlanner(
+        snapshot=snapshot,
+        vpc_pair_by_switch_ip={
+            "192.0.2.1": "SERIAL2",
+            "192.0.2.2": "SERIAL1",
+        },
+    )
+
+    workflow_plan = planner.plan(
+        [
+            {
+                "type": "vpc_access",
+                "config": [
+                    {
+                        "switch_ip": "192.0.2.1",
+                        "interface_name": "vpc10",
+                        "config_data": {"network_os": {"policy": {"access_vlan": 10}}},
+                    }
+                ],
+            },
+            {
+                "type": "vpc_trunk_host",
+                "config": [
+                    {
+                        "switch_ip": "192.0.2.2",
+                        "interface_name": "vpc20",
+                        "config_data": {"network_os": {"policy": {"allowed_vlans": "10-20"}}},
+                    }
+                ],
+            },
+        ]
+    )
+
+    access_orchestrator, trunk_orchestrator = (resource.orchestrator for resource in workflow_plan.resources)
+    assert access_orchestrator._peer_serial_cache is trunk_orchestrator._peer_serial_cache
+    assert access_orchestrator._peer_serial_cache == {
+        "SERIAL1": "SERIAL2",
+        "SERIAL2": "SERIAL1",
+    }
+    assert access_orchestrator._resolve_peer_switch_id("192.0.2.1", "SERIAL1") == "SERIAL2"
+    assert trunk_orchestrator._resolve_peer_switch_id("192.0.2.2", "SERIAL2") == "SERIAL1"
+    assert len(requests) == 2

--- a/tests/unit/module_utils/test_interface_workflow_coordinator.py
+++ b/tests/unit/module_utils/test_interface_workflow_coordinator.py
@@ -116,12 +116,13 @@ class FakeTransition:
 class FakeModule:
     """Module shape needed by the coordinator."""
 
-    def __init__(self, *, check_mode, output_level="normal"):
+    def __init__(self, *, check_mode, output_level="normal", verify_enabled=False):
         self.check_mode = check_mode
         self.params = {
             "fabric_name": "FABRIC1",
             "resources": [],
             "config_actions": {"deploy": True},
+            "verify": {"enabled": verify_enabled},
             "output_level": output_level,
         }
 
@@ -179,7 +180,7 @@ class FakeExecutionItem:
 class FakeExecution:
     """InterfaceWorkflowExecution-compatible result for coordinator wiring tests."""
 
-    def __init__(self, workflow_plan, *, deploy, deployment_targets=(), failed=False):
+    def __init__(self, workflow_plan, *, deploy, verify, deployment_targets=(), failed=False):
         self.deployment_targets = tuple(deployment_targets)
         deployment_sent = deploy and bool(workflow_plan.changed or self.deployment_targets) and not failed
         self.changed = not failed and bool(workflow_plan.changed or deployment_sent)
@@ -188,7 +189,10 @@ class FakeExecution:
         self.mutation_requests = int(workflow_plan.changed)
         self.deploy_requests = int(deployment_sent)
         self.deploy = deploy
-        self.actual_after_by_resource = {item.resource_index: item.operations.after if not failed else item.before for item in workflow_plan.resources}
+        observed_after = verify or not workflow_plan.changed or failed
+        self.actual_after_by_resource = (
+            {item.resource_index: item.operations.after if not failed else item.before for item in workflow_plan.resources} if observed_after else {}
+        )
         status = "failed" if failed else "succeeded"
         items = []
         for resource_plan in workflow_plan.resources:
@@ -249,11 +253,18 @@ class FakeExecutor:
         self.calls = calls
         self.failed = failed
         self.deploy = kwargs["deploy"]
+        self.verify = kwargs["verify"]
         self.calls.append(("init", kwargs))
 
     def execute(self, workflow_plan, deployment_targets=()):
         self.calls.append(("execute", workflow_plan, tuple(deployment_targets)))
-        return FakeExecution(workflow_plan, deploy=self.deploy, deployment_targets=deployment_targets, failed=self.failed)
+        return FakeExecution(
+            workflow_plan,
+            deploy=self.deploy,
+            verify=self.verify,
+            deployment_targets=deployment_targets,
+            failed=self.failed,
+        )
 
 
 def test_check_mode_result_retains_repeated_groups_and_reports_planned_change():
@@ -357,6 +368,7 @@ def test_normal_no_change_run_succeeds_without_execution(monkeypatch):
     assert result["changed"] is False
     assert result["planned_changed"] is False
     assert result["execution"]["status"] == "no_change"
+    assert result["resources"][0]["after_verified"] is True
 
 
 def test_normal_no_change_defaults_deploy_to_false_when_omitted(monkeypatch):
@@ -371,10 +383,10 @@ def test_normal_no_change_defaults_deploy_to_false_when_omitted(monkeypatch):
     assert result["execution"]["deployment"]["requested"] is False
 
 
-def test_normal_changing_run_executes_and_reports_actual_state(monkeypatch):
+def test_normal_changing_run_with_verify_enabled_executes_and_reports_actual_state(monkeypatch):
     calls = []
     coordinator = InterfaceWorkflowCoordinator(
-        FakeModule(check_mode=False),
+        FakeModule(check_mode=False, verify_enabled=True),
         executor_factory=lambda **kwargs: FakeExecutor(calls, **kwargs),
     )
     coordinator._snapshot = SimpleNamespace(request_stats={"switches": 2, "interface_inventory_gets": 2})
@@ -385,6 +397,7 @@ def test_normal_changing_run_executes_and_reports_actual_state(monkeypatch):
 
     assert [call[0] for call in calls] == ["init", "execute"]
     assert calls[0][1]["deploy"] is True
+    assert calls[0][1]["verify"] is True
     assert result["changed"] is True
     assert result["execution"]["status"] == "completed"
     assert result["resources"][0]["after_verified"] is True
@@ -393,6 +406,35 @@ def test_normal_changing_run_executes_and_reports_actual_state(monkeypatch):
     assert result["execution"]["deployments_sent"] == 1
     assert "mutation_requests" not in result["request_stats"]
     assert "deploy_requests" not in result["request_stats"]
+
+
+def test_normal_changing_run_defaults_verify_to_false_and_reports_projected_after(monkeypatch):
+    calls = []
+    module = FakeModule(check_mode=False)
+    module.params.pop("verify")
+    coordinator = InterfaceWorkflowCoordinator(
+        module,
+        executor_factory=lambda **kwargs: FakeExecutor(calls, **kwargs),
+    )
+    coordinator._snapshot = SimpleNamespace(
+        request_stats={
+            "switches": 2,
+            "interface_inventory_gets": 2,
+            "interface_inventory_refreshes": 0,
+            "interface_inventory_dirty_refetches": 0,
+        }
+    )
+    workflow_plan = plan()
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: workflow_plan)
+
+    result = coordinator.run()
+
+    assert calls[0][1]["verify"] is False
+    assert result["changed"] is True
+    assert result["resources"][0]["after_verified"] is False
+    assert result["resources"][0]["after"] == [{"switch_ip": "192.0.2.1", "interface_name": "Ethernet1/1", "value": "new"}]
+    assert result["request_stats"]["interface_inventory_refreshes"] == 0
+    assert result["request_stats"]["interface_inventory_dirty_refetches"] == 0
 
 
 def test_normal_changing_run_defaults_deploy_to_false_when_omitted(monkeypatch):
@@ -410,6 +452,7 @@ def test_normal_changing_run_defaults_deploy_to_false_when_omitted(monkeypatch):
     coordinator.run()
 
     assert calls[0][1]["deploy"] is False
+    assert calls[0][1]["verify"] is False
 
 
 def test_normal_execution_failure_preserves_structured_result(monkeypatch):
@@ -428,6 +471,7 @@ def test_normal_execution_failure_preserves_structured_result(monkeypatch):
     assert exc_info.value.result["execution"]["status"] == "failed"
     assert exc_info.value.result["execution"]["mutations_sent"] == 1
     assert exc_info.value.result["resources"][0]["operations"][0]["status"] == "failed"
+    assert exc_info.value.result["resources"][0]["after_verified"] is True
 
 
 class FakeFabricContext:
@@ -571,12 +615,14 @@ def test_normal_zero_mutation_pending_target_executes_one_deployment(monkeypatch
 
     result = coordinator.run()
 
+    assert calls[0][1]["verify"] is False
     assert calls[1][0] == "execute"
     assert calls[1][2] == (("Ethernet1/40", "SERIAL1"),)
     assert result["changed"] is True
     assert result["planned_changed"] is False
     assert result["mutation_count"] == 0
     assert result["resources"][0]["changed"] is False
+    assert result["resources"][0]["after_verified"] is True
     assert result["execution"]["status"] == "completed"
     assert result["execution"]["mutations_sent"] == 0
     assert result["execution"]["deployments_sent"] == 1

--- a/tests/unit/module_utils/test_interface_workflow_coordinator.py
+++ b/tests/unit/module_utils/test_interface_workflow_coordinator.py
@@ -6,10 +6,12 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from types import SimpleNamespace
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.interface_family_adapters import INTERFACE_FAMILY_ADAPTERS
 from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
 from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_coordinator import (
     InterfaceWorkflowCoordinator,
@@ -19,20 +21,50 @@ from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planne
     InterfaceWorkflowPlanner,
     InterfaceWorkflowValidationError,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import InterfaceDefaultConfig
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+
+COMPACT_RESULT_KEYS = {
+    "changed",
+    "planned_changed",
+    "mutation_count",
+    "target_switch_ids",
+    "resources",
+    "request_stats",
+    "execution",
+}
+COMPACT_RESOURCE_KEYS = {
+    "resource_index",
+    "type",
+    "module",
+    "state",
+    "changed",
+    "planned_changed",
+    "before",
+    "after",
+    "after_verified",
+    "operations",
+}
 
 
 class FakeCollection:
     """Small NDConfigCollection-compatible serializer for coordinator output tests."""
 
     def __init__(self, config):
-        self.config = config
+        self._items = [FakeModel(item) for item in config]
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def get(self, key):
+        return next((item for item in self._items if item.get_identifier_value() == key), None)
 
     def to_ansible_config(self):
-        return self.config
+        return [item.to_config() for item in self._items]
 
     def get_diff_collection(self, other):
-        return self.config != other.config
+        return self.to_ansible_config() != other.to_ansible_config()
 
 
 class FakeModel:
@@ -41,12 +73,34 @@ class FakeModel:
     def __init__(self, value):
         self.value = value
 
+    @property
+    def interface_name(self):
+        return self.value["interface_name"]
+
+    @property
+    def switch_ip(self):
+        return self.value.get("switch_ip", "192.0.2.1")
+
+    def get_identifier_value(self):
+        return self.value["interface_name"]
+
     def to_config(self):
-        return self.value
+        return {"switch_ip": self.switch_ip, **self.value}
+
+    def to_payload(self):
+        return {}
 
 
 class FakeTransition:
     """Small transition serializer that keeps raw desired/current state internal."""
+
+    def __init__(self, desired):
+        self.desired = desired
+        self.switch_ip = "192.0.2.1"
+        self.switch_id = "SERIAL1"
+        self.interface_name = "Ethernet1/1"
+        self.from_policy_type = "routedHost"
+        self.to_policy_type = "accessHost"
 
     def to_dict(self):
         return {
@@ -87,10 +141,11 @@ def resource(index, *, changed=True, transition=False):
     return SimpleNamespace(
         resource_index=index,
         resource_type="ethernet_access",
-        adapter=SimpleNamespace(module_name="cisco.nd.nd_interface_ethernet_access"),
+        adapter=SimpleNamespace(module_name="cisco.nd.nd_interface_ethernet_access", ownership_domain="switch"),
+        orchestrator=SimpleNamespace(fabric_context=FakeFabricContext()),
         state="merged",
         changed=changed,
-        transitions=((FakeTransition(),) if transition else ()),
+        transitions=((FakeTransition(FakeModel({"interface_name": f"Ethernet1/{index + 1}"})),) if transition else ()),
         before=before,
         proposed=FakeCollection(after_config),
         operations=operations,
@@ -110,28 +165,78 @@ def plan(*, changed=True, transition=False):
     )
 
 
+class FakeExecutionItem:
+    """Small execution-item result used to qualify operation status merging."""
+
+    def __init__(self, **data):
+        self.__dict__.update(data)
+
+    def to_dict(self):
+        """Return the public execution item shape."""
+        return dict(self.__dict__)
+
+
 class FakeExecution:
     """InterfaceWorkflowExecution-compatible result for coordinator wiring tests."""
 
-    def __init__(self, workflow_plan, *, failed=False):
-        self.changed = not failed
+    def __init__(self, workflow_plan, *, deploy, deployment_targets=(), failed=False):
+        self.deployment_targets = tuple(deployment_targets)
+        deployment_sent = deploy and bool(workflow_plan.changed or self.deployment_targets) and not failed
+        self.changed = not failed and bool(workflow_plan.changed or deployment_sent)
         self.failed = failed
         self.message = "execution failed" if failed else ""
-        self.mutation_requests = 1
-        self.deploy_requests = 1 if not failed else 0
+        self.mutation_requests = int(workflow_plan.changed)
+        self.deploy_requests = int(deployment_sent)
+        self.deploy = deploy
         self.actual_after_by_resource = {item.resource_index: item.operations.after if not failed else item.before for item in workflow_plan.resources}
+        status = "failed" if failed else "succeeded"
+        items = []
+        for resource_plan in workflow_plan.resources:
+            for transition in resource_plan.transitions:
+                items.append(
+                    FakeExecutionItem(
+                        resource_index=resource_plan.resource_index,
+                        type=resource_plan.resource_type,
+                        status=status,
+                        **transition.to_dict(),
+                    )
+                )
+            for action, models in (
+                ("create", resource_plan.operations.creates),
+                ("update", resource_plan.operations.updates),
+                ("delete", resource_plan.operations.deletes),
+            ):
+                for model in models:
+                    items.append(
+                        FakeExecutionItem(
+                            resource_index=resource_plan.resource_index,
+                            type=resource_plan.resource_type,
+                            action=action,
+                            switch_ip=model.switch_ip,
+                            switch_id=resource_plan.orchestrator.fabric_context.get_switch_id(model.switch_ip),
+                            interface_name=model.interface_name,
+                            status=status,
+                        )
+                    )
+        self.items = tuple(items)
 
     def to_dict(self):
+        if self.failed:
+            status = "failed"
+        elif self.deploy:
+            status = "completed"
+        else:
+            status = "staged"
         return {
-            "status": "failed" if self.failed else "completed",
+            "status": status,
             "mutations_sent": self.mutation_requests,
             "deployments_sent": self.deploy_requests,
-            "affected_switch_ids": ["SERIAL1"],
-            "items": [],
+            "affected_switch_ids": ["SERIAL1"] if self.mutation_requests else [],
+            "items": [item.to_dict() for item in self.items],
             "deployment": {
-                "requested": True,
-                "status": "succeeded" if not self.failed else "not_attempted",
-                "targets": [],
+                "requested": self.deploy,
+                "status": "succeeded" if self.deploy_requests else ("not_attempted" if self.failed else "not_needed"),
+                "targets": [{"interface_name": name, "switch_id": switch_id, "status": "succeeded"} for name, switch_id in self.deployment_targets],
             },
             "errors": [self.message] if self.failed else [],
         }
@@ -143,17 +248,19 @@ class FakeExecutor:
     def __init__(self, calls, *, failed=False, **kwargs):
         self.calls = calls
         self.failed = failed
+        self.deploy = kwargs["deploy"]
         self.calls.append(("init", kwargs))
 
-    def execute(self, workflow_plan):
-        self.calls.append(("execute", workflow_plan))
-        return FakeExecution(workflow_plan, failed=self.failed)
+    def execute(self, workflow_plan, deployment_targets=()):
+        self.calls.append(("execute", workflow_plan, tuple(deployment_targets)))
+        return FakeExecution(workflow_plan, deploy=self.deploy, deployment_targets=deployment_targets, failed=self.failed)
 
 
 def test_check_mode_result_retains_repeated_groups_and_reports_planned_change():
     coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
     result = coordinator._format_result(plan())
 
+    assert set(result) == COMPACT_RESULT_KEYS
     assert result["changed"] is True
     assert result["planned_changed"] is True
     assert result["execution"]["status"] == "check_mode"
@@ -163,15 +270,24 @@ def test_check_mode_result_retains_repeated_groups_and_reports_planned_change():
         "ethernet_access",
         "ethernet_access",
     ]
-    assert result["resources"][0]["diff"] == {
-        "before": [{"interface_name": "Ethernet1/1", "value": "old"}],
-        "after": [{"interface_name": "Ethernet1/1", "value": "new"}],
-    }
-    assert result["resources"][0]["after_verified"] is False
-    assert "proposed" not in result["resources"][0]
+    resource_result = result["resources"][0]
+    assert set(resource_result) == COMPACT_RESOURCE_KEYS
+    assert resource_result["before"] == [{"switch_ip": "192.0.2.1", "interface_name": "Ethernet1/1", "value": "old"}]
+    assert resource_result["after"] == [{"switch_ip": "192.0.2.1", "interface_name": "Ethernet1/1", "value": "new"}]
+    assert resource_result["operations"] == [
+        {
+            "action": "create",
+            "switch_ip": "192.0.2.1",
+            "switch_id": "SERIAL1",
+            "interface_name": "Ethernet1/1",
+            "status": "planned",
+        }
+    ]
+    assert resource_result["after_verified"] is False
+    assert "proposed" not in resource_result
     assert result["request_stats"]["interface_inventory_gets"] == 2
-    assert result["request_stats"]["mutation_requests"] == 0
-    assert result["request_stats"]["deploy_requests"] == 0
+    assert "mutation_requests" not in result["request_stats"]
+    assert "deploy_requests" not in result["request_stats"]
 
 
 def test_check_mode_result_exposes_transition_metadata_without_raw_state():
@@ -181,15 +297,37 @@ def test_check_mode_result_exposes_transition_metadata_without_raw_state():
 
     resource_result = result["resources"][0]
     assert "allow_policy_transition" not in resource_result
-    assert resource_result["created"] == []
-    assert resource_result["transitions"] == [
+    assert resource_result["operations"] == [
         {
             "action": "transition",
             "switch_ip": "192.0.2.1",
             "switch_id": "SERIAL1",
             "interface_name": "Ethernet1/1",
+            "status": "planned",
             "from_policy_type": "routedHost",
             "to_policy_type": "accessHost",
+            "changes": [{"path": "value", "before": "old", "after": "new"}],
+        }
+    ]
+
+
+def test_check_mode_update_operation_reports_only_leaf_changes():
+    workflow_plan = plan()
+    resource_plan = workflow_plan.resources[0]
+    resource_plan.operations.creates = ()
+    resource_plan.operations.updates = (FakeModel({"interface_name": "Ethernet1/1", "value": "new"}),)
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+
+    result = coordinator._format_result(workflow_plan)
+
+    assert result["resources"][0]["operations"] == [
+        {
+            "action": "update",
+            "switch_ip": "192.0.2.1",
+            "switch_id": "SERIAL1",
+            "interface_name": "Ethernet1/1",
+            "status": "planned",
+            "changes": [{"path": "value", "before": "old", "after": "new"}],
         }
     ]
 
@@ -197,7 +335,11 @@ def test_check_mode_result_exposes_transition_metadata_without_raw_state():
 def test_info_output_includes_normalized_proposed_config():
     coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True, output_level="info"))
     result = coordinator._format_result(plan())
-    assert result["resources"][0]["proposed"][0]["value"] == "new"
+    resource_result = result["resources"][0]
+
+    assert set(result) == COMPACT_RESULT_KEYS
+    assert set(resource_result) == COMPACT_RESOURCE_KEYS | {"proposed"}
+    assert resource_result["proposed"][0]["value"] == "new"
 
 
 def test_check_mode_run_returns_complete_plan_without_execution(monkeypatch):
@@ -225,7 +367,7 @@ def test_normal_no_change_defaults_deploy_to_false_when_omitted(monkeypatch):
 
     result = coordinator.run()
 
-    assert result["config_actions"] == {}
+    assert "config_actions" not in result
     assert result["execution"]["deployment"]["requested"] is False
 
 
@@ -246,8 +388,11 @@ def test_normal_changing_run_executes_and_reports_actual_state(monkeypatch):
     assert result["changed"] is True
     assert result["execution"]["status"] == "completed"
     assert result["resources"][0]["after_verified"] is True
-    assert result["request_stats"]["mutation_requests"] == 1
-    assert result["request_stats"]["deploy_requests"] == 1
+    assert result["resources"][0]["operations"][0]["status"] == "succeeded"
+    assert result["execution"]["mutations_sent"] == 1
+    assert result["execution"]["deployments_sent"] == 1
+    assert "mutation_requests" not in result["request_stats"]
+    assert "deploy_requests" not in result["request_stats"]
 
 
 def test_normal_changing_run_defaults_deploy_to_false_when_omitted(monkeypatch):
@@ -281,7 +426,8 @@ def test_normal_execution_failure_preserves_structured_result(monkeypatch):
 
     assert exc_info.value.result["failed"] is True
     assert exc_info.value.result["execution"]["status"] == "failed"
-    assert exc_info.value.result["request_stats"]["mutation_requests"] == 1
+    assert exc_info.value.result["execution"]["mutations_sent"] == 1
+    assert exc_info.value.result["resources"][0]["operations"][0]["status"] == "failed"
 
 
 class FakeFabricContext:
@@ -293,12 +439,626 @@ class FakeFabricContext:
         "SERIAL3": "192.0.2.3",
         "SERIAL4": "192.0.2.4",
     }
+    switch_id_by_ip = {switch_ip: switch_id for switch_id, switch_ip in switch_ip_by_id.items()}
+
+    def __init__(self, sync_status_by_id=None):
+        self.sync_status_by_id = dict(sync_status_by_id or {switch_id: True for switch_id in self.switch_ip_by_id})
+        self.sync_status_reads = []
+
+    def switch_config_in_sync(self, switch_id):
+        self.sync_status_reads.append(switch_id)
+        return self.sync_status_by_id.get(switch_id)
 
     def get_switch_ip(self, switch_id):
         try:
             return self.switch_ip_by_id[switch_id]
         except KeyError as exc:
             raise RuntimeError("unknown switch") from exc
+
+    def get_switch_id(self, switch_ip):
+        try:
+            return self.switch_id_by_ip[switch_ip]
+        except KeyError as exc:
+            raise RuntimeError("unknown switch") from exc
+
+
+def _deployment_only_plan(resource_type, sync_status_by_id, *, mutation=False, state="merged"):
+    adapter = INTERFACE_FAMILY_ADAPTERS[resource_type]
+    config = {"switch_ip": "192.0.2.1", "interface_name": "Ethernet1/40", "value": "same"}
+    model = FakeModel(config)
+    proposed = FakeCollection([config])
+    before = FakeCollection([config])
+    operations = SimpleNamespace(
+        after=FakeCollection([config]),
+        creates=(),
+        updates=(model,) if mutation else (),
+        deletes=(),
+    )
+    context = FakeFabricContext(sync_status_by_id)
+    peer_cache = {"SERIAL1": "SERIAL2"} if adapter.ownership_domain == "vpc" else {}
+    resource_plan = SimpleNamespace(
+        resource_index=0,
+        resource_type=resource_type,
+        adapter=adapter,
+        orchestrator=SimpleNamespace(fabric_context=context, _peer_serial_cache=peer_cache),
+        state=state,
+        changed=mutation,
+        transitions=(),
+        before=before,
+        proposed=proposed,
+        operations=operations,
+    )
+    target_switch_ids = ("SERIAL1", "SERIAL2") if adapter.ownership_domain == "vpc" else ("SERIAL1",)
+    workflow_plan = SimpleNamespace(
+        changed=mutation,
+        fabric_name="FABRIC1",
+        mutation_count=int(mutation),
+        target_switch_ids=target_switch_ids,
+        resources=(resource_plan,),
+        request_stats={"switches": len(target_switch_ids), "interface_inventory_gets": len(target_switch_ids)},
+    )
+    return workflow_plan, context
+
+
+@pytest.mark.parametrize("resource_type", sorted(INTERFACE_FAMILY_ADAPTERS))
+def test_pending_deployment_selection_covers_all_ten_explicit_interface_types(resource_type):
+    adapter = INTERFACE_FAMILY_ADAPTERS[resource_type]
+    statuses = {"SERIAL1": False, "SERIAL2": True}
+    if adapter.ownership_domain == "vpc":
+        statuses = {"SERIAL1": True, "SERIAL2": False}
+    workflow_plan, context = _deployment_only_plan(resource_type, statuses)
+
+    targets = InterfaceWorkflowCoordinator._pending_deployment_targets(workflow_plan)
+
+    assert targets == (("Ethernet1/40", "SERIAL1"),)
+    assert context.sync_status_reads == (["SERIAL1", "SERIAL2"] if adapter.ownership_domain == "vpc" else ["SERIAL1"])
+
+
+@pytest.mark.parametrize("status", (True, None))
+def test_synchronized_or_unknown_switch_status_does_not_trigger_blind_deployment(status):
+    workflow_plan, _context = _deployment_only_plan("ethernet_access", {"SERIAL1": status, "SERIAL2": False})
+
+    assert InterfaceWorkflowCoordinator._pending_deployment_targets(workflow_plan) == ()
+
+
+def test_same_invocation_mutation_target_is_left_to_the_orchestrator_queue():
+    workflow_plan, context = _deployment_only_plan("ethernet_access", {"SERIAL1": False}, mutation=True)
+
+    assert InterfaceWorkflowCoordinator._pending_deployment_targets(workflow_plan) == ()
+    assert context.sync_status_reads == []
+
+
+@pytest.mark.parametrize("state", ("merged", "replaced", "deleted"))
+def test_explicit_no_mutation_target_is_deployable_for_supported_target_scoped_states(state):
+    workflow_plan, _context = _deployment_only_plan("ethernet_access", {"SERIAL1": False}, state=state)
+
+    assert InterfaceWorkflowCoordinator._pending_deployment_targets(workflow_plan) == (("Ethernet1/40", "SERIAL1"),)
+
+
+def test_check_mode_previews_zero_mutation_deployment_only_action(monkeypatch):
+    module = FakeModule(check_mode=True)
+    coordinator = InterfaceWorkflowCoordinator(module)
+    workflow_plan, _context = _deployment_only_plan("ethernet_access", {"SERIAL1": False})
+    coordinator._snapshot = SimpleNamespace(request_stats=workflow_plan.request_stats)
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: workflow_plan)
+
+    result = coordinator.run()
+
+    assert result["changed"] is True
+    assert result["planned_changed"] is False
+    assert result["mutation_count"] == 0
+    assert result["resources"][0]["changed"] is False
+    assert result["execution"]["status"] == "check_mode"
+    assert result["execution"]["mutations_sent"] == 0
+    assert result["execution"]["deployments_sent"] == 0
+    assert result["execution"]["deployment"] == {
+        "requested": True,
+        "status": "would_deploy",
+        "targets": [{"interface_name": "Ethernet1/40", "switch_id": "SERIAL1", "status": "would_deploy"}],
+    }
+
+
+def test_normal_zero_mutation_pending_target_executes_one_deployment(monkeypatch):
+    calls = []
+    module = FakeModule(check_mode=False)
+    coordinator = InterfaceWorkflowCoordinator(
+        module,
+        executor_factory=lambda **kwargs: FakeExecutor(calls, **kwargs),
+    )
+    workflow_plan, _context = _deployment_only_plan("ethernet_access", {"SERIAL1": False})
+    coordinator._snapshot = SimpleNamespace(request_stats=workflow_plan.request_stats)
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: workflow_plan)
+
+    result = coordinator.run()
+
+    assert calls[1][0] == "execute"
+    assert calls[1][2] == (("Ethernet1/40", "SERIAL1"),)
+    assert result["changed"] is True
+    assert result["planned_changed"] is False
+    assert result["mutation_count"] == 0
+    assert result["resources"][0]["changed"] is False
+    assert result["execution"]["status"] == "completed"
+    assert result["execution"]["mutations_sent"] == 0
+    assert result["execution"]["deployments_sent"] == 1
+    assert result["execution"]["deployment"]["status"] == "succeeded"
+
+
+def test_normal_in_sync_zero_mutation_target_keeps_no_change_short_circuit(monkeypatch):
+    calls = []
+    coordinator = InterfaceWorkflowCoordinator(
+        FakeModule(check_mode=False),
+        executor_factory=lambda **kwargs: FakeExecutor(calls, **kwargs),
+    )
+    workflow_plan, _context = _deployment_only_plan("ethernet_access", {"SERIAL1": True})
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: workflow_plan)
+
+    result = coordinator.run()
+
+    assert calls == []
+    assert result["changed"] is False
+    assert result["execution"]["status"] == "no_change"
+    assert result["execution"]["deployments_sent"] == 0
+
+
+class InverseSerialOrderFabricContext(FakeFabricContext):
+    """Map lower management IPs to lexically later vPC-pair serials."""
+
+    switch_ip_by_id = {
+        "SERIAL-Z1": "192.0.2.1",
+        "SERIAL-Z2": "192.0.2.2",
+        "SERIAL-A1": "192.0.2.3",
+        "SERIAL-A2": "192.0.2.4",
+    }
+    switch_id_by_ip = {switch_ip: switch_id for switch_id, switch_ip in switch_ip_by_id.items()}
+
+
+class ProjectionSnapshot:
+    """Cached raw records used by projection tests without network access."""
+
+    def __init__(self, original, current=None):
+        self.original = {(switch_id, name.lower()): deepcopy(raw) for switch_id, name, raw in original}
+        self.current = dict(self.original)
+        if current is not None:
+            self.current = {(switch_id, name.lower()): deepcopy(raw) for switch_id, name, raw in current}
+        self.lookups = []
+        self.request_stats = {"switches": len({key[0] for key in self.current}), "interface_inventory_gets": 0}
+
+    def cached_interface(self, switch_id, interface_name, *, original=False):
+        self.lookups.append((switch_id, interface_name.lower(), original))
+        source = self.original if original else self.current
+        value = source.get((switch_id, interface_name.lower()))
+        return deepcopy(value) if value is not None else None
+
+    @property
+    def interfaces_by_identity(self):
+        return deepcopy(self.current)
+
+
+def _raw_ethernet(name, policy_type, **policy):
+    mode = "access" if policy_type == "accessHost" else "trunk"
+    return {
+        "interfaceName": name,
+        "interfaceType": "ethernet",
+        "configData": {
+            "mode": mode,
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {"policyType": policy_type, **policy},
+            },
+        },
+    }
+
+
+def _raw_loopback(name):
+    return {
+        "interfaceName": name,
+        "interfaceType": "loopback",
+        "configData": {
+            "mode": "managed",
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {"policyType": "loopback", "description": "requested loopback"},
+            },
+        },
+    }
+
+
+def _ethernet_config(switch_ip, name, *, access_vlan=None):
+    item = {"switch_ip": switch_ip, "interface_names": [name]}
+    if access_vlan is not None:
+        item["config_data"] = {"network_os": {"policy": {"access_vlan": access_vlan}}}
+    return item
+
+
+def _validated(adapter, config, state):
+    if not config:
+        return NDConfigCollection(model_class=adapter.model_class)
+    return adapter.validate_config(config, state, 0)
+
+
+def _projection_resource(
+    resource_type,
+    state,
+    proposed_config,
+    *,
+    family_before=(),
+    family_after=(),
+    action=None,
+    context=None,
+):
+    adapter = INTERFACE_FAMILY_ADAPTERS[resource_type]
+    proposed = _validated(adapter, list(proposed_config), state)
+    before = _validated(adapter, list(family_before), "merged")
+    after = _validated(adapter, list(family_after), "merged")
+    desired = tuple(proposed)
+    creates = desired if action == "create" else ()
+    updates = desired if action == "update" else ()
+    deletes = desired if action == "delete" else ()
+    transitions = (FakeTransition(desired[0]),) if action == "transition" else ()
+    return SimpleNamespace(
+        resource_index=0,
+        resource_type=resource_type,
+        adapter=adapter,
+        state=state,
+        changed=action is not None,
+        transitions=transitions,
+        before=before,
+        proposed=proposed,
+        operations=SimpleNamespace(
+            after=after,
+            creates=creates,
+            updates=updates,
+            deletes=deletes,
+        ),
+        orchestrator=SimpleNamespace(fabric_context=context or FakeFabricContext()),
+    )
+
+
+def _projection_plan(resource_plan):
+    return SimpleNamespace(
+        changed=resource_plan.changed,
+        fabric_name="FABRIC1",
+        mutation_count=1 if resource_plan.changed else 0,
+        target_switch_ids=("SERIAL1", "SERIAL2"),
+        resources=(resource_plan,),
+        request_stats={"switches": 2, "interface_inventory_gets": 0},
+    )
+
+
+def test_target_projection_is_switch_aware_and_debug_retains_full_family():
+    proposed = [_ethernet_config("192.0.2.2", "Ethernet1/1", access_vlan=200)]
+    family = [
+        _ethernet_config("192.0.2.1", "Ethernet1/1", access_vlan=100),
+        *proposed,
+        _ethernet_config("192.0.2.2", "Ethernet1/5", access_vlan=5),
+    ]
+    resource_plan = _projection_resource(
+        "ethernet_access",
+        "merged",
+        proposed,
+        family_before=family,
+        family_after=family,
+    )
+    snapshot = ProjectionSnapshot(
+        [
+            ("SERIAL1", "Ethernet1/1", _raw_ethernet("Ethernet1/1", "accessHost", accessVlan=100)),
+            ("SERIAL2", "Ethernet1/1", _raw_ethernet("Ethernet1/1", "accessHost", accessVlan=200)),
+            ("SERIAL2", "Ethernet1/5", _raw_ethernet("Ethernet1/5", "accessHost", accessVlan=5)),
+        ]
+    )
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True, output_level="debug"))
+    coordinator._snapshot = snapshot
+
+    result = coordinator._format_result(_projection_plan(resource_plan))
+
+    projected = result["resources"][0]
+    assert set(result) == COMPACT_RESULT_KEYS
+    assert set(projected) == COMPACT_RESOURCE_KEYS | {"proposed", "family_before", "family_after"}
+    assert [(item["switch_ip"], item["interface_name"]) for item in projected["before"]] == [("192.0.2.2", "Ethernet1/1")]
+    assert projected["before"][0]["config_data"]["network_os"]["policy"]["access_vlan"] == 200
+    assert projected["after"] == projected["before"]
+    assert len(projected["family_before"]) == 3
+    assert len(projected["family_after"]) == 3
+    assert "family_diff" not in projected
+    assert "diff" not in projected
+    assert "before" not in result
+    assert "after" not in result
+    assert "diff" not in result
+    assert "check_mode" not in result
+    assert "output_level" not in result
+
+
+def test_cross_policy_transition_uses_unknown_source_fallback_and_destination_model():
+    proposed = [_ethernet_config("192.0.2.1", "Ethernet1/1", access_vlan=3900)]
+    resource_plan = _projection_resource(
+        "ethernet_access",
+        "merged",
+        proposed,
+        family_after=proposed,
+        action="transition",
+    )
+    raw = _raw_ethernet(
+        "Ethernet1/1",
+        "dot1qTunnel",
+        customerVlanId=[100, 200],
+        providerVlanId=3900,
+    )
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    coordinator._snapshot = ProjectionSnapshot([("SERIAL1", "Ethernet1/1", raw)])
+
+    result = coordinator._format_result(_projection_plan(resource_plan))
+    projected = result["resources"][0]
+
+    assert projected["before"][0]["policy_type"] == "dot1qTunnel"
+    source_policy = projected["before"][0]["config_data"]["network_os"]["policy"]
+    assert source_policy["customer_vlan_id"] == [100, 200]
+    assert source_policy["provider_vlan_id"] == 3900
+    assert projected["after"][0]["policy_type"] == "accessHost"
+    assert projected["after"][0]["config_data"]["network_os"]["policy"]["access_vlan"] == 3900
+    assert projected["operations"][0]["action"] == "transition"
+    assert projected["operations"][0]["from_policy_type"] == "routedHost"
+    assert projected["operations"][0]["to_policy_type"] == "accessHost"
+    assert projected["operations"][0]["status"] == "planned"
+    assert projected["operations"][0]["changes"]
+
+
+@pytest.mark.parametrize(
+    ("raw", "action", "expected_changed"),
+    [
+        (_raw_ethernet("Ethernet1/1", "accessHost", accessVlan=3900), "delete", True),
+        (
+            {
+                **InterfaceDefaultConfig().to_payload(),
+                "interfaceName": "Ethernet1/1",
+            },
+            None,
+            False,
+        ),
+    ],
+)
+def test_physical_delete_reports_reset_default_or_idempotent_default(raw, action, expected_changed):
+    proposed = [_ethernet_config("192.0.2.1", "Ethernet1/1")]
+    resource_plan = _projection_resource(
+        "ethernet_access",
+        "deleted",
+        proposed,
+        action=action,
+    )
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    coordinator._snapshot = ProjectionSnapshot([("SERIAL1", "Ethernet1/1", raw)])
+
+    projected = coordinator._format_result(_projection_plan(resource_plan))["resources"][0]
+
+    assert projected["before"][0]["interface_name"] == "Ethernet1/1"
+    assert projected["after"][0]["interface_name"] == "Ethernet1/1"
+    assert projected["after"][0]["policy_type"] == "trunkHost"
+    assert projected["after"][0]["config_data"]["network_os"]["policy"]["allowed_vlans"] == "none"
+    assert projected["changed"] is expected_changed
+    assert bool(projected["operations"]) is expected_changed
+    if expected_changed:
+        assert projected["operations"][0]["action"] == "reset"
+        assert {"path": "policy_type", "before": "accessHost", "after": "trunkHost"} in projected["operations"][0]["changes"]
+
+
+@pytest.mark.parametrize("present", [True, False])
+def test_logical_delete_reports_requested_resource_or_clean_absence(present):
+    config = [{"switch_ip": "192.0.2.1", "interface_name": "loopback10"}]
+    resource_plan = _projection_resource(
+        "loopback",
+        "deleted",
+        config,
+        action="delete" if present else None,
+    )
+    records = [("SERIAL1", "loopback10", _raw_loopback("loopback10"))] if present else []
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    coordinator._snapshot = ProjectionSnapshot(records)
+
+    projected = coordinator._format_result(_projection_plan(resource_plan))["resources"][0]
+
+    assert len(projected["before"]) == int(present)
+    assert projected["after"] == []
+    assert projected["changed"] is present
+    assert bool(projected["operations"]) is present
+    if present:
+        assert projected["operations"][0]["action"] == "delete"
+        assert "changes" not in projected["operations"][0]
+
+
+def _raw_vpc(name, peer_switch_id, access_vlan=3900):
+    return {
+        "interfaceName": name,
+        "interfaceType": "vpc",
+        "configData": {
+            "mode": "access",
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "policyType": "accessVpcHost",
+                    "accessVlan": access_vlan,
+                    "peerSwitchId": peer_switch_id,
+                },
+            },
+        },
+    }
+
+
+def _vpc_access_config(switch_ip, peer_switch_id, access_vlan):
+    """Return one reporting-equivalent vPC access model config."""
+    return {
+        "switch_ip": switch_ip,
+        "interface_name": "vpc10",
+        "config_data": {
+            "network_os": {
+                "policy": {
+                    "access_vlan": access_vlan,
+                    "peer_switch_id": peer_switch_id,
+                }
+            }
+        },
+    }
+
+
+def test_observed_vpc_target_requires_both_consistent_peer_records():
+    adapter = INTERFACE_FAMILY_ADAPTERS["vpc_access"]
+    desired = SimpleNamespace(switch_ip="192.0.2.1", interface_name="vpc10")
+    orchestrator = SimpleNamespace(
+        fabric_context=FakeFabricContext(),
+        _peer_serial_cache={"SERIAL1": "SERIAL2", "SERIAL2": "SERIAL1"},
+    )
+    resource_plan = SimpleNamespace(adapter=adapter, orchestrator=orchestrator)
+    primary = _raw_vpc("vpc10", "SERIAL2")
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=False))
+    coordinator._snapshot = ProjectionSnapshot([("SERIAL1", "vpc10", primary)])
+
+    assert not coordinator._vpc_target_is_pair_consistent(resource_plan, desired, primary)
+
+    coordinator._snapshot = ProjectionSnapshot(
+        [
+            ("SERIAL1", "vpc10", primary),
+            ("SERIAL2", "vpc10", _raw_vpc("vpc10", "SERIAL1")),
+        ]
+    )
+    assert coordinator._vpc_target_is_pair_consistent(resource_plan, desired, primary)
+
+
+@pytest.mark.parametrize(
+    ("primary_peer_id", "peer_peer_id"),
+    [
+        pytest.param("SERIAL1", "SERIAL2", id="self-references"),
+        pytest.param("OUTSIDE-PAIR", "OUTSIDE-PAIR", id="outside-authoritative-pair"),
+    ],
+)
+def test_observed_vpc_target_rejects_wrong_or_self_peer_switch_ids(primary_peer_id, peer_peer_id):
+    """Matching policy data cannot hide peer IDs that contradict the authoritative pair."""
+    adapter = INTERFACE_FAMILY_ADAPTERS["vpc_access"]
+    desired = SimpleNamespace(switch_ip="192.0.2.1", interface_name="vpc10")
+    resource_plan = SimpleNamespace(
+        adapter=adapter,
+        orchestrator=SimpleNamespace(
+            fabric_context=FakeFabricContext(),
+            _peer_serial_cache={"SERIAL1": "SERIAL2", "SERIAL2": "SERIAL1"},
+        ),
+    )
+    primary = _raw_vpc("vpc10", primary_peer_id)
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=False))
+    coordinator._snapshot = ProjectionSnapshot(
+        [
+            ("SERIAL1", "vpc10", primary),
+            ("SERIAL2", "vpc10", _raw_vpc("vpc10", peer_peer_id)),
+        ]
+    )
+
+    assert not coordinator._vpc_target_is_pair_consistent(resource_plan, desired, primary)
+
+
+@pytest.mark.parametrize(
+    ("primary_peer_id", "peer_peer_id"),
+    [
+        pytest.param("SERIAL1", "SERIAL2", id="self-references"),
+        pytest.param("OUTSIDE-PAIR", "OUTSIDE-PAIR", id="outside-authoritative-pair"),
+    ],
+)
+def test_observed_overridden_vpc_rejects_wrong_or_self_peer_switch_ids(primary_peer_id, peer_peer_id):
+    """A full-family observation is unverified when reciprocal records name invalid peers."""
+    adapter = INTERFACE_FAMILY_ADAPTERS["vpc_access"]
+    resource_plan = SimpleNamespace(
+        adapter=adapter,
+        proposed=(),
+        orchestrator=SimpleNamespace(
+            fabric_context=FakeFabricContext(),
+            _peer_serial_cache={"SERIAL1": "SERIAL2", "SERIAL2": "SERIAL1"},
+        ),
+    )
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=False))
+    coordinator._snapshot = ProjectionSnapshot(
+        [
+            ("SERIAL1", "vpc10", _raw_vpc("vpc10", primary_peer_id)),
+            ("SERIAL2", "vpc10", _raw_vpc("vpc10", peer_peer_id)),
+        ]
+    )
+
+    projected, verified = coordinator._observed_overridden_vpc_after(resource_plan, FakeCollection([]))
+
+    assert len(projected) == 1
+    assert not verified
+
+
+def test_observed_overridden_vpc_preserves_equal_names_on_independent_pairs():
+    adapter = INTERFACE_FAMILY_ADAPTERS["vpc_access"]
+    peer_cache = {
+        "SERIAL1": "SERIAL2",
+        "SERIAL2": "SERIAL1",
+        "SERIAL3": "SERIAL4",
+        "SERIAL4": "SERIAL3",
+    }
+    resource_plan = SimpleNamespace(
+        adapter=adapter,
+        proposed=(),
+        orchestrator=SimpleNamespace(
+            fabric_context=FakeFabricContext(),
+            _peer_serial_cache=peer_cache,
+        ),
+    )
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=False))
+    coordinator._snapshot = ProjectionSnapshot(
+        [
+            ("SERIAL1", "vpc10", _raw_vpc("vpc10", "SERIAL2", 100)),
+            ("SERIAL2", "vpc10", _raw_vpc("vpc10", "SERIAL1", 100)),
+            ("SERIAL3", "vpc10", _raw_vpc("vpc10", "SERIAL4", 200)),
+            ("SERIAL4", "vpc10", _raw_vpc("vpc10", "SERIAL3", 200)),
+        ]
+    )
+
+    projected, verified = coordinator._observed_overridden_vpc_after(resource_plan, FakeCollection([]))
+
+    assert verified
+    assert [(item["switch_ip"], item["interface_name"]) for item in projected] == [
+        ("192.0.2.1", "vpc10"),
+        ("192.0.2.3", "vpc10"),
+    ]
+
+
+def test_overridden_vpc_observation_uses_model_identity_order_without_false_diff():
+    """Serial-pair ordering cannot make equal full-scope state appear changed."""
+    context = InverseSerialOrderFabricContext()
+    family = [
+        _vpc_access_config("192.0.2.1", "SERIAL-Z2", 100),
+        _vpc_access_config("192.0.2.3", "SERIAL-A2", 200),
+    ]
+    resource_plan = _projection_resource(
+        "vpc_access",
+        "overridden",
+        family,
+        family_before=family,
+        family_after=family,
+        context=context,
+    )
+    resource_plan.orchestrator._peer_serial_cache = {
+        "SERIAL-Z1": "SERIAL-Z2",
+        "SERIAL-Z2": "SERIAL-Z1",
+        "SERIAL-A1": "SERIAL-A2",
+        "SERIAL-A2": "SERIAL-A1",
+    }
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=False, output_level="debug"))
+    coordinator._snapshot = ProjectionSnapshot(
+        [
+            ("SERIAL-Z1", "vpc10", _raw_vpc("vpc10", "SERIAL-Z2", 100)),
+            ("SERIAL-Z2", "vpc10", _raw_vpc("vpc10", "SERIAL-Z1", 100)),
+            ("SERIAL-A1", "vpc10", _raw_vpc("vpc10", "SERIAL-A2", 200)),
+            ("SERIAL-A2", "vpc10", _raw_vpc("vpc10", "SERIAL-A1", 200)),
+        ]
+    )
+
+    result = coordinator._format_result(_projection_plan(resource_plan))
+    projected = result["resources"][0]
+
+    assert result["changed"] is False
+    assert projected["changed"] is False
+    assert projected["operations"] == []
+    assert projected["before"] == projected["after"]
+    assert "diff" not in projected
+    assert projected["family_before"] == projected["family_after"]
+    assert "family_diff" not in projected
 
 
 def test_vpc_pair_map_is_authoritative_and_bidirectional(monkeypatch):
@@ -329,9 +1089,7 @@ def test_vpc_pair_map_accepts_consistent_duplicate_and_inverse_records(monkeypat
         },
     )
 
-    pair_map = coordinator._vpc_pair_map(
-        resources=[{"type": "vpc_access", "config": []}], fabric_context=FakeFabricContext(), rest_send=object()
-    )
+    pair_map = coordinator._vpc_pair_map(resources=[{"type": "vpc_access", "config": []}], fabric_context=FakeFabricContext(), rest_send=object())
     assert pair_map == {"192.0.2.1": "SERIAL2", "192.0.2.2": "SERIAL1"}
 
 

--- a/tests/unit/module_utils/test_interface_workflow_coordinator.py
+++ b/tests/unit/module_utils/test_interface_workflow_coordinator.py
@@ -1,0 +1,302 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the Phase 3 public interface workflow coordinator."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_coordinator import (
+    InterfaceWorkflowCoordinator,
+    InterfaceWorkflowExecutionFailed,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planner import (
+    InterfaceWorkflowValidationError,
+)
+
+
+class FakeCollection:
+    """Small NDConfigCollection-compatible serializer for coordinator output tests."""
+
+    def __init__(self, config):
+        self.config = config
+
+    def to_ansible_config(self):
+        return self.config
+
+    def get_diff_collection(self, other):
+        return self.config != other.config
+
+
+class FakeModel:
+    """Small model serializer for action output."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def to_config(self):
+        return self.value
+
+
+class FakeModule:
+    """Module shape needed by the coordinator."""
+
+    def __init__(self, *, check_mode, output_level="normal"):
+        self.check_mode = check_mode
+        self.params = {
+            "fabric_name": "FABRIC1",
+            "resources": [],
+            "config_actions": {"deploy": True},
+            "output_level": output_level,
+        }
+
+
+def resource(index, *, changed=True):
+    """Return one InterfaceResourcePlan-shaped object."""
+    before_config = [{"interface_name": f"Ethernet1/{index + 1}", "value": "old"}]
+    after_config = (
+        [{"interface_name": f"Ethernet1/{index + 1}", "value": "new"}]
+        if changed
+        else before_config
+    )
+    before = FakeCollection(before_config)
+    after = FakeCollection(after_config)
+    operations = SimpleNamespace(
+        after=after,
+        creates=(
+            (FakeModel({"interface_name": f"Ethernet1/{index + 1}"}),)
+            if changed
+            else ()
+        ),
+        updates=(),
+        deletes=(),
+    )
+    return SimpleNamespace(
+        resource_index=index,
+        resource_type="ethernet_access",
+        adapter=SimpleNamespace(module_name="cisco.nd.nd_interface_ethernet_access"),
+        state="merged",
+        changed=changed,
+        before=before,
+        proposed=FakeCollection(after_config),
+        operations=operations,
+    )
+
+
+def plan(*, changed=True):
+    """Return one InterfaceWorkflowPlan-shaped object with repeated family types."""
+    resources = (resource(0, changed=changed), resource(1, changed=False))
+    return SimpleNamespace(
+        changed=changed,
+        fabric_name="FABRIC1",
+        mutation_count=1 if changed else 0,
+        target_switch_ids=("SERIAL1", "SERIAL2"),
+        resources=resources,
+        request_stats={"switches": 2, "interface_inventory_gets": 2},
+    )
+
+
+class FakeExecution:
+    """InterfaceWorkflowExecution-compatible result for coordinator wiring tests."""
+
+    def __init__(self, workflow_plan, *, failed=False):
+        self.changed = not failed
+        self.failed = failed
+        self.message = "execution failed" if failed else ""
+        self.mutation_requests = 1
+        self.deploy_requests = 1 if not failed else 0
+        self.actual_after_by_resource = {
+            item.resource_index: item.operations.after if not failed else item.before
+            for item in workflow_plan.resources
+        }
+
+    def to_dict(self):
+        return {
+            "status": "failed" if self.failed else "completed",
+            "mutations_sent": self.mutation_requests,
+            "deployments_sent": self.deploy_requests,
+            "affected_switch_ids": ["SERIAL1"],
+            "items": [],
+            "deployment": {
+                "requested": True,
+                "status": "succeeded" if not self.failed else "not_attempted",
+                "targets": [],
+            },
+            "errors": [self.message] if self.failed else [],
+        }
+
+
+class FakeExecutor:
+    """Capture coordinator execution settings and return a configured result."""
+
+    def __init__(self, calls, *, failed=False, **kwargs):
+        self.calls = calls
+        self.failed = failed
+        self.calls.append(("init", kwargs))
+
+    def execute(self, workflow_plan):
+        self.calls.append(("execute", workflow_plan))
+        return FakeExecution(workflow_plan, failed=self.failed)
+
+
+def test_check_mode_result_retains_repeated_groups_and_reports_planned_change():
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    result = coordinator._format_result(plan())
+
+    assert result["changed"] is True
+    assert result["planned_changed"] is True
+    assert result["execution"]["status"] == "check_mode"
+    assert result["execution"]["mutations_sent"] == 0
+    assert [item["resource_index"] for item in result["resources"]] == [0, 1]
+    assert [item["type"] for item in result["resources"]] == [
+        "ethernet_access",
+        "ethernet_access",
+    ]
+    assert result["resources"][0]["diff"] == {
+        "before": [{"interface_name": "Ethernet1/1", "value": "old"}],
+        "after": [{"interface_name": "Ethernet1/1", "value": "new"}],
+    }
+    assert result["resources"][0]["after_verified"] is False
+    assert "proposed" not in result["resources"][0]
+    assert result["request_stats"]["interface_inventory_gets"] == 2
+    assert result["request_stats"]["mutation_requests"] == 0
+    assert result["request_stats"]["deploy_requests"] == 0
+
+
+def test_info_output_includes_normalized_proposed_config():
+    coordinator = InterfaceWorkflowCoordinator(
+        FakeModule(check_mode=True, output_level="info")
+    )
+    result = coordinator._format_result(plan())
+    assert result["resources"][0]["proposed"][0]["value"] == "new"
+
+
+def test_check_mode_run_returns_complete_plan_without_execution(monkeypatch):
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: plan())
+    result = coordinator.run()
+    assert result["changed"] is True
+    assert result["execution"]["status"] == "check_mode"
+
+
+def test_normal_no_change_run_succeeds_without_execution(monkeypatch):
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=False))
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: plan(changed=False))
+    result = coordinator.run()
+    assert result["changed"] is False
+    assert result["planned_changed"] is False
+    assert result["execution"]["status"] == "no_change"
+
+
+def test_normal_changing_run_executes_and_reports_actual_state(monkeypatch):
+    calls = []
+    coordinator = InterfaceWorkflowCoordinator(
+        FakeModule(check_mode=False),
+        executor_factory=lambda **kwargs: FakeExecutor(calls, **kwargs),
+    )
+    coordinator._snapshot = SimpleNamespace(
+        request_stats={"switches": 2, "interface_inventory_gets": 2}
+    )
+    workflow_plan = plan()
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: workflow_plan)
+
+    result = coordinator.run()
+
+    assert [call[0] for call in calls] == ["init", "execute"]
+    assert calls[0][1]["deploy"] is True
+    assert result["changed"] is True
+    assert result["execution"]["status"] == "completed"
+    assert result["resources"][0]["after_verified"] is True
+    assert result["request_stats"]["mutation_requests"] == 1
+    assert result["request_stats"]["deploy_requests"] == 1
+
+
+def test_normal_execution_failure_preserves_structured_result(monkeypatch):
+    calls = []
+    coordinator = InterfaceWorkflowCoordinator(
+        FakeModule(check_mode=False),
+        executor_factory=lambda **kwargs: FakeExecutor(calls, failed=True, **kwargs),
+    )
+    coordinator._snapshot = SimpleNamespace(
+        request_stats={"switches": 2, "interface_inventory_gets": 2}
+    )
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: plan())
+
+    with pytest.raises(InterfaceWorkflowExecutionFailed) as exc_info:
+        coordinator.run()
+
+    assert exc_info.value.result["failed"] is True
+    assert exc_info.value.result["execution"]["status"] == "failed"
+    assert exc_info.value.result["request_stats"]["mutation_requests"] == 1
+
+
+class FakeFabricContext:
+    fabric_name = "FABRIC1"
+
+    switch_ip_by_id = {"SERIAL1": "192.0.2.1", "SERIAL2": "192.0.2.2"}
+
+    def get_switch_ip(self, switch_id):
+        try:
+            return self.switch_ip_by_id[switch_id]
+        except KeyError as exc:
+            raise RuntimeError("unknown switch") from exc
+
+
+def test_vpc_pair_map_is_authoritative_and_bidirectional(monkeypatch):
+    module = FakeModule(check_mode=True)
+    resources = [{"type": "vpc_access", "config": [{"switch_ip": "192.0.2.2"}]}]
+    coordinator = InterfaceWorkflowCoordinator(module)
+    monkeypatch.setattr(
+        coordinator,
+        "_request",
+        lambda *_args, **_kwargs: {
+            "vpcPairs": [{"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"}]
+        },
+    )
+    pair_map = coordinator._vpc_pair_map(
+        resources=resources, fabric_context=FakeFabricContext(), rest_send=object()
+    )
+    assert pair_map == {"192.0.2.1": "SERIAL2", "192.0.2.2": "SERIAL1"}
+    assert coordinator._vpc_pair_gets == 1
+
+
+def test_vpc_group_rejects_switch_missing_from_authoritative_pair_inventory(
+    monkeypatch,
+):
+    module = FakeModule(check_mode=True)
+    resources = [{"type": "vpc_trunk_host", "config": [{"switch_ip": "192.0.2.99"}]}]
+    coordinator = InterfaceWorkflowCoordinator(module)
+    monkeypatch.setattr(
+        coordinator,
+        "_request",
+        lambda *_args, **_kwargs: {
+            "vpcPairs": [{"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"}]
+        },
+    )
+    with pytest.raises(
+        InterfaceWorkflowValidationError,
+        match=r"resources\[0\]\.config\[0\].*192\.0\.2\.99",
+    ):
+        coordinator._vpc_pair_map(
+            resources=resources, fabric_context=FakeFabricContext(), rest_send=object()
+        )
+
+
+def test_non_vpc_workflow_skips_pair_inventory(monkeypatch):
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    monkeypatch.setattr(
+        coordinator,
+        "_request",
+        lambda *_args, **_kwargs: pytest.fail("vPC request was not expected"),
+    )
+    pair_map = coordinator._vpc_pair_map(
+        resources=[{"type": "loopback", "config": []}],
+        fabric_context=FakeFabricContext(),
+        rest_send=object(),
+    )
+    assert pair_map == {}
+    assert coordinator._vpc_pair_gets == 0

--- a/tests/unit/module_utils/test_interface_workflow_coordinator.py
+++ b/tests/unit/module_utils/test_interface_workflow_coordinator.py
@@ -58,20 +58,12 @@ class FakeModule:
 def resource(index, *, changed=True):
     """Return one InterfaceResourcePlan-shaped object."""
     before_config = [{"interface_name": f"Ethernet1/{index + 1}", "value": "old"}]
-    after_config = (
-        [{"interface_name": f"Ethernet1/{index + 1}", "value": "new"}]
-        if changed
-        else before_config
-    )
+    after_config = [{"interface_name": f"Ethernet1/{index + 1}", "value": "new"}] if changed else before_config
     before = FakeCollection(before_config)
     after = FakeCollection(after_config)
     operations = SimpleNamespace(
         after=after,
-        creates=(
-            (FakeModel({"interface_name": f"Ethernet1/{index + 1}"}),)
-            if changed
-            else ()
-        ),
+        creates=((FakeModel({"interface_name": f"Ethernet1/{index + 1}"}),) if changed else ()),
         updates=(),
         deletes=(),
     )
@@ -109,10 +101,7 @@ class FakeExecution:
         self.message = "execution failed" if failed else ""
         self.mutation_requests = 1
         self.deploy_requests = 1 if not failed else 0
-        self.actual_after_by_resource = {
-            item.resource_index: item.operations.after if not failed else item.before
-            for item in workflow_plan.resources
-        }
+        self.actual_after_by_resource = {item.resource_index: item.operations.after if not failed else item.before for item in workflow_plan.resources}
 
     def to_dict(self):
         return {
@@ -168,9 +157,7 @@ def test_check_mode_result_retains_repeated_groups_and_reports_planned_change():
 
 
 def test_info_output_includes_normalized_proposed_config():
-    coordinator = InterfaceWorkflowCoordinator(
-        FakeModule(check_mode=True, output_level="info")
-    )
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True, output_level="info"))
     result = coordinator._format_result(plan())
     assert result["resources"][0]["proposed"][0]["value"] == "new"
 
@@ -192,15 +179,25 @@ def test_normal_no_change_run_succeeds_without_execution(monkeypatch):
     assert result["execution"]["status"] == "no_change"
 
 
+def test_normal_no_change_defaults_deploy_to_false_when_omitted(monkeypatch):
+    module = FakeModule(check_mode=False)
+    module.params["config_actions"] = {}
+    coordinator = InterfaceWorkflowCoordinator(module)
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: plan(changed=False))
+
+    result = coordinator.run()
+
+    assert result["config_actions"] == {}
+    assert result["execution"]["deployment"]["requested"] is False
+
+
 def test_normal_changing_run_executes_and_reports_actual_state(monkeypatch):
     calls = []
     coordinator = InterfaceWorkflowCoordinator(
         FakeModule(check_mode=False),
         executor_factory=lambda **kwargs: FakeExecutor(calls, **kwargs),
     )
-    coordinator._snapshot = SimpleNamespace(
-        request_stats={"switches": 2, "interface_inventory_gets": 2}
-    )
+    coordinator._snapshot = SimpleNamespace(request_stats={"switches": 2, "interface_inventory_gets": 2})
     workflow_plan = plan()
     monkeypatch.setattr(coordinator, "_build_plan", lambda: workflow_plan)
 
@@ -215,15 +212,30 @@ def test_normal_changing_run_executes_and_reports_actual_state(monkeypatch):
     assert result["request_stats"]["deploy_requests"] == 1
 
 
+def test_normal_changing_run_defaults_deploy_to_false_when_omitted(monkeypatch):
+    calls = []
+    module = FakeModule(check_mode=False)
+    module.params["config_actions"] = {}
+    coordinator = InterfaceWorkflowCoordinator(
+        module,
+        executor_factory=lambda **kwargs: FakeExecutor(calls, **kwargs),
+    )
+    coordinator._snapshot = SimpleNamespace(request_stats={"switches": 2, "interface_inventory_gets": 2})
+    workflow_plan = plan()
+    monkeypatch.setattr(coordinator, "_build_plan", lambda: workflow_plan)
+
+    coordinator.run()
+
+    assert calls[0][1]["deploy"] is False
+
+
 def test_normal_execution_failure_preserves_structured_result(monkeypatch):
     calls = []
     coordinator = InterfaceWorkflowCoordinator(
         FakeModule(check_mode=False),
         executor_factory=lambda **kwargs: FakeExecutor(calls, failed=True, **kwargs),
     )
-    coordinator._snapshot = SimpleNamespace(
-        request_stats={"switches": 2, "interface_inventory_gets": 2}
-    )
+    coordinator._snapshot = SimpleNamespace(request_stats={"switches": 2, "interface_inventory_gets": 2})
     monkeypatch.setattr(coordinator, "_build_plan", lambda: plan())
 
     with pytest.raises(InterfaceWorkflowExecutionFailed) as exc_info:
@@ -253,13 +265,9 @@ def test_vpc_pair_map_is_authoritative_and_bidirectional(monkeypatch):
     monkeypatch.setattr(
         coordinator,
         "_request",
-        lambda *_args, **_kwargs: {
-            "vpcPairs": [{"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"}]
-        },
+        lambda *_args, **_kwargs: {"vpcPairs": [{"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"}]},
     )
-    pair_map = coordinator._vpc_pair_map(
-        resources=resources, fabric_context=FakeFabricContext(), rest_send=object()
-    )
+    pair_map = coordinator._vpc_pair_map(resources=resources, fabric_context=FakeFabricContext(), rest_send=object())
     assert pair_map == {"192.0.2.1": "SERIAL2", "192.0.2.2": "SERIAL1"}
     assert coordinator._vpc_pair_gets == 1
 
@@ -273,17 +281,13 @@ def test_vpc_group_rejects_switch_missing_from_authoritative_pair_inventory(
     monkeypatch.setattr(
         coordinator,
         "_request",
-        lambda *_args, **_kwargs: {
-            "vpcPairs": [{"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"}]
-        },
+        lambda *_args, **_kwargs: {"vpcPairs": [{"switchId": "SERIAL1", "peerSwitchId": "SERIAL2"}]},
     )
     with pytest.raises(
         InterfaceWorkflowValidationError,
         match=r"resources\[0\]\.config\[0\].*192\.0\.2\.99",
     ):
-        coordinator._vpc_pair_map(
-            resources=resources, fabric_context=FakeFabricContext(), rest_send=object()
-        )
+        coordinator._vpc_pair_map(resources=resources, fabric_context=FakeFabricContext(), rest_send=object())
 
 
 def test_non_vpc_workflow_skips_pair_inventory(monkeypatch):

--- a/tests/unit/module_utils/test_interface_workflow_coordinator.py
+++ b/tests/unit/module_utils/test_interface_workflow_coordinator.py
@@ -164,7 +164,7 @@ def test_info_output_includes_normalized_proposed_config():
 
 def test_check_mode_run_returns_complete_plan_without_execution(monkeypatch):
     coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
-    monkeypatch.setattr(coordinator, "_build_plan", lambda: plan())
+    monkeypatch.setattr(coordinator, "_build_plan", plan)
     result = coordinator.run()
     assert result["changed"] is True
     assert result["execution"]["status"] == "check_mode"
@@ -236,7 +236,7 @@ def test_normal_execution_failure_preserves_structured_result(monkeypatch):
         executor_factory=lambda **kwargs: FakeExecutor(calls, failed=True, **kwargs),
     )
     coordinator._snapshot = SimpleNamespace(request_stats={"switches": 2, "interface_inventory_gets": 2})
-    monkeypatch.setattr(coordinator, "_build_plan", lambda: plan())
+    monkeypatch.setattr(coordinator, "_build_plan", plan)
 
     with pytest.raises(InterfaceWorkflowExecutionFailed) as exc_info:
         coordinator.run()

--- a/tests/unit/module_utils/test_interface_workflow_coordinator.py
+++ b/tests/unit/module_utils/test_interface_workflow_coordinator.py
@@ -912,6 +912,43 @@ def test_physical_delete_reports_reset_default_or_idempotent_default(raw, action
         assert {"path": "policy_type", "before": "accessHost", "after": "trunkHost"} in projected["operations"][0]["changes"]
 
 
+def test_ios_xe_physical_delete_projects_defaults_only_routed_policy() -> None:
+    """Verification-disabled output reflects the IOS-XE PUT reset rather than the NX-OS trunk default."""
+    proposed = [_ethernet_config("192.0.2.1", "GigabitEthernet3")]
+    resource_plan = _projection_resource("ethernet_access", "deleted", proposed, action="delete")
+    raw = {
+        "interfaceName": "GigabitEthernet3",
+        "interfaceType": "ethernet",
+        "configData": {
+            "mode": "routed",
+            "networkOS": {
+                "networkOSType": "ios-xe",
+                "policy": {
+                    "policyType": "iosXeRoutedHost",
+                    "adminState": True,
+                    "ip": "198.51.100.1",
+                    "prefix": 30,
+                },
+            },
+        },
+    }
+    coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
+    coordinator._snapshot = ProjectionSnapshot([("SERIAL1", "GigabitEthernet3", raw)])
+
+    projected = coordinator._format_result(_projection_plan(resource_plan))["resources"][0]
+
+    assert projected["before"][0]["policy_type"] == "iosXeRoutedHost"
+    assert projected["after"][0]["policy_type"] == "iosXeRoutedHost"
+    assert projected["after"][0]["config_data"]["network_os"] == {
+        "network_os_type": "ios-xe",
+        "policy": {"admin_state": True},
+    }
+    assert projected["operations"][0]["action"] == "reset"
+    changes = projected["operations"][0]["changes"]
+    assert {"path": "config_data.network_os.policy.ip", "before": "198.51.100.1", "after": None} in changes
+    assert {"path": "config_data.network_os.policy.prefix", "before": 30, "after": None} in changes
+
+
 @pytest.mark.parametrize("present", [True, False])
 def test_logical_delete_reports_requested_resource_or_clean_absence(present):
     config = [{"switch_ip": "192.0.2.1", "interface_name": "loopback10"}]
@@ -1392,10 +1429,13 @@ def test_vpc_pair_inventory_count_remains_visible_in_request_stats():
     coordinator = InterfaceWorkflowCoordinator(FakeModule(check_mode=True))
     coordinator._snapshot = SimpleNamespace(request_stats={"switches": 2, "interface_inventory_gets": 2})
     coordinator._vpc_pair_gets = 1
+    workflow_plan = plan()
+    workflow_plan.request_stats["fabric_link_gets"] = 2
 
-    result = coordinator._format_result(plan())
+    result = coordinator._format_result(workflow_plan)
 
     assert result["request_stats"]["vpc_pair_gets"] == 1
+    assert result["request_stats"]["fabric_link_gets"] == 2
 
 
 def test_authoritative_pair_inventory_seeds_one_cache_shared_by_all_vpc_orchestrators():

--- a/tests/unit/module_utils/test_interface_workflow_executor.py
+++ b/tests/unit/module_utils/test_interface_workflow_executor.py
@@ -8,15 +8,19 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
 from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_executor import (
     InterfaceWorkflowExecutor,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planner import (
     InterfacePolicyTransition,
+    InterfaceWorkflowPlanner,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import (
     VpcInterfaceBaseOrchestrator,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 
 
 class FakeModel:
@@ -329,6 +333,77 @@ def test_executor_defaults_to_staging_changes_without_deployment():
     assert "deploy" not in [event[0] for event in events]
 
 
+def test_deployment_only_execution_sends_one_exact_target_without_mutation_or_refresh():
+    events = []
+    orchestrator = FakeOrchestrator("only", events)
+    workflow_plan = plan(resource(0, orchestrator, actual=("before",)))
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(
+        workflow_plan,
+        deployment_targets=(("loopback1", "SERIAL1"),),
+    )
+
+    assert result.failed is False
+    assert result.status == "completed"
+    assert result.changed is True
+    assert result.mutation_requests == 0
+    assert result.deploy_requests == 1
+    assert result.affected_switch_ids == ()
+    assert result.items == ()
+    assert result.deployment == {
+        "requested": True,
+        "status": "succeeded",
+        "targets": [{"interface_name": "loopback1", "switch_id": "SERIAL1", "status": "succeeded"}],
+    }
+    assert events == [
+        ("validate", "only"),
+        ("deploy", "only", (("loopback1", "SERIAL1"),)),
+    ]
+
+
+def test_supplemental_and_mutation_deployment_targets_are_deduplicated_into_one_post():
+    events = []
+    orchestrator = FakeOrchestrator("only", events)
+    workflow_plan = plan(resource(0, orchestrator, creates=[FakeModel("loopback1")]))
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(
+        workflow_plan,
+        deployment_targets=(("loopback1", "SERIAL1"), ("loopback2", "SERIAL1")),
+    )
+
+    deploy_events = [event for event in events if event[0] == "deploy"]
+    assert result.failed is False
+    assert result.mutation_requests == 1
+    assert result.deploy_requests == 1
+    assert len(deploy_events) == 1
+    assert set(deploy_events[0][2]) == {
+        ("loopback1", "SERIAL1"),
+        ("loopback2", "SERIAL1"),
+    }
+
+
+def test_partial_deployment_only_failure_reports_successful_target_as_changed():
+    events = []
+    orchestrator = FakeOrchestrator("only", events, fail_deploy=True)
+    workflow_plan = plan(resource(0, orchestrator, actual=("before",)))
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(
+        workflow_plan,
+        deployment_targets=(("loopback1", "SERIAL1"), ("loopback2", "SERIAL1")),
+    )
+
+    assert result.failed is True
+    assert result.status == "partial_failure"
+    assert result.changed is True
+    assert result.mutation_requests == 0
+    assert result.deploy_requests == 1
+    assert result.deployment["status"] == "partial_failure"
+    assert {target["interface_name"]: target["status"] for target in result.deployment["targets"]} == {
+        "loopback1": "succeeded",
+        "loopback2": "failed",
+    }
+
+
 def test_transition_put_precedes_ordinary_updates_and_creates_then_deploys_once():
     events = []
     orchestrator = FakeOrchestrator("only", events)
@@ -433,6 +508,94 @@ def test_preflight_failure_sends_no_writes_and_leaves_every_item_not_attempted()
     assert result.deploy_requests == 0
     assert result.items[0].status == "not_attempted"
     assert not any(event[0] in {"create", "deploy", "dirty", "refresh"} for event in events)
+
+
+def test_preflight_failure_reconciles_equal_vpc_names_by_pair_without_false_change(monkeypatch):
+    """A read-only failed run keeps independent same-name pairs and reports no controller change."""
+    switch_map = {
+        "192.0.2.1": "SERIAL1",
+        "192.0.2.2": "SERIAL2",
+        "192.0.2.3": "SERIAL3",
+        "192.0.2.4": "SERIAL4",
+    }
+    peer_ids = ("SERIAL2", "SERIAL1", "SERIAL4", "SERIAL3")
+    responses = iter(
+        {
+            "interfaces": [
+                {
+                    "interfaceName": "vpc10",
+                    "interfaceType": "vpc",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessVpcHost",
+                                "accessVlan": 10,
+                                "peerSwitchId": peer_id,
+                            },
+                        },
+                    },
+                }
+            ]
+        }
+        for peer_id in peer_ids
+    )
+    rest_send = RestSend({"fabric_name": "FABRIC1", "check_mode": True})
+    context = FabricContext(rest_send=rest_send, fabric_name="FABRIC1")
+    context._fabric_summary = {"local": True, "fabricStatus": "default"}
+    context._switch_map = switch_map
+    context._switch_map_by_id = {switch_id: switch_ip for switch_ip, switch_id in switch_map.items()}
+    snapshot = InterfaceStateSnapshot(
+        fabric_name="FABRIC1",
+        fabric_context=context,
+        request=lambda **_kwargs: next(responses),
+    )
+    planner = InterfaceWorkflowPlanner(
+        snapshot=snapshot,
+        vpc_pair_by_switch_ip={
+            "192.0.2.1": "SERIAL2",
+            "192.0.2.2": "SERIAL1",
+            "192.0.2.3": "SERIAL4",
+            "192.0.2.4": "SERIAL3",
+        },
+    )
+    workflow_plan = planner.plan(
+        [
+            {
+                "type": "vpc_access",
+                "state": "merged",
+                "config": [
+                    {
+                        "switch_ip": switch_ip,
+                        "interface_name": "vpc10",
+                        "config_data": {"network_os": {"policy": {"access_vlan": 20}}},
+                    }
+                    for switch_ip in ("192.0.2.1", "192.0.2.3")
+                ],
+            }
+        ]
+    )
+    resource_plan = workflow_plan.resources[0]
+
+    def reject_preflight(_self, _models):
+        raise RuntimeError("switch is not capable")
+
+    monkeypatch.setattr(type(resource_plan.orchestrator), "preflight", reject_preflight)
+
+    result = InterfaceWorkflowExecutor(snapshot=snapshot).execute(workflow_plan)
+
+    actual = result.actual_after_by_resource[0]
+    assert result.failed is True
+    assert result.mutation_requests == 0
+    assert snapshot.request_stats["interface_inventory_gets"] == 4
+    assert len(actual) == 2
+    assert {item.get_identifier_value() for item in actual} == {
+        ("192.0.2.1", "vpc10"),
+        ("192.0.2.3", "vpc10"),
+    }
+    assert result.changed is False
+    assert result.status == "failed"
 
 
 def test_mixed_create_response_preserves_per_item_partial_success_and_stops_deploy():

--- a/tests/unit/module_utils/test_interface_workflow_executor.py
+++ b/tests/unit/module_utils/test_interface_workflow_executor.py
@@ -11,6 +11,12 @@ from types import SimpleNamespace
 from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_executor import (
     InterfaceWorkflowExecutor,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planner import (
+    InterfacePolicyTransition,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import (
+    VpcInterfaceBaseOrchestrator,
+)
 
 
 class FakeModel:
@@ -81,6 +87,7 @@ class FakeOrchestrator:
         fail_preflight=False,
         fail_create=False,
         fail_deploy=False,
+        fail_transition=False,
     ):
         self.name = name
         self.events = events
@@ -93,6 +100,7 @@ class FakeOrchestrator:
         self.deploy = True
         self._deploys = []
         self._removes = []
+        self.fail_transition = fail_transition
 
     @property
     def pending_deploys(self):
@@ -138,12 +146,16 @@ class FakeOrchestrator:
         self.rest_send.record("/interfaceActions/remove")
         self._removes = []
 
-    def update(self, model):
+    def update(self, model, existing_data=None):
         target = (
             model.interface_name,
             self.fabric_context.get_switch_id(model.switch_ip),
         )
-        self.events.append(("update", self.name, model.interface_name))
+        action = "transition" if existing_data is not None else "update"
+        self.events.append((action, self.name, model.interface_name))
+        if action == "transition" and self.fail_transition:
+            self.rest_send.record(f"/interfaces/{model.interface_name}", success=False, changed=False, method="PUT")
+            raise RuntimeError("policy transition rejected")
         self.rest_send.record(f"/interfaces/{model.interface_name}", method="PUT")
         self.queue_deploy_targets([target])
 
@@ -219,7 +231,7 @@ class FakeSnapshot:
         self.events.append(("refresh", tuple(switch_ids)))
 
 
-def resource(index, orchestrator, *, deletes=(), updates=(), creates=(), actual=("after",)):
+def resource(index, orchestrator, *, deletes=(), transitions=(), updates=(), creates=(), actual=("after",)):
     """Build one InterfaceResourcePlan-shaped value."""
     before = FakeCollection(["before"])
     return SimpleNamespace(
@@ -228,9 +240,23 @@ def resource(index, orchestrator, *, deletes=(), updates=(), creates=(), actual=
         state="merged",
         proposed=FakeCollection(["proposed"]),
         before=before,
+        transitions=tuple(transitions),
         operations=SimpleNamespace(deletes=tuple(deletes), updates=tuple(updates), creates=tuple(creates)),
         orchestrator=orchestrator,
         adapter=FakeAdapter(FakeCollection(actual)),
+    )
+
+
+def policy_transition(name="Ethernet1/1"):
+    """Build one explicit routed-to-access transition."""
+    return InterfacePolicyTransition(
+        desired=FakeModel(name),
+        current={"configData": {"networkOS": {"policy": {"policyType": "routedHost"}}}},
+        switch_ip="192.0.2.1",
+        switch_id="SERIAL1",
+        interface_name=name,
+        from_policy_type="routedHost",
+        to_policy_type="accessHost",
     )
 
 
@@ -303,6 +329,96 @@ def test_executor_defaults_to_staging_changes_without_deployment():
     assert "deploy" not in [event[0] for event in events]
 
 
+def test_transition_put_precedes_ordinary_updates_and_creates_then_deploys_once():
+    events = []
+    orchestrator = FakeOrchestrator("only", events)
+    workflow_plan = plan(
+        resource(
+            0,
+            orchestrator,
+            transitions=[policy_transition("Ethernet1/1")],
+            updates=[FakeModel("Ethernet1/2")],
+            creates=[FakeModel("Ethernet1/3")],
+        )
+    )
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
+
+    phase_names = [event[0] for event in events]
+    assert result.failed is False
+    assert result.status == "completed"
+    assert result.mutation_requests == 3
+    assert result.deploy_requests == 1
+    assert phase_names.index("transition") < phase_names.index("update") < phase_names.index("create") < phase_names.index("deploy")
+    transition_item = next(item for item in result.items if item.action == "transition")
+    assert transition_item.status == "succeeded"
+    assert transition_item.to_dict() == {
+        "resource_index": 0,
+        "type": "loopback",
+        "action": "transition",
+        "switch_ip": "192.0.2.1",
+        "switch_id": "SERIAL1",
+        "interface_name": "Ethernet1/1",
+        "status": "succeeded",
+        "from_policy_type": "routedHost",
+        "to_policy_type": "accessHost",
+    }
+    deploy_event = next(event for event in events if event[0] == "deploy")
+    assert set(deploy_event[2]) == {
+        ("Ethernet1/1", "SERIAL1"),
+        ("Ethernet1/2", "SERIAL1"),
+        ("Ethernet1/3", "SERIAL1"),
+    }
+
+
+def test_transition_with_deploy_false_stages_one_put_without_physical_deployment():
+    events = []
+    orchestrator = FakeOrchestrator("only", events)
+    workflow_plan = plan(resource(0, orchestrator, transitions=[policy_transition()]))
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=False).execute(workflow_plan)
+
+    assert result.failed is False
+    assert result.status == "staged"
+    assert result.mutation_requests == 1
+    assert result.deploy_requests == 0
+    assert result.deployment["requested"] is False
+    assert result.deployment["status"] == "disabled"
+    assert [event[0] for event in events].count("transition") == 1
+    assert "deploy" not in [event[0] for event in events]
+
+
+def test_transition_failure_stops_updates_creates_and_deployment():
+    events = []
+    orchestrator = FakeOrchestrator("only", events, fail_transition=True)
+    workflow_plan = plan(
+        resource(
+            0,
+            orchestrator,
+            transitions=[policy_transition("Ethernet1/1")],
+            updates=[FakeModel("Ethernet1/2")],
+            creates=[FakeModel("Ethernet1/3")],
+            actual=("before",),
+        )
+    )
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
+
+    status_by_action = {item.action: item.status for item in result.items}
+    assert result.failed is True
+    assert result.status == "failed"
+    assert result.changed is False
+    assert result.mutation_requests == 1
+    assert result.deploy_requests == 0
+    assert status_by_action == {
+        "transition": "failed",
+        "update": "not_attempted",
+        "create": "not_attempted",
+    }
+    assert result.deployment["status"] == "not_attempted"
+    assert not any(event[0] in {"update", "create", "deploy"} for event in events)
+
+
 def test_preflight_failure_sends_no_writes_and_leaves_every_item_not_attempted():
     events = []
     orchestrator = FakeOrchestrator("only", events, fail_preflight=True)
@@ -372,3 +488,66 @@ def test_deploy_false_stages_changes_without_sending_deploy_request():
     assert result.deploy_requests == 0
     assert result.deployment["status"] == "disabled"
     assert "deploy" not in [event[0] for event in events]
+
+
+class CacheAwareFakeVpcOrchestrator(FakeOrchestrator):
+    """Exercise the production vPC peer resolver through each executor write phase."""
+
+    fabric_name = "FABRIC1"
+
+    def __init__(self, name, events):
+        super().__init__(name, events)
+        self._peer_serial_cache = {}
+
+    def _request(self, *, path, verb, not_found_ok=False):
+        del verb, not_found_ok
+        self.rest_send.record(path, changed=False, method="GET")
+        return {"peerSwitchId": "UNSEEDED_PEER"}
+
+    def _resolve_model_peer(self, model):
+        switch_id = self.fabric_context.get_switch_id(model.switch_ip)
+        return VpcInterfaceBaseOrchestrator._resolve_peer_switch_id(self, model.switch_ip, switch_id)
+
+    def update(self, model, existing_data=None):
+        self._resolve_model_peer(model)
+        return super().update(model, existing_data=existing_data)
+
+    def create_bulk(self, models):
+        for model in models:
+            self._resolve_model_peer(model)
+        return super().create_bulk(models)
+
+
+def test_seeded_shared_vpc_cache_avoids_pair_gets_during_transition_update_and_create():
+    events = []
+    access = CacheAwareFakeVpcOrchestrator("access", events)
+    trunk = CacheAwareFakeVpcOrchestrator("trunk", events)
+    shared_cache = {
+        "SERIAL1": "SERIAL2",
+        "SERIAL2": "SERIAL1",
+    }
+    VpcInterfaceBaseOrchestrator.share_peer_serial_cache(access, shared_cache)
+    VpcInterfaceBaseOrchestrator.share_peer_serial_cache(trunk, shared_cache)
+    workflow_plan = plan(
+        resource(
+            0,
+            access,
+            transitions=[policy_transition("vpc10")],
+            updates=[FakeModel("vpc11")],
+        ),
+        resource(
+            1,
+            trunk,
+            creates=[FakeModel("vpc20", "192.0.2.2")],
+        ),
+    )
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events)).execute(workflow_plan)
+
+    responses = [*access.rest_send.responses, *trunk.rest_send.responses]
+    assert result.failed is False
+    assert result.mutation_requests == 3
+    assert access._peer_serial_cache is shared_cache
+    assert trunk._peer_serial_cache is shared_cache
+    assert all(response["METHOD"] != "GET" for response in responses)
+    assert all("/vpcPair" not in response["REQUEST_PATH"] for response in responses)

--- a/tests/unit/module_utils/test_interface_workflow_executor.py
+++ b/tests/unit/module_utils/test_interface_workflow_executor.py
@@ -414,12 +414,28 @@ class FakeSnapshot:
 
     def __init__(self, events):
         self.events = events
+        self._refreshes = 0
+        self._dirty_refetches = 0
+        self._interface_inventory_gets = 0
 
     def mark_dirty(self, switch_ids):
         self.events.append(("dirty", tuple(switch_ids)))
 
     def refresh(self, switch_ids):
-        self.events.append(("refresh", tuple(switch_ids)))
+        switch_ids = tuple(dict.fromkeys(switch_ids))
+        self.events.append(("refresh", switch_ids))
+        self._refreshes += len(switch_ids)
+        self._dirty_refetches += len(switch_ids)
+        self._interface_inventory_gets += len(switch_ids)
+
+    @property
+    def request_stats(self):
+        """Return the refresh counters relevant to optional verification tests."""
+        return {
+            "interface_inventory_gets": self._interface_inventory_gets,
+            "interface_inventory_refreshes": self._refreshes,
+            "interface_inventory_dirty_refetches": self._dirty_refetches,
+        }
 
 
 def resource(index, orchestrator, *, deletes=(), transitions=(), updates=(), creates=(), actual=("after",)):
@@ -476,7 +492,8 @@ def test_executor_orders_phases_consolidates_remove_and_deploy_then_refreshes():
         ),
     )
 
-    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
+    snapshot = FakeSnapshot(events)
+    result = InterfaceWorkflowExecutor(snapshot=snapshot, deploy=True, verify=True).execute(workflow_plan)
 
     phase_names = [event[0] for event in events]
     assert result.failed is False
@@ -501,7 +518,41 @@ def test_executor_orders_phases_consolidates_remove_and_deploy_then_refreshes():
         ("dirty", ("SERIAL1", "SERIAL2")),
         ("refresh", ("SERIAL1", "SERIAL2")),
     ]
+    assert snapshot.request_stats == {
+        "interface_inventory_gets": 2,
+        "interface_inventory_refreshes": 2,
+        "interface_inventory_dirty_refetches": 2,
+    }
+    assert set(result.actual_after_by_resource) == {0, 1}
     assert {item.status for item in result.items} == {"succeeded"}
+
+
+class SuccessfulChangedFalseFakeOrchestrator(FakeOrchestrator):
+    """Return exact mutation success while the generic result changed flag is false."""
+
+    def create_bulk(self, models):
+        super().create_bulk(models)
+        self.rest_send.results[-1]["changed"] = False
+
+
+def test_executor_defaults_to_no_verification_and_skips_post_mutation_inventory_gets():
+    events = []
+    orchestrator = SuccessfulChangedFalseFakeOrchestrator("only", events)
+    workflow_plan = plan(resource(0, orchestrator, creates=[FakeModel("loopback1")]))
+    snapshot = FakeSnapshot(events)
+
+    result = InterfaceWorkflowExecutor(snapshot=snapshot).execute(workflow_plan)
+
+    assert result.failed is False
+    assert result.changed is True
+    assert result.status == "staged"
+    assert result.actual_after_by_resource == {}
+    assert not any(event[0] in {"dirty", "refresh"} for event in events)
+    assert snapshot.request_stats == {
+        "interface_inventory_gets": 0,
+        "interface_inventory_refreshes": 0,
+        "interface_inventory_dirty_refetches": 0,
+    }
 
 
 def test_executor_defaults_to_staging_changes_without_deployment():
@@ -518,6 +569,8 @@ def test_executor_defaults_to_staging_changes_without_deployment():
     assert result.deployment["requested"] is False
     assert result.deployment["status"] == "disabled"
     assert "deploy" not in [event[0] for event in events]
+    assert not any(event[0] in {"dirty", "refresh"} for event in events)
+    assert result.actual_after_by_resource == {}
 
 
 def test_deployment_only_execution_sends_one_exact_target_without_mutation_or_refresh():
@@ -537,6 +590,7 @@ def test_deployment_only_execution_sends_one_exact_target_without_mutation_or_re
     assert result.deploy_requests == 1
     assert result.affected_switch_ids == ()
     assert result.items == ()
+    assert result.actual_after_by_resource[0].values == ["before"]
     assert result.deployment == {
         "requested": True,
         "status": "succeeded",
@@ -679,6 +733,11 @@ def test_transition_failure_stops_updates_creates_and_deployment():
     }
     assert result.deployment["status"] == "not_attempted"
     assert not any(event[0] in {"update", "create", "deploy"} for event in events)
+    assert events[-2:] == [
+        ("dirty", ("SERIAL1", "SERIAL2")),
+        ("refresh", ("SERIAL1", "SERIAL2")),
+    ]
+    assert result.actual_after_by_resource[0].values == ["before"]
 
 
 def test_preflight_failure_sends_no_writes_and_leaves_every_item_not_attempted():

--- a/tests/unit/module_utils/test_interface_workflow_executor.py
+++ b/tests/unit/module_utils/test_interface_workflow_executor.py
@@ -1,0 +1,397 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for aggregate interface mutation execution."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_executor import (
+    InterfaceWorkflowExecutor,
+)
+
+
+class FakeModel:
+    """Minimal interface model used by the executor."""
+
+    def __init__(self, name, switch_ip="192.0.2.1"):
+        self.interface_name = name
+        self.switch_ip = switch_ip
+
+    def get_identifier_value(self):
+        return self.switch_ip, self.interface_name
+
+
+class FakeCollection:
+    """Minimal collection used for actual-state reconciliation."""
+
+    def __init__(self, values):
+        self.values = list(values)
+
+    def __iter__(self):
+        return iter(self.values)
+
+    def get_diff_collection(self, other):
+        return self.values != other.values
+
+
+class FakeRestSend:
+    """Record controller request/response history."""
+
+    def __init__(self):
+        self.check_mode = True
+        self.params = {"check_mode": True}
+        self.responses = []
+        self.results = []
+
+    def record(self, path, *, success=True, changed=True, data=None, method="POST"):
+        self.responses.append(
+            {
+                "METHOD": method,
+                "REQUEST_PATH": path,
+                "RETURN_CODE": 200 if success else 207,
+                "DATA": data or {},
+            }
+        )
+        self.results.append({"success": success, "changed": changed})
+
+
+class FakeFabricContext:
+    """Resolve two stable switch identities."""
+
+    switch_ids = {"192.0.2.1": "SERIAL1", "192.0.2.2": "SERIAL2"}
+
+    def get_switch_id(self, switch_ip):
+        return self.switch_ids[switch_ip]
+
+
+class FakeOrchestrator:
+    """Develop-orchestrator lifecycle surface used by the executor."""
+
+    supports_bulk_delete = True
+    supports_bulk_create = True
+
+    def __init__(
+        self,
+        name,
+        events,
+        *,
+        fail_preflight=False,
+        fail_create=False,
+        fail_deploy=False,
+    ):
+        self.name = name
+        self.events = events
+        self.fail_preflight = fail_preflight
+        self.fail_create = fail_create
+        self.fail_deploy = fail_deploy
+        self.rest_send = FakeRestSend()
+        self.results = SimpleNamespace(check_mode=True)
+        self.fabric_context = FakeFabricContext()
+        self.deploy = True
+        self._deploys = []
+        self._removes = []
+
+    @property
+    def pending_deploys(self):
+        return tuple(self._deploys)
+
+    @property
+    def pending_removes(self):
+        return tuple(self._removes)
+
+    def queue_deploy_targets(self, targets):
+        for target in targets:
+            if target not in self._deploys:
+                self._deploys.append(target)
+
+    def queue_remove_targets(self, targets):
+        for target in targets:
+            if target not in self._removes:
+                self._removes.append(target)
+
+    def validate_prerequisites(self):
+        self.events.append(("validate", self.name))
+
+    def preflight_create(self, _models):
+        self.events.append(("preflight_create", self.name))
+
+    def preflight(self, _models):
+        self.events.append(("preflight", self.name))
+        if self.fail_preflight:
+            raise RuntimeError("switch is not capable")
+
+    def delete_bulk(self, models):
+        self.events.append(
+            ("delete_bulk", self.name, tuple(model.interface_name for model in models))
+        )
+        for model in models:
+            target = (
+                model.interface_name,
+                self.fabric_context.get_switch_id(model.switch_ip),
+            )
+            self.queue_remove_targets([target])
+            self.queue_deploy_targets([target])
+
+    def remove_pending(self):
+        self.events.append(("remove", self.name, tuple(self._removes)))
+        self.rest_send.record("/interfaceActions/remove")
+        self._removes = []
+
+    def update(self, model):
+        target = (
+            model.interface_name,
+            self.fabric_context.get_switch_id(model.switch_ip),
+        )
+        self.events.append(("update", self.name, model.interface_name))
+        self.rest_send.record(f"/interfaces/{model.interface_name}", method="PUT")
+        self.queue_deploy_targets([target])
+
+    def create_bulk(self, models):
+        names = tuple(model.interface_name for model in models)
+        self.events.append(("create", self.name, names))
+        if self.fail_create:
+            outcomes = [
+                {"name": names[0], "switchId": "SERIAL1", "status": "success"},
+                {
+                    "name": names[1],
+                    "switchId": "SERIAL1",
+                    "status": "failed",
+                    "message": "invalid policy",
+                },
+            ]
+            self.rest_send.record(
+                "/interfaces", success=False, changed=True, data={"results": outcomes}
+            )
+            raise RuntimeError("mixed create result")
+        self.rest_send.record("/interfaces")
+        for model in models:
+            target = (
+                model.interface_name,
+                self.fabric_context.get_switch_id(model.switch_ip),
+            )
+            self.queue_deploy_targets([target])
+
+    def deploy_pending(self):
+        targets = tuple(self._deploys)
+        self.events.append(("deploy", self.name, targets))
+        if self.fail_deploy:
+            outcomes = [
+                {"name": targets[0][0], "switchId": targets[0][1], "status": "success"},
+                {
+                    "name": targets[1][0],
+                    "switchId": targets[1][1],
+                    "status": "failed",
+                    "message": "switch rejected deploy",
+                },
+            ]
+            self.rest_send.record(
+                "/interfaceActions/deploy",
+                success=False,
+                changed=True,
+                data={"results": outcomes},
+            )
+            raise RuntimeError("mixed deploy result")
+        self.rest_send.record("/interfaceActions/deploy")
+        self._deploys = []
+
+
+class FakeAdapter:
+    """Return a preselected actual collection after snapshot refresh."""
+
+    ownership_domain = "loopback"
+
+    def __init__(self, actual):
+        self.actual = actual
+
+    def existing_collection(self, _orchestrator):
+        return self.actual
+
+
+class FakeSnapshot:
+    """Record dirty/refresh lifecycle calls."""
+
+    def __init__(self, events):
+        self.events = events
+
+    def mark_dirty(self, switch_ids):
+        self.events.append(("dirty", tuple(switch_ids)))
+
+    def refresh(self, switch_ids):
+        self.events.append(("refresh", tuple(switch_ids)))
+
+
+def resource(
+    index, orchestrator, *, deletes=(), updates=(), creates=(), actual=("after",)
+):
+    """Build one InterfaceResourcePlan-shaped value."""
+    before = FakeCollection(["before"])
+    return SimpleNamespace(
+        resource_index=index,
+        resource_type="loopback",
+        state="merged",
+        proposed=FakeCollection(["proposed"]),
+        before=before,
+        operations=SimpleNamespace(
+            deletes=tuple(deletes), updates=tuple(updates), creates=tuple(creates)
+        ),
+        orchestrator=orchestrator,
+        adapter=FakeAdapter(FakeCollection(actual)),
+    )
+
+
+def plan(*resources):
+    """Build one InterfaceWorkflowPlan-shaped value."""
+    return SimpleNamespace(
+        resources=tuple(resources), target_switch_ids=("SERIAL1", "SERIAL2")
+    )
+
+
+def test_executor_orders_phases_consolidates_remove_and_deploy_then_refreshes():
+    events = []
+    first = FakeOrchestrator("first", events)
+    second = FakeOrchestrator("second", events)
+    workflow_plan = plan(
+        resource(
+            0,
+            first,
+            deletes=[FakeModel("loopback1")],
+            updates=[FakeModel("loopback2")],
+            creates=[FakeModel("loopback3")],
+        ),
+        resource(
+            1,
+            second,
+            deletes=[FakeModel("loopback4", "192.0.2.2")],
+            creates=[FakeModel("loopback5", "192.0.2.2")],
+        ),
+    )
+
+    result = InterfaceWorkflowExecutor(
+        snapshot=FakeSnapshot(events), deploy=True
+    ).execute(workflow_plan)
+
+    phase_names = [event[0] for event in events]
+    assert result.failed is False
+    assert result.status == "completed"
+    assert result.changed is True
+    assert result.mutation_requests == 4
+    assert result.deploy_requests == 1
+    assert (
+        phase_names.index("remove")
+        < phase_names.index("update")
+        < phase_names.index("create")
+        < phase_names.index("deploy")
+    )
+    assert phase_names.count("remove") == 1
+    assert phase_names.count("deploy") == 1
+    remove_event = next(event for event in events if event[0] == "remove")
+    assert set(remove_event[2]) == {("loopback1", "SERIAL1"), ("loopback4", "SERIAL2")}
+    deploy_event = next(event for event in events if event[0] == "deploy")
+    assert set(deploy_event[2]) == {
+        ("loopback1", "SERIAL1"),
+        ("loopback2", "SERIAL1"),
+        ("loopback3", "SERIAL1"),
+        ("loopback4", "SERIAL2"),
+        ("loopback5", "SERIAL2"),
+    }
+    assert events[-2:] == [
+        ("dirty", ("SERIAL1", "SERIAL2")),
+        ("refresh", ("SERIAL1", "SERIAL2")),
+    ]
+    assert {item.status for item in result.items} == {"succeeded"}
+
+
+def test_preflight_failure_sends_no_writes_and_leaves_every_item_not_attempted():
+    events = []
+    orchestrator = FakeOrchestrator("only", events, fail_preflight=True)
+    workflow_plan = plan(
+        resource(0, orchestrator, creates=[FakeModel("loopback1")], actual=("before",))
+    )
+
+    result = InterfaceWorkflowExecutor(
+        snapshot=FakeSnapshot(events), deploy=True
+    ).execute(workflow_plan)
+
+    assert result.failed is True
+    assert result.status == "failed"
+    assert result.changed is False
+    assert result.mutation_requests == 0
+    assert result.deploy_requests == 0
+    assert result.items[0].status == "not_attempted"
+    assert not any(
+        event[0] in {"create", "deploy", "dirty", "refresh"} for event in events
+    )
+
+
+def test_mixed_create_response_preserves_per_item_partial_success_and_stops_deploy():
+    events = []
+    orchestrator = FakeOrchestrator("only", events, fail_create=True)
+    workflow_plan = plan(
+        resource(
+            0, orchestrator, creates=[FakeModel("loopback1"), FakeModel("loopback2")]
+        )
+    )
+
+    result = InterfaceWorkflowExecutor(
+        snapshot=FakeSnapshot(events), deploy=True
+    ).execute(workflow_plan)
+
+    statuses = {item.interface_name: item.status for item in result.items}
+    assert result.failed is True
+    assert result.status == "partial_failure"
+    assert result.changed is True
+    assert result.mutation_requests == 1
+    assert result.deploy_requests == 0
+    assert statuses == {"loopback1": "succeeded", "loopback2": "failed"}
+    assert result.deployment["status"] == "not_attempted"
+    assert "deploy" not in [event[0] for event in events]
+    assert events[-2:] == [
+        ("dirty", ("SERIAL1", "SERIAL2")),
+        ("refresh", ("SERIAL1", "SERIAL2")),
+    ]
+
+
+def test_mixed_deploy_response_reports_target_outcomes_without_erasing_mutation_success():
+    events = []
+    orchestrator = FakeOrchestrator("only", events, fail_deploy=True)
+    workflow_plan = plan(
+        resource(
+            0, orchestrator, creates=[FakeModel("loopback1"), FakeModel("loopback2")]
+        )
+    )
+
+    result = InterfaceWorkflowExecutor(
+        snapshot=FakeSnapshot(events), deploy=True
+    ).execute(workflow_plan)
+
+    deploy_statuses = {
+        item["interface_name"]: item["status"] for item in result.deployment["targets"]
+    }
+    assert result.failed is True
+    assert result.status == "partial_failure"
+    assert result.changed is True
+    assert result.mutation_requests == 1
+    assert result.deploy_requests == 1
+    assert {item.status for item in result.items} == {"succeeded"}
+    assert result.deployment["status"] == "partial_failure"
+    assert deploy_statuses == {"loopback1": "succeeded", "loopback2": "failed"}
+
+
+def test_deploy_false_stages_changes_without_sending_deploy_request():
+    events = []
+    orchestrator = FakeOrchestrator("only", events)
+    workflow_plan = plan(resource(0, orchestrator, creates=[FakeModel("loopback1")]))
+
+    result = InterfaceWorkflowExecutor(
+        snapshot=FakeSnapshot(events), deploy=False
+    ).execute(workflow_plan)
+
+    assert result.failed is False
+    assert result.status == "staged"
+    assert result.mutation_requests == 1
+    assert result.deploy_requests == 0
+    assert result.deployment["status"] == "disabled"
+    assert "deploy" not in [event[0] for event in events]

--- a/tests/unit/module_utils/test_interface_workflow_executor.py
+++ b/tests/unit/module_utils/test_interface_workflow_executor.py
@@ -124,9 +124,7 @@ class FakeOrchestrator:
             raise RuntimeError("switch is not capable")
 
     def delete_bulk(self, models):
-        self.events.append(
-            ("delete_bulk", self.name, tuple(model.interface_name for model in models))
-        )
+        self.events.append(("delete_bulk", self.name, tuple(model.interface_name for model in models)))
         for model in models:
             target = (
                 model.interface_name,
@@ -162,9 +160,7 @@ class FakeOrchestrator:
                     "message": "invalid policy",
                 },
             ]
-            self.rest_send.record(
-                "/interfaces", success=False, changed=True, data={"results": outcomes}
-            )
+            self.rest_send.record("/interfaces", success=False, changed=True, data={"results": outcomes})
             raise RuntimeError("mixed create result")
         self.rest_send.record("/interfaces")
         for model in models:
@@ -223,9 +219,7 @@ class FakeSnapshot:
         self.events.append(("refresh", tuple(switch_ids)))
 
 
-def resource(
-    index, orchestrator, *, deletes=(), updates=(), creates=(), actual=("after",)
-):
+def resource(index, orchestrator, *, deletes=(), updates=(), creates=(), actual=("after",)):
     """Build one InterfaceResourcePlan-shaped value."""
     before = FakeCollection(["before"])
     return SimpleNamespace(
@@ -234,9 +228,7 @@ def resource(
         state="merged",
         proposed=FakeCollection(["proposed"]),
         before=before,
-        operations=SimpleNamespace(
-            deletes=tuple(deletes), updates=tuple(updates), creates=tuple(creates)
-        ),
+        operations=SimpleNamespace(deletes=tuple(deletes), updates=tuple(updates), creates=tuple(creates)),
         orchestrator=orchestrator,
         adapter=FakeAdapter(FakeCollection(actual)),
     )
@@ -244,9 +236,7 @@ def resource(
 
 def plan(*resources):
     """Build one InterfaceWorkflowPlan-shaped value."""
-    return SimpleNamespace(
-        resources=tuple(resources), target_switch_ids=("SERIAL1", "SERIAL2")
-    )
+    return SimpleNamespace(resources=tuple(resources), target_switch_ids=("SERIAL1", "SERIAL2"))
 
 
 def test_executor_orders_phases_consolidates_remove_and_deploy_then_refreshes():
@@ -269,9 +259,7 @@ def test_executor_orders_phases_consolidates_remove_and_deploy_then_refreshes():
         ),
     )
 
-    result = InterfaceWorkflowExecutor(
-        snapshot=FakeSnapshot(events), deploy=True
-    ).execute(workflow_plan)
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
 
     phase_names = [event[0] for event in events]
     assert result.failed is False
@@ -279,12 +267,7 @@ def test_executor_orders_phases_consolidates_remove_and_deploy_then_refreshes():
     assert result.changed is True
     assert result.mutation_requests == 4
     assert result.deploy_requests == 1
-    assert (
-        phase_names.index("remove")
-        < phase_names.index("update")
-        < phase_names.index("create")
-        < phase_names.index("deploy")
-    )
+    assert phase_names.index("remove") < phase_names.index("update") < phase_names.index("create") < phase_names.index("deploy")
     assert phase_names.count("remove") == 1
     assert phase_names.count("deploy") == 1
     remove_event = next(event for event in events if event[0] == "remove")
@@ -304,16 +287,28 @@ def test_executor_orders_phases_consolidates_remove_and_deploy_then_refreshes():
     assert {item.status for item in result.items} == {"succeeded"}
 
 
+def test_executor_defaults_to_staging_changes_without_deployment():
+    events = []
+    orchestrator = FakeOrchestrator("only", events)
+    workflow_plan = plan(resource(0, orchestrator, creates=[FakeModel("loopback1")]))
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events)).execute(workflow_plan)
+
+    assert result.failed is False
+    assert result.status == "staged"
+    assert result.mutation_requests == 1
+    assert result.deploy_requests == 0
+    assert result.deployment["requested"] is False
+    assert result.deployment["status"] == "disabled"
+    assert "deploy" not in [event[0] for event in events]
+
+
 def test_preflight_failure_sends_no_writes_and_leaves_every_item_not_attempted():
     events = []
     orchestrator = FakeOrchestrator("only", events, fail_preflight=True)
-    workflow_plan = plan(
-        resource(0, orchestrator, creates=[FakeModel("loopback1")], actual=("before",))
-    )
+    workflow_plan = plan(resource(0, orchestrator, creates=[FakeModel("loopback1")], actual=("before",)))
 
-    result = InterfaceWorkflowExecutor(
-        snapshot=FakeSnapshot(events), deploy=True
-    ).execute(workflow_plan)
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
 
     assert result.failed is True
     assert result.status == "failed"
@@ -321,23 +316,15 @@ def test_preflight_failure_sends_no_writes_and_leaves_every_item_not_attempted()
     assert result.mutation_requests == 0
     assert result.deploy_requests == 0
     assert result.items[0].status == "not_attempted"
-    assert not any(
-        event[0] in {"create", "deploy", "dirty", "refresh"} for event in events
-    )
+    assert not any(event[0] in {"create", "deploy", "dirty", "refresh"} for event in events)
 
 
 def test_mixed_create_response_preserves_per_item_partial_success_and_stops_deploy():
     events = []
     orchestrator = FakeOrchestrator("only", events, fail_create=True)
-    workflow_plan = plan(
-        resource(
-            0, orchestrator, creates=[FakeModel("loopback1"), FakeModel("loopback2")]
-        )
-    )
+    workflow_plan = plan(resource(0, orchestrator, creates=[FakeModel("loopback1"), FakeModel("loopback2")]))
 
-    result = InterfaceWorkflowExecutor(
-        snapshot=FakeSnapshot(events), deploy=True
-    ).execute(workflow_plan)
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
 
     statuses = {item.interface_name: item.status for item in result.items}
     assert result.failed is True
@@ -357,19 +344,11 @@ def test_mixed_create_response_preserves_per_item_partial_success_and_stops_depl
 def test_mixed_deploy_response_reports_target_outcomes_without_erasing_mutation_success():
     events = []
     orchestrator = FakeOrchestrator("only", events, fail_deploy=True)
-    workflow_plan = plan(
-        resource(
-            0, orchestrator, creates=[FakeModel("loopback1"), FakeModel("loopback2")]
-        )
-    )
+    workflow_plan = plan(resource(0, orchestrator, creates=[FakeModel("loopback1"), FakeModel("loopback2")]))
 
-    result = InterfaceWorkflowExecutor(
-        snapshot=FakeSnapshot(events), deploy=True
-    ).execute(workflow_plan)
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
 
-    deploy_statuses = {
-        item["interface_name"]: item["status"] for item in result.deployment["targets"]
-    }
+    deploy_statuses = {item["interface_name"]: item["status"] for item in result.deployment["targets"]}
     assert result.failed is True
     assert result.status == "partial_failure"
     assert result.changed is True
@@ -385,9 +364,7 @@ def test_deploy_false_stages_changes_without_sending_deploy_request():
     orchestrator = FakeOrchestrator("only", events)
     workflow_plan = plan(resource(0, orchestrator, creates=[FakeModel("loopback1")]))
 
-    result = InterfaceWorkflowExecutor(
-        snapshot=FakeSnapshot(events), deploy=False
-    ).execute(workflow_plan)
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=False).execute(workflow_plan)
 
     assert result.failed is False
     assert result.status == "staged"

--- a/tests/unit/module_utils/test_interface_workflow_executor.py
+++ b/tests/unit/module_utils/test_interface_workflow_executor.py
@@ -17,6 +17,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planne
     InterfacePolicyTransition,
     InterfaceWorkflowPlanner,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import DeferredDeleteRequestGroup
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_interface_base import (
     VpcInterfaceBaseOrchestrator,
 )
@@ -83,6 +84,7 @@ class FakeOrchestrator:
 
     supports_bulk_delete = True
     supports_bulk_create = True
+    deferred_delete_queue_names = frozenset({"remove"})
 
     def __init__(
         self,
@@ -90,6 +92,7 @@ class FakeOrchestrator:
         events,
         *,
         fail_preflight=False,
+        fail_delete_preflight=False,
         fail_create=False,
         fail_deploy=False,
         fail_transition=False,
@@ -97,6 +100,7 @@ class FakeOrchestrator:
         self.name = name
         self.events = events
         self.fail_preflight = fail_preflight
+        self.fail_delete_preflight = fail_delete_preflight
         self.fail_create = fail_create
         self.fail_deploy = fail_deploy
         self.rest_send = FakeRestSend()
@@ -125,6 +129,28 @@ class FakeOrchestrator:
             if target not in self._removes:
                 self._removes.append(target)
 
+    @property
+    def deferred_delete_queues(self):
+        return {"remove": self.pending_removes}
+
+    @property
+    def pending_deferred_delete_targets(self):
+        return self.pending_removes
+
+    def queue_deferred_delete_targets(self, queue_name, targets):
+        assert queue_name == "remove"
+        self.queue_remove_targets(targets)
+
+    def dequeue_deferred_delete_targets(self, queue_name, targets):
+        assert queue_name == "remove"
+        removed = set(targets)
+        self._removes = [target for target in self._removes if target not in removed]
+
+    def deferred_delete_request_groups(self):
+        if not self.pending_removes:
+            return ()
+        return (DeferredDeleteRequestGroup("remove", self.pending_removes),)
+
     def validate_prerequisites(self):
         self.events.append(("validate", self.name))
 
@@ -135,6 +161,11 @@ class FakeOrchestrator:
         self.events.append(("preflight", self.name))
         if self.fail_preflight:
             raise RuntimeError("switch is not capable")
+
+    def preflight_delete(self, _models):
+        self.events.append(("preflight_delete", self.name))
+        if self.fail_delete_preflight:
+            raise RuntimeError("delete target is fabric-owned")
 
     def delete_bulk(self, models):
         self.events.append(("delete_bulk", self.name, tuple(model.interface_name for model in models)))
@@ -187,8 +218,12 @@ class FakeOrchestrator:
             )
             self.queue_deploy_targets([target])
 
-    def deploy_pending(self):
-        targets = tuple(self._deploys)
+    def dequeue_deploy_targets(self, targets):
+        removed = set(targets)
+        self._deploys = [target for target in self._deploys if target not in removed]
+
+    def deploy_targets(self, targets):
+        targets = tuple(dict.fromkeys(targets))
         self.events.append(("deploy", self.name, targets))
         if self.fail_deploy:
             outcomes = [
@@ -208,7 +243,12 @@ class FakeOrchestrator:
             )
             raise RuntimeError("mixed deploy result")
         self.rest_send.record("/interfaceActions/deploy")
-        self._deploys = []
+
+    def deploy_pending(self):
+        targets = tuple(self._deploys)
+        result = self.deploy_targets(targets)
+        self.dequeue_deploy_targets(targets)
+        return result
 
 
 class PolicyGroupedFakeOrchestrator(FakeOrchestrator):
@@ -286,8 +326,8 @@ class NormalReturn207CreateFakeOrchestrator(FakeOrchestrator):
 class NormalReturn207DeployFakeOrchestrator(FakeOrchestrator):
     """Return a superficially successful HTTP 207 that omits one deployed target."""
 
-    def deploy_pending(self):
-        targets = tuple(self._deploys)
+    def deploy_targets(self, targets):
+        targets = tuple(dict.fromkeys(targets))
         self.events.append(("deploy", self.name, targets))
         self.rest_send.record(
             "/interfaceActions/deploy",
@@ -304,14 +344,13 @@ class NormalReturn207DeployFakeOrchestrator(FakeOrchestrator):
             },
             return_code=207,
         )
-        self._deploys = []
 
 
 class MixedSwitch207DeployFakeOrchestrator(FakeOrchestrator):
     """Fail deployment with per-switch outcomes rather than per-interface outcomes."""
 
-    def deploy_pending(self):
-        targets = tuple(self._deploys)
+    def deploy_targets(self, targets):
+        targets = tuple(dict.fromkeys(targets))
         self.events.append(("deploy", self.name, targets))
         self.rest_send.record(
             "/interfaceActions/deploy",
@@ -342,6 +381,8 @@ class MixedSwitch207DeployFakeOrchestrator(FakeOrchestrator):
 class NormalReturn207EthernetFakeOrchestrator(FakeOrchestrator):
     """Model Ethernet normalize returning HTTP 207 while omitting one target."""
 
+    deferred_delete_queue_names = frozenset({"normalize", "reset"})
+
     def __init__(self, name, events):
         super().__init__(name, events)
         self._normalizes = []
@@ -364,6 +405,36 @@ class NormalReturn207EthernetFakeOrchestrator(FakeOrchestrator):
         for target in targets:
             if target not in self._resets:
                 self._resets.append(target)
+
+    @property
+    def deferred_delete_queues(self):
+        return {"normalize": self.pending_normalizes, "reset": self.pending_resets}
+
+    @property
+    def pending_deferred_delete_targets(self):
+        return tuple((*self.pending_normalizes, *self.pending_resets))
+
+    def queue_deferred_delete_targets(self, queue_name, targets):
+        if queue_name == "normalize":
+            self.queue_normalize_targets(targets)
+            return
+        assert queue_name == "reset"
+        self.queue_reset_targets(targets)
+
+    def dequeue_deferred_delete_targets(self, queue_name, targets):
+        removed = set(targets)
+        if queue_name == "normalize":
+            self._normalizes = [target for target in self._normalizes if target not in removed]
+            return
+        assert queue_name == "reset"
+        self._resets = [target for target in self._resets if target not in removed]
+
+    def deferred_delete_request_groups(self):
+        groups = []
+        if self.pending_normalizes:
+            groups.append(DeferredDeleteRequestGroup("normalize", self.pending_normalizes))
+        groups.extend(DeferredDeleteRequestGroup("reset", (target,)) for target in self.pending_resets)
+        return tuple(groups)
 
     def delete_bulk(self, models):
         self.events.append(("delete_bulk", self.name, tuple(model.interface_name for model in models)))
@@ -395,6 +466,71 @@ class NormalReturn207EthernetFakeOrchestrator(FakeOrchestrator):
         )
         self._normalizes = []
         self._resets = []
+
+
+class PlatformResetFakeOrchestrator(FakeOrchestrator):
+    """Model the routed orchestrator's per-interface IOS-XE reset queue."""
+
+    deferred_delete_queue_names = frozenset({"platform_reset"})
+
+    def __init__(self, name, events):
+        super().__init__(name, events)
+        self._platform_resets = []
+
+    @property
+    def deferred_delete_queues(self):
+        return {"platform_reset": tuple(self._platform_resets)}
+
+    @property
+    def pending_deferred_delete_targets(self):
+        return tuple(self._platform_resets)
+
+    def queue_deferred_delete_targets(self, queue_name, targets):
+        assert queue_name == "platform_reset"
+        for target in targets:
+            if target not in self._platform_resets:
+                self._platform_resets.append(target)
+
+    def dequeue_deferred_delete_targets(self, queue_name, targets):
+        assert queue_name == "platform_reset"
+        removed = set(targets)
+        self._platform_resets = [target for target in self._platform_resets if target not in removed]
+
+    def deferred_delete_request_groups(self):
+        return tuple(DeferredDeleteRequestGroup("platform_reset", (target,)) for target in self._platform_resets)
+
+    def delete_bulk(self, models):
+        self.events.append(("platform_delete_bulk", self.name, tuple(model.interface_name for model in models)))
+        for model in models:
+            target = (model.interface_name, self.fabric_context.get_switch_id(model.switch_ip))
+            self.queue_deferred_delete_targets("platform_reset", [target])
+            self.queue_deploy_targets([target])
+
+    def remove_pending(self):
+        for target in tuple(self._platform_resets):
+            self.events.append(("platform_reset", self.name, target))
+            self.rest_send.record(f"/interfaces/{target[0]}", method="PUT")
+            self._platform_resets.remove(target)
+
+
+class OverriddenPlatformResetFakeOrchestrator(PlatformResetFakeOrchestrator):
+    """Model the routed overridden contract, which skips IOS-XE physical deletes."""
+
+    def delete_bulk(self, models):
+        self.events.append(("platform_delete_bulk_skipped", self.name, tuple(model.interface_name for model in models)))
+
+
+class PlatformResetPreflightFakeOrchestrator(PlatformResetFakeOrchestrator):
+    """Fail only when the platform-aware IOS-XE reset proxy is preflighted."""
+
+    def __init__(self, name, events, blocked_model):
+        super().__init__(name, events)
+        self.blocked_model = blocked_model
+
+    def preflight_delete(self, models):
+        self.events.append(("preflight_delete_models", self.name, tuple(models)))
+        if self.blocked_model in models:
+            raise RuntimeError("IOS-XE target became a fabric-link endpoint")
 
 
 class FakeAdapter:
@@ -438,18 +574,31 @@ class FakeSnapshot:
         }
 
 
-def resource(index, orchestrator, *, deletes=(), transitions=(), updates=(), creates=(), actual=("after",)):
+def resource(
+    index,
+    orchestrator,
+    *,
+    deletes=(),
+    transitions=(),
+    updates=(),
+    creates=(),
+    platform_deletes=(),
+    state="merged",
+    resource_type="loopback",
+    actual=("after",),
+):
     """Build one InterfaceResourcePlan-shaped value."""
     before = FakeCollection(["before"])
     return SimpleNamespace(
         resource_index=index,
-        resource_type="loopback",
-        state="merged",
+        resource_type=resource_type,
+        state=state,
         proposed=FakeCollection(["proposed"]),
         before=before,
         transitions=tuple(transitions),
         operations=SimpleNamespace(deletes=tuple(deletes), updates=tuple(updates), creates=tuple(creates)),
         orchestrator=orchestrator,
+        platform_deletes=tuple(platform_deletes),
         adapter=FakeAdapter(FakeCollection(actual)),
     )
 
@@ -467,9 +616,13 @@ def policy_transition(name="Ethernet1/1"):
     )
 
 
-def plan(*resources):
+def plan(*resources, auxiliary_orchestrators=()):
     """Build one InterfaceWorkflowPlan-shaped value."""
-    return SimpleNamespace(resources=tuple(resources), target_switch_ids=("SERIAL1", "SERIAL2"))
+    return SimpleNamespace(
+        resources=tuple(resources),
+        target_switch_ids=("SERIAL1", "SERIAL2"),
+        auxiliary_orchestrators=tuple(auxiliary_orchestrators),
+    )
 
 
 def test_executor_orders_phases_consolidates_remove_and_deploy_then_refreshes():
@@ -514,6 +667,10 @@ def test_executor_orders_phases_consolidates_remove_and_deploy_then_refreshes():
         ("loopback4", "SERIAL2"),
         ("loopback5", "SERIAL2"),
     }
+    assert first.pending_removes == ()
+    assert second.pending_removes == ()
+    assert first.pending_deploys == ()
+    assert second.pending_deploys == ()
     assert events[-2:] == [
         ("dirty", ("SERIAL1", "SERIAL2")),
         ("refresh", ("SERIAL1", "SERIAL2")),
@@ -756,6 +913,148 @@ def test_preflight_failure_sends_no_writes_and_leaves_every_item_not_attempted()
     assert not any(event[0] in {"create", "deploy", "dirty", "refresh"} for event in events)
 
 
+def test_explicit_delete_preflight_is_repeated_immediately_before_writes() -> None:
+    """Normal execution refuses a newly unsafe explicit delete before queueing or sending any mutation."""
+    events = []
+    orchestrator = FakeOrchestrator("only", events, fail_delete_preflight=True)
+    workflow_plan = plan(resource(0, orchestrator, deletes=[FakeModel("Ethernet1/1")], state="deleted", actual=("before",)))
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
+
+    assert result.failed is True
+    assert result.changed is False
+    assert result.mutation_requests == 0
+    assert result.deploy_requests == 0
+    assert result.items[0].status == "not_attempted"
+    assert ("preflight_delete", "only") in events
+    assert not any(event[0] in {"delete_bulk", "remove", "deploy"} for event in events)
+
+
+def test_overridden_delete_does_not_call_explicit_delete_preflight() -> None:
+    """Fabric-wide overridden keeps its distinct skip semantics instead of using the explicit-delete refusal hook."""
+    events = []
+    orchestrator = FakeOrchestrator("only", events, fail_delete_preflight=True)
+    workflow_plan = plan(resource(0, orchestrator, deletes=[FakeModel("loopback1")], state="overridden"))
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events)).execute(workflow_plan)
+
+    assert result.failed is False
+    assert result.mutation_requests == 1
+    assert ("preflight_delete", "only") not in events
+    assert ("delete_bulk", "only", ("loopback1",)) in events
+
+
+def test_ios_xe_physical_delete_uses_auxiliary_routed_reset_and_one_consolidated_deploy(monkeypatch) -> None:
+    """A delete requested through another Ethernet family routes its IOS-XE reset through the routed orchestrator."""
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_executor.EthernetBaseOrchestrator",
+        PlatformResetFakeOrchestrator,
+    )
+    events = []
+    selected = FakeOrchestrator("access", events)
+    routed = PlatformResetFakeOrchestrator("routed", events)
+    desired = FakeModel("GigabitEthernet3")
+    routed_proxy = FakeModel("GigabitEthernet3")
+    workflow_plan = plan(
+        resource(
+            0,
+            selected,
+            deletes=[desired],
+            platform_deletes=[routed_proxy],
+            state="deleted",
+            resource_type="ethernet_access",
+        ),
+        auxiliary_orchestrators=(routed,),
+    )
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
+
+    assert result.failed is False
+    assert result.status == "completed"
+    assert result.mutation_requests == 1
+    assert result.deploy_requests == 1
+    assert result.items[0].status == "succeeded"
+    assert ("delete_bulk", "access", ("GigabitEthernet3",)) not in events
+    assert ("platform_delete_bulk", "routed", ("GigabitEthernet3",)) in events
+    assert ("platform_reset", "routed", ("GigabitEthernet3", "SERIAL1")) in events
+    deploy_events = [event for event in events if event[0] == "deploy"]
+    assert deploy_events == [("deploy", "access", (("GigabitEthernet3", "SERIAL1"),))]
+    assert routed.pending_deferred_delete_targets == ()
+    assert selected.pending_deploys == ()
+    assert routed.pending_deploys == ()
+
+
+def test_ios_xe_explicit_delete_prefers_planner_selected_reset_after_routed_overridden(monkeypatch) -> None:
+    """An earlier routed overridden group cannot suppress a later explicit IOS-XE physical reset."""
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_executor.EthernetBaseOrchestrator",
+        PlatformResetFakeOrchestrator,
+    )
+    events = []
+    overridden = OverriddenPlatformResetFakeOrchestrator("routed_overridden", events)
+    selected = FakeOrchestrator("access_deleted", events)
+    reset = PlatformResetFakeOrchestrator("routed_deleted", events)
+    desired = FakeModel("GigabitEthernet4")
+    routed_proxy = FakeModel("GigabitEthernet4")
+    workflow_plan = plan(
+        resource(0, overridden, state="overridden", resource_type="ethernet_routed"),
+        resource(
+            1,
+            selected,
+            deletes=[desired],
+            platform_deletes=[routed_proxy],
+            state="deleted",
+            resource_type="ethernet_access",
+        ),
+        auxiliary_orchestrators=(reset,),
+    )
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
+
+    assert result.failed is False
+    assert result.mutation_requests == 1
+    assert result.deploy_requests == 1
+    assert result.items[0].status == "succeeded"
+    assert ("platform_delete_bulk_skipped", "routed_overridden", ("GigabitEthernet4",)) not in events
+    assert ("platform_delete_bulk", "routed_deleted", ("GigabitEthernet4",)) in events
+    assert ("platform_reset", "routed_deleted", ("GigabitEthernet4", "SERIAL1")) in events
+
+
+def test_direct_routed_ios_xe_delete_rechecks_platform_proxy_immediately_before_writes(monkeypatch) -> None:
+    """A newly fabric-owned direct routed target is refused through its IOS-XE proxy before any mutation request."""
+    monkeypatch.setattr(
+        "ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_executor.EthernetBaseOrchestrator",
+        PlatformResetFakeOrchestrator,
+    )
+    events = []
+    desired = FakeModel("GigabitEthernet5")
+    routed_proxy = FakeModel("GigabitEthernet5")
+    routed = PlatformResetPreflightFakeOrchestrator("routed_deleted", events, routed_proxy)
+    workflow_plan = plan(
+        resource(
+            0,
+            routed,
+            deletes=[desired],
+            platform_deletes=[routed_proxy],
+            state="deleted",
+            resource_type="ethernet_routed",
+        ),
+        auxiliary_orchestrators=(routed,),
+    )
+
+    result = InterfaceWorkflowExecutor(snapshot=FakeSnapshot(events), deploy=True).execute(workflow_plan)
+
+    assert result.failed is True
+    assert result.mutation_requests == 0
+    assert result.deploy_requests == 0
+    assert result.items[0].status == "not_attempted"
+    assert [(event[0], event[1]) for event in events if event[0] == "preflight_delete_models"] == [
+        ("preflight_delete_models", "routed_deleted"),
+        ("preflight_delete_models", "routed_deleted"),
+    ]
+    assert not any(event[0] in {"platform_delete_bulk", "platform_reset", "deploy"} for event in events)
+
+
 def test_preflight_failure_reconciles_equal_vpc_names_by_pair_without_false_change(monkeypatch):
     """A read-only failed run keeps independent same-name pairs and reports no controller change."""
     switch_map = {
@@ -942,13 +1241,16 @@ def test_normal_return_207_create_omitting_target_fails_end_to_end():
     assert result.failed is True
     assert result.status == "partial_failure"
     assert result.mutation_requests == 1
-    assert result.deploy_requests == 0
+    assert result.deploy_requests == 1
     assert {item.interface_name: item.status for item in result.items} == {
         "loopback1": "succeeded",
         "loopback2": "failed",
     }
-    assert result.deployment["status"] == "not_attempted"
-    assert "deploy" not in [event[0] for event in events]
+    assert result.deployment == {
+        "requested": True,
+        "status": "succeeded",
+        "targets": [{"interface_name": "loopback1", "switch_id": "SERIAL1", "status": "succeeded"}],
+    }
     assert result.errors == (
         "resources[0] loopback bulk create failed on SERIAL1: HTTP 207 response did not report exact success for every requested interface.",
     )
@@ -985,13 +1287,16 @@ def test_normal_return_207_ethernet_normalize_omitting_target_fails_end_to_end(m
     assert result.failed is True
     assert result.status == "partial_failure"
     assert result.mutation_requests == 1
-    assert result.deploy_requests == 0
+    assert result.deploy_requests == 1
     assert {item.interface_name: item.status for item in result.items} == {
         "Ethernet1/1": "succeeded",
         "Ethernet1/2": "failed",
     }
-    assert result.deployment["status"] == "not_attempted"
-    assert "deploy" not in [event[0] for event in events]
+    assert result.deployment == {
+        "requested": True,
+        "status": "succeeded",
+        "targets": [{"interface_name": "Ethernet1/1", "switch_id": "SERIAL1", "status": "succeeded"}],
+    }
 
 
 def test_normal_return_207_deploy_omitting_target_fails_end_to_end():
@@ -1077,7 +1382,7 @@ def test_bulk_create_matches_loopback_switch_and_policy_request_boundaries():
     assert result.deploy_requests == 0
 
 
-def test_mixed_create_response_preserves_per_item_partial_success_and_stops_deploy():
+def test_mixed_create_response_deploys_only_the_exact_successful_item():
     events = []
     orchestrator = FakeOrchestrator("only", events, fail_create=True)
     workflow_plan = plan(resource(0, orchestrator, creates=[FakeModel("loopback1"), FakeModel("loopback2")]))
@@ -1089,10 +1394,13 @@ def test_mixed_create_response_preserves_per_item_partial_success_and_stops_depl
     assert result.status == "partial_failure"
     assert result.changed is True
     assert result.mutation_requests == 1
-    assert result.deploy_requests == 0
+    assert result.deploy_requests == 1
     assert statuses == {"loopback1": "succeeded", "loopback2": "failed"}
-    assert result.deployment["status"] == "not_attempted"
-    assert "deploy" not in [event[0] for event in events]
+    assert result.deployment == {
+        "requested": True,
+        "status": "succeeded",
+        "targets": [{"interface_name": "loopback1", "switch_id": "SERIAL1", "status": "succeeded"}],
+    }
     assert events[-2:] == [
         ("dirty", ("SERIAL1", "SERIAL2")),
         ("refresh", ("SERIAL1", "SERIAL2")),

--- a/tests/unit/module_utils/test_interface_workflow_planner.py
+++ b/tests/unit/module_utils/test_interface_workflow_planner.py
@@ -1,0 +1,386 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for interface-family adapters and aggregate read-only planning."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Any
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
+from ansible_collections.cisco.nd.plugins.module_utils.interface_family_adapters import (
+    INTERFACE_FAMILY_ADAPTERS,
+    InterfaceWorkflowValidationError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
+from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planner import (
+    InterfaceWorkflowConflictError,
+    InterfaceWorkflowPlanner,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+
+
+class _RequestRecorder:
+    """Return queued interface-list bodies and record every inventory request."""
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses: Iterator[dict[str, Any]] = iter(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return next(self._responses)
+
+
+def _planner(
+    *,
+    switches: Mapping[str, str] | None = None,
+    responses: list[dict[str, Any]] | None = None,
+    vpc_pairs: Mapping[str, str | tuple[str, str]] | None = None,
+) -> tuple[InterfaceWorkflowPlanner, _RequestRecorder]:
+    switch_map = dict(switches or {"192.0.2.1": "SERIAL1", "192.0.2.2": "SERIAL2"})
+    recorder = _RequestRecorder(responses or [{"interfaces": []} for _switch in switch_map])
+    rest_send = RestSend({"fabric_name": "fabric_1", "check_mode": True})
+    context = FabricContext(rest_send=rest_send, fabric_name="fabric_1")
+    context._fabric_summary = {"local": True, "fabricStatus": "default"}
+    context._switch_map = switch_map
+    context._switch_map_by_id = {switch_id: switch_ip for switch_ip, switch_id in switch_map.items()}
+    snapshot = InterfaceStateSnapshot(fabric_name="fabric_1", fabric_context=context, request=recorder)
+    return InterfaceWorkflowPlanner(snapshot=snapshot, vpc_pair_by_switch_ip=vpc_pairs), recorder
+
+
+def _loopback(switch_ip: str, name: str = "loopback10") -> dict[str, Any]:
+    return {
+        "switch_ip": switch_ip,
+        "interface_name": name,
+        "config_data": {"network_os": {"policy": {"ip": "198.51.100.10/32"}}},
+    }
+
+
+def _ethernet(switch_ip: str, name: str = "Ethernet1/1", *, trunk: bool = False) -> dict[str, Any]:
+    policy = {"allowed_vlans": "10-20"} if trunk else {"access_vlan": 10}
+    return {
+        "switch_ip": switch_ip,
+        "interface_names": [name],
+        "config_data": {"network_os": {"policy": policy}},
+    }
+
+
+def _port_channel(switch_ip: str, name: str = "port-channel10", members: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "switch_ip": switch_ip,
+        "interface_name": name,
+        "config_data": {"network_os": {"policy": {"ports": members or ["Ethernet1/1"], "port_channel_mode": "active"}}},
+    }
+
+
+def _vpc(switch_ip: str, name: str = "vpc10") -> dict[str, Any]:
+    return {
+        "switch_ip": switch_ip,
+        "interface_name": name,
+        "config_data": {"network_os": {"policy": {"access_vlan": 10}}},
+    }
+
+
+def _wire_interface(name: str, interface_type: str, policy_type: str, **policy: Any) -> dict[str, Any]:
+    return {
+        "interfaceName": name,
+        "interfaceType": interface_type,
+        "configData": {
+            "mode": "access",
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {"policyType": policy_type, **policy},
+            },
+        },
+    }
+
+
+def test_registry_is_the_exact_ten_family_scope_and_delegates_model_ownership() -> None:
+    """The authoritative registry excludes flow-rules and derives every model from its orchestrator."""
+    assert set(INTERFACE_FAMILY_ADAPTERS) == {
+        "ethernet_access",
+        "ethernet_trunk_host",
+        "loopback",
+        "port_channel_access",
+        "port_channel_trunk_host",
+        "subinterface_managed",
+        "subinterface_unmanaged",
+        "svi",
+        "vpc_access",
+        "vpc_trunk_host",
+    }
+    assert "flow_rules" not in INTERFACE_FAMILY_ADAPTERS
+    assert all(adapter.model_class is adapter.orchestrator_class.model_class for adapter in INTERFACE_FAMILY_ADAPTERS.values())
+    assert all(adapter.supported_states == frozenset({"merged", "replaced", "overridden", "deleted"}) for adapter in INTERFACE_FAMILY_ADAPTERS.values())
+
+
+def test_ethernet_adapter_accepts_the_grouped_standalone_input_contract() -> None:
+    """The adapter expands interface_names before invoking the existing concrete model."""
+    adapter = INTERFACE_FAMILY_ADAPTERS["ethernet_access"]
+
+    proposed = adapter.validate_config(
+        [
+            {
+                "switch_ip": "192.0.2.1",
+                "interface_names": ["e1/1", "ETHERNET1/2"],
+                "config_data": {"network_os": {"policy": {"access_vlan": 10}}},
+            }
+        ],
+        "merged",
+        3,
+    )
+
+    assert proposed.keys() == [("192.0.2.1", "Ethernet1/1"), ("192.0.2.1", "Ethernet1/2")]
+
+
+def test_adapter_validation_error_names_index_type_and_standalone_module() -> None:
+    """Workflow validation keeps the authoritative standalone contract discoverable."""
+    adapter = INTERFACE_FAMILY_ADAPTERS["loopback"]
+
+    with pytest.raises(InterfaceWorkflowValidationError) as exc_info:
+        adapter.validate_config([{"switch_ip": "192.0.2.1"}], "merged", 4)
+
+    message = str(exc_info.value)
+    assert "resources[4]" in message
+    assert "loopback" in message
+    assert "cisco.nd.nd_interface_loopback" in message
+
+
+def test_two_family_plan_uses_one_inventory_get_per_union_switch() -> None:
+    """Two families over two switches plan fully with exactly two interface GETs."""
+    planner, recorder = _planner()
+
+    plan = planner.plan(
+        [
+            {"type": "loopback", "state": "merged", "config": [_loopback("192.0.2.1")]},
+            {"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.2")]},
+        ]
+    )
+
+    assert plan.changed is True
+    assert plan.mutation_count == 2
+    assert plan.target_switch_ids == ("SERIAL1", "SERIAL2")
+    assert plan.request_stats["interface_inventory_gets"] == 2
+    assert len(recorder.calls) == 2
+    assert [resource.operations.mutation_count for resource in plan.resources] == [1, 1]
+
+
+def test_any_overridden_group_expands_initial_scope_to_the_full_fabric() -> None:
+    """Override preloads all fabric switches even when config names one switch."""
+    switches = {"192.0.2.1": "SERIAL1", "192.0.2.2": "SERIAL2", "192.0.2.3": "SERIAL3"}
+    planner, recorder = _planner(switches=switches)
+
+    plan = planner.plan([{"type": "loopback", "state": "overridden", "config": [_loopback("192.0.2.1")]}])
+
+    assert plan.target_switch_ids == ("SERIAL1", "SERIAL2", "SERIAL3")
+    assert plan.request_stats["interface_inventory_gets"] == 3
+    assert len(recorder.calls) == 3
+
+
+def test_sibling_families_cannot_claim_the_same_switch_interface() -> None:
+    """Access and trunk claims for one physical identity fail before writes."""
+    planner, _recorder = _planner(responses=[{"interfaces": []}, {"interfaces": []}])
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.1")]},
+                {"type": "ethernet_trunk_host", "state": "merged", "config": [_ethernet("192.0.2.1", trunk=True)]},
+            ]
+        )
+
+    assert "duplicate_ownership" in {conflict.code for conflict in exc_info.value.conflicts}
+    assert exc_info.value.conflicts[0].resource_indices == (0, 1)
+
+
+def test_create_over_a_current_sibling_policy_requires_an_explicit_transition() -> None:
+    """A family-filtered create cannot silently collide with existing sibling ownership."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10)
+    planner, _recorder = _planner(responses=[{"interfaces": [current]}])
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan([{"type": "ethernet_trunk_host", "state": "merged", "config": [_ethernet("192.0.2.1", trunk=True)]}])
+
+    assert "existing_policy_ownership" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_override_delete_conflicts_with_another_group_desiring_the_identity() -> None:
+    """An override cannot remove an identity retained by a sibling group in the same task."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10)
+    planner, _recorder = _planner(responses=[{"interfaces": [current]}, {"interfaces": []}])
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {"type": "ethernet_access", "state": "overridden", "config": []},
+                {"type": "ethernet_trunk_host", "state": "merged", "config": [_ethernet("192.0.2.1", trunk=True)]},
+            ]
+        )
+
+    codes = {conflict.code for conflict in exc_info.value.conflicts}
+    assert "delete_write_collision" in codes
+    assert "overridden_ownership" in codes
+
+
+def test_ethernet_mutation_cannot_race_a_new_port_channel_membership() -> None:
+    """A physical port cannot be changed independently while a port-channel claims it."""
+    planner, _recorder = _planner()
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.1")]},
+                {"type": "port_channel_access", "state": "merged", "config": [_port_channel("192.0.2.1")]},
+            ]
+        )
+
+    assert "ethernet_member_collision" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_same_vpc_name_on_different_pairs_is_not_a_global_identity_conflict() -> None:
+    """Pair-aware keys preserve equal vPC names on independent pairs."""
+    switches = {
+        "192.0.2.1": "SERIAL1",
+        "192.0.2.2": "SERIAL2",
+        "192.0.2.3": "SERIAL3",
+        "192.0.2.4": "SERIAL4",
+    }
+    pairs = {
+        "192.0.2.1": ("192.0.2.1", "192.0.2.2"),
+        "192.0.2.3": ("192.0.2.3", "192.0.2.4"),
+    }
+    planner, recorder = _planner(switches=switches, vpc_pairs=pairs)
+
+    plan = planner.plan(
+        [
+            {"type": "vpc_access", "state": "merged", "config": [_vpc("192.0.2.1")]},
+            {"type": "vpc_access", "state": "merged", "config": [_vpc("192.0.2.3")]},
+        ]
+    )
+
+    assert plan.mutation_count == 2
+    assert plan.target_switch_ids == ("SERIAL1", "SERIAL2", "SERIAL3", "SERIAL4")
+    assert len(recorder.calls) == 4
+
+
+def test_opposite_primaries_on_the_same_vpc_pair_share_one_identity() -> None:
+    """The unordered pair discriminator detects same-pair duplicate declarations."""
+    pairs = {
+        "192.0.2.1": ("192.0.2.1", "192.0.2.2"),
+        "192.0.2.2": ("192.0.2.1", "192.0.2.2"),
+    }
+    planner, _recorder = _planner(vpc_pairs=pairs)
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {"type": "vpc_access", "state": "merged", "config": [_vpc("192.0.2.1")]},
+                {"type": "vpc_access", "state": "merged", "config": [_vpc("192.0.2.2")]},
+            ]
+        )
+
+    assert "duplicate_ownership" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_ten_family_plan_shares_one_inventory_fetch_per_switch() -> None:
+    """The actual workflow path reduces ten family inventories over two switches to two GETs."""
+
+    def config(switch_ip: str, interface_name: str, policy: dict[str, Any] | None = None) -> dict[str, Any]:
+        return {
+            "switch_ip": switch_ip,
+            "interface_name": interface_name,
+            "config_data": {"network_os": {"policy": policy or {}}},
+        }
+
+    planner, recorder = _planner(vpc_pairs={"192.0.2.1": "192.0.2.2"})
+    resources = [
+        {
+            "type": "ethernet_access",
+            "state": "merged",
+            "config": [_ethernet("192.0.2.1", "Ethernet1/1")],
+        },
+        {
+            "type": "ethernet_trunk_host",
+            "state": "merged",
+            "config": [_ethernet("192.0.2.2", "Ethernet1/2", trunk=True)],
+        },
+        {
+            "type": "loopback",
+            "state": "merged",
+            "config": [_loopback("192.0.2.1", "loopback10")],
+        },
+        {
+            "type": "port_channel_access",
+            "state": "merged",
+            "config": [config("192.0.2.1", "port-channel10", {"port_channel_mode": "active"})],
+        },
+        {
+            "type": "port_channel_trunk_host",
+            "state": "merged",
+            "config": [config("192.0.2.2", "port-channel11", {"port_channel_mode": "active"})],
+        },
+        {
+            "type": "subinterface_managed",
+            "state": "merged",
+            "config": [config("192.0.2.1", "Ethernet1/3.10", {"vlan_id": 10})],
+        },
+        {
+            "type": "subinterface_unmanaged",
+            "state": "merged",
+            "config": [config("192.0.2.2", "Ethernet1/4.20")],
+        },
+        {
+            "type": "svi",
+            "state": "merged",
+            "config": [config("192.0.2.1", "vlan100")],
+        },
+        {
+            "type": "vpc_access",
+            "state": "merged",
+            "config": [_vpc("192.0.2.1", "vpc10")],
+        },
+        {
+            "type": "vpc_trunk_host",
+            "state": "merged",
+            "config": [config("192.0.2.1", "vpc11")],
+        },
+    ]
+
+    plan = planner.plan(resources)
+
+    assert len(plan.resources) == 10
+    assert plan.mutation_count == 10
+    assert plan.target_switch_ids == ("SERIAL1", "SERIAL2")
+    assert plan.request_stats["interface_inventory_gets"] == 2
+    assert len(recorder.calls) == 2
+
+
+def test_overridden_still_rejects_an_unknown_configured_switch_before_inventory() -> None:
+    """Fabric-wide scope cannot hide an invalid switch_ip in desired config."""
+    planner, recorder = _planner()
+
+    with pytest.raises(InterfaceWorkflowValidationError, match=r"resources\[0\].*192\.0\.2\.99"):
+        planner.plan([{"type": "loopback", "state": "overridden", "config": [_loopback("192.0.2.99")]}])
+
+    assert recorder.calls == []
+
+
+def test_vpc_create_detects_a_sibling_policy_observed_only_on_the_peer() -> None:
+    """Pair-scoped current-policy checks inspect both preloaded peer inventories."""
+    peer_current = _wire_interface("vpc10", "vpc", "trunkVpcHost")
+    pairs = {"192.0.2.1": ("192.0.2.1", "192.0.2.2")}
+    planner, _recorder = _planner(
+        responses=[{"interfaces": []}, {"interfaces": [peer_current]}],
+        vpc_pairs=pairs,
+    )
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan([{"type": "vpc_access", "state": "merged", "config": [_vpc("192.0.2.1")]}])
+
+    assert "existing_policy_ownership" in {conflict.code for conflict in exc_info.value.conflicts}

--- a/tests/unit/module_utils/test_interface_workflow_planner.py
+++ b/tests/unit/module_utils/test_interface_workflow_planner.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
 from ansible_collections.cisco.nd.plugins.module_utils.interface_family_adapters import (
+    IMPLICIT_TRANSITION_STATES,
     INTERFACE_FAMILY_ADAPTERS,
+    InterfaceDeleteStrategy,
+    InterfaceTransitionStrategy,
     InterfaceWorkflowValidationError,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.interface_state_snapshot import InterfaceStateSnapshot
@@ -26,14 +30,28 @@ from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import Res
 
 
 class _RequestRecorder:
-    """Return queued interface-list bodies and record every inventory request."""
+    """Route queued inventory and per-switch summary bodies and record every request."""
 
-    def __init__(self, responses: list[dict[str, Any]]) -> None:
+    def __init__(
+        self,
+        responses: list[dict[str, Any]],
+        summary_responses: Mapping[str, dict[str, Any] | list[dict[str, Any]]] | None = None,
+    ) -> None:
         self._responses: Iterator[dict[str, Any]] = iter(responses)
+        self._summary_responses = {
+            switch_id: iter(value if isinstance(value, list) else [value])
+            for switch_id, value in (summary_responses or {}).items()
+        }
         self.calls: list[dict[str, Any]] = []
 
     def __call__(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append(kwargs)
+        path = str(kwargs.get("path") or "")
+        if "/interfacesSummary" in path:
+            switch_ids = parse_qs(urlsplit(path).query).get("switchId", [])
+            if len(switch_ids) != 1 or switch_ids[0] not in self._summary_responses:
+                raise AssertionError(f"Unexpected interface-summary request: {path}")
+            return next(self._summary_responses[switch_ids[0]])
         return next(self._responses)
 
 
@@ -41,10 +59,14 @@ def _planner(
     *,
     switches: Mapping[str, str] | None = None,
     responses: list[dict[str, Any]] | None = None,
+    summary_responses: Mapping[str, dict[str, Any] | list[dict[str, Any]]] | None = None,
     vpc_pairs: Mapping[str, str | tuple[str, str]] | None = None,
 ) -> tuple[InterfaceWorkflowPlanner, _RequestRecorder]:
     switch_map = dict(switches or {"192.0.2.1": "SERIAL1", "192.0.2.2": "SERIAL2"})
-    recorder = _RequestRecorder(responses or [{"interfaces": []} for _switch in switch_map])
+    recorder = _RequestRecorder(
+        responses or [{"interfaces": []} for _switch in switch_map],
+        summary_responses=summary_responses,
+    )
     rest_send = RestSend({"fabric_name": "fabric_1", "check_mode": True})
     context = FabricContext(rest_send=rest_send, fabric_name="fabric_1")
     context._fabric_summary = {"local": True, "fabricStatus": "default"}
@@ -79,11 +101,23 @@ def _port_channel(switch_ip: str, name: str = "port-channel10", members: list[st
     }
 
 
-def _vpc(switch_ip: str, name: str = "vpc10") -> dict[str, Any]:
+def _vpc(
+    switch_ip: str,
+    name: str = "vpc10",
+    *,
+    trunk: bool = False,
+    peer1_members: list[str] | None = None,
+    peer2_members: list[str] | None = None,
+) -> dict[str, Any]:
+    policy: dict[str, Any] = {"allowed_vlans": "10-20"} if trunk else {"access_vlan": 10}
+    if peer1_members is not None:
+        policy["peer1_member_ports"] = peer1_members
+    if peer2_members is not None:
+        policy["peer2_member_ports"] = peer2_members
     return {
         "switch_ip": switch_ip,
         "interface_name": name,
-        "config_data": {"network_os": {"policy": {"access_vlan": 10}}},
+        "config_data": {"network_os": {"policy": policy}},
     }
 
 
@@ -99,6 +133,29 @@ def _wire_interface(name: str, interface_type: str, policy_type: str, **policy: 
             },
         },
     }
+
+
+def _summary_row(
+    current: Mapping[str, Any],
+    switch_id: str,
+    **overrides: Any,
+) -> dict[str, Any]:
+    """Return one controller-eligible summary row matching a raw record."""
+    row = {
+        "interfaceName": current["interfaceName"],
+        "interfaceType": current["interfaceType"],
+        "policyType": InterfaceStateSnapshot.policy_type(dict(current)),
+        "switchId": switch_id,
+        "editAllowed": True,
+        "rbacAccessible": True,
+        "blockConfig": False,
+        "markDeleted": False,
+        "hasDeletedOverlay": False,
+        "policyChangeSupported": True,
+        "deletable": True,
+    }
+    row.update(overrides)
+    return row
 
 
 def test_registry_is_the_exact_ten_family_scope_and_delegates_model_ownership() -> None:
@@ -118,6 +175,41 @@ def test_registry_is_the_exact_ten_family_scope_and_delegates_model_ownership() 
     assert "flow_rules" not in INTERFACE_FAMILY_ADAPTERS
     assert all(adapter.model_class is adapter.orchestrator_class.model_class for adapter in INTERFACE_FAMILY_ADAPTERS.values())
     assert all(adapter.supported_states == frozenset({"merged", "replaced", "overridden", "deleted"}) for adapter in INTERFACE_FAMILY_ADAPTERS.values())
+
+
+def test_registry_declares_generic_transition_delete_and_structural_safety_metadata() -> None:
+    """Every adapter advertises its mutation strategy and structural dependency guards."""
+    expected = {
+        "ethernet_access": (InterfaceDeleteStrategy.NORMALIZE, False, False, True),
+        "ethernet_trunk_host": (InterfaceDeleteStrategy.NORMALIZE, False, False, True),
+        "loopback": (InterfaceDeleteStrategy.REMOVE, False, False, False),
+        "port_channel_access": (InterfaceDeleteStrategy.REMOVE, False, True, True),
+        "port_channel_trunk_host": (InterfaceDeleteStrategy.REMOVE, False, True, True),
+        "subinterface_managed": (InterfaceDeleteStrategy.REMOVE, False, False, False),
+        "subinterface_unmanaged": (InterfaceDeleteStrategy.REMOVE, False, False, False),
+        "svi": (InterfaceDeleteStrategy.REMOVE, False, False, False),
+        "vpc_access": (InterfaceDeleteStrategy.DELETE, True, True, False),
+        "vpc_trunk_host": (InterfaceDeleteStrategy.DELETE, True, True, False),
+    }
+
+    for resource_type, adapter in INTERFACE_FAMILY_ADAPTERS.items():
+        delete_strategy, pair_consistency, owns_members, child_guard = expected[resource_type]
+        assert adapter.transition_strategy is InterfaceTransitionStrategy.UPDATE
+        assert adapter.transition_states == IMPLICIT_TRANSITION_STATES
+        assert adapter.delete_strategy is delete_strategy
+        assert adapter.safety.requires_pair_consistency is pair_consistency
+        assert adapter.safety.owns_physical_members is owns_members
+        assert adapter.safety.guards_child_subinterfaces is child_guard
+        assert not hasattr(adapter, "policy_transition_sources")
+
+    assert IMPLICIT_TRANSITION_STATES == frozenset({"merged", "replaced"})
+    assert {
+        adapter.delete_strategy for adapter in INTERFACE_FAMILY_ADAPTERS.values()
+    } == {
+        InterfaceDeleteStrategy.NORMALIZE,
+        InterfaceDeleteStrategy.REMOVE,
+        InterfaceDeleteStrategy.DELETE,
+    }
 
 
 def test_ethernet_adapter_accepts_the_grouped_standalone_input_contract() -> None:
@@ -199,21 +291,1086 @@ def test_sibling_families_cannot_claim_the_same_switch_interface() -> None:
     assert exc_info.value.conflicts[0].resource_indices == (0, 1)
 
 
-def test_create_over_a_current_sibling_policy_requires_an_explicit_transition() -> None:
-    """A family-filtered create cannot silently collide with existing sibling ownership."""
-    current = _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10)
-    planner, _recorder = _planner(responses=[{"interfaces": [current]}])
+@pytest.mark.parametrize("state", ["merged", "replaced"])
+def test_implicit_ethernet_transition_supports_merged_and_replaced(state: str) -> None:
+    """A foreign Ethernet policy is implicitly replaced for both write states."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "futureArbitraryPolicy")
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [current]}],
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}},
+    )
+
+    plan = planner.plan([{"type": "ethernet_access", "state": state, "config": [_ethernet("192.0.2.1")]}])
+
+    resource = plan.resources[0]
+    assert resource.operations.creates == ()
+    assert resource.operations.updates == ()
+    assert resource.operations.deletes == ()
+    assert len(resource.transitions) == 1
+    assert resource.transitions[0].from_policy_type == "futureArbitraryPolicy"
+    assert resource.transitions[0].to_policy_type == "accessHost"
+    assert plan.request_stats["interface_summary_gets"] == 1
+
+
+def test_legacy_allow_policy_transition_key_is_rejected_before_inventory() -> None:
+    """The removed opt-in key cannot silently survive through direct planner calls."""
+    planner, recorder = _planner()
+
+    with pytest.raises(InterfaceWorkflowValidationError, match=r"unsupported keys: allow_policy_transition"):
+        planner.plan(
+            [
+                {
+                    "type": "ethernet_access",
+                    "state": "merged",
+                    "allow_policy_transition": True,
+                    "config": [_ethernet("192.0.2.1")],
+                }
+            ]
+        )
+
+    assert recorder.calls == []
+
+
+@pytest.mark.parametrize(
+    ("resource_type", "config", "interface_name", "interface_type"),
+    [
+        ("ethernet_access", _ethernet("192.0.2.1", "Ethernet1/10"), "Ethernet1/10", "ethernet"),
+        ("ethernet_trunk_host", _ethernet("192.0.2.1", "Ethernet1/11", trunk=True), "Ethernet1/11", "ethernet"),
+        ("loopback", _loopback("192.0.2.1", "loopback10"), "loopback10", "loopback"),
+        ("port_channel_access", _port_channel("192.0.2.1", "port-channel10"), "port-channel10", "portChannel"),
+        ("port_channel_trunk_host", _port_channel("192.0.2.1", "port-channel11"), "port-channel11", "portChannel"),
+        (
+            "subinterface_managed",
+            {
+                "switch_ip": "192.0.2.1",
+                "interface_name": "Ethernet1/3.10",
+                "config_data": {"network_os": {"policy": {"vlan_id": 10}}},
+            },
+            "Ethernet1/3.10",
+            "subInterface",
+        ),
+        (
+            "subinterface_unmanaged",
+            {
+                "switch_ip": "192.0.2.1",
+                "interface_name": "Ethernet1/4.20",
+                "config_data": {"network_os": {"policy": {}}},
+            },
+            "Ethernet1/4.20",
+            "subInterface",
+        ),
+        (
+            "svi",
+            {
+                "switch_ip": "192.0.2.1",
+                "interface_name": "vlan100",
+                "config_data": {"network_os": {"policy": {}}},
+            },
+            "vlan100",
+            "svi",
+        ),
+    ],
+)
+def test_implicit_transition_is_generic_across_non_vpc_adapters(
+    resource_type: str,
+    config: dict[str, Any],
+    interface_name: str,
+    interface_type: str,
+) -> None:
+    """Every non-vPC adapter can replace an arbitrary same-structure policy."""
+    current = _wire_interface(interface_name, interface_type, f"foreign-{resource_type}")
+    inventory = [current]
+    if resource_type.startswith("subinterface_"):
+        parent_name = interface_name.rsplit(".", 1)[0]
+        inventory.append(_wire_interface(parent_name, "ethernet", "routedHost"))
+    planner, _recorder = _planner(
+        responses=[{"interfaces": inventory}],
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}},
+    )
+
+    plan = planner.plan([{"type": resource_type, "state": "merged", "config": [config]}])
+
+    resource = plan.resources[0]
+    assert len(resource.transitions) == 1
+    assert resource.operations.creates == ()
+    assert resource.transitions[0].to_policy_type in resource.adapter.policy_types
+
+
+def test_svi_transition_accepts_switch_virtual_interface_summary_alias() -> None:
+    """The interfacesSummary SVI spelling is canonicalized to the raw-record structure."""
+    current = _wire_interface("vlan100", "switchVirtualInterface", "foreignSviPolicy")
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [current]}],
+        summary_responses={
+            "SERIAL1": {
+                "interfaces": [
+                    _summary_row(current, "SERIAL1", interfaceType="switchVirtualInterface")
+                ]
+            }
+        },
+    )
+    config = {
+        "switch_ip": "192.0.2.1",
+        "interface_name": "vlan100",
+        "config_data": {"network_os": {"policy": {}}},
+    }
+
+    plan = planner.plan([{"type": "svi", "state": "merged", "config": [config]}])
+
+    assert len(plan.resources[0].transitions) == 1
+    assert plan.request_stats["interface_summary_gets"] == 1
+
+
+@pytest.mark.parametrize(("resource_type", "trunk"), [("vpc_access", False), ("vpc_trunk_host", True)])
+def test_implicit_transition_requires_and_accepts_a_consistent_vpc_pair(resource_type: str, trunk: bool) -> None:
+    """Both vPC adapters transition only after equivalent records and safety rows exist on both peers."""
+    primary = _wire_interface("vpc10", "vpc", "foreignVpcPolicy")
+    peer = _wire_interface("vpc10", "vpc", "foreignVpcPolicy")
+    pairs = {"192.0.2.1": ("192.0.2.1", "192.0.2.2")}
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [primary]}, {"interfaces": [peer]}],
+        summary_responses={
+            "SERIAL1": {"interfaces": [_summary_row(primary, "SERIAL1")]},
+            "SERIAL2": {"interfaces": [_summary_row(peer, "SERIAL2")]},
+        },
+        vpc_pairs=pairs,
+    )
+
+    plan = planner.plan(
+        [{"type": resource_type, "state": "merged", "config": [_vpc("192.0.2.1", trunk=trunk)]}]
+    )
+
+    transition = plan.resources[0].transitions[0]
+    assert len(transition.current_records) == 2
+    assert plan.request_stats["interface_summary_gets"] == 2
+
+
+def test_vpc_pair_fingerprint_accepts_reciprocal_peer_fields_and_same_owner() -> None:
+    """Endpoint-relative peer1/peer2 fields normalize to one pair-scoped configuration."""
+    primary = _wire_interface(
+        "vpc10",
+        "vpc",
+        "foreignVpcPolicy",
+        peerSwitchId="SERIAL2",
+        peer1MemberPorts=["Ethernet1/1", "Ethernet1/3"],
+        peer2MemberPorts=["Ethernet1/2", "Ethernet1/4"],
+    )
+    peer = _wire_interface(
+        "vpc10",
+        "vpc",
+        "foreignVpcPolicy",
+        peerSwitchId="SERIAL1",
+        peer1MemberPorts=["ethernet1/4", "ETHERNET1/2"],
+        peer2MemberPorts=["ethernet1/3", "ETHERNET1/1"],
+    )
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [primary]}, {"interfaces": [peer]}],
+        summary_responses={
+            "SERIAL1": {"interfaces": [_summary_row(primary, "SERIAL1")]},
+            "SERIAL2": {"interfaces": [_summary_row(peer, "SERIAL2")]},
+        },
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    plan = planner.plan(
+        [
+            {
+                "type": "vpc_access",
+                "state": "merged",
+                "config": [
+                    _vpc(
+                        "192.0.2.1",
+                        peer1_members=["Ethernet1/1", "Ethernet1/3"],
+                        peer2_members=["Ethernet1/2", "Ethernet1/4"],
+                    )
+                ],
+            }
+        ]
+    )
+
+    assert len(plan.resources[0].transitions) == 1
+
+
+def test_summary_inventory_is_lazy_and_shared_for_two_transitions_on_one_switch() -> None:
+    """Two foreign policies on one switch add one summary GET, never one per interface."""
+    first = _wire_interface("Ethernet1/10", "ethernet", "routedHost")
+    second = _wire_interface("Ethernet1/11", "ethernet", "dot1qTunnelHost")
+    planner, recorder = _planner(
+        responses=[{"interfaces": [first, second]}],
+        summary_responses={
+            "SERIAL1": {"interfaces": [_summary_row(first, "SERIAL1"), _summary_row(second, "SERIAL1")]}
+        },
+    )
+    config = {
+        "switch_ip": "192.0.2.1",
+        "interface_names": ["Ethernet1/10", "Ethernet1/11"],
+        "config_data": {"network_os": {"policy": {"access_vlan": 10}}},
+    }
+
+    plan = planner.plan([{"type": "ethernet_access", "state": "merged", "config": [config]}])
+
+    assert len(plan.resources[0].transitions) == 2
+    assert plan.request_stats["interface_inventory_gets"] == 1
+    assert plan.request_stats["interface_summary_gets"] == 1
+    assert len(recorder.calls) == 2
+
+
+def test_default_trunk_host_keeps_bulk_create_path_without_summary_get() -> None:
+    """An unconfigured physical default remains an ordinary batched create candidate."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "trunkHost")
+    planner, recorder = _planner(responses=[{"interfaces": [current]}])
+
+    plan = planner.plan([{"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.1")]}])
+
+    resource = plan.resources[0]
+    assert resource.transitions == ()
+    assert len(resource.operations.creates) == 1
+    assert plan.request_stats["interface_summary_gets"] == 0
+    assert len(recorder.calls) == 1
+
+
+def test_same_name_different_interface_type_is_a_structural_collision() -> None:
+    """A same-name object of another structural kind is never treated as create or transition."""
+    current = _wire_interface("Ethernet1/1", "svi", "svi")
+    planner, recorder = _planner(responses=[{"interfaces": [current]}])
 
     with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
-        planner.plan([{"type": "ethernet_trunk_host", "state": "merged", "config": [_ethernet("192.0.2.1", trunk=True)]}])
+        planner.plan([{"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.1")]}])
 
-    assert "existing_policy_ownership" in {conflict.code for conflict in exc_info.value.conflicts}
+    assert {conflict.code for conflict in exc_info.value.conflicts} == {"structural_type_collision"}
+    assert len(recorder.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("resource_type", "config", "interface_name", "interface_type"),
+    [
+        (
+            "ethernet_access",
+            {"switch_ip": "192.0.2.1", "interface_names": ["Ethernet1/1"]},
+            "Ethernet1/1",
+            "ethernet",
+        ),
+        (
+            "ethernet_trunk_host",
+            {"switch_ip": "192.0.2.1", "interface_names": ["Ethernet1/2"]},
+            "Ethernet1/2",
+            "ethernet",
+        ),
+        ("loopback", {"switch_ip": "192.0.2.1", "interface_name": "loopback10"}, "loopback10", "loopback"),
+        (
+            "port_channel_access",
+            {"switch_ip": "192.0.2.1", "interface_name": "port-channel10"},
+            "port-channel10",
+            "portChannel",
+        ),
+        (
+            "port_channel_trunk_host",
+            {"switch_ip": "192.0.2.1", "interface_name": "port-channel11"},
+            "port-channel11",
+            "portChannel",
+        ),
+        (
+            "subinterface_managed",
+            {
+                "switch_ip": "192.0.2.1",
+                "interface_name": "Ethernet1/3.10",
+            },
+            "Ethernet1/3.10",
+            "subInterface",
+        ),
+        (
+            "subinterface_unmanaged",
+            {
+                "switch_ip": "192.0.2.1",
+                "interface_name": "Ethernet1/4.20",
+            },
+            "Ethernet1/4.20",
+            "subInterface",
+        ),
+        (
+            "svi",
+            {
+                "switch_ip": "192.0.2.1",
+                "interface_name": "vlan100",
+            },
+            "vlan100",
+            "svi",
+        ),
+    ],
+)
+def test_deleted_is_policy_independent_within_the_selected_structure(
+    resource_type: str,
+    config: dict[str, Any],
+    interface_name: str,
+    interface_type: str,
+) -> None:
+    """Explicit deleted targets a foreign policy and uses the destination adapter's delete path."""
+    current = _wire_interface(interface_name, interface_type, "foreignDeletablePolicy")
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [current]}],
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}},
+    )
+
+    plan = planner.plan([{"type": resource_type, "state": "deleted", "config": [config]}])
+
+    resource = plan.resources[0]
+    assert resource.transitions == ()
+    assert len(resource.operations.deletes) == 1
+    assert resource.mutation_count == 1
+
+
+@pytest.mark.parametrize(
+    "inventory",
+    [
+        [],
+        [_wire_interface("Ethernet1/1", "ethernet", "trunkHost")],
+    ],
+)
+def test_deleted_absent_or_default_ethernet_is_idempotent_without_summary(inventory: list[dict[str, Any]]) -> None:
+    """Deleting an absent or already-normalized physical interface is a no-op."""
+    planner, recorder = _planner(responses=[{"interfaces": inventory}])
+
+    plan = planner.plan([{"type": "ethernet_access", "state": "deleted", "config": [_ethernet("192.0.2.1")]}])
+
+    assert plan.changed is False
+    assert plan.mutation_count == 0
+    assert plan.request_stats["interface_summary_gets"] == 0
+    assert len(recorder.calls) == 1
+
+
+@pytest.mark.parametrize("resource_type", ["vpc_access", "vpc_trunk_host"])
+def test_vpc_deleted_is_policy_independent_and_pair_consistent(resource_type: str) -> None:
+    """vPC deleted accepts a foreign policy only when both peers agree and are deletable."""
+    primary = _wire_interface("vpc10", "vpc", "foreignVpcPolicy")
+    peer = _wire_interface("vpc10", "vpc", "foreignVpcPolicy")
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [primary]}, {"interfaces": [peer]}],
+        summary_responses={
+            "SERIAL1": {"interfaces": [_summary_row(primary, "SERIAL1")]},
+            "SERIAL2": {"interfaces": [_summary_row(peer, "SERIAL2")]},
+        },
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    plan = planner.plan(
+        [
+            {
+                "type": resource_type,
+                "state": "deleted",
+                "config": [{"switch_ip": "192.0.2.1", "interface_name": "vpc10"}],
+            }
+        ]
+    )
+
+    assert len(plan.resources[0].operations.deletes) == 1
+    assert plan.request_stats["interface_summary_gets"] == 2
+
+
+def test_vpc_transition_rejects_a_record_missing_on_one_peer() -> None:
+    """A one-sided vPC record fails before summary lookup or mutation planning."""
+    current = _wire_interface("vpc10", "vpc", "foreignVpcPolicy")
+    planner, recorder = _planner(
+        responses=[{"interfaces": [current]}, {"interfaces": []}],
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="missing on peer"):
+        planner.plan([{"type": "vpc_access", "state": "merged", "config": [_vpc("192.0.2.1")]}])
+
+    assert len(recorder.calls) == 2
+
+
+def test_vpc_transition_rejects_mismatched_peer_policy_data() -> None:
+    """Pair records with different policy data fail closed before summary lookup."""
+    primary = _wire_interface("vpc10", "vpc", "foreignVpcPolicy", peer1MemberPorts=["Ethernet1/1"])
+    peer = _wire_interface("vpc10", "vpc", "foreignVpcPolicy", peer1MemberPorts=["Ethernet1/2"])
+    planner, recorder = _planner(
+        responses=[{"interfaces": [primary]}, {"interfaces": [peer]}],
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="inconsistent vPC pair records"):
+        planner.plan([{"type": "vpc_access", "state": "merged", "config": [_vpc("192.0.2.1")]}])
+
+    assert len(recorder.calls) == 2
+
+
+def test_vpc_transition_rejects_peer_switch_id_outside_authoritative_pair() -> None:
+    """A reciprocal-looking row cannot point outside the configured pair."""
+    primary = _wire_interface(
+        "vpc10",
+        "vpc",
+        "foreignVpcPolicy",
+        peerSwitchId="SERIAL3",
+    )
+    peer = _wire_interface("vpc10", "vpc", "foreignVpcPolicy", peerSwitchId="SERIAL1")
+    planner, recorder = _planner(
+        responses=[{"interfaces": [primary]}, {"interfaces": [peer]}],
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="expected 'SERIAL2'"):
+        planner.plan([{"type": "vpc_access", "state": "merged", "config": [_vpc("192.0.2.1")]}])
+
+    assert len(recorder.calls) == 2
+
+
+def test_vpc_overridden_delete_rejects_a_record_missing_on_one_peer() -> None:
+    """An overridden cleanup cannot delete a one-sided vPC record."""
+    current = _wire_interface("vpc10", "vpc", "accessVpcHost", accessVlan=10)
+    planner, recorder = _planner(
+        responses=[{"interfaces": [current]}, {"interfaces": []}],
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="missing on peer"):
+        planner.plan([{"type": "vpc_access", "state": "overridden", "config": []}])
+
+    assert len(recorder.calls) == 2
+
+
+def test_transition_rejects_ethernet_port_channel_member_before_summary() -> None:
+    """A physical member cannot be reset or policy-transitioned independently."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "routedHost")
+    current["operData"] = {"portChannelId": 10}
+    planner, recorder = _planner(responses=[{"interfaces": [current]}])
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="member of port-channel 10"):
+        planner.plan([{"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.1")]}])
+
+    assert len(recorder.calls) == 1
+
+
+def test_same_family_ethernet_member_update_is_preflighted_before_execution() -> None:
+    """A prohibited member update fails during planning, before delete-side writes could run."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10)
+    current["operData"] = {"portChannelId": 20}
+    desired = _ethernet("192.0.2.1")
+    desired["config_data"]["network_os"]["policy"]["access_vlan"] = 20
+    planner, recorder = _planner(responses=[{"interfaces": [current]}])
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="cannot update.*member of port-channel 20"):
+        planner.plan([{"type": "ethernet_access", "state": "merged", "config": [desired]}])
+
+    assert len(recorder.calls) == 1
+
+
+def test_same_family_ethernet_member_update_preserves_standalone_whitelist() -> None:
+    """Description-only member changes remain allowed by the standalone whitelist."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10, description="old")
+    current["operData"] = {"portChannelId": 20}
+    desired = _ethernet("192.0.2.1")
+    desired["config_data"]["network_os"]["policy"]["description"] = "new"
+    planner, _recorder = _planner(responses=[{"interfaces": [current]}])
+
+    plan = planner.plan([{"type": "ethernet_access", "state": "merged", "config": [desired]}])
+
+    assert len(plan.resources[0].operations.updates) == 1
+
+
+@pytest.mark.parametrize(
+    ("resource_type", "parent", "interface_type", "policy_type"),
+    [
+        ("ethernet_access", "Ethernet1/1", "ethernet", "accessHost"),
+        ("port_channel_access", "port-channel10", "portChannel", "accessPoHost"),
+    ],
+)
+def test_overridden_parent_delete_rejects_existing_child_subinterface(
+    resource_type: str,
+    parent: str,
+    interface_type: str,
+    policy_type: str,
+) -> None:
+    """Override-generated parent cleanup cannot bypass existing-child protection."""
+    current = _wire_interface(parent, interface_type, policy_type)
+    child = _wire_interface(f"{parent}.10", "subInterface", "subinterface")
+    planner, recorder = _planner(responses=[{"interfaces": [current, child]}, {"interfaces": []}])
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="child subinterfaces exist"):
+        planner.plan([{"type": resource_type, "state": "overridden", "config": []}])
+
+    assert len(recorder.calls) == 2
+
+
+@pytest.mark.parametrize(
+    ("resource_type", "config", "parent", "interface_type"),
+    [
+        ("ethernet_access", _ethernet("192.0.2.1"), "Ethernet1/1", "ethernet"),
+        ("port_channel_access", _port_channel("192.0.2.1"), "port-channel10", "portChannel"),
+    ],
+)
+def test_parent_transition_rejects_existing_child_subinterfaces(
+    resource_type: str,
+    config: dict[str, Any],
+    parent: str,
+    interface_type: str,
+) -> None:
+    """Ethernet and port-channel parents both protect existing child subinterfaces."""
+    current = _wire_interface(parent, interface_type, "foreignParentPolicy")
+    child = _wire_interface(f"{parent}.10", "subInterface", "subinterface")
+    planner, recorder = _planner(responses=[{"interfaces": [current, child]}])
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="child subinterfaces exist"):
+        planner.plan([{"type": resource_type, "state": "merged", "config": [config]}])
+
+    assert len(recorder.calls) == 1
+
+
+def test_parent_transition_conflicts_with_planned_child_create() -> None:
+    """A planned child operation cannot race its parent policy replacement."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "routedHost")
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [current]}],
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}},
+    )
+    child = {
+        "switch_ip": "192.0.2.1",
+        "interface_name": "Ethernet1/1.10",
+        "config_data": {"network_os": {"policy": {"vlan_id": 10}}},
+    }
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.1")]},
+                {"type": "subinterface_managed", "state": "merged", "config": [child]},
+            ]
+        )
+
+    assert "parent_subinterface_collision" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+@pytest.mark.parametrize(
+    ("resource_type", "parent", "interface_type", "policy_type", "config"),
+    [
+        (
+            "ethernet_access",
+            "Ethernet1/1",
+            "ethernet",
+            "accessHost",
+            _ethernet("192.0.2.1"),
+        ),
+        (
+            "port_channel_access",
+            "port-channel10",
+            "portChannel",
+            "accessPoHost",
+            _port_channel("192.0.2.1"),
+        ),
+    ],
+)
+def test_same_family_parent_update_rejects_existing_child_subinterface(
+    resource_type: str,
+    parent: str,
+    interface_type: str,
+    policy_type: str,
+    config: dict[str, Any],
+) -> None:
+    """Ordinary same-family parent updates cannot bypass current-child protection."""
+    current = _wire_interface(parent, interface_type, policy_type, accessVlan=10)
+    child = _wire_interface(f"{parent}.10", "subInterface", "subinterface")
+    config["config_data"]["network_os"]["policy"]["access_vlan"] = 20
+    planner, recorder = _planner(responses=[{"interfaces": [current, child]}])
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="child subinterfaces exist"):
+        planner.plan([{"type": resource_type, "state": "merged", "config": [config]}])
+
+    assert len(recorder.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("parent_resource", "parent_config", "child_name", "inventory"),
+    [
+        (
+            "ethernet_access",
+            _ethernet("192.0.2.1"),
+            "Ethernet1/1.10",
+            [_wire_interface("Ethernet1/1", "ethernet", "trunkHost")],
+        ),
+        (
+            "port_channel_access",
+            _port_channel("192.0.2.1"),
+            "port-channel10.10",
+            [],
+        ),
+    ],
+)
+def test_parent_create_conflicts_with_planned_child_create(
+    parent_resource: str,
+    parent_config: dict[str, Any],
+    child_name: str,
+    inventory: list[dict[str, Any]],
+) -> None:
+    """Default-Ethernet bulk create and new port-channel create both protect children."""
+    planner, _recorder = _planner(responses=[{"interfaces": inventory}])
+    child = {
+        "switch_ip": "192.0.2.1",
+        "interface_name": child_name,
+        "config_data": {"network_os": {"policy": {"vlan_id": 10}}},
+    }
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {"type": parent_resource, "state": "merged", "config": [parent_config]},
+                {"type": "subinterface_managed", "state": "merged", "config": [child]},
+            ]
+        )
+
+    assert "parent_subinterface_collision" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+@pytest.mark.parametrize(
+    ("parent", "expected_reason"),
+    [
+        (None, "does not exist"),
+        (
+            _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10),
+            "expected routed policy 'routedHost'",
+        ),
+    ],
+)
+def test_subinterface_write_requires_existing_routed_parent(
+    parent: dict[str, Any] | None,
+    expected_reason: str,
+) -> None:
+    """Subinterface writes fail locally when the external routed-parent prerequisite is unmet."""
+    inventory = [] if parent is None else [parent]
+    planner, _recorder = _planner(responses=[{"interfaces": inventory}])
+    child = {
+        "switch_ip": "192.0.2.1",
+        "interface_name": "Ethernet1/1.10",
+        "config_data": {"network_os": {"policy": {"vlan_id": 10}}},
+    }
+
+    with pytest.raises(InterfaceWorkflowConflictError, match=expected_reason) as exc_info:
+        planner.plan([{"type": "subinterface_managed", "state": "merged", "config": [child]}])
+
+    assert "subinterface_parent_prerequisite" in {
+        conflict.code
+        for conflict in exc_info.value.conflicts
+    }
+
+
+@pytest.mark.parametrize(
+    ("resource_type", "policy"),
+    [
+        ("subinterface_managed", {"vlan_id": 10}),
+        ("subinterface_unmanaged", {}),
+    ],
+)
+def test_subinterface_write_accepts_existing_routed_port_channel_parent(
+    resource_type: str,
+    policy: dict[str, Any],
+) -> None:
+    """Both subinterface families accept the documented l3PortChannel parent."""
+    parent = _wire_interface("port-channel10", "portChannel", "l3PortChannel")
+    planner, _recorder = _planner(responses=[{"interfaces": [parent]}])
+    child = {
+        "switch_ip": "192.0.2.1",
+        "interface_name": "port-channel10.10",
+        "config_data": {"network_os": {"policy": policy}},
+    }
+
+    plan = planner.plan([{"type": resource_type, "state": "merged", "config": [child]}])
+
+    assert len(plan.resources[0].operations.creates) == 1
+
+
+@pytest.mark.parametrize(
+    ("resource_type", "config"),
+    [
+        ("port_channel_access", _port_channel("192.0.2.1", members=["Ethernet1/1", "ethernet1/1"])),
+        ("vpc_access", _vpc("192.0.2.1", peer1_members=["Ethernet1/1", "ethernet1/1"])),
+    ],
+)
+def test_duplicate_members_within_one_aggregate_are_rejected(
+    resource_type: str,
+    config: dict[str, Any],
+) -> None:
+    """Canonical duplicate members cannot be hidden by conflict-set deduplication."""
+    pairs = {"192.0.2.1": ("192.0.2.1", "192.0.2.2")} if resource_type.startswith("vpc_") else None
+    planner, _recorder = _planner(vpc_pairs=pairs)
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="contains duplicate"):
+        planner.plan([{"type": resource_type, "state": "merged", "config": [config]}])
+
+
+@pytest.mark.parametrize("current_member", [False, True])
+def test_port_channel_current_and_final_members_conflict_with_ethernet_mutation(current_member: bool) -> None:
+    """Both current and final port-channel members are protected from Ethernet actions."""
+    current = _wire_interface("port-channel10", "portChannel", "foreignPoPolicy", ports=["Ethernet1/1"])
+    responses = [{"interfaces": [current]}] if current_member else [{"interfaces": []}]
+    summaries = (
+        {"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}}
+        if current_member
+        else None
+    )
+    final_members = ["Ethernet1/2"] if current_member else ["Ethernet1/1"]
+    planner, _recorder = _planner(responses=responses, summary_responses=summaries)
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {
+                    "type": "port_channel_access",
+                    "state": "merged",
+                    "config": [_port_channel("192.0.2.1", members=final_members)],
+                },
+                {"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.1")]},
+            ]
+        )
+
+    assert "ethernet_member_collision" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+@pytest.mark.parametrize("current_member", [False, True])
+def test_vpc_current_and_final_members_conflict_with_ethernet_mutation(current_member: bool) -> None:
+    """Both current and final per-peer vPC members are protected from Ethernet actions."""
+    primary = _wire_interface(
+        "vpc10", "vpc", "foreignVpcPolicy", peerSwitchId="SERIAL2", peer1MemberPorts=["Ethernet1/1"]
+    )
+    peer = _wire_interface(
+        "vpc10", "vpc", "foreignVpcPolicy", peerSwitchId="SERIAL1", peer2MemberPorts=["Ethernet1/1"]
+    )
+    responses = (
+        [{"interfaces": [primary]}, {"interfaces": [peer]}]
+        if current_member
+        else [{"interfaces": []}, {"interfaces": []}]
+    )
+    summaries = (
+        {
+            "SERIAL1": {"interfaces": [_summary_row(primary, "SERIAL1")]},
+            "SERIAL2": {"interfaces": [_summary_row(peer, "SERIAL2")]},
+        }
+        if current_member
+        else None
+    )
+    final_members = ["Ethernet1/2"] if current_member else ["Ethernet1/1"]
+    planner, _recorder = _planner(
+        responses=responses,
+        summary_responses=summaries,
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {
+                    "type": "vpc_access",
+                    "state": "merged",
+                    "config": [_vpc("192.0.2.1", peer1_members=final_members)],
+                },
+                {"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.1")]},
+            ]
+        )
+
+    assert "ethernet_member_collision" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_new_port_channel_cannot_claim_member_of_untouched_existing_port_channel() -> None:
+    """Raw aggregate inventory protects members even when their current owner has no planned action."""
+    current_owner = _wire_interface(
+        "port-channel20",
+        "portChannel",
+        "accessPoHost",
+        ports=["Ethernet1/1"],
+    )
+    planner, _recorder = _planner(responses=[{"interfaces": [current_owner]}])
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {
+                    "type": "port_channel_access",
+                    "state": "merged",
+                    "config": [_port_channel("192.0.2.1", "port-channel10", ["Ethernet1/1"])],
+                }
+            ]
+        )
+
+    assert "existing_member_ownership" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_existing_port_channel_can_retain_its_operational_member() -> None:
+    """The operational backstop allows a member when raw inventory proves the same owner."""
+    current_owner = _wire_interface(
+        "port-channel10",
+        "portChannel",
+        "accessPoHost",
+        ports=["Ethernet1/1"],
+        portChannelMode="active",
+        accessVlan=10,
+    )
+    ethernet = _wire_interface("Ethernet1/1", "ethernet", "trunkHost")
+    ethernet["operData"] = {"portChannelId": 10}
+    desired = _port_channel("192.0.2.1", "port-channel10", ["Ethernet1/1"])
+    desired["config_data"]["network_os"]["policy"]["access_vlan"] = 20
+    planner, _recorder = _planner(responses=[{"interfaces": [current_owner, ethernet]}])
+
+    plan = planner.plan([{"type": "port_channel_access", "state": "merged", "config": [desired]}])
+
+    assert len(plan.resources[0].operations.updates) == 1
+
+
+def test_new_vpc_cannot_claim_member_of_untouched_existing_vpc() -> None:
+    """Pair-scoped raw vPC owners protect their physical members without extra GETs."""
+    primary = _wire_interface(
+        "vpc20",
+        "vpc",
+        "accessVpcHost",
+        peerSwitchId="SERIAL2",
+        peer1MemberPorts=["Ethernet1/1"],
+    )
+    peer = _wire_interface(
+        "vpc20",
+        "vpc",
+        "accessVpcHost",
+        peerSwitchId="SERIAL1",
+        peer1MemberPorts=["Ethernet1/1"],
+    )
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [primary]}, {"interfaces": [peer]}],
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {
+                    "type": "vpc_access",
+                    "state": "merged",
+                    "config": [_vpc("192.0.2.1", "vpc10", peer1_members=["Ethernet1/1"])],
+                }
+            ]
+        )
+
+    assert "existing_member_ownership" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_new_vpc_cannot_claim_peer2_member_of_untouched_existing_vpc() -> None:
+    """Current-owner indexing maps peer2 members onto the resolved peer switch."""
+    primary = _wire_interface(
+        "vpc20",
+        "vpc",
+        "accessVpcHost",
+        peerSwitchId="SERIAL2",
+        peer1MemberPorts=["Ethernet1/1"],
+        peer2MemberPorts=["Ethernet1/2"],
+    )
+    peer = _wire_interface(
+        "vpc20",
+        "vpc",
+        "accessVpcHost",
+        peerSwitchId="SERIAL1",
+        peer1MemberPorts=["Ethernet1/2"],
+        peer2MemberPorts=["Ethernet1/1"],
+    )
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [primary]}, {"interfaces": [peer]}],
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {
+                    "type": "vpc_access",
+                    "state": "merged",
+                    "config": [_vpc("192.0.2.1", "vpc10", peer2_members=["Ethernet1/2"])],
+                }
+            ]
+        )
+
+    assert "existing_member_ownership" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_operational_membership_is_a_fail_closed_backstop() -> None:
+    """A positive operational port-channel ID blocks a claim when no owner record proves equivalence."""
+    ethernet = _wire_interface("Ethernet1/1", "ethernet", "trunkHost")
+    ethernet["operData"] = {"portChannelId": 20}
+    planner, _recorder = _planner(responses=[{"interfaces": [ethernet]}])
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [
+                {
+                    "type": "port_channel_access",
+                    "state": "merged",
+                    "config": [_port_channel("192.0.2.1", "port-channel10", ["Ethernet1/1"])],
+                }
+            ]
+        )
+
+    assert "operational_member_ownership" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+@pytest.mark.parametrize(
+    ("state", "policy_type"),
+    [
+        ("merged", "routedHost"),
+        ("deleted", "accessHost"),
+    ],
+)
+def test_ethernet_only_action_cannot_mutate_untouched_port_channel_member(
+    state: str,
+    policy_type: str,
+) -> None:
+    """A parent-owned member is protected even when operational membership is stale."""
+    parent = _wire_interface(
+        "port-channel10",
+        "portChannel",
+        "accessPoHost",
+        ports=["Ethernet1/1"],
+    )
+    ethernet = _wire_interface("Ethernet1/1", "ethernet", policy_type, accessVlan=10)
+    ethernet["operData"] = {"portChannelId": -1}
+    summaries = (
+        {"SERIAL1": {"interfaces": [_summary_row(ethernet, "SERIAL1")]}}
+        if state == "merged"
+        else None
+    )
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [parent, ethernet]}],
+        summary_responses=summaries,
+    )
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan([{"type": "ethernet_access", "state": state, "config": [_ethernet("192.0.2.1")]}])
+
+    assert "ethernet_member_collision" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_ethernet_only_action_cannot_mutate_untouched_vpc_member() -> None:
+    """A row-local vPC owner protects its member without a vPC resource action."""
+    parent = _wire_interface(
+        "vpc10",
+        "vpc",
+        "accessVpcHost",
+        peerSwitchId="SERIAL2",
+        peer1MemberPorts=["Ethernet1/1"],
+        peer1PortChannelId="port-channel10",
+    )
+    ethernet = _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10)
+    ethernet["operData"] = {"portChannelId": -1}
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [parent, ethernet]}],
+        vpc_pairs={"192.0.2.1": ("192.0.2.1", "192.0.2.2")},
+    )
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan(
+            [{"type": "ethernet_access", "state": "deleted", "config": [_ethernet("192.0.2.1")]}]
+        )
+
+    assert "ethernet_member_collision" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+@pytest.mark.parametrize("state", ["merged", "deleted"])
+def test_configured_member_policy_is_a_fail_closed_backstop(state: str) -> None:
+    """Configured PoMember state protects a member when parent and operational data are stale."""
+    ethernet = _wire_interface(
+        "Ethernet1/1",
+        "ethernet",
+        "accessPoMember",
+        portChannelId="port-channel901",
+    )
+    ethernet["operData"] = {"portChannelId": -1}
+    planner, recorder = _planner(responses=[{"interfaces": [ethernet]}])
+
+    with pytest.raises(InterfaceWorkflowValidationError, match="member of port-channel 901"):
+        planner.plan([{"type": "ethernet_access", "state": state, "config": [_ethernet("192.0.2.1")]}])
+
+    assert len(recorder.calls) == 1
+
+
+def test_untouched_owner_preserves_whitelisted_ethernet_member_update() -> None:
+    """Description-only updates remain valid for a member whose parent is untouched."""
+    parent = _wire_interface(
+        "port-channel10",
+        "portChannel",
+        "accessPoHost",
+        ports=["Ethernet1/1"],
+    )
+    ethernet = _wire_interface(
+        "Ethernet1/1",
+        "ethernet",
+        "accessHost",
+        accessVlan=10,
+        description="old",
+    )
+    ethernet["operData"] = {"portChannelId": -1}
+    desired = _ethernet("192.0.2.1")
+    desired["config_data"]["network_os"]["policy"]["description"] = "new"
+    planner, _recorder = _planner(responses=[{"interfaces": [parent, ethernet]}])
+
+    plan = planner.plan([{"type": "ethernet_access", "state": "merged", "config": [desired]}])
+
+    assert len(plan.resources[0].operations.updates) == 1
+
+
+def test_untouched_owner_rejects_non_whitelisted_ethernet_member_update() -> None:
+    """A stale operational ID cannot hide a VLAN change to an aggregate member."""
+    parent = _wire_interface(
+        "port-channel10",
+        "portChannel",
+        "accessPoHost",
+        ports=["Ethernet1/1"],
+    )
+    ethernet = _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10)
+    ethernet["operData"] = {"portChannelId": -1}
+    desired = _ethernet("192.0.2.1")
+    desired["config_data"]["network_os"]["policy"]["access_vlan"] = 20
+    planner, _recorder = _planner(responses=[{"interfaces": [parent, ethernet]}])
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan([{"type": "ethernet_access", "state": "merged", "config": [desired]}])
+
+    assert "ethernet_member_collision" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_operational_member_id_must_match_the_retained_owner() -> None:
+    """A positive operational ID cannot be reconciled to a different retained parent."""
+    parent = _wire_interface(
+        "port-channel10",
+        "portChannel",
+        "accessPoHost",
+        ports=["Ethernet1/1"],
+        portChannelMode="active",
+        accessVlan=10,
+    )
+    ethernet = _wire_interface("Ethernet1/1", "ethernet", "trunkHost")
+    ethernet["operData"] = {"portChannelId": 20}
+    desired = _port_channel("192.0.2.1", "port-channel10", ["Ethernet1/1"])
+    desired["config_data"]["network_os"]["policy"]["access_vlan"] = 20
+    planner, _recorder = _planner(responses=[{"interfaces": [parent, ethernet]}])
+
+    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
+        planner.plan([{"type": "port_channel_access", "state": "merged", "config": [desired]}])
+
+    assert "operational_member_mismatch" in {conflict.code for conflict in exc_info.value.conflicts}
+
+
+def test_matching_destination_policy_is_idempotent_without_summary() -> None:
+    """A converged destination-family interface neither transitions nor fetches safety metadata."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10)
+    planner, recorder = _planner(responses=[{"interfaces": [current]}])
+
+    plan = planner.plan([{"type": "ethernet_access", "state": "merged", "config": [_ethernet("192.0.2.1")]}])
+
+    assert plan.changed is False
+    assert plan.resources[0].transitions == ()
+    assert plan.request_stats["interface_summary_gets"] == 0
+    assert len(recorder.calls) == 1
 
 
 def test_override_delete_conflicts_with_another_group_desiring_the_identity() -> None:
     """An override cannot remove an identity retained by a sibling group in the same task."""
     current = _wire_interface("Ethernet1/1", "ethernet", "accessHost", accessVlan=10)
-    planner, _recorder = _planner(responses=[{"interfaces": [current]}, {"interfaces": []}])
+    planner, _recorder = _planner(
+        responses=[{"interfaces": [current]}, {"interfaces": []}],
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}},
+    )
 
     with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
         planner.plan(
@@ -269,6 +1426,62 @@ def test_same_vpc_name_on_different_pairs_is_not_a_global_identity_conflict() ->
     assert len(recorder.calls) == 4
 
 
+def test_overridden_preserves_same_vpc_name_as_two_pair_scoped_records() -> None:
+    """Fabric-wide discovery does not collapse equal vPC names on independent pairs."""
+    switches = {
+        "192.0.2.1": "SERIAL1",
+        "192.0.2.2": "SERIAL2",
+        "192.0.2.3": "SERIAL3",
+        "192.0.2.4": "SERIAL4",
+    }
+    pairs = {
+        "192.0.2.1": ("192.0.2.1", "192.0.2.2"),
+        "192.0.2.3": ("192.0.2.3", "192.0.2.4"),
+    }
+    records = [
+        _wire_interface(
+            "vpc10",
+            "vpc",
+            "accessVpcHost",
+            accessVlan=10,
+            peerSwitchId=peer_id,
+        )
+        for peer_id in ("SERIAL2", "SERIAL1", "SERIAL4", "SERIAL3")
+    ]
+    planner, recorder = _planner(
+        switches=switches,
+        responses=[
+            {"interfaces": [records[0]]},
+            {"interfaces": [records[1]]},
+            {"interfaces": [records[2]]},
+            {"interfaces": [records[3]]},
+        ],
+        vpc_pairs=pairs,
+    )
+
+    plan = planner.plan(
+        [
+            {
+                "type": "vpc_access",
+                "state": "overridden",
+                "config": [],
+            }
+        ]
+    )
+
+    resource = plan.resources[0]
+    assert len(resource.before) == 2
+    assert len(resource.operations.deletes) == 2
+    assert {
+        (item.switch_ip, item.interface_name)
+        for item in resource.operations.deletes
+    } == {
+        ("192.0.2.1", "vpc10"),
+        ("192.0.2.3", "vpc10"),
+    }
+    assert len(recorder.calls) == 4
+
+
 def test_opposite_primaries_on_the_same_vpc_pair_share_one_identity() -> None:
     """The unordered pair discriminator detects same-pair duplicate declarations."""
     pairs = {
@@ -298,7 +1511,21 @@ def test_ten_family_plan_shares_one_inventory_fetch_per_switch() -> None:
             "config_data": {"network_os": {"policy": policy or {}}},
         }
 
-    planner, recorder = _planner(vpc_pairs={"192.0.2.1": "192.0.2.2"})
+    planner, recorder = _planner(
+        responses=[
+            {
+                "interfaces": [
+                    _wire_interface("Ethernet1/3", "ethernet", "routedHost"),
+                ]
+            },
+            {
+                "interfaces": [
+                    _wire_interface("Ethernet1/4", "ethernet", "routedHost"),
+                ]
+            },
+        ],
+        vpc_pairs={"192.0.2.1": "192.0.2.2"},
+    )
     resources = [
         {
             "type": "ethernet_access",
@@ -369,18 +1596,3 @@ def test_overridden_still_rejects_an_unknown_configured_switch_before_inventory(
         planner.plan([{"type": "loopback", "state": "overridden", "config": [_loopback("192.0.2.99")]}])
 
     assert recorder.calls == []
-
-
-def test_vpc_create_detects_a_sibling_policy_observed_only_on_the_peer() -> None:
-    """Pair-scoped current-policy checks inspect both preloaded peer inventories."""
-    peer_current = _wire_interface("vpc10", "vpc", "trunkVpcHost")
-    pairs = {"192.0.2.1": ("192.0.2.1", "192.0.2.2")}
-    planner, _recorder = _planner(
-        responses=[{"interfaces": []}, {"interfaces": [peer_current]}],
-        vpc_pairs=pairs,
-    )
-
-    with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
-        planner.plan([{"type": "vpc_access", "state": "merged", "config": [_vpc("192.0.2.1")]}])
-
-    assert "existing_policy_ownership" in {conflict.code for conflict in exc_info.value.conflicts}

--- a/tests/unit/module_utils/test_interface_workflow_planner.py
+++ b/tests/unit/module_utils/test_interface_workflow_planner.py
@@ -26,6 +26,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.interface_workflow_planne
     InterfaceWorkflowConflictError,
     InterfaceWorkflowPlanner,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_routed_interface import EthernetRoutedInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 
 
@@ -38,10 +39,7 @@ class _RequestRecorder:
         summary_responses: Mapping[str, dict[str, Any] | list[dict[str, Any]]] | None = None,
     ) -> None:
         self._responses: Iterator[dict[str, Any]] = iter(responses)
-        self._summary_responses = {
-            switch_id: iter(value if isinstance(value, list) else [value])
-            for switch_id, value in (summary_responses or {}).items()
-        }
+        self._summary_responses = {switch_id: iter(value if isinstance(value, list) else [value]) for switch_id, value in (summary_responses or {}).items()}
         self.calls: list[dict[str, Any]] = []
 
     def __call__(self, **kwargs: Any) -> dict[str, Any]:
@@ -193,10 +191,11 @@ def _summary_row(
     return row
 
 
-def test_registry_is_the_exact_ten_family_scope_and_delegates_model_ownership() -> None:
+def test_registry_is_the_exact_eleven_family_scope_and_delegates_model_ownership() -> None:
     """The authoritative registry excludes flow-rules and derives every model from its orchestrator."""
     assert set(INTERFACE_FAMILY_ADAPTERS) == {
         "ethernet_access",
+        "ethernet_routed",
         "ethernet_trunk_host",
         "loopback",
         "port_channel_access",
@@ -216,6 +215,7 @@ def test_registry_declares_generic_transition_delete_and_structural_safety_metad
     """Every adapter advertises its mutation strategy and structural dependency guards."""
     expected = {
         "ethernet_access": (InterfaceDeleteStrategy.NORMALIZE, False, False, True),
+        "ethernet_routed": (InterfaceDeleteStrategy.NORMALIZE, False, False, True),
         "ethernet_trunk_host": (InterfaceDeleteStrategy.NORMALIZE, False, False, True),
         "loopback": (InterfaceDeleteStrategy.REMOVE, False, False, False),
         "port_channel_access": (InterfaceDeleteStrategy.REMOVE, False, True, True),
@@ -235,13 +235,11 @@ def test_registry_declares_generic_transition_delete_and_structural_safety_metad
         assert adapter.safety.requires_pair_consistency is pair_consistency
         assert adapter.safety.owns_physical_members is owns_members
         assert adapter.safety.guards_child_subinterfaces is child_guard
-        assert adapter.supports_intra_family_policy_transitions is (resource_type == "loopback")
+        assert adapter.supports_intra_family_policy_transitions is (resource_type in {"ethernet_routed", "loopback"})
         assert not hasattr(adapter, "policy_transition_sources")
 
     assert IMPLICIT_TRANSITION_STATES == frozenset({"merged", "replaced"})
-    assert {
-        adapter.delete_strategy for adapter in INTERFACE_FAMILY_ADAPTERS.values()
-    } == {
+    assert {adapter.delete_strategy for adapter in INTERFACE_FAMILY_ADAPTERS.values()} == {
         InterfaceDeleteStrategy.NORMALIZE,
         InterfaceDeleteStrategy.REMOVE,
         InterfaceDeleteStrategy.DELETE,
@@ -628,13 +626,7 @@ def test_svi_transition_accepts_switch_virtual_interface_summary_alias() -> None
     current = _wire_interface("vlan100", "switchVirtualInterface", "foreignSviPolicy")
     planner, _recorder = _planner(
         responses=[{"interfaces": [current]}],
-        summary_responses={
-            "SERIAL1": {
-                "interfaces": [
-                    _summary_row(current, "SERIAL1", interfaceType="switchVirtualInterface")
-                ]
-            }
-        },
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1", interfaceType="switchVirtualInterface")]}},
     )
     config = {
         "switch_ip": "192.0.2.1",
@@ -663,9 +655,7 @@ def test_implicit_transition_requires_and_accepts_a_consistent_vpc_pair(resource
         vpc_pairs=pairs,
     )
 
-    plan = planner.plan(
-        [{"type": resource_type, "state": "merged", "config": [_vpc("192.0.2.1", trunk=trunk)]}]
-    )
+    plan = planner.plan([{"type": resource_type, "state": "merged", "config": [_vpc("192.0.2.1", trunk=trunk)]}])
 
     transition = plan.resources[0].transitions[0]
     assert len(transition.current_records) == 2
@@ -724,9 +714,7 @@ def test_summary_inventory_is_lazy_and_shared_for_two_transitions_on_one_switch(
     second = _wire_interface("Ethernet1/11", "ethernet", "dot1qTunnelHost")
     planner, recorder = _planner(
         responses=[{"interfaces": [first, second]}],
-        summary_responses={
-            "SERIAL1": {"interfaces": [_summary_row(first, "SERIAL1"), _summary_row(second, "SERIAL1")]}
-        },
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(first, "SERIAL1"), _summary_row(second, "SERIAL1")]}},
     )
     config = {
         "switch_ip": "192.0.2.1",
@@ -769,32 +757,49 @@ def test_same_name_different_interface_type_is_a_structural_collision() -> None:
 
 
 @pytest.mark.parametrize(
-    ("resource_type", "config", "interface_name", "interface_type"),
+    ("resource_type", "config", "interface_name", "interface_type", "current_policy_type"),
     [
         (
             "ethernet_access",
             {"switch_ip": "192.0.2.1", "interface_names": ["Ethernet1/1"]},
             "Ethernet1/1",
             "ethernet",
+            "dot1qTunnelHost",
+        ),
+        (
+            "ethernet_routed",
+            {"switch_ip": "192.0.2.1", "interface_name": "Ethernet1/3"},
+            "Ethernet1/3",
+            "ethernet",
+            "accessHost",
         ),
         (
             "ethernet_trunk_host",
             {"switch_ip": "192.0.2.1", "interface_names": ["Ethernet1/2"]},
             "Ethernet1/2",
             "ethernet",
+            "dot1qTunnelHost",
         ),
-        ("loopback", {"switch_ip": "192.0.2.1", "interface_name": "loopback10"}, "loopback10", "loopback"),
+        (
+            "loopback",
+            {"switch_ip": "192.0.2.1", "interface_name": "loopback10"},
+            "loopback10",
+            "loopback",
+            "foreignDeletablePolicy",
+        ),
         (
             "port_channel_access",
             {"switch_ip": "192.0.2.1", "interface_name": "port-channel10"},
             "port-channel10",
             "portChannel",
+            "foreignDeletablePolicy",
         ),
         (
             "port_channel_trunk_host",
             {"switch_ip": "192.0.2.1", "interface_name": "port-channel11"},
             "port-channel11",
             "portChannel",
+            "foreignDeletablePolicy",
         ),
         (
             "subinterface_managed",
@@ -804,6 +809,7 @@ def test_same_name_different_interface_type_is_a_structural_collision() -> None:
             },
             "Ethernet1/3.10",
             "subInterface",
+            "foreignDeletablePolicy",
         ),
         (
             "subinterface_unmanaged",
@@ -813,6 +819,7 @@ def test_same_name_different_interface_type_is_a_structural_collision() -> None:
             },
             "Ethernet1/4.20",
             "subInterface",
+            "foreignDeletablePolicy",
         ),
         (
             "svi",
@@ -822,6 +829,7 @@ def test_same_name_different_interface_type_is_a_structural_collision() -> None:
             },
             "vlan100",
             "svi",
+            "foreignDeletablePolicy",
         ),
     ],
 )
@@ -830,9 +838,10 @@ def test_deleted_is_policy_independent_within_the_selected_structure(
     config: dict[str, Any],
     interface_name: str,
     interface_type: str,
+    current_policy_type: str,
 ) -> None:
-    """Explicit deleted targets a foreign policy and uses the destination adapter's delete path."""
-    current = _wire_interface(interface_name, interface_type, "foreignDeletablePolicy")
+    """Explicit deleted targets a safe cross-family policy and uses the destination adapter's delete path."""
+    current = _wire_interface(interface_name, interface_type, current_policy_type)
     planner, _recorder = _planner(
         responses=[{"interfaces": [current]}],
         summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}},
@@ -844,6 +853,20 @@ def test_deleted_is_policy_independent_within_the_selected_structure(
     assert resource.transitions == ()
     assert len(resource.operations.deletes) == 1
     assert resource.mutation_count == 1
+
+
+def test_deleted_rejects_fabric_owned_ethernet_policy_before_writes() -> None:
+    """Explicit physical delete cannot normalize a fabric link carrying a system-owned policy."""
+    current = _wire_interface("Ethernet1/1", "ethernet", "numbered", ip="198.51.100.1", prefix=30)
+    planner, recorder = _planner(
+        responses=[{"interfaces": [current]}],
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}},
+    )
+
+    with pytest.raises(InterfaceWorkflowValidationError, match=r"system policy 'numbered'"):
+        planner.plan([{"type": "ethernet_access", "state": "deleted", "config": [_ethernet("192.0.2.1")]}])
+
+    assert len(recorder.calls) == 2
 
 
 @pytest.mark.parametrize(
@@ -863,6 +886,260 @@ def test_deleted_absent_or_default_ethernet_is_idempotent_without_summary(invent
     assert plan.mutation_count == 0
     assert plan.request_stats["interface_summary_gets"] == 0
     assert len(recorder.calls) == 1
+
+
+def test_deleted_ios_xe_default_is_idempotent_without_platform_reset_or_summary() -> None:
+    """A defaults-only IOS-XE routed physical port is already at its platform reset target."""
+    current = _wire_interface("GigabitEthernet3", "ethernet", "iosXeRoutedHost", adminState=True, speed="auto")
+    current["configData"]["mode"] = "routed"
+    current["configData"]["networkOS"]["networkOSType"] = "ios-xe"
+    planner, recorder = _planner(responses=[{"interfaces": [current]}])
+    config = {"switch_ip": "192.0.2.1", "interface_names": ["GigabitEthernet3"]}
+
+    plan = planner.plan([{"type": "ethernet_access", "state": "deleted", "config": [config]}])
+
+    assert plan.changed is False
+    assert plan.mutation_count == 0
+    assert plan.auxiliary_orchestrators == ()
+    assert plan.request_stats["interface_summary_gets"] == 0
+    assert len(recorder.calls) == 1
+
+
+def test_deleted_ios_xe_configured_port_uses_routed_platform_reset_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cross-family IOS-XE physical delete keeps one logical item while selecting the routed reset implementation."""
+    current = _wire_interface(
+        "GigabitEthernet3",
+        "ethernet",
+        "iosXeRoutedHost",
+        adminState=True,
+        ip="198.51.100.1",
+        prefix=30,
+    )
+    current["configData"]["mode"] = "routed"
+    current["configData"]["networkOS"]["networkOSType"] = "ios-xe"
+    planner, recorder = _planner(
+        responses=[{"interfaces": [current]}],
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}},
+    )
+    monkeypatch.setattr(EthernetRoutedInterfaceOrchestrator, "preflight_delete", lambda _self, _models: None)
+    config = {"switch_ip": "192.0.2.1", "interface_names": ["GigabitEthernet3"]}
+
+    plan = planner.plan([{"type": "ethernet_access", "state": "deleted", "config": [config]}])
+
+    resource = plan.resources[0]
+    assert len(resource.operations.deletes) == 1
+    assert len(resource.platform_deletes) == 1
+    proxy = resource.platform_deletes[0]
+    assert proxy.get_identifier_value() == ("192.0.2.1", "GigabitEthernet3")
+    assert proxy.config_data.network_os.network_os_type == "ios-xe"
+    assert len(plan.auxiliary_orchestrators) == 1
+    assert isinstance(plan.auxiliary_orchestrators[0], EthernetRoutedInterfaceOrchestrator)
+    assert plan.request_stats["interface_inventory_gets"] == 1
+    assert plan.request_stats["interface_summary_gets"] == 1
+    assert len(recorder.calls) == 2
+
+
+def test_direct_routed_ios_xe_delete_refuses_a_fabric_link_endpoint_during_planning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A direct routed delete fails closed on an IOS-XE fabric-link endpoint before any mutation can run."""
+    current = _wire_interface(
+        "GigabitEthernet3",
+        "ethernet",
+        "iosXeRoutedHost",
+        adminState=True,
+        description="fabric-owned endpoint",
+        ip="198.51.100.1",
+        prefix=30,
+    )
+    current["configData"]["mode"] = "routed"
+    current["configData"]["networkOS"]["networkOSType"] = "ios-xe"
+    planner, recorder = _planner(
+        switches={"192.0.2.1": "SERIAL1"},
+        responses=[{"interfaces": [current]}],
+        summary_responses={"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}},
+    )
+    link_calls: list[tuple[str, str]] = []
+
+    def links_request(_orchestrator, *, path, verb, **_kwargs):
+        link_calls.append((getattr(verb, "value", verb), path))
+        return {
+            "links": [
+                {
+                    "linkId": "LINK-UUID-1",
+                    "configData": {"policyType": "ebgpVrfLite"},
+                    "srcSwitchName": "WAN1",
+                    "srcSwitchId": "SERIAL1",
+                    "srcInterfaceName": "GigabitEthernet3",
+                    "dstSwitchName": "BORDER1",
+                    "dstSwitchId": "SERIAL9",
+                    "dstInterfaceName": "Ethernet1/3",
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        }
+
+    monkeypatch.setattr(EthernetRoutedInterfaceOrchestrator, "_request", links_request)
+    resources = [
+        {
+            "type": "ethernet_routed",
+            "state": "deleted",
+            "config": [{"switch_ip": "192.0.2.1", "interface_name": "GigabitEthernet3"}],
+        }
+    ]
+
+    with pytest.raises(
+        InterfaceWorkflowValidationError,
+        match=r"resources\[0\] type 'ethernet_routed' preflight failed: Interface GigabitEthernet3 .* endpoint of fabric link LINK-UUID-1",
+    ):
+        planner.plan(resources)
+
+    assert link_calls == [("GET", "/api/v1/manage/links?fabricName=fabric_1")]
+    assert planner.snapshot.request_stats["interface_inventory_gets"] == 1
+    assert planner.snapshot.request_stats["interface_summary_gets"] == 0
+    assert len(recorder.calls) == 1
+    assert {getattr(call["verb"], "value", call["verb"]) for call in recorder.calls} == {"GET"}
+
+
+def test_first_of_two_direct_routed_ios_xe_deletes_refuses_a_fabric_link_endpoint_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two direct routed groups load their inventories, then the first link-owned target stops planning after one links GET."""
+    first = _wire_interface(
+        "GigabitEthernet3",
+        "ethernet",
+        "iosXeRoutedHost",
+        adminState=True,
+        description="fabric-owned endpoint",
+        ip="198.51.100.1",
+        prefix=30,
+    )
+    second = _wire_interface(
+        "GigabitEthernet4",
+        "ethernet",
+        "iosXeRoutedHost",
+        adminState=True,
+        description="ordinary routed interface",
+        ip="198.51.100.5",
+        prefix=30,
+    )
+    for current in (first, second):
+        current["configData"]["mode"] = "routed"
+        current["configData"]["networkOS"]["networkOSType"] = "ios-xe"
+    planner, recorder = _planner(
+        responses=[{"interfaces": [first]}, {"interfaces": [second]}],
+        summary_responses={
+            "SERIAL1": {"interfaces": [_summary_row(first, "SERIAL1")]},
+            "SERIAL2": {"interfaces": [_summary_row(second, "SERIAL2")]},
+        },
+    )
+    link_calls: list[tuple[str, str]] = []
+
+    def links_request(_orchestrator, *, path, verb, **_kwargs):
+        link_calls.append((getattr(verb, "value", verb), path))
+        return {
+            "links": [
+                {
+                    "linkId": "LINK-UUID-1",
+                    "configData": {"policyType": "ebgpVrfLite"},
+                    "srcSwitchName": "WAN1",
+                    "srcSwitchId": "SERIAL1",
+                    "srcInterfaceName": "GigabitEthernet3",
+                    "dstSwitchName": "BORDER1",
+                    "dstSwitchId": "SERIAL9",
+                    "dstInterfaceName": "Ethernet1/3",
+                }
+            ],
+            "meta": {"counts": {"remaining": 0}},
+        }
+
+    monkeypatch.setattr(EthernetRoutedInterfaceOrchestrator, "_request", links_request)
+    resources = [
+        {
+            "type": "ethernet_routed",
+            "state": "deleted",
+            "config": [{"switch_ip": "192.0.2.1", "interface_name": "GigabitEthernet3"}],
+        },
+        {
+            "type": "ethernet_routed",
+            "state": "deleted",
+            "config": [{"switch_ip": "192.0.2.2", "interface_name": "GigabitEthernet4"}],
+        },
+    ]
+
+    with pytest.raises(
+        InterfaceWorkflowValidationError,
+        match=r"resources\[0\] type 'ethernet_routed' preflight failed: Interface GigabitEthernet3 .* endpoint of fabric link LINK-UUID-1",
+    ):
+        planner.plan(resources)
+
+    assert link_calls == [("GET", "/api/v1/manage/links?fabricName=fabric_1")]
+    assert planner.snapshot.request_stats["interface_inventory_gets"] == 2
+    assert planner.snapshot.request_stats["interface_summary_gets"] == 0
+    assert len(recorder.calls) == 2
+    assert {getattr(call["verb"], "value", call["verb"]) for call in recorder.calls} == {"GET"}
+
+
+def test_multiple_routed_ios_xe_deletes_share_one_link_inventory_and_reset_orchestrator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Direct routed delete groups reuse one lazy link query and the first resource orchestrator for platform resets."""
+    first = _wire_interface(
+        "GigabitEthernet3",
+        "ethernet",
+        "iosXeRoutedHost",
+        adminState=True,
+        ip="198.51.100.1",
+        prefix=30,
+    )
+    second = _wire_interface(
+        "GigabitEthernet4",
+        "ethernet",
+        "iosXeRoutedHost",
+        adminState=True,
+        ip="198.51.100.5",
+        prefix=30,
+    )
+    for current in (first, second):
+        current["configData"]["mode"] = "routed"
+        current["configData"]["networkOS"]["networkOSType"] = "ios-xe"
+    planner, recorder = _planner(
+        responses=[{"interfaces": [first]}, {"interfaces": [second]}],
+        summary_responses={
+            "SERIAL1": {"interfaces": [_summary_row(first, "SERIAL1")]},
+            "SERIAL2": {"interfaces": [_summary_row(second, "SERIAL2")]},
+        },
+    )
+    link_calls = []
+
+    def links_request(orchestrator, *, path, verb, **_kwargs):
+        link_calls.append((id(orchestrator), path))
+        response = {
+            "RETURN_CODE": 200,
+            "METHOD": getattr(verb, "value", verb),
+            "REQUEST_PATH": path,
+            "DATA": {"links": []},
+        }
+        orchestrator.rest_send._response.append(response)
+        orchestrator.rest_send._result.append({"success": True, "changed": False})
+        return {"links": []}
+
+    monkeypatch.setattr(EthernetRoutedInterfaceOrchestrator, "_request", links_request)
+    resources = [
+        {
+            "type": "ethernet_routed",
+            "state": "deleted",
+            "config": [{"switch_ip": "192.0.2.1", "interface_name": "GigabitEthernet3"}],
+        },
+        {
+            "type": "ethernet_routed",
+            "state": "deleted",
+            "config": [{"switch_ip": "192.0.2.2", "interface_name": "GigabitEthernet4"}],
+        },
+    ]
+
+    plan = planner.plan(resources)
+
+    assert len(link_calls) == 1
+    assert plan.request_stats["fabric_link_gets"] == 1
+    assert plan.auxiliary_orchestrators == (plan.resources[0].orchestrator,)
+    assert plan.resources[1].orchestrator._fabric_link_cache_provider is plan.resources[0].orchestrator
+    assert all(len(resource.platform_deletes) == 1 for resource in plan.resources)
+    assert len(recorder.calls) == 2
 
 
 @pytest.mark.parametrize("resource_type", ["vpc_access", "vpc_trunk_host"])
@@ -1173,10 +1450,7 @@ def test_subinterface_write_requires_existing_routed_parent(
     with pytest.raises(InterfaceWorkflowConflictError, match=expected_reason) as exc_info:
         planner.plan([{"type": "subinterface_managed", "state": "merged", "config": [child]}])
 
-    assert "subinterface_parent_prerequisite" in {
-        conflict.code
-        for conflict in exc_info.value.conflicts
-    }
+    assert "subinterface_parent_prerequisite" in {conflict.code for conflict in exc_info.value.conflicts}
 
 
 @pytest.mark.parametrize(
@@ -1228,11 +1502,7 @@ def test_port_channel_current_and_final_members_conflict_with_ethernet_mutation(
     """Both current and final port-channel members are protected from Ethernet actions."""
     current = _wire_interface("port-channel10", "portChannel", "foreignPoPolicy", ports=["Ethernet1/1"])
     responses = [{"interfaces": [current]}] if current_member else [{"interfaces": []}]
-    summaries = (
-        {"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}}
-        if current_member
-        else None
-    )
+    summaries = {"SERIAL1": {"interfaces": [_summary_row(current, "SERIAL1")]}} if current_member else None
     final_members = ["Ethernet1/2"] if current_member else ["Ethernet1/1"]
     planner, _recorder = _planner(responses=responses, summary_responses=summaries)
 
@@ -1254,17 +1524,9 @@ def test_port_channel_current_and_final_members_conflict_with_ethernet_mutation(
 @pytest.mark.parametrize("current_member", [False, True])
 def test_vpc_current_and_final_members_conflict_with_ethernet_mutation(current_member: bool) -> None:
     """Both current and final per-peer vPC members are protected from Ethernet actions."""
-    primary = _wire_interface(
-        "vpc10", "vpc", "foreignVpcPolicy", peerSwitchId="SERIAL2", peer1MemberPorts=["Ethernet1/1"]
-    )
-    peer = _wire_interface(
-        "vpc10", "vpc", "foreignVpcPolicy", peerSwitchId="SERIAL1", peer1MemberPorts=["Ethernet1/1"]
-    )
-    responses = (
-        [{"interfaces": [primary]}, {"interfaces": [peer]}]
-        if current_member
-        else [{"interfaces": []}, {"interfaces": []}]
-    )
+    primary = _wire_interface("vpc10", "vpc", "foreignVpcPolicy", peerSwitchId="SERIAL2", peer1MemberPorts=["Ethernet1/1"])
+    peer = _wire_interface("vpc10", "vpc", "foreignVpcPolicy", peerSwitchId="SERIAL1", peer1MemberPorts=["Ethernet1/1"])
+    responses = [{"interfaces": [primary]}, {"interfaces": [peer]}] if current_member else [{"interfaces": []}, {"interfaces": []}]
     summaries = (
         {
             "SERIAL1": {"interfaces": [_summary_row(primary, "SERIAL1")]},
@@ -1452,11 +1714,7 @@ def test_ethernet_only_action_cannot_mutate_untouched_port_channel_member(
     )
     ethernet = _wire_interface("Ethernet1/1", "ethernet", policy_type, accessVlan=10)
     ethernet["operData"] = {"portChannelId": -1}
-    summaries = (
-        {"SERIAL1": {"interfaces": [_summary_row(ethernet, "SERIAL1")]}}
-        if state == "merged"
-        else None
-    )
+    summaries = {"SERIAL1": {"interfaces": [_summary_row(ethernet, "SERIAL1")]}} if state == "merged" else None
     planner, _recorder = _planner(
         responses=[{"interfaces": [parent, ethernet]}],
         summary_responses=summaries,
@@ -1486,9 +1744,7 @@ def test_ethernet_only_action_cannot_mutate_untouched_vpc_member() -> None:
     )
 
     with pytest.raises(InterfaceWorkflowConflictError) as exc_info:
-        planner.plan(
-            [{"type": "ethernet_access", "state": "deleted", "config": [_ethernet("192.0.2.1")]}]
-        )
+        planner.plan([{"type": "ethernet_access", "state": "deleted", "config": [_ethernet("192.0.2.1")]}])
 
     assert "ethernet_member_collision" in {conflict.code for conflict in exc_info.value.conflicts}
 
@@ -1699,10 +1955,7 @@ def test_overridden_preserves_same_vpc_name_as_two_pair_scoped_records() -> None
     resource = plan.resources[0]
     assert len(resource.before) == 2
     assert len(resource.operations.deletes) == 2
-    assert {
-        (item.switch_ip, item.interface_name)
-        for item in resource.operations.deletes
-    } == {
+    assert {(item.switch_ip, item.interface_name) for item in resource.operations.deletes} == {
         ("192.0.2.1", "vpc10"),
         ("192.0.2.3", "vpc10"),
     }
@@ -1728,8 +1981,8 @@ def test_opposite_primaries_on_the_same_vpc_pair_share_one_identity() -> None:
     assert "duplicate_ownership" in {conflict.code for conflict in exc_info.value.conflicts}
 
 
-def test_ten_family_plan_shares_one_inventory_fetch_per_switch() -> None:
-    """The actual workflow path reduces ten family inventories over two switches to two GETs."""
+def test_eleven_family_plan_shares_one_inventory_fetch_per_switch() -> None:
+    """The actual workflow path reduces eleven family inventories over two switches to two GETs."""
 
     def config(switch_ip: str, interface_name: str, policy: dict[str, Any] | None = None) -> dict[str, Any]:
         return {
@@ -1758,6 +2011,22 @@ def test_ten_family_plan_shares_one_inventory_fetch_per_switch() -> None:
             "type": "ethernet_access",
             "state": "merged",
             "config": [_ethernet("192.0.2.1", "Ethernet1/1")],
+        },
+        {
+            "type": "ethernet_routed",
+            "state": "merged",
+            "config": [
+                {
+                    "switch_ip": "192.0.2.1",
+                    "interface_name": "Ethernet1/5",
+                    "config_data": {
+                        "network_os": {
+                            "network_os_type": "nx-os",
+                            "policy": {"ip": "198.51.100.1", "prefix": 30},
+                        }
+                    },
+                }
+            ],
         },
         {
             "type": "ethernet_trunk_host",
@@ -1808,8 +2077,8 @@ def test_ten_family_plan_shares_one_inventory_fetch_per_switch() -> None:
 
     plan = planner.plan(resources)
 
-    assert len(plan.resources) == 10
-    assert plan.mutation_count == 10
+    assert len(plan.resources) == 11
+    assert plan.mutation_count == 11
     assert plan.target_switch_ids == ("SERIAL1", "SERIAL2")
     assert plan.request_stats["interface_inventory_gets"] == 2
     assert len(recorder.calls) == 2

--- a/tests/unit/module_utils/test_manage_vpc_pair_resources.py
+++ b/tests/unit/module_utils/test_manage_vpc_pair_resources.py
@@ -1,0 +1,50 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the vPC pair state-machine resource service."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from ansible_collections.cisco.nd.plugins.module_utils.manage_vpc_pair.resources import (
+    VpcPairStateMachine,
+)
+
+
+def test_vpc_override_deletions_respect_override_exceptions():
+    """An override exception must retain its pair while other stale pairs are deleted."""
+    retained_identifier = ("SERIAL1", "SERIAL2")
+    deleted_identifier = ("SERIAL3", "SERIAL4")
+    retained_item = Mock()
+    deleted_item = Mock()
+    deleted_item.model_dump.return_value = {
+        "switchId": "SERIAL3",
+        "peerSwitchId": "SERIAL4",
+    }
+
+    state_machine = object.__new__(VpcPairStateMachine)
+    state_machine.previous = Mock()
+    state_machine.previous.get_diff_identifiers.return_value = [
+        retained_identifier,
+        deleted_identifier,
+    ]
+    state_machine.proposed = Mock()
+    state_machine.existing = Mock()
+    state_machine.existing.get.side_effect = {
+        retained_identifier: retained_item,
+        deleted_identifier: deleted_item,
+    }.get
+    state_machine.model_orchestrator = Mock()
+    state_machine.model_orchestrator.delete.return_value = True
+    state_machine.format_log = Mock()
+    state_machine.module = SimpleNamespace(params={"ignore_errors": False})
+
+    state_machine._manage_vpc_override_deletions([retained_identifier])
+
+    state_machine.model_orchestrator.delete.assert_called_once_with(deleted_item)
+    state_machine.existing.delete.assert_called_once_with(deleted_identifier)
+    state_machine.format_log.assert_called_once_with(
+        identifier=deleted_identifier,
+        status="deleted",
+        after_data={},
+    )

--- a/tests/unit/module_utils/test_nd_state_plan.py
+++ b/tests/unit/module_utils/test_nd_state_plan.py
@@ -39,7 +39,7 @@ def test_merged_plan_preserves_unspecified_current_fields_without_mutating_befor
     assert not plan.creates
     assert not plan.deletes
     policy = plan.after.to_ansible_config()[0]["config_data"]["network_os"]["policy"]
-    assert policy["ip"] == "192.0.2.10/32"
+    assert policy["ip"] == "192.0.2.10"
     assert policy["description"] == "new"
     assert before.to_ansible_config() == original_before
 

--- a/tests/unit/module_utils/test_nd_state_plan.py
+++ b/tests/unit/module_utils/test_nd_state_plan.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the mutation-free ND state planning boundary."""
+
+from __future__ import annotations
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
+from ansible_collections.cisco.nd.plugins.module_utils.nd_config_collection import NDConfigCollection
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_plan import NDStatePlanner
+
+
+def _loopback(name: str, *, ip: str | None = None, description: str | None = None) -> dict:
+    policy = {key: value for key, value in {"ip": ip, "description": description}.items() if value is not None}
+    return {
+        "switch_ip": "192.0.2.1",
+        "interface_name": name,
+        "config_data": {"network_os": {"policy": policy}},
+    }
+
+
+def _collection(config: list[dict], state: str = "merged") -> NDConfigCollection:
+    return NDConfigCollection.from_ansible_config(data=config, model_class=LoopbackInterfaceModel, context={"state": state})
+
+
+def test_merged_plan_preserves_unspecified_current_fields_without_mutating_before() -> None:
+    """Merged planning emits the final merged item and leaves its inputs unchanged."""
+    before = _collection([_loopback("loopback10", ip="192.0.2.10/32", description="old")])
+    proposed = _collection([_loopback("LOOPBACK10", description="new")])
+    original_before = before.to_ansible_config()
+
+    plan = NDStatePlanner.plan(state="merged", before=before, proposed=proposed)
+
+    assert len(plan.updates) == 1
+    assert not plan.creates
+    assert not plan.deletes
+    policy = plan.after.to_ansible_config()[0]["config_data"]["network_os"]["policy"]
+    assert policy["ip"] == "192.0.2.10/32"
+    assert policy["description"] == "new"
+    assert before.to_ansible_config() == original_before
+
+
+def test_overridden_plan_calculates_update_create_delete_and_after_state() -> None:
+    """Override planning is complete before execution and remains mutation-free."""
+    before = _collection(
+        [
+            _loopback("loopback10", ip="192.0.2.10/32"),
+            _loopback("loopback20", ip="192.0.2.20/32"),
+        ],
+        state="overridden",
+    )
+    proposed = _collection(
+        [
+            _loopback("loopback10", ip="192.0.2.110/32"),
+            _loopback("loopback30", ip="192.0.2.30/32"),
+        ],
+        state="overridden",
+    )
+
+    plan = NDStatePlanner.plan(state="overridden", before=before, proposed=proposed)
+
+    assert [item.interface_name for item in plan.updates] == ["loopback10"]
+    assert [item.interface_name for item in plan.creates] == ["loopback30"]
+    assert [item.interface_name for item in plan.deletes] == ["loopback20"]
+    assert set(plan.after.keys()) == {("192.0.2.1", "loopback10"), ("192.0.2.1", "loopback30")}
+    assert plan.changed is True
+    assert plan.mutation_count == 3
+    assert set(before.keys()) == {
+        ("192.0.2.1", "loopback10"),
+        ("192.0.2.1", "loopback20"),
+    }
+
+
+def test_deleted_plan_only_selects_identifiers_that_exist() -> None:
+    """Delete planning ignores absent identifiers and produces the final collection."""
+    before = _collection([_loopback("loopback10", ip="192.0.2.10/32")])
+    proposed = _collection(
+        [
+            {"switch_ip": "192.0.2.1", "interface_name": "loopback10"},
+            {"switch_ip": "192.0.2.1", "interface_name": "loopback99"},
+        ],
+        state="deleted",
+    )
+
+    plan = NDStatePlanner.plan(state="deleted", before=before, proposed=proposed)
+
+    assert [item.interface_name for item in plan.deletes] == ["loopback10"]
+    assert len(plan.after) == 0
+    assert len(before) == 1
+
+
+def test_invalid_state_fails_without_changing_inputs() -> None:
+    """Unsupported state values cannot reach execution."""
+    before = _collection([])
+    proposed = _collection([])
+
+    with pytest.raises(ValueError, match="Invalid state"):
+        NDStatePlanner.plan(state="gathered", before=before, proposed=proposed)
+
+    assert len(before) == 0
+    assert len(proposed) == 0

--- a/tests/unit/module_utils/test_response_handler_nd.py
+++ b/tests/unit/module_utils/test_response_handler_nd.py
@@ -2310,12 +2310,13 @@ def test_response_handler_nd_01440():
     """
     # Summary
 
-    Verify GET results carry no retryable key (GET retry semantics are unchanged).
+    Verify a GET failing with a 5xx code remains retryable (GET retries serve eventual-consistency polling and 5xx is
+    potentially transient; only 4xx-except-429 is terminal — see issue #457).
 
     ## Test
 
     - GET returns 500
-    - result has no "retryable" key, so RestSend's .get("retryable", True) default preserves today's GET retry behavior
+    - success is False and retryable is True
 
     ## Classes and Methods
 
@@ -2332,7 +2333,7 @@ def test_response_handler_nd_01440():
     with does_not_raise():
         instance.commit()
     assert instance.result["success"] is False
-    assert "retryable" not in instance.result
+    assert instance.result["retryable"] is True
 
 
 def test_response_handler_nd_01450():
@@ -2495,3 +2496,163 @@ def test_response_handler_nd_01490():
         instance.commit()
     assert instance.result["success"] is False
     assert instance.result["changed"] is False
+
+
+def test_response_handler_nd_01500():
+    """
+    # Summary
+
+    Verify a POST failing with a 4xx code is terminal (retryable=False): the request reached the application and was
+    rejected, so an identical replay cannot succeed (issue #457 — deterministic 400s previously burned the full retry
+    budget).
+
+    ## Test
+
+    - POST returns 400
+    - success is False, retryable is False, changed is False
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_post_put_delete_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 400,
+        "MESSAGE": "Bad Request",
+        "DATA": {"error": "Invalid fabric settings"},
+    }
+    instance.verb = HttpVerbEnum.POST
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["retryable"] is False
+    assert instance.result["changed"] is False
+
+
+def test_response_handler_nd_01510():
+    """
+    # Summary
+
+    Verify a POST failing with 429 (Too Many Requests) remains retryable: rate limiting is the one transient 4xx, so
+    it is excluded from the 4xx-terminal rule (issue #457).
+
+    ## Test
+
+    - POST returns 429
+    - success is False and retryable is True
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_post_put_delete_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 429,
+        "MESSAGE": "Too Many Requests",
+        "DATA": {},
+    }
+    instance.verb = HttpVerbEnum.POST
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["retryable"] is True
+
+
+def test_response_handler_nd_01520():
+    """
+    # Summary
+
+    Verify a GET failing with a 4xx code is terminal (retryable=False): a deterministic client error on a GET (bad
+    query parameter, malformed path segment) previously burned the full retry budget just like a mutation (issue
+    #457 scope note — the 4xx-terminal rule applies to all verbs).
+
+    ## Test
+
+    - GET returns 400
+    - success is False, found is False, retryable is False
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_get_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 400,
+        "MESSAGE": "Bad Request",
+        "DATA": {"error": "invalid query parameter"},
+    }
+    instance.verb = HttpVerbEnum.GET
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["found"] is False
+    assert instance.result["retryable"] is False
+
+
+def test_response_handler_nd_01530():
+    """
+    # Summary
+
+    Verify a GET returning 404 keeps its not-found-is-success contract with retryable=False (the key is now present
+    on every GET result for a consistent shape; a successful result never re-enters the retry loop).
+
+    ## Test
+
+    - GET returns 404
+    - success is True, found is False, retryable is False
+
+    ## Classes and Methods
+
+    - ResponseHandler._handle_get_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 404,
+        "MESSAGE": "Not Found",
+        "DATA": {},
+    }
+    instance.verb = HttpVerbEnum.GET
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is True
+    assert instance.result["found"] is False
+    assert instance.result["retryable"] is False
+
+
+def test_response_handler_nd_01540():
+    """
+    # Summary
+
+    Verify a DELETE failing with 404 is terminal (retryable=False): only GET treats 404 as not-found-success; for a
+    mutation it is a client error, and replaying an identical DELETE against a missing resource cannot succeed
+    (issue #457 — orchestrators with bounded domain-level retries, e.g. L3Out attach, own that pacing themselves).
+
+    ## Test
+
+    - DELETE returns 404
+    - success is False and retryable is False
+
+    ## Classes and Methods
+
+    - ResponseHandler._is_terminal_client_error()
+    - ResponseHandler._handle_post_put_delete_response()
+    - ResponseHandler.commit()
+    """
+    instance = ResponseHandler()
+    instance.response = {
+        "RETURN_CODE": 404,
+        "MESSAGE": "Not Found",
+        "DATA": {"error": "resource does not exist"},
+    }
+    instance.verb = HttpVerbEnum.DELETE
+    with does_not_raise():
+        instance.commit()
+    assert instance.result["success"] is False
+    assert instance.result["retryable"] is False

--- a/tests/unit/module_utils/test_rest_send.py
+++ b/tests/unit/module_utils/test_rest_send.py
@@ -900,20 +900,20 @@ def test_rest_send_00510():
     ## Test
 
     - Failed POST request returns 400 response
-    - Loop retries until timeout is exhausted
+    - The deterministic 400 is terminal and is submitted exactly once
+    - A following sentinel 200 response is not consumed
 
     ## Classes and Methods
 
     - RestSend.commit()
     - RestSend._commit_normal_mode()
+    - ResponseHandler._is_terminal_client_error()
     """
     method_name = inspect.stack()[0][3]
-    key = f"{method_name}a"
 
     def responses():
-        # Provide responses for multiple retry attempts (60 retries * 5 second interval = 300 seconds)
-        for _ in range(60):
-            yield responses_rest_send(key)
+        yield responses_rest_send(f"{method_name}a")
+        yield responses_rest_send(f"{method_name}b")
 
     gen_responses = ResponseGenerator(responses())
 
@@ -940,9 +940,10 @@ def test_rest_send_00510():
         instance.payload = {"invalid": "data"}
         instance.commit()
 
-    # Verify error response
+    # One submission: the terminal 400 is final; the sentinel 200 was never consumed.
     assert instance.response_current["RETURN_CODE"] == 400
     assert instance.result_current["success"] is False
+    assert instance.result_current["retryable"] is False
 
 
 def test_rest_send_00520():

--- a/tests/unit/modules/test_nd_interfaces_workflow.py
+++ b/tests/unit/modules/test_nd_interfaces_workflow.py
@@ -36,6 +36,7 @@ def test_argument_spec_uses_exact_registry_and_excludes_flow_rules():
         "overridden",
         "replaced",
     ]
+    assert "allow_policy_transition" not in resource_options
     assert resource_options["config"] == {
         "type": "list",
         "elements": "dict",
@@ -61,6 +62,12 @@ def test_documentation_links_every_standalone_module_and_not_flow_rules():
     assert "M(cisco.nd.nd_interface_flow_rules)" not in nd_interfaces_workflow.DOCUMENTATION
     assert "default: false" in nd_interfaces_workflow.DOCUMENTATION
     assert "Outstanding interface" not in nd_interfaces_workflow.DOCUMENTATION
+    assert "allow_policy_transition" not in nd_interfaces_workflow.DOCUMENTATION
+    assert "allow_policy_transition" not in nd_interfaces_workflow.EXAMPLES
+    assert "policy transition" in nd_interfaces_workflow.DOCUMENTATION
+    assert "unconfigured default" in nd_interfaces_workflow.DOCUMENTATION
+    assert "regardless of its current policy family" in nd_interfaces_workflow.DOCUMENTATION
+    assert "from_policy_type" in nd_interfaces_workflow.RETURN
 
 
 def test_main_requires_pydantic_then_runs_coordinator_and_exits():

--- a/tests/unit/modules/test_nd_interfaces_workflow.py
+++ b/tests/unit/modules/test_nd_interfaces_workflow.py
@@ -41,9 +41,7 @@ def test_argument_spec_uses_exact_registry_and_excludes_flow_rules():
         "elements": "dict",
         "required": True,
     }
-    assert spec["config_actions"]["options"] == {
-        "deploy": {"type": "bool", "default": True}
-    }
+    assert spec["config_actions"]["options"] == {"deploy": {"type": "bool", "default": False}}
 
 
 def test_documentation_links_every_standalone_module_and_not_flow_rules():
@@ -60,10 +58,9 @@ def test_documentation_links_every_standalone_module_and_not_flow_rules():
         "nd_interface_vpc_trunk_host",
     ):
         assert f"M(cisco.nd.{module_name})" in nd_interfaces_workflow.DOCUMENTATION
-    assert (
-        "M(cisco.nd.nd_interface_flow_rules)"
-        not in nd_interfaces_workflow.DOCUMENTATION
-    )
+    assert "M(cisco.nd.nd_interface_flow_rules)" not in nd_interfaces_workflow.DOCUMENTATION
+    assert "default: false" in nd_interfaces_workflow.DOCUMENTATION
+    assert "Outstanding interface" not in nd_interfaces_workflow.DOCUMENTATION
 
 
 def test_main_requires_pydantic_then_runs_coordinator_and_exits():
@@ -100,9 +97,7 @@ def test_main_requires_pydantic_then_runs_coordinator_and_exits():
     with (
         patch.object(nd_interfaces_workflow, "AnsibleModule", FakeAnsibleModule),
         patch.object(nd_interfaces_workflow, "require_pydantic", fake_require_pydantic),
-        patch.object(
-            nd_interfaces_workflow, "InterfaceWorkflowCoordinator", FakeCoordinator
-        ),
+        patch.object(nd_interfaces_workflow, "InterfaceWorkflowCoordinator", FakeCoordinator),
     ):
         nd_interfaces_workflow.main()
 
@@ -152,9 +147,7 @@ def test_main_preserves_structured_execution_failure():
     with (
         patch.object(nd_interfaces_workflow, "AnsibleModule", FakeAnsibleModule),
         patch.object(nd_interfaces_workflow, "require_pydantic", lambda _module: None),
-        patch.object(
-            nd_interfaces_workflow, "InterfaceWorkflowCoordinator", FakeCoordinator
-        ),
+        patch.object(nd_interfaces_workflow, "InterfaceWorkflowCoordinator", FakeCoordinator),
     ):
         nd_interfaces_workflow.main()
 

--- a/tests/unit/modules/test_nd_interfaces_workflow.py
+++ b/tests/unit/modules/test_nd_interfaces_workflow.py
@@ -43,6 +43,10 @@ def test_argument_spec_uses_exact_registry_and_excludes_flow_rules():
         "required": True,
     }
     assert spec["config_actions"]["options"] == {"deploy": {"type": "bool", "default": False}}
+    assert spec["verify"] == {
+        "type": "dict",
+        "options": {"enabled": {"type": "bool", "default": False}},
+    }
 
 
 def test_documentation_links_every_standalone_module_and_not_flow_rules():
@@ -67,6 +71,8 @@ def test_documentation_links_every_standalone_module_and_not_flow_rules():
     assert "policy transition" in nd_interfaces_workflow.DOCUMENTATION
     assert "unconfigured default" in nd_interfaces_workflow.DOCUMENTATION
     assert "regardless of its current policy family" in nd_interfaces_workflow.DOCUMENTATION
+    assert "\n  verify:" in nd_interfaces_workflow.DOCUMENTATION
+    assert "after_verified" in nd_interfaces_workflow.DOCUMENTATION
     assert "from_policy_type" in nd_interfaces_workflow.RETURN
 
 

--- a/tests/unit/modules/test_nd_interfaces_workflow.py
+++ b/tests/unit/modules/test_nd_interfaces_workflow.py
@@ -1,0 +1,168 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the public nd_interfaces_workflow module wrapper."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from ansible_collections.cisco.nd.plugins.modules import nd_interfaces_workflow
+
+
+def test_argument_spec_uses_exact_registry_and_excludes_flow_rules():
+    spec = nd_interfaces_workflow.interface_workflow_argument_spec()
+    resource_options = spec["resources"]["options"]
+    choices = resource_options["type"]["choices"]
+
+    assert len(choices) == 10
+    assert set(choices) == {
+        "ethernet_access",
+        "ethernet_trunk_host",
+        "loopback",
+        "port_channel_access",
+        "port_channel_trunk_host",
+        "subinterface_managed",
+        "subinterface_unmanaged",
+        "svi",
+        "vpc_access",
+        "vpc_trunk_host",
+    }
+    assert "flow_rules" not in choices
+    assert resource_options["state"]["choices"] == [
+        "deleted",
+        "merged",
+        "overridden",
+        "replaced",
+    ]
+    assert resource_options["config"] == {
+        "type": "list",
+        "elements": "dict",
+        "required": True,
+    }
+    assert spec["config_actions"]["options"] == {
+        "deploy": {"type": "bool", "default": True}
+    }
+
+
+def test_documentation_links_every_standalone_module_and_not_flow_rules():
+    for module_name in (
+        "nd_interface_ethernet_access",
+        "nd_interface_ethernet_trunk_host",
+        "nd_interface_loopback",
+        "nd_interface_port_channel_access",
+        "nd_interface_port_channel_trunk_host",
+        "nd_interface_subinterface_managed",
+        "nd_interface_subinterface_unmanaged",
+        "nd_interface_svi",
+        "nd_interface_vpc_access",
+        "nd_interface_vpc_trunk_host",
+    ):
+        assert f"M(cisco.nd.{module_name})" in nd_interfaces_workflow.DOCUMENTATION
+    assert (
+        "M(cisco.nd.nd_interface_flow_rules)"
+        not in nd_interfaces_workflow.DOCUMENTATION
+    )
+
+
+def test_main_requires_pydantic_then_runs_coordinator_and_exits():
+    events = []
+
+    class FakeAnsibleModule:
+        def __init__(self, **kwargs):
+            self.params = {
+                "fabric_name": "FABRIC1",
+                "resources": [],
+                "config_actions": {"deploy": True},
+            }
+            self.check_mode = True
+            self.kwargs = kwargs
+            events.append(("AnsibleModule", self))
+
+        def exit_json(self, **kwargs):
+            events.append(("exit_json", kwargs))
+
+        def fail_json(self, **kwargs):
+            raise AssertionError(f"fail_json called unexpectedly: {kwargs}")
+
+    class FakeCoordinator:
+        def __init__(self, module):
+            events.append(("InterfaceWorkflowCoordinator", module))
+
+        def run(self):
+            events.append(("run",))
+            return {"changed": True, "check_mode": True}
+
+    def fake_require_pydantic(module):
+        events.append(("require_pydantic", module))
+
+    with (
+        patch.object(nd_interfaces_workflow, "AnsibleModule", FakeAnsibleModule),
+        patch.object(nd_interfaces_workflow, "require_pydantic", fake_require_pydantic),
+        patch.object(
+            nd_interfaces_workflow, "InterfaceWorkflowCoordinator", FakeCoordinator
+        ),
+    ):
+        nd_interfaces_workflow.main()
+
+    assert [event[0] for event in events] == [
+        "AnsibleModule",
+        "require_pydantic",
+        "InterfaceWorkflowCoordinator",
+        "run",
+        "exit_json",
+    ]
+    assert events[0][1].kwargs["supports_check_mode"] is True
+    assert events[-1][1] == {"changed": True, "check_mode": True}
+
+
+def test_main_preserves_structured_execution_failure():
+    events = []
+
+    class FakeAnsibleModule:
+        def __init__(self, **_kwargs):
+            self.params = {
+                "fabric_name": "FABRIC1",
+                "resources": [],
+                "config_actions": {"deploy": True},
+            }
+            self.check_mode = False
+
+        def exit_json(self, **kwargs):
+            raise AssertionError(f"exit_json called unexpectedly: {kwargs}")
+
+        def fail_json(self, **kwargs):
+            events.append(kwargs)
+
+    class FakeCoordinator:
+        def __init__(self, module):
+            self.module = module
+
+        def run(self):
+            raise nd_interfaces_workflow.InterfaceWorkflowExecutionFailed(
+                {
+                    "changed": True,
+                    "failed": True,
+                    "execution": {"status": "partial_failure"},
+                },
+                "bulk create failed",
+            )
+
+    with (
+        patch.object(nd_interfaces_workflow, "AnsibleModule", FakeAnsibleModule),
+        patch.object(nd_interfaces_workflow, "require_pydantic", lambda _module: None),
+        patch.object(
+            nd_interfaces_workflow, "InterfaceWorkflowCoordinator", FakeCoordinator
+        ),
+    ):
+        nd_interfaces_workflow.main()
+
+    assert events == [
+        {
+            "msg": "bulk create failed",
+            "changed": True,
+            "failed": True,
+            "execution": {"status": "partial_failure"},
+        }
+    ]

--- a/tests/unit/modules/test_nd_interfaces_workflow.py
+++ b/tests/unit/modules/test_nd_interfaces_workflow.py
@@ -16,9 +16,10 @@ def test_argument_spec_uses_exact_registry_and_excludes_flow_rules():
     resource_options = spec["resources"]["options"]
     choices = resource_options["type"]["choices"]
 
-    assert len(choices) == 10
+    assert len(choices) == 11
     assert set(choices) == {
         "ethernet_access",
+        "ethernet_routed",
         "ethernet_trunk_host",
         "loopback",
         "port_channel_access",
@@ -30,6 +31,8 @@ def test_argument_spec_uses_exact_registry_and_excludes_flow_rules():
         "vpc_trunk_host",
     }
     assert "flow_rules" not in choices
+    assert "interface_flow_rules" not in choices
+    assert "manage_links" not in choices
     assert resource_options["state"]["choices"] == [
         "deleted",
         "merged",
@@ -52,6 +55,7 @@ def test_argument_spec_uses_exact_registry_and_excludes_flow_rules():
 def test_documentation_links_every_standalone_module_and_not_flow_rules():
     for module_name in (
         "nd_interface_ethernet_access",
+        "nd_interface_ethernet_routed",
         "nd_interface_ethernet_trunk_host",
         "nd_interface_loopback",
         "nd_interface_port_channel_access",
@@ -64,6 +68,8 @@ def test_documentation_links_every_standalone_module_and_not_flow_rules():
     ):
         assert f"M(cisco.nd.{module_name})" in nd_interfaces_workflow.DOCUMENTATION
     assert "M(cisco.nd.nd_interface_flow_rules)" not in nd_interfaces_workflow.DOCUMENTATION
+    assert "M(cisco.nd.nd_manage_links)" not in nd_interfaces_workflow.DOCUMENTATION
+    assert "C(cisco.nd.nd_manage_links)" in nd_interfaces_workflow.DOCUMENTATION
     assert "default: false" in nd_interfaces_workflow.DOCUMENTATION
     assert "Outstanding interface" not in nd_interfaces_workflow.DOCUMENTATION
     assert "allow_policy_transition" not in nd_interfaces_workflow.DOCUMENTATION
@@ -74,6 +80,15 @@ def test_documentation_links_every_standalone_module_and_not_flow_rules():
     assert "\n  verify:" in nd_interfaces_workflow.DOCUMENTATION
     assert "after_verified" in nd_interfaces_workflow.DOCUMENTATION
     assert "from_policy_type" in nd_interfaces_workflow.RETURN
+
+
+def test_ethernet_routed_union_and_reset_contract_is_explicit_in_documentation():
+    assert "V(ethernet_routed) uses M(cisco.nd.nd_interface_ethernet_routed)" in nd_interfaces_workflow.DOCUMENTATION
+    assert "C(network_os_type)" in nd_interfaces_workflow.DOCUMENTATION
+    assert "V(routedHost)" in nd_interfaces_workflow.DOCUMENTATION
+    assert "V(iosXeRoutedHost)" in nd_interfaces_workflow.DOCUMENTATION
+    assert "defaults-only V(iosXeRoutedHost)" in nd_interfaces_workflow.DOCUMENTATION
+    assert "type: ethernet_routed" in nd_interfaces_workflow.EXAMPLES
 
 
 def test_loopback_union_contract_is_explicit_in_documentation_and_examples():


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)

Resolves https://github.com/CiscoDevNet/ansible-nd/issues/456

Related safety/correlation defect: https://github.com/CiscoDevNet/ansible-nd/issues/554

## Proposed Changes

- Adds `cisco.nd.nd_interfaces_workCHANT`, a single aggregate workflow for all eleven interface families now available on `develop`: Ethernet access, Ethernet routed, Ethernet trunk-host, loopback, port-channel access/trunk-host, managed/unmanaged subinterfaces, SVI, and vPC access/trunk-host.
- Keeps `cisco.nd.nd_interface_flow_rules` outside the aggregator scope. `cisco.nd.nd_manage_links` also remains outside because it manages topology links rather than a host-interface policy family.
- Shares fabric resolution, paginated interface inventory, vPC-pair discovery, and lazy IOS-XE fabric-link discovery across resource groups to avoid redundant controller GETs.
- Separates validation/planning from mutation; supports implicit safe policy transitions for `merged` and `replaced`; consolidates compatible deletes and deployment requests; and keeps `verify.enabled=false` as the scale-oriented default.
- Makes explicit `deleted` policy-independent within the selected structural family. Logical interfaces are deleted. Physical NX-OS Ethernet interfaces reset to default `trunkHost`; IOS-XE routed ports retain `iosXeRoutedHost` with defaults-only policy data.
- Rejects link-owned/system-owned Ethernet transitions and deletes during planning and repeats the check immediately before writes.
- Adds exact request-boundary response correlation for deferred operations, resolving issue #554's stale HTTP 207 response hazard.
- On partial mutation failure with `deploy=true`, deploys only targets backed by exact controller-success evidence; failed, uncertain, unattempted, and supplemental replay targets are excluded.
- Preserves standalone interface-module models/orchestrators while keeping child deployment disabled and issuing at most one consolidated deployment request per execution path.

## Develop Reconciliation

Merged `develop` through `49d3d697713f939f4af3118f76ac75cf5f55066e` and retained both feature sets from:

- PR #550: routed Ethernet plus interface deletion/partial-success safety.
- PR #404: fail-closed `FabricContext`, retained switch records, platform lookup, and shared sync-state lookup.
- PR #524: shared interface `config_actions_spec()` and `apply_config_actions()`.
- PR #502: strategy-owned terminal/transient HTTP retry classification.
- PR #312: `nd_manage_links` plus gathered/prepared-config/secret/unsupported-policy framework behavior.

The four content conflicts and nine semantic overlap files were reconciled without discarding either the aggregator behavior or the merged `develop` behavior.

### Why `manage_vpc_pair/resources.py` changes

`VpcPairStateMachine` already had a private `_manage_override_deletions(override_exceptions)` helper on `develop`. The shared `NDStateMachine` also had a same-named method. The interface-aggregator planning refactor changed the shared method to accept an optional `NDStatePlan`, allowing a plan calculated before mutation to be reused during execution.

That signature change exposed the pre-existing name collision as a pylint `arguments-renamed` failure: the shared method expects a state plan, while the vPC helper expects identifiers to retain. The specialized vPC helper and its sole caller are therefore renamed to `_manage_vpc_override_deletions(override_exceptions)`. This is behavior-preserving; a focused regression verifies override exceptions remain while other stale vPC pairs are deleted.

## Test Notes

Local validation against the repaired branch head:

- Full unit suite: `4,872 passed`.
- Black, line length 159: all `563` tracked Python files unchanged.
- Compileall: `562` Python files passed.
- Integration YAML safe-load: all `49` files passed.
- `git diff --check`: passed.
- Strict conflict-marker scan: no matches across `1,031` Git-visible files.
- `ansible-test sanity --docker --python 3.11 -v --color --truncate 0`: exit `0`; ansible-doc, compile/import, pep8, pylint, validate-modules, yamllint, and the remaining sanity targets passed.
- Clean-staging collection build: exit `0`; private context, Git metadata, caches, bytecode, and test output were absent from the archive.
- Galaxy importer 0.4.43: exit `0`, zero errors; only the four repository-accepted Ansible 2.16–2.19 sanity-ignore warnings.
- Guarded VXLAN iBGP integration smoke in internal check mode: `145` tasks passed, `0` failed, `0` unreachable; all eleven family files were included, with `mutations_sent=0` and `deployments_sent=0`.

Live mutation/idempotency was not run because the shared-lab global ownership gate detected an unrelated controller/registry identity mismatch and a prior stop marker remains. No testbed mutations or deployments were issued. Mutation qualification must remain pending until a fresh global ownership audit passes.

## Cisco Nexus Dashboard Version

The workflow continues to use the existing per-interface mutation paths supported by the underlying standalone modules. No ND 4.3.1-only bulk-modify dependency is introduced by this repair.

## Related ND API Resource Category

* [ ] analyze
* [ ] infa
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit incorporates current `develop` with merge conflicts resolved
* [x] New or updated module documentation has been made accordingly
* [x] Unit, formatting, sanity, build, and importer validation completed
* [x] Guarded eleven-family check-mode integration completed
* [ ] Guarded live mutation/idempotency (blocked by shared-testbed ownership gate)
* [ ] Assigned the proper reviewers
