### PR TITLE
Add Routed and AI Routed fabric types

### DIFF
--- a/changelogs/fragments/add_nd_manage_fabric_routed.yml
+++ b/changelogs/fragments/add_nd_manage_fabric_routed.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add ``nd_manage_fabric_routed`` module to manage Routed (``routed``) fabrics on Nexus Dashboard.
+  - Add ``nd_manage_fabric_ai_routed`` module to manage AI/ML Routed (``aimlRouted``) fabrics on Nexus Dashboard.

--- a/plugins/module_utils/models/manage_fabric/constants.py
+++ b/plugins/module_utils/models/manage_fabric/constants.py
@@ -124,6 +124,33 @@ FABRIC_SUPPORTED_POOLS: dict[FabricTypeEnum, frozenset[str]] = {
             "vrfVlan",
         }
     ),
+    FabricTypeEnum.ROUTED: frozenset(
+        {
+            "ANYCAST_RP_IP_POOL",
+            "DCI subnet pool",
+            "DEVICE_BGP_ASN",
+            "HYPERSHIELD_HA_PEER_LINK_SUBNET_POOL",
+            "HYPERSHIELD_HA_SOURCE_IP_POOL",
+            "IPv6 DCI subnet pool",
+            "L2_VNI",
+            "L3_VNI",
+            "LOOPBACK0_IP_POOL",
+            "LOOPBACK1_IP_POOL",
+            "MCAST_IP_POOL",
+            "ROUTER_ID_POOL",
+            "ROUTE_MAP_SEQUENCE_NUMBER_POOL",
+            "SUBNET",
+            "VPC_DOMAIN_ID",
+            "fexId",
+            "loopbackId",
+            "networkVlan",
+            "portChannelId",
+            "topDownL3Dot1q",
+            "vpcId",
+            "vpcPeerLinkVlan",
+            "vrfVlan",
+        }
+    ),
     FabricTypeEnum.EXTERNAL_CONNECTIVITY: frozenset(
         {
             "DCI subnet pool",
@@ -168,6 +195,10 @@ FABRIC_DYNAMIC_POOL_PATTERNS: dict[FabricTypeEnum, tuple[re.Pattern[str], ...]] 
         _IPV4_CIDR_RE,
         _IPV6_CIDR_RE,
     ),
+    FabricTypeEnum.ROUTED: (
+        _IPV4_CIDR_RE,
+        _IPV6_CIDR_RE,
+    ),
     FabricTypeEnum.EXTERNAL_CONNECTIVITY: (),
 }
 
@@ -180,6 +211,7 @@ FABRIC_TYPE_STRING_MAP: dict[str, FabricTypeEnum] = {
     "vxlanIbgp": FabricTypeEnum.VXLAN_IBGP,
     "vxlanEbgp": FabricTypeEnum.VXLAN_EBGP,
     "externalConnectivity": FabricTypeEnum.EXTERNAL_CONNECTIVITY,
+    "routed": FabricTypeEnum.ROUTED,
 }
 
 

--- a/plugins/module_utils/models/manage_fabric/enums.py
+++ b/plugins/module_utils/models/manage_fabric/enums.py
@@ -33,6 +33,8 @@ class FabricTypeEnum(str, Enum):
     - `VXLAN_EBGP` - VXLAN fabric with eBGP overlay
     - `AIML_VXLAN_IBGP` - AI/ML VXLAN fabric with iBGP overlay
     - `AIML_VXLAN_EBGP` - AI/ML VXLAN fabric with eBGP overlay
+    - `ROUTED` - Routed fabric
+    - `AIML_ROUTED` - AI/ML Routed fabric
     """
 
     VXLAN_IBGP = "vxlanIbgp"
@@ -40,6 +42,8 @@ class FabricTypeEnum(str, Enum):
     EXTERNAL_CONNECTIVITY = "externalConnectivity"
     AIML_VXLAN_IBGP = "aimlVxlanIbgp"
     AIML_VXLAN_EBGP = "aimlVxlanEbgp"
+    ROUTED = "routed"
+    AIML_ROUTED = "aimlRouted"
 
 
 class AlertSuspendEnum(str, Enum):

--- a/plugins/module_utils/models/manage_fabric/manage_fabric_ai_routed.py
+++ b/plugins/module_utils/models/manage_fabric/manage_fabric_ai_routed.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Matt Tarkington (@mtarking)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function, annotations
+
+__metaclass__ = type
+
+from typing import Any, Dict, ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import Field
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.enums import FabricTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_routed import (
+    FabricRoutedModel,
+    RoutedManagementModel,
+)
+
+"""
+# Pydantic models for AI Routed fabric management via Nexus Dashboard
+
+This module provides Pydantic models for creating, updating, and deleting
+AI Routed fabrics through the Nexus Dashboard (ND) API.
+
+The AI Routed fabric type (aimlRouted) is structurally identical to
+the standard Routed fabric type (routed) — they share the same
+management properties. The only difference is the type discriminator value.
+
+## Models
+
+- `AimlRoutedManagementModel` - AI Routed specific management settings
+- `FabricAiRoutedModel` - Complete AI Routed fabric creation model
+"""
+
+
+class AimlRoutedManagementModel(RoutedManagementModel):
+    """
+    # Summary
+
+    AI Routed fabric management configuration.
+
+    Inherits all properties from RoutedManagementModel and overrides
+    the type discriminator to `aimlRouted`.
+
+    ## Raises
+
+    - `ValueError` - If BGP ASN, VLAN ranges, or IP ranges are invalid
+    - `TypeError` - If required string fields are not provided
+    """
+
+    _argspec_exclude_fields: ClassVar[set[str]] = {"name", "aiml_qos"}
+
+    type: Literal["aimlRouted"] = Field(description="Type of the fabric", default="aimlRouted")
+    aiml_qos: Literal[True] = Field(
+        alias="aimlQos",
+        description="Always enabled for AI Routed fabrics.",
+        default=True,
+        frozen=True,
+    )
+
+
+class FabricAiRoutedModel(FabricRoutedModel):
+    """
+    # Summary
+
+    Complete model for creating a new AI Routed fabric.
+
+    This model combines all necessary components for AI Routed fabric creation
+    including basic fabric properties, management settings, telemetry, and streaming
+    configuration.
+
+    ## Raises
+
+    - `ValueError` - If required fields are missing or invalid
+    - `TypeError` - If field types don't match expected types
+    """
+
+    _fabric_type: ClassVar[FabricTypeEnum] = FabricTypeEnum.AIML_ROUTED
+
+    # Core Management Configuration
+    management: AimlRoutedManagementModel | None = Field(description="AI Routed management configuration", default=None)
+
+    def to_diff_dict(self, **kwargs) -> Dict[str, Any]:
+        """Export for diff comparison, excluding fields that ND overrides for routed fabrics."""
+        d = super().to_diff_dict(**kwargs)
+        # ND always returns nxapiHttp=True for routed fabrics regardless of the configured value,
+        # so exclude it from diff comparison to prevent a persistent false-positive diff.
+        if "management" in d:
+            d["management"].pop("nxapiHttp", None)
+        return d

--- a/plugins/module_utils/models/manage_fabric/manage_fabric_routed.py
+++ b/plugins/module_utils/models/manage_fabric/manage_fabric_routed.py
@@ -1,0 +1,825 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Matt Tarkington (@mtarking)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import re
+from typing import ClassVar, Literal
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import NDNestedModel
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    ConfigDict,
+    Field,
+    field_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.enums import (
+    AimlQosPolicyEnum,
+    AllowVlanOnLeafTorPairingEnum,
+    BgpAsModeEnum,
+    BgpAuthenticationKeyTypeEnum,
+    CoppPolicyEnum,
+    DhcpProtocolVersionEnum,
+    DlbMixedModeDefaultEnum,
+    DlbModeEnum,
+    FabricTypeEnum,
+    FirstHopRedundancyProtocolEnum,
+    GreenfieldDebugFlagEnum,
+    MacsecAlgorithmEnum,
+    MacsecCipherSuiteEnum,
+    OverlayModeEnum,
+    PowerRedundancyModeEnum,
+    RendezvousPointCountEnum,
+    RendezvousPointModeEnum,
+    ReplicationModeEnum,
+    UnderlayMulticastGroupAddressLimitEnum,
+    VpcPeerKeepAliveOptionEnum,
+    VrfLiteAutoConfigEnum,
+)
+
+# Re-use shared nested models from the common module
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_common import (
+    BGP_ASN_RE,
+    BootstrapSubnetModel,
+    NetflowSettingsModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_base import FabricBaseModel
+
+"""
+# Comprehensive Pydantic models for Routed fabric management via Nexus Dashboard
+
+This module provides Pydantic models for creating, updating, and deleting
+Routed fabrics through the Nexus Dashboard (ND) API.
+
+The Routed fabric type (routed) is structurally identical to the eBGP VXLAN
+fabric type (vxlanEbgp) — they share the same management properties. The only
+difference is the type discriminator value.
+
+## Models Overview
+
+- `FabricRoutedModel` - Complete fabric creation model for Routed fabrics
+- `RoutedManagementModel` - Routed fabric specific management settings
+
+## Usage
+
+```python
+# Create a new Routed fabric
+fabric_data = {
+    "name": "MyRoutedFabric",
+    "management": {
+        "type": "routed",
+        "bgpAsnAutoAllocation": True,
+        "bgpAsnRange": "65000-65535"
+    }
+}
+fabric = FabricRoutedModel(**fabric_data)
+```
+"""
+
+
+class RoutedManagementModel(NDNestedModel):
+    """
+    # Summary
+
+    Comprehensive Routed fabric management configuration.
+
+    This model contains all settings specific to Routed fabric types including
+    overlay configuration, BGP AS allocation, multicast settings, and advanced features.
+
+    ## Raises
+
+    - `ValueError` - If BGP ASN, VLAN ranges, or IP ranges are invalid
+    - `TypeError` - If required string fields are not provided
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True, validate_assignment=True, populate_by_name=True, extra="allow")
+
+    _argspec_exclude_fields: ClassVar[set[str]] = {"name"}
+
+    # Fabric Type (required for discriminated union)
+    type: Literal[FabricTypeEnum.ROUTED] = Field(description="Type of the fabric", default=FabricTypeEnum.ROUTED)
+
+    # Core eBGP Configuration
+    bgp_asn: str = Field(alias="bgpAsn", description="BGP Autonomous System Number for Spines 1-4294967295 | 1-65535[.0-65535].")
+    site_id: str | None = Field(alias="siteId", description="For EVPN Multi-Site Support. Defaults to Fabric ASN for Spines", default="")
+    bgp_as_mode: BgpAsModeEnum = Field(
+        alias="bgpAsMode",
+        description=(
+            "Multi-AS Unique ASN per Leaf/Border/Border Gateway (Borders and border gateways are "
+            "allowed to share ASN). Same-Tier-AS Leafs share one ASN, Borders/border gateways share one ASN"
+        ),
+        default=BgpAsModeEnum.MULTI_AS,
+    )
+    bgp_asn_auto_allocation: bool = Field(
+        alias="bgpAsnAutoAllocation",
+        description=("Automatically allocate and track BGP ASN for leafs, borders and border gateways in Multi-AS mode"),
+        default=True,
+    )
+    bgp_asn_range: str | None = Field(
+        alias="bgpAsnRange", description=("BGP ASN range for auto-allocation (minimum: 1 or 1.0, maximum: 4294967295 or 65535.65535)"), default=None
+    )
+    bgp_allow_as_in_num: int = Field(alias="bgpAllowAsInNum", description="Number of occurrences of ASN allowed in the BGP AS-path", default=1)
+    bgp_max_path: int = Field(alias="bgpMaxPath", description="BGP Maximum Paths", default=4)
+    bgp_underlay_failure_protect: bool = Field(alias="bgpUnderlayFailureProtect", description="Enable BGP underlay failure protection", default=False)
+    auto_configure_ebgp_evpn_peering: bool = Field(
+        alias="autoConfigureEbgpEvpnPeering", description=("Automatically configure eBGP EVPN overlay peering between leaf and spine switches"), default=True
+    )
+    allow_leaf_same_as: bool = Field(alias="allowLeafSameAs", description="Leafs can have same BGP ASN even when AS mode is Multi-AS", default=False)
+    assign_ipv4_to_loopback0: bool = Field(
+        alias="assignIpv4ToLoopback0",
+        description=(
+            "In an IPv6 routed fabric or VXLAN EVPN fabric with IPv6 underlay, assign IPv4 address used for BGP Router ID to the routing loopback interface"
+        ),
+        default=True,
+    )
+    evpn: Literal[True] = Field(description="Enable BGP EVPN as the control plane and VXLAN as the data plane for this fabric", default=True, frozen=True)
+    route_map_tag: int = Field(alias="routeMapTag", description="Tag for Route Map FABRIC-RMAP-REDIST-SUBNET. (Min:0, Max:4294967295)", default=12345)
+    disable_route_map_tag: bool = Field(alias="disableRouteMapTag", description="No match tag for Route Map FABRIC-RMAP-REDIST-SUBNET", default=False)
+    leaf_bgp_as: str | None = Field(alias="leafBgpAs", description="BGP Autonomous System Number for Leafs 1-4294967295 | 1-65535[.0-65535]", default=None)
+    border_bgp_as: str | None = Field(
+        alias="borderBgpAs", description="BGP Autonomous System Number for Borders 1-4294967295 | 1-65535[.0-65535]", default=None
+    )
+    super_spine_bgp_as: str | None = Field(
+        alias="superSpineBgpAs", description="BGP Autonomous System Number for Super Spines 1-4294967295 | 1-65535[.0-65535]", default=None
+    )
+
+    # Propagated from FabricRoutedModel.fabric_name during validation
+    name: str | None = Field(description="Fabric name", min_length=1, max_length=64, default=None)
+
+    # Network Addressing
+    bgp_loopback_id: int = Field(alias="bgpLoopbackId", description="Underlay Routing Loopback Id", ge=0, le=1023, default=0)
+    bgp_loopback_ip_range: str = Field(alias="bgpLoopbackIpRange", description="Typically Loopback0 IP Address Range", default="10.2.0.0/22")
+    bgp_loopback_ipv6_range: str = Field(alias="bgpLoopbackIpv6Range", description="Typically Loopback0 IPv6 Address Range", default="fd00::a02:0/119")
+    nve_loopback_id: int = Field(
+        alias="nveLoopbackId",
+        description=("Underlay VTEP loopback Id associated with the Network Virtualization Edge (nve) interface"),
+        ge=0,
+        le=1023,
+        default=1,
+    )
+    nve_loopback_ip_range: str = Field(alias="nveLoopbackIpRange", description="Typically Loopback1 IP Address Range", default="10.3.0.0/22")
+    nve_loopback_ipv6_range: str = Field(
+        alias="nveLoopbackIpv6Range", description="Typically Loopback1 and Anycast Loopback IPv6 Address Range", default="fd00::a03:0/118"
+    )
+    anycast_loopback_id: int = Field(
+        alias="anycastLoopbackId", description="Underlay Anycast Loopback Id.  Used for vPC Peering in VXLANv6 Fabrics", default=10
+    )
+    anycast_rendezvous_point_ip_range: str = Field(
+        alias="anycastRendezvousPointIpRange", description="Anycast or Phantom RP IP Address Range", default="10.254.254.0/24"
+    )
+    ipv6_anycast_rendezvous_point_ip_range: str = Field(
+        alias="ipv6AnycastRendezvousPointIpRange", description="Anycast RP IPv6 Address Range", default="fd00::254:254:0/118"
+    )
+    intra_fabric_subnet_range: str = Field(
+        alias="intraFabricSubnetRange", description="Address range to assign numbered and peer link SVI IPs", default="10.4.0.0/16"
+    )
+
+    # VLAN and VNI Ranges
+    l2_vni_range: str = Field(alias="l2VniRange", description="Overlay network identifier range (minimum: 1, maximum: 16777214)", default="30000-49000")
+    l3_vni_range: str = Field(alias="l3VniRange", description="Overlay VRF identifier range (minimum: 1, maximum: 16777214)", default="50000-59000")
+    network_vlan_range: str = Field(
+        alias="networkVlanRange", description="Per Switch Overlay Network VLAN Range (minimum: 2, maximum: 4094)", default="2300-2999"
+    )
+    vrf_vlan_range: str = Field(alias="vrfVlanRange", description="Per Switch Overlay VRF VLAN Range (minimum: 2, maximum: 4094)", default="2000-2299")
+
+    # Overlay Configuration
+    overlay_mode: OverlayModeEnum = Field(
+        alias="overlayMode", description="Overlay Mode. VRF/Network configuration using config-profile or CLI", default=OverlayModeEnum.CLI
+    )
+    replication_mode: ReplicationModeEnum = Field(
+        alias="replicationMode", description="Replication Mode for BUM Traffic", default=ReplicationModeEnum.MULTICAST
+    )
+    multicast_group_subnet: str = Field(
+        alias="multicastGroupSubnet",
+        description=("Multicast pool prefix between 8 to 30. A multicast group ipv4 from this pool is used for BUM traffic for each overlay network."),
+        default="239.1.1.0/25",
+    )
+    auto_generate_multicast_group_address: bool = Field(
+        alias="autoGenerateMulticastGroupAddress",
+        description=("Generate a new multicast group address from the multicast pool using a round-robin approach"),
+        default=False,
+    )
+    underlay_multicast_group_address_limit: UnderlayMulticastGroupAddressLimitEnum = Field(
+        alias="underlayMulticastGroupAddressLimit",
+        description=("The maximum supported value is 128 for NX-OS version 10.2(1) or earlier and 512 for versions above 10.2(1)"),
+        default=UnderlayMulticastGroupAddressLimitEnum.V_128,
+    )
+    tenant_routed_multicast: bool = Field(alias="tenantRoutedMulticast", description="For Overlay ipv4 Multicast Support In VXLAN Fabrics", default=False)
+    tenant_routed_multicast_ipv6: bool = Field(
+        alias="tenantRoutedMulticastIpv6", description="For Overlay IPv6 Multicast Support In VXLAN Fabrics", default=False
+    )
+    first_hop_redundancy_protocol: FirstHopRedundancyProtocolEnum = Field(
+        alias="firstHopRedundancyProtocol", description="First Hop Redundancy Protocol HSRP or VRRP", default=FirstHopRedundancyProtocolEnum.HSRP
+    )
+
+    # Multicast / Rendezvous Point
+    rendezvous_point_count: RendezvousPointCountEnum = Field(
+        alias="rendezvousPointCount", description="Number of spines acting as Rendezvous-Points (RPs)", default=RendezvousPointCountEnum.TWO
+    )
+    rendezvous_point_loopback_id: int = Field(alias="rendezvousPointLoopbackId", description="Rendezvous point loopback Id", default=254)
+    rendezvous_point_mode: RendezvousPointModeEnum = Field(
+        alias="rendezvousPointMode", description="Multicast rendezvous point Mode. For ipv6 underlay, please use asm only", default=RendezvousPointModeEnum.ASM
+    )
+    phantom_rendezvous_point_loopback_id1: int = Field(
+        alias="phantomRendezvousPointLoopbackId1", description="Underlay phantom rendezvous point loopback primary Id for PIM Bidir deployments", default=2
+    )
+    phantom_rendezvous_point_loopback_id2: int = Field(
+        alias="phantomRendezvousPointLoopbackId2", description="Underlay phantom rendezvous point loopback secondary Id for PIM Bidir deployments", default=3
+    )
+    phantom_rendezvous_point_loopback_id3: int = Field(
+        alias="phantomRendezvousPointLoopbackId3", description="Underlay phantom rendezvous point loopback tertiary Id for PIM Bidir deployments", default=4
+    )
+    phantom_rendezvous_point_loopback_id4: int = Field(
+        alias="phantomRendezvousPointLoopbackId4",
+        description=("Underlay phantom rendezvous point loopback quaternary Id for PIM Bidir deployments"),
+        default=5,
+    )
+    l3vni_multicast_group: str = Field(
+        alias="l3vniMulticastGroup", description="Default Underlay Multicast group IPv4 address assigned for every overlay VRF", default="239.1.1.0"
+    )
+    l3_vni_ipv6_multicast_group: str = Field(
+        alias="l3VniIpv6MulticastGroup", description="Default Underlay Multicast group IP6 address assigned for every overlay VRF", default="ff1e::"
+    )
+    ipv6_multicast_group_subnet: str = Field(
+        alias="ipv6MulticastGroupSubnet", description="IPv6 Multicast address with prefix 112 to 128", default="ff1e::/121"
+    )
+    mvpn_vrf_route_import_id: bool = Field(
+        alias="mvpnVrfRouteImportId", description="Enable MVPN VRI ID Generation For Tenant Routed Multicast With IPv4 Underlay", default=True
+    )
+    mvpn_vrf_route_import_id_range: str | None = Field(
+        alias="mvpnVrfRouteImportIdRange",
+        description=(
+            "MVPN VRI ID (minimum: 1, maximum: 65535) for vPC, applicable when TRM enabled "
+            "with IPv6 underlay, or mvpnVrfRouteImportId enabled with IPv4 underlay"
+        ),
+        default="",
+    )
+    vrf_route_import_id_reallocation: bool = Field(
+        alias="vrfRouteImportIdReallocation", description="One time VRI ID re-allocation based on 'MVPN VRI ID Range'", default=False
+    )
+
+    # Advanced Features
+    anycast_gateway_mac: str = Field(alias="anycastGatewayMac", description="Shared anycast gateway MAC address for all VTEPs", default="2020.0000.00aa")
+    target_subnet_mask: int = Field(alias="targetSubnetMask", description="Mask for underlay subnet IP range", ge=30, le=31, default=30)
+    fabric_mtu: int = Field(alias="fabricMtu", description="Intra Fabric Interface MTU. Must be an even number", ge=1500, le=9216, default=9216)
+    l2_host_interface_mtu: int = Field(
+        alias="l2HostInterfaceMtu", description="Layer 2 host interface MTU. Must be an even number", ge=1500, le=9216, default=9216
+    )
+    l3_vni_no_vlan_default_option: bool = Field(
+        alias="l3VniNoVlanDefaultOption",
+        description=(
+            "L3 VNI configuration without VLAN configuration. This value is propagated on vrf "
+            "creation as the default value of 'Enable L3VNI w/o VLAN' in vrf"
+        ),
+        default=False,
+    )
+    underlay_ipv6: bool = Field(alias="underlayIpv6", description="If not enabled, IPv4 underlay is used", default=False)
+    static_underlay_ip_allocation: bool = Field(
+        alias="staticUnderlayIpAllocation", description="Checking this will disable Dynamic Underlay IP Address Allocations", default=False
+    )
+    anycast_border_gateway_advertise_physical_ip: bool = Field(
+        alias="anycastBorderGatewayAdvertisePhysicalIp",
+        description=("To advertise Anycast Border Gateway PIP as VTEP. Effective on MSD fabric 'Recalculate Config'"),
+        default=False,
+    )
+
+    # VPC Configuration
+    vpc_domain_id_range: str = Field(
+        alias="vpcDomainIdRange", description="vPC Domain id range (minimum: 1, maximum: 1000) to use for new pairings", default="1-1000"
+    )
+    vpc_peer_link_vlan: str = Field(alias="vpcPeerLinkVlan", description="VLAN range (minimum: 2, maximum: 4094) for vPC Peer Link SVI", default="3600")
+    vpc_peer_link_enable_native_vlan: bool = Field(alias="vpcPeerLinkEnableNativeVlan", description="Enable VpcPeer Link for Native Vlan", default=False)
+    vpc_peer_keep_alive_option: VpcPeerKeepAliveOptionEnum = Field(
+        alias="vpcPeerKeepAliveOption", description="Use vPC Peer Keep Alive with Loopback or Management", default=VpcPeerKeepAliveOptionEnum.MANAGEMENT
+    )
+    vpc_auto_recovery_timer: int = Field(alias="vpcAutoRecoveryTimer", description="vPC auto recovery timer (in seconds)", ge=240, le=3600, default=360)
+    vpc_delay_restore_timer: int = Field(alias="vpcDelayRestoreTimer", description="vPC delay restore timer (in seconds)", ge=1, le=3600, default=150)
+    vpc_peer_link_port_channel_id: str = Field(
+        alias="vpcPeerLinkPortChannelId", description="vPC Peer Link Port Channel ID (minimum: 1, maximum: 4096)", default="500"
+    )
+    vpc_ipv6_neighbor_discovery_sync: bool = Field(
+        alias="vpcIpv6NeighborDiscoverySync", description="Enable IPv6 ND synchronization between vPC peers", default=True
+    )
+    vpc_layer3_peer_router: bool = Field(alias="vpcLayer3PeerRouter", description="Enable Layer-3 Peer-Router on all Leaf switches", default=True)
+    vpc_tor_delay_restore_timer: int = Field(alias="vpcTorDelayRestoreTimer", description="vPC delay restore timer for ToR switches (in seconds)", default=30)
+    fabric_vpc_domain_id: bool = Field(
+        alias="fabricVpcDomainId", description="Enable the same vPC Domain Id for all vPC Pairs.  Not Recommended.", default=False
+    )
+    shared_vpc_domain_id: int = Field(alias="sharedVpcDomainId", description="vPC Domain Id to be used on all vPC pairs", default=1)
+    fabric_vpc_qos: bool = Field(alias="fabricVpcQos", description="Qos on spines for guaranteed delivery of vPC Fabric Peering communication", default=False)
+    fabric_vpc_qos_policy_name: str = Field(
+        alias="fabricVpcQosPolicyName", description="Qos Policy name should be same on all spines", default="spine_qos_for_fabric_vpc_peering"
+    )
+    enable_peer_switch: bool = Field(alias="enablePeerSwitch", description="Enable the vPC peer-switch feature on ToR switches", default=False)
+
+    # Per-VRF Loopback
+    per_vrf_loopback_auto_provision: bool = Field(
+        alias="perVrfLoopbackAutoProvision",
+        description=(
+            "Auto provision an IPv4 loopback on a VTEP on VRF attachment. Note: Enabling this option "
+            "auto-provisions loopback on existing VRF attachments and also when Edit, QuickAttach, or "
+            "Multiattach actions are performed. Provisioned loopbacks cannot be deleted until VRFs "
+            "are unattached."
+        ),
+        default=False,
+    )
+    per_vrf_loopback_ip_range: str = Field(
+        alias="perVrfLoopbackIpRange", description="Prefix pool to assign IPv4 addresses to loopbacks on VTEPs on a per VRF basis", default="10.5.0.0/22"
+    )
+    per_vrf_loopback_auto_provision_ipv6: bool = Field(
+        alias="perVrfLoopbackAutoProvisionIpv6", description="Auto provision an IPv6 loopback on a VTEP on VRF attachment.", default=False
+    )
+    per_vrf_loopback_ipv6_range: str = Field(
+        alias="perVrfLoopbackIpv6Range", description="Prefix pool to assign IPv6 addresses to loopbacks on VTEPs on a per VRF basis", default="fd00::a05:0/112"
+    )
+
+    # Templates
+    vrf_template: str = Field(alias="vrfTemplate", description="Default overlay VRF template for leafs", default="Default_VRF_Universal")
+    network_template: str = Field(alias="networkTemplate", description="Default overlay network template for leafs", default="Default_Network_Universal")
+    vrf_extension_template: str = Field(
+        alias="vrfExtensionTemplate", description="Default overlay VRF template for borders", default="Default_VRF_Extension_Universal"
+    )
+    network_extension_template: str = Field(
+        alias="networkExtensionTemplate", description="Default overlay network template for borders", default="Default_Network_Extension_Universal"
+    )
+
+    # Optional Advanced Settings
+    performance_monitoring: bool = Field(
+        alias="performanceMonitoring",
+        description=("If enabled, switch metrics are collected through periodic SNMP polling. Alternative to real-time telemetry"),
+        default=False,
+    )
+    tenant_dhcp: bool = Field(alias="tenantDhcp", description="Enable tenant DHCP", default=True)
+    advertise_physical_ip: bool = Field(
+        alias="advertisePhysicalIp", description="For Primary VTEP IP Advertisement As Next-Hop Of Prefix Routes", default=False
+    )
+    advertise_physical_ip_on_border: bool = Field(
+        alias="advertisePhysicalIpOnBorder",
+        description=("Enable advertise-pip on vPC borders and border gateways only. Applicable only when vPC advertise-pip is not enabled"),
+        default=True,
+    )
+
+    # Protocol Settings — BGP
+    bgp_authentication: bool = Field(alias="bgpAuthentication", description="Enables or disables the BGP authentication", default=False)
+    bgp_authentication_key_type: BgpAuthenticationKeyTypeEnum = Field(
+        alias="bgpAuthenticationKeyType",
+        description="BGP key encryption type: 3 - 3DES, 6 - Cisco type 6, 7 - Cisco type 7",
+        default=BgpAuthenticationKeyTypeEnum.THREE_DES,
+    )
+    bgp_authentication_key: str = Field(alias="bgpAuthenticationKey", description="Encrypted BGP authentication key based on type", default="")
+
+    # Protocol Settings — BFD
+    bfd: bool = Field(description="Enable BFD.  Valid for IPv4 Underlay only", default=False)
+    bfd_ibgp: bool = Field(alias="bfdIbgp", description="Enable BFD For iBGP", default=False)
+    bfd_authentication: bool = Field(alias="bfdAuthentication", description="Enable BFD Authentication.  Valid for P2P Interfaces only", default=False)
+    bfd_authentication_key_id: int = Field(alias="bfdAuthenticationKeyId", description="BFD Authentication Key ID", default=100)
+    bfd_authentication_key: str = Field(alias="bfdAuthenticationKey", description="Encrypted SHA1 secret value", default="")
+
+    # Protocol Settings — PIM
+    pim_hello_authentication: bool = Field(alias="pimHelloAuthentication", description="Valid for IPv4 Underlay only", default=False)
+    pim_hello_authentication_key: str = Field(alias="pimHelloAuthenticationKey", description="3DES Encrypted", default="")
+
+    # Management Settings
+    nxapi: bool = Field(description="Enable NX-API over HTTPS", default=True)
+    nxapi_http: bool = Field(alias="nxapiHttp", description="Enable NX-API over HTTP", default=False)
+    nxapi_https_port: int = Field(alias="nxapiHttpsPort", description="HTTPS port for NX-API", ge=1, le=65535, default=443)
+    nxapi_http_port: int = Field(alias="nxapiHttpPort", description="HTTP port for NX-API", ge=1, le=65535, default=80)
+
+    # Bootstrap / Day-0 / DHCP
+    day0_bootstrap: bool = Field(alias="day0Bootstrap", description="Automatic IP Assignment For POAP", default=False)
+    bootstrap_subnet_collection: list[BootstrapSubnetModel] = Field(
+        alias="bootstrapSubnetCollection", description="List of IPv4 or IPv6 subnets to be used for bootstrap", default_factory=list
+    )
+    local_dhcp_server: bool = Field(alias="localDhcpServer", description="Automatic IP Assignment For POAP From Local DHCP Server", default=False)
+    dhcp_protocol_version: DhcpProtocolVersionEnum = Field(
+        alias="dhcpProtocolVersion", description="IP protocol version for Local DHCP Server", default=DhcpProtocolVersionEnum.DHCPV4
+    )
+    dhcp_start_address: str = Field(alias="dhcpStartAddress", description="DHCP Scope Start Address For Switch POAP", default="")
+    dhcp_end_address: str = Field(alias="dhcpEndAddress", description="DHCP Scope End Address For Switch POAP", default="")
+    management_gateway: str = Field(alias="managementGateway", description="Default Gateway For Management VRF On The Switch", default="")
+    management_ipv4_prefix: int = Field(alias="managementIpv4Prefix", description="Switch Mgmt IP Subnet Prefix if ipv4", default=24)
+    management_ipv6_prefix: int = Field(alias="managementIpv6Prefix", description="Switch Management IP Subnet Prefix if ipv6", default=64)
+
+    # Netflow Settings
+    netflow_settings: NetflowSettingsModel = Field(alias="netflowSettings", description="Netflow configuration", default_factory=NetflowSettingsModel)
+
+    # Backup / Restore
+    real_time_backup: bool | None = Field(
+        alias="realTimeBackup", description="Backup hourly only if there is any config deployment since last backup", default=False
+    )
+    scheduled_backup: bool | None = Field(alias="scheduledBackup", description="Enable backup at the specified time daily", default=False)
+    scheduled_backup_time: str = Field(
+        alias="scheduledBackupTime", description=("Time (UTC) in 24 hour format to take a daily backup if enabled (00:00 to 23:59)"), default=""
+    )
+
+    # VRF Lite / Sub-Interface
+    sub_interface_dot1q_range: str = Field(
+        alias="subInterfaceDot1qRange", description="Per aggregation dot1q range for VRF-Lite connectivity (minimum: 2, maximum: 4093)", default="2-511"
+    )
+    vrf_lite_auto_config: VrfLiteAutoConfigEnum = Field(
+        alias="vrfLiteAutoConfig",
+        description=(
+            "VRF Lite Inter-Fabric Connection Deployment Options. If 'back2BackAndToExternal' is "
+            "selected, VRF Lite IFCs are auto created between border devices of two Easy Fabrics, "
+            "and between border devices in Easy Fabric and edge routers in External Fabric. "
+            "The IP address is taken from the 'VRF Lite Subnet IP Range' pool."
+        ),
+        default=VrfLiteAutoConfigEnum.MANUAL,
+    )
+    vrf_lite_subnet_range: str = Field(alias="vrfLiteSubnetRange", description="Address range to assign P2P Interfabric Connections", default="10.33.0.0/16")
+    vrf_lite_subnet_target_mask: int = Field(alias="vrfLiteSubnetTargetMask", description="VRF Lite Subnet Mask", default=30)
+    auto_unique_vrf_lite_ip_prefix: bool = Field(
+        alias="autoUniqueVrfLiteIpPrefix",
+        description=(
+            "When enabled, IP prefix allocated to the VRF LITE IFC is not reused on VRF extension "
+            "over VRF LITE IFC. Instead, unique IP Subnet is allocated for each VRF extension "
+            "over VRF LITE IFC."
+        ),
+        default=False,
+    )
+
+    # Leaf / TOR
+    leaf_tor_id_range: bool = Field(alias="leafTorIdRange", description="Use specific vPC/Port-channel ID range for leaf-tor pairings", default=False)
+    leaf_tor_vpc_port_channel_id_range: str = Field(
+        alias="leafTorVpcPortChannelIdRange",
+        description=(
+            "Specify vPC/Port-channel ID range (minimum: 1, maximum: 4096), this range is used "
+            "for auto-allocating vPC/Port-Channel IDs for leaf-tor pairings"
+        ),
+        default="1-499",
+    )
+    allow_vlan_on_leaf_tor_pairing: AllowVlanOnLeafTorPairingEnum = Field(
+        alias="allowVlanOnLeafTorPairing",
+        description="Set trunk allowed vlan to 'none' or 'all' for leaf-tor pairing port-channels",
+        default=AllowVlanOnLeafTorPairingEnum.NONE,
+    )
+
+    # DNS / NTP / Syslog Collections
+    ntp_server_collection: list[str] = Field(
+        default_factory=list, alias="ntpServerCollection", description="List of NTP server IPv4/IPv6 addresses and/or hostnames"
+    )
+    ntp_server_vrf_collection: list[str] = Field(
+        default_factory=list,
+        alias="ntpServerVrfCollection",
+        description=("NTP Server VRFs. One VRF for all NTP servers or a list of VRFs, one per NTP server"),
+    )
+    dns_collection: list[str] = Field(default_factory=list, alias="dnsCollection", description="List of IPv4 and IPv6 DNS addresses")
+    dns_vrf_collection: list[str] = Field(
+        default_factory=list,
+        alias="dnsVrfCollection",
+        description=("DNS Server VRFs. One VRF for all DNS servers or a list of VRFs, one per DNS server"),
+    )
+    syslog_server_collection: list[str] = Field(
+        default_factory=list, alias="syslogServerCollection", description="List of Syslog server IPv4/IPv6 addresses and/or hostnames"
+    )
+    syslog_server_vrf_collection: list[str] = Field(
+        default_factory=list,
+        alias="syslogServerVrfCollection",
+        description=("Syslog Server VRFs. One VRF for all Syslog servers or a list of VRFs, one per Syslog server"),
+    )
+    syslog_severity_collection: list[int] = Field(
+        default_factory=list, alias="syslogSeverityCollection", description="List of Syslog severity values, one per Syslog server"
+    )
+
+    # Extra Config / Pre-Interface Config / AAA / Banner
+    banner: str = Field(
+        description=("Message of the Day (motd) banner. Delimiter char (very first char is delimiter char) followed by message ending with delimiter"),
+        default="",
+    )
+    extra_config_leaf: str = Field(
+        alias="extraConfigLeaf",
+        description=(
+            "Additional CLIs as captured from the show running configuration, added after interface "
+            "configurations for all switches with a VTEP unless they have some spine role"
+        ),
+        default="",
+    )
+    extra_config_spine: str = Field(
+        alias="extraConfigSpine",
+        description=(
+            "Additional CLIs as captured from the show running configuration, added after interface configurations for all switches with some spine role"
+        ),
+        default="",
+    )
+    extra_config_tor: str = Field(
+        alias="extraConfigTor",
+        description=("Additional CLIs as captured from the show running configuration, added after interface configurations for all ToRs"),
+        default="",
+    )
+    extra_config_intra_fabric_links: str = Field(alias="extraConfigIntraFabricLinks", description="Additional CLIs for all Intra-Fabric links", default="")
+    extra_config_aaa: str = Field(alias="extraConfigAaa", description="AAA Configurations", default="")
+    extra_config_nxos_bootstrap: str = Field(
+        alias="extraConfigNxosBootstrap", description="Additional CLIs required during device bootup/login e.g. AAA/Radius", default=""
+    )
+    aaa: bool = Field(description="Include AAA configs from Manageability tab during device bootup", default=False)
+    pre_interface_config_leaf: str = Field(
+        alias="preInterfaceConfigLeaf",
+        description=(
+            "Additional CLIs as captured from the show running configuration, added before interface "
+            "configurations for all switches with a VTEP unless they have some spine role"
+        ),
+        default="",
+    )
+    pre_interface_config_spine: str = Field(
+        alias="preInterfaceConfigSpine",
+        description=(
+            "Additional CLIs as captured from the show running configuration, added before interface configurations for all switches with some spine role"
+        ),
+        default="",
+    )
+    pre_interface_config_tor: str = Field(
+        alias="preInterfaceConfigTor",
+        description=("Additional CLIs as captured from the show running configuration, added before interface configurations for all ToRs"),
+        default="",
+    )
+
+    # System / Compliance / OAM / Misc
+    greenfield_debug_flag: GreenfieldDebugFlagEnum = Field(
+        alias="greenfieldDebugFlag",
+        description=("Allow switch configuration to be cleared without a reload when preserveConfig is set to false"),
+        default=GreenfieldDebugFlagEnum.DISABLE,
+    )
+    interface_statistics_load_interval: int = Field(
+        alias="interfaceStatisticsLoadInterval", description="Interface Statistics Load Interval. Time in seconds", default=10
+    )
+    nve_hold_down_timer: int = Field(alias="nveHoldDownTimer", description="NVE Source Inteface HoldDown Time in seconds", default=180)
+    next_generation_oam: bool = Field(
+        alias="nextGenerationOAM",
+        description=("Enable the Next Generation (NG) OAM feature for all switches in the fabric to aid in trouble-shooting VXLAN EVPN fabrics"),
+        default=True,
+    )
+    ngoam_south_bound_loop_detect: bool = Field(
+        alias="ngoamSouthBoundLoopDetect", description="Enable the Next Generation (NG) OAM southbound loop detection", default=False
+    )
+    ngoam_south_bound_loop_detect_probe_interval: int = Field(
+        alias="ngoamSouthBoundLoopDetectProbeInterval",
+        description=("Set Next Generation (NG) OAM southbound loop detection probe interval in seconds."),
+        default=300,
+    )
+    ngoam_south_bound_loop_detect_recovery_interval: int = Field(
+        alias="ngoamSouthBoundLoopDetectRecoveryInterval",
+        description=("Set the Next Generation (NG) OAM southbound loop detection recovery interval in seconds"),
+        default=600,
+    )
+    strict_config_compliance_mode: bool = Field(
+        alias="strictConfigComplianceMode",
+        description=("Enable bi-directional compliance checks to flag additional configs in the running config that are not in the intent/expected config"),
+        default=False,
+    )
+    advanced_ssh_option: bool = Field(
+        alias="advancedSshOption",
+        description=("Enable AAA IP Authorization. Enable only, when IP Authorization is enabled in the AAA Server"),
+        default=False,
+    )
+    copp_policy: CoppPolicyEnum = Field(
+        alias="coppPolicy",
+        description=("Fabric wide CoPP policy. Customized CoPP policy should be provided when 'manual' is selected."),
+        default=CoppPolicyEnum.STRICT,
+    )
+    power_redundancy_mode: PowerRedundancyModeEnum = Field(
+        alias="powerRedundancyMode", description="Default Power Supply Mode for NX-OS Switches", default=PowerRedundancyModeEnum.REDUNDANT
+    )
+    heartbeat_interval: int = Field(alias="heartbeatInterval", description="XConnect heartbeat interval for periodic link status checks", default=190)
+    snmp_trap: bool = Field(alias="snmpTrap", description="Configure ND as a receiver for SNMP traps", default=True)
+    cdp: bool = Field(description="Enable CDP on management interface", default=False)
+    real_time_interface_statistics_collection: bool = Field(
+        alias="realTimeInterfaceStatisticsCollection", description="Enable Real Time Interface Statistics Collection. Valid for NX-OS only", default=False
+    )
+    tcam_allocation: bool = Field(
+        alias="tcamAllocation", description=("TCAM commands are automatically generated for VxLAN and vPC Fabric Peering when Enabled"), default=True
+    )
+
+    # Queuing / QoS
+    default_queuing_policy: bool = Field(alias="defaultQueuingPolicy", description="Enable Default Queuing Policies", default=False)
+    default_queuing_policy_cloudscale: str = Field(
+        alias="defaultQueuingPolicyCloudscale",
+        description=("Queuing Policy for all 92xx, -EX, -FX, -FX2, -FX3, -GX series switches in the fabric"),
+        default="queuing_policy_default_8q_cloudscale",
+    )
+    default_queuing_policy_r_series: str = Field(
+        alias="defaultQueuingPolicyRSeries", description="Queueing policy for all Nexus R-series switches", default="queuing_policy_default_r_series"
+    )
+    default_queuing_policy_other: str = Field(
+        alias="defaultQueuingPolicyOther", description="Queuing Policy for all other switches in the fabric", default="queuing_policy_default_other"
+    )
+    aiml_qos: bool = Field(
+        alias="aimlQos",
+        description=("Configures QoS and Queuing Policies specific to N9K Cloud Scale (CS) & Silicon One (S1) switch fabric for AI network workloads"),
+        default=False,
+    )
+    aiml_qos_policy: AimlQosPolicyEnum = Field(
+        alias="aimlQosPolicy",
+        description=("Queuing Policy based on predominant fabric link speed: 800G / 400G / 100G / 25G. User-defined allows for custom configuration."),
+        default=AimlQosPolicyEnum.V_400G,
+    )
+    roce_v2: str = Field(
+        alias="roceV2",
+        description=(
+            "DSCP for RDMA traffic: numeric (0-63) with ranges/comma, named values "
+            "(af11,af12,af13,af21,af22,af23,af31,af32,af33,af41,af42,af43,"
+            "cs1,cs2,cs3,cs4,cs5,cs6,cs7,default,ef)"
+        ),
+        default="26",
+    )
+    cnp: str = Field(
+        description=(
+            "DSCP value for Congestion Notification: numeric (0-63) with ranges/comma, named values "
+            "(af11,af12,af13,af21,af22,af23,af31,af32,af33,af41,af42,af43,"
+            "cs1,cs2,cs3,cs4,cs5,cs6,cs7,default,ef)"
+        ),
+        default="48",
+    )
+    wred_min: int = Field(alias="wredMin", description="WRED minimum threshold (in kbytes)", default=950)
+    wred_max: int = Field(alias="wredMax", description="WRED maximum threshold (in kbytes)", default=3000)
+    wred_drop_probability: int = Field(alias="wredDropProbability", description="Drop probability %", default=7)
+    wred_weight: int = Field(alias="wredWeight", description="Influences how quickly WRED reacts to queue depth changes", default=0)
+    bandwidth_remaining: int = Field(alias="bandwidthRemaining", description="Percentage of remaining bandwidth allocated to AI traffic queues", default=50)
+    dlb: bool = Field(
+        description=("Enables fabric-level Dynamic Load Balancing (DLB) configuration. Note: Inter-Switch-Links (ISL) will be configured as DLB Interfaces"),
+        default=False,
+    )
+    dlb_mode: DlbModeEnum = Field(
+        alias="dlbMode",
+        description=(
+            "Select system-wide flowlet, per-packet (packet spraying) or policy driven mixed mode. "
+            "Note: Mixed mode is supported on Silicon One (S1) platform only."
+        ),
+        default=DlbModeEnum.FLOWLET,
+    )
+    dlb_mixed_mode_default: DlbMixedModeDefaultEnum = Field(
+        alias="dlbMixedModeDefault", description="Default load balancing mode for policy driven mixed mode DLB", default=DlbMixedModeDefaultEnum.ECMP
+    )
+    flowlet_aging: int | None = Field(
+        alias="flowletAging",
+        description=(
+            "Flowlet aging timer in microseconds. Valid range depends on platform: "
+            "Cloud Scale (CS)=1-2000000 (default 500), Silicon One (S1)=1-1024 (default 256)"
+        ),
+        default=None,
+    )
+    flowlet_dscp: str = Field(
+        alias="flowletDscp",
+        description=(
+            "DSCP values for flowlet load balancing: numeric (0-63) with ranges/comma, named values "
+            "(af11,af12,af13,af21,af22,af23,af31,af32,af33,af41,af42,af43,"
+            "cs1,cs2,cs3,cs4,cs5,cs6,cs7,default,ef)"
+        ),
+        default="",
+    )
+    per_packet_dscp: str = Field(
+        alias="perPacketDscp",
+        description=(
+            "DSCP values for per-packet load balancing: numeric (0-63) with ranges/comma, named values "
+            "(af11,af12,af13,af21,af22,af23,af31,af32,af33,af41,af42,af43,"
+            "cs1,cs2,cs3,cs4,cs5,cs6,cs7,default,ef)"
+        ),
+        default="",
+    )
+    ai_load_sharing: bool = Field(
+        alias="aiLoadSharing", description=("Enable IP load sharing using source and destination address for AI workloads"), default=False
+    )
+    priority_flow_control_watch_interval: int | None = Field(
+        alias="priorityFlowControlWatchInterval",
+        description=("Acceptable values from 101 to 1000 (milliseconds). Leave blank for system default (100ms)."),
+        default=None,
+    )
+
+    # PTP
+    ptp: bool = Field(description="Enable Precision Time Protocol (PTP)", default=False)
+    ptp_loopback_id: int = Field(alias="ptpLoopbackId", description="Precision Time Protocol Source Loopback Id", default=0)
+    ptp_domain_id: int = Field(alias="ptpDomainId", description="Multiple Independent PTP Clocking Subdomains on a Single Network", default=0)
+
+    # Private VLAN
+    private_vlan: bool = Field(alias="privateVlan", description="Enable PVLAN on switches except spines and super spines", default=False)
+    default_private_vlan_secondary_network_template: str = Field(
+        alias="defaultPrivateVlanSecondaryNetworkTemplate", description="Default PVLAN secondary network template", default="Pvlan_Secondary_Network"
+    )
+
+    # MACsec
+    macsec: bool = Field(
+        description=(
+            "Enable MACsec in the fabric. MACsec fabric parameters are used for configuring MACsec on a fabric link if MACsec is enabled on the link."
+        ),
+        default=False,
+    )
+    macsec_cipher_suite: MacsecCipherSuiteEnum = Field(
+        alias="macsecCipherSuite", description="Configure Cipher Suite", default=MacsecCipherSuiteEnum.GCM_AES_XPN_256
+    )
+    macsec_key_string: str = Field(alias="macsecKeyString", description="MACsec Primary Key String.  Cisco Type 7 Encrypted Octet String", default="")
+    macsec_algorithm: MacsecAlgorithmEnum = Field(
+        alias="macsecAlgorithm", description="MACsec Primary Cryptographic Algorithm.  AES_128_CMAC or AES_256_CMAC", default=MacsecAlgorithmEnum.AES_128_CMAC
+    )
+    macsec_fallback_key_string: str = Field(
+        alias="macsecFallbackKeyString", description="MACsec Fallback Key String. Cisco Type 7 Encrypted Octet String", default=""
+    )
+    macsec_fallback_algorithm: MacsecAlgorithmEnum = Field(
+        alias="macsecFallbackAlgorithm",
+        description="MACsec Fallback Cryptographic Algorithm.  AES_128_CMAC or AES_256_CMAC",
+        default=MacsecAlgorithmEnum.AES_128_CMAC,
+    )
+    macsec_report_timer: int = Field(alias="macsecReportTimer", description="MACsec Operational Status periodic report timer in minutes", default=5)
+
+    # Hypershield / Connectivity
+    allow_smart_switch_onboarding: bool = Field(
+        alias="allowSmartSwitchOnboarding", description="Enable onboarding of smart switches to Hypershield for firewall service", default=False
+    )
+    enable_dpu_pinning: bool = Field(
+        alias="enableDpuPinning", description="Enable pinning of VRFs and networks to specific DPUs on smart switches", default=False
+    )
+    connectivity_domain_name: str | None = Field(alias="connectivityDomainName", description="Domain name to connect to Hypershield", default=None)
+    hypershield_connectivity_proxy_server: str | None = Field(
+        alias="hypershieldConnectivityProxyServer",
+        description="IPv4 address, IPv6 address, or DNS name of the proxy server for Hypershield communication",
+        default=None,
+    )
+    hypershield_connectivity_proxy_server_port: int | None = Field(
+        alias="hypershieldConnectivityProxyServerPort", description="Proxy port number for communication with Hypershield", default=None
+    )
+    hypershield_connectivity_source_intf: str | None = Field(
+        alias="hypershieldConnectivitySourceIntf", description="Loopback interface on smart switch for communication with Hypershield", default=None
+    )
+
+    @field_validator("bgp_asn")
+    @classmethod
+    def validate_bgp_asn(cls, value: str) -> str:
+        """
+        # Summary
+
+        Validate BGP ASN format and range when provided.
+
+        ## Raises
+
+        - `ValueError` - If value does not match the expected ASN format
+        """
+        if not BGP_ASN_RE.match(value):
+            raise ValueError(f"Invalid BGP ASN '{value}'. Expected a plain integer (1-4294967295) or dotted notation (1-65535.0-65535).")
+        return value
+
+    @field_validator("site_id")
+    @classmethod
+    def validate_site_id(cls, value: str) -> str:
+        """
+        # Summary
+
+        Validate site ID format.
+
+        ## Raises
+
+        - `ValueError` - If site ID is not numeric or outside valid range
+        """
+        if value == "":
+            return value
+        if not value.isdigit():
+            raise ValueError(f"Site ID must be numeric, got: {value}")
+        site_id_int = int(value)
+        if not (1 <= site_id_int <= 281474976710655):
+            raise ValueError(f"Site ID must be between 1 and 281474976710655, got: {site_id_int}")
+        return value
+
+    @field_validator("anycast_gateway_mac")
+    @classmethod
+    def validate_mac_address(cls, value: str) -> str:
+        """
+        # Summary
+
+        Validate MAC address format.
+
+        ## Raises
+
+        - `ValueError` - If MAC address format is invalid
+        """
+        mac_pattern = re.compile(r"^([0-9a-fA-F]{4}\.){2}[0-9a-fA-F]{4}$")
+        if not mac_pattern.match(value):
+            raise ValueError(f"Invalid MAC address format, expected xxxx.xxxx.xxxx, got: {value}")
+        return value.lower()
+
+
+class FabricRoutedModel(FabricBaseModel):
+    """
+    # Summary
+
+    Complete model for creating a new Routed fabric.
+
+    ## Raises
+
+    - `ValueError` - If required fields are missing or invalid
+    - `TypeError` - If field types don't match expected types
+    """
+
+    _fabric_type: ClassVar[FabricTypeEnum] = FabricTypeEnum.ROUTED
+
+    # Core Management Configuration
+    management: RoutedManagementModel | None = Field(description="Routed management configuration", default=None)
+
+    def _post_validate_consistency(self) -> None:
+        """Propagate BGP ASN to site_id if site_id is empty."""
+        super()._post_validate_consistency()
+        if self.management is not None and self.management.site_id == "":
+            bgp_asn = self.management.bgp_asn
+            if "." in bgp_asn:
+                high, low = bgp_asn.split(".")
+                self.management.site_id = str(int(high) * 65536 + int(low))
+            else:
+                self.management.site_id = bgp_asn

--- a/plugins/module_utils/orchestrators/manage_fabric_ai_routed.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_ai_routed.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Matt Tarkington (@mtarking)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from typing import ClassVar
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.config_actions_mixin import ConfigActionsMixin
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ai_routed import FabricAiRoutedModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import (
+    EpManageFabricsGet,
+    EpManageFabricsListGet,
+    EpManageFabricsPost,
+    EpManageFabricsPut,
+    EpManageFabricsDelete,
+)
+
+
+class ManageAiRoutedFabricOrchestrator(ConfigActionsMixin, NDBaseOrchestrator):
+    model_class: ClassVar[type[NDBaseModel]] = FabricAiRoutedModel
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageFabricsDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageFabricsListGet
+
+    def query_all(self) -> ResponseType:
+        """
+        Custom query_all action to extract 'fabrics' from response,
+        filtered to only aimlRouted fabric types.
+        """
+        try:
+            api_endpoint = self.query_all_endpoint()
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            fabrics = result.get("fabrics", []) or []
+            return [f for f in fabrics if f.get("management", {}).get("type") == "aimlRouted"]
+        except Exception as e:
+            raise Exception(f"Query all failed: {e}") from e

--- a/plugins/module_utils/orchestrators/manage_fabric_routed.py
+++ b/plugins/module_utils/orchestrators/manage_fabric_routed.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Matt Tarkington (@mtarking)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from typing import ClassVar
+
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics import (
+    EpManageFabricsDelete,
+    EpManageFabricsGet,
+    EpManageFabricsListGet,
+    EpManageFabricsPost,
+    EpManageFabricsPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_routed import FabricRoutedModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base import NDBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.config_actions_mixin import ConfigActionsMixin
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+
+
+class ManageRoutedFabricOrchestrator(ConfigActionsMixin, NDBaseOrchestrator):
+    model_class: ClassVar[type[NDBaseModel]] = FabricRoutedModel
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageFabricsPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageFabricsDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageFabricsGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageFabricsListGet
+
+    def query_all(self) -> ResponseType:
+        """
+        Custom query_all action to extract 'fabrics' from response,
+        filtered to only routed fabric types.
+        """
+        try:
+            api_endpoint = self.query_all_endpoint()
+            result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
+            fabrics = result.get("fabrics", []) or []
+            return [f for f in fabrics if f.get("management", {}).get("type") == "routed"]
+        except Exception as e:
+            raise Exception(f"Query all failed: {e}") from e

--- a/plugins/modules/nd_manage_fabric_ai_routed.py
+++ b/plugins/modules/nd_manage_fabric_ai_routed.py
@@ -1,0 +1,1806 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Matt Tarkington (@mtarking)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_manage_fabric_ai_routed
+version_added: "2.0.0"
+short_description: Manage AI/ML Routed fabrics on Cisco Nexus Dashboard
+description:
+- Manage AI/ML Routed fabrics on Cisco Nexus Dashboard (ND).
+- It supports creating, updating, replacing, and deleting AI/ML Routed fabrics.
+- AI/ML Routed fabrics are optimized for AI and machine learning workloads using a routed (eBGP) underlay.
+- The AI/ML Routed fabric type (C(aimlRouted)) shares the same management properties as the standard Routed
+  fabric type (C(routed)), but is specifically designated for AI/ML workloads.
+author:
+- Matt Tarkington (@mtarking)
+options:
+  config:
+    description:
+    - The list of AI/ML Routed fabrics to configure.
+    type: list
+    elements: dict
+    suboptions:
+      fabric_name:
+        description:
+        - The name of the fabric.
+        - Only letters, numbers, underscores, and hyphens are allowed.
+        - The O(config.fabric_name) must be defined when creating, updating or deleting a fabric.
+        type: str
+        required: true
+      location:
+        description:
+        - The geographic location of the fabric.
+        type: dict
+        suboptions:
+          latitude:
+            description:
+            - Latitude coordinate of the fabric location (-90 to 90).
+            type: float
+            required: true
+          longitude:
+            description:
+            - Longitude coordinate of the fabric location (-180 to 180).
+            type: float
+            required: true
+      license_tier:
+        description:
+        - The License Tier for fabric.
+        type: str
+        default: essentials
+        choices: [ essentials, advantage, premier ]
+      alert_suspend:
+        description:
+        - The Alert Suspend state configured on the fabric.
+        type: str
+        default: disabled
+        choices: [ enabled, disabled ]
+      telemetry_collection:
+        description:
+        - Enable telemetry collection.
+        type: bool
+        default: false
+      telemetry_collection_type:
+        description:
+        - The telemetry collection method.
+        type: str
+        default: inBand
+        choices: [ inBand, outOfBand ]
+      telemetry_streaming_protocol:
+        description:
+        - The Telemetry Streaming Protocol.
+        type: str
+        default: ipv4
+        choices: [ ipv4, ipv6 ]
+      telemetry_source_interface:
+        description:
+        - Telemetry Source Interface Loopback ID, only valid if Telemetry Collection is set to inBand.
+        type: str
+        default: loopback0
+      telemetry_source_vrf:
+        description:
+        - VRF over which telemetry is streamed, valid only if Telemetry Collection is set to inBand.
+        type: str
+        default: default
+      security_domain:
+        description:
+        - The Security Domain associated with the fabric.
+        type: str
+        default: all
+      management:
+        description:
+        - The AI/ML Routed management configuration for the fabric.
+        - AI QoS (aimlQos) is always enabled for AI/ML fabrics and is not user-configurable in this module.
+        - Properties are grouped by template section for readability in the module documentation source.
+        type: dict
+        suboptions:
+          # General
+          bgp_asn:
+            description:
+            - The BGP Autonomous System Number for the fabric.
+            - Must be a numeric value between 1 and 4294967295, or dotted notation (1-65535.0-65535).
+            type: str
+            required: true
+          bgp_asn_auto_allocation:
+            description:
+            - Enable automatic BGP ASN allocation from the O(config.management.bgp_asn_range) pool.
+            type: bool
+            default: true
+          bgp_asn_range:
+            description:
+            - The BGP ASN range to use for automatic ASN allocation (e.g. C(65000-65535)).
+            - Required when O(config.management.bgp_asn_auto_allocation) is C(true).
+            type: str
+          bgp_as_mode:
+            description:
+            - The BGP AS mode for the fabric.
+            - C(multiAS) assigns a unique AS number per leaf/border/border gateway (borders and border gateways may share ASN).
+            - C(sameTierAS) assigns the same AS number within a tier (leafs share one ASN, borders/border gateways share one ASN).
+            type: str
+            default: multiAS
+            choices: [ multiAS, sameTierAS ]
+          bgp_allow_as_in_num:
+            description:
+            - The number of occurrences of the local AS number allowed in the BGP AS-path.
+            type: int
+            default: 1
+          bgp_max_path:
+            description:
+            - The maximum number of BGP equal-cost paths.
+            type: int
+            default: 4
+          bgp_underlay_failure_protect:
+            description:
+            - Enable BGP underlay failure protection.
+            type: bool
+            default: false
+          auto_configure_ebgp_evpn_peering:
+            description:
+            - Automatically configure eBGP EVPN overlay peering between leaf and spine switches.
+            type: bool
+            default: true
+          allow_leaf_same_as:
+            description:
+            - Allow leaf switches to have the same BGP ASN even when AS mode is Multi-AS.
+            type: bool
+            default: false
+          assign_ipv4_to_loopback0:
+            description:
+            - In an IPv6 routed fabric or VXLAN EVPN fabric with IPv6 underlay, assign IPv4 address
+              used for BGP Router ID to the routing loopback interface.
+            type: bool
+            default: true
+          evpn:
+            description:
+            - Enable BGP EVPN as the control plane and VXLAN as the data plane for this fabric.
+            type: bool
+            default: true
+          route_map_tag:
+            description:
+            - Tag for Route Map FABRIC-RMAP-REDIST-SUBNET. (Min 0, Max 4294967295).
+            type: int
+            default: 12345
+          disable_route_map_tag:
+            description:
+            - Disable match tag for Route Map FABRIC-RMAP-REDIST-SUBNET.
+            type: bool
+            default: false
+          leaf_bgp_as:
+            description:
+            - The BGP AS number for leaf switches.
+            - Autonomous system number 1-4294967295 or dotted notation 1-65535.0-65535.
+            type: str
+          border_bgp_as:
+            description:
+            - The BGP AS number for border switches.
+            - Autonomous system number 1-4294967295 or dotted notation 1-65535.0-65535.
+            type: str
+          super_spine_bgp_as:
+            description:
+            - The BGP AS number for super-spine switches.
+            - Autonomous system number 1-4294967295 or dotted notation 1-65535.0-65535.
+            type: str
+          site_id:
+            description:
+            - The site identifier for EVPN Multi-Site support.
+            - Defaults to the value of O(config.management.bgp_asn) if not provided.
+            type: str
+            default: ""
+          bgp_loopback_id:
+            description:
+            - The underlay routing loopback interface ID (0-1023).
+            type: int
+            default: 0
+          bgp_loopback_ip_range:
+            description:
+            - Typically Loopback0 IP address range.
+            type: str
+            default: "10.2.0.0/22"
+          bgp_loopback_ipv6_range:
+            description:
+            - Typically Loopback0 IPv6 address range.
+            type: str
+            default: "fd00::a02:0/119"
+          nve_loopback_id:
+            description:
+            - The underlay VTEP loopback ID associated with the NVE interface (0-1023).
+            type: int
+            default: 1
+          nve_loopback_ip_range:
+            description:
+            - Typically Loopback1 IP address range.
+            type: str
+            default: "10.3.0.0/22"
+          nve_loopback_ipv6_range:
+            description:
+            - Typically Loopback1 and Anycast Loopback IPv6 address range.
+            type: str
+            default: "fd00::a03:0/118"
+          anycast_loopback_id:
+            description:
+            - Underlay anycast loopback ID. Used for vPC peering in VXLANv6 fabrics.
+            type: int
+            default: 10
+          anycast_rendezvous_point_ip_range:
+            description:
+            - Anycast or Phantom RP IP address range.
+            type: str
+            default: "10.254.254.0/24"
+          ipv6_anycast_rendezvous_point_ip_range:
+            description:
+            - Anycast RP IPv6 address range.
+            type: str
+            default: "fd00::254:254:0/118"
+          intra_fabric_subnet_range:
+            description:
+            - Address range to assign numbered and peer link SVI IPs.
+            type: str
+            default: "10.4.0.0/16"
+          l2_vni_range:
+            description:
+            - Overlay network identifier range (minimum 1, maximum 16777214).
+            type: str
+            default: "30000-49000"
+          l3_vni_range:
+            description:
+            - Overlay VRF identifier range (minimum 1, maximum 16777214).
+            type: str
+            default: "50000-59000"
+          network_vlan_range:
+            description:
+            - Per switch overlay network VLAN range (minimum 2, maximum 4094).
+            type: str
+            default: "2300-2999"
+          vrf_vlan_range:
+            description:
+            - Per switch overlay VRF VLAN range (minimum 2, maximum 4094).
+            type: str
+            default: "2000-2299"
+          overlay_mode:
+            description:
+            - Overlay mode. VRF/Network configuration using config-profile or CLI.
+            type: str
+            default: cli
+            choices: [ cli, config-profile ]
+          replication_mode:
+            description:
+            - Replication mode for BUM traffic.
+            type: str
+            default: multicast
+            choices: [ multicast, ingress ]
+          multicast_group_subnet:
+            description:
+            - Multicast pool prefix between 8 to 30. A multicast group IPv4 from this pool
+              is used for BUM traffic for each overlay network.
+            type: str
+            default: "239.1.1.0/25"
+          auto_generate_multicast_group_address:
+            description:
+            - Generate a new multicast group address from the multicast pool using a round-robin approach.
+            type: bool
+            default: false
+          underlay_multicast_group_address_limit:
+            description:
+            - The maximum supported value is 128 for NX-OS version 10.2(1) or earlier
+              and 512 for versions above 10.2(1).
+            type: int
+            default: 128
+            choices: [ 128, 512 ]
+          tenant_routed_multicast:
+            description:
+            - Enable overlay IPv4 multicast support in VXLAN fabrics.
+            type: bool
+            default: false
+          tenant_routed_multicast_ipv6:
+            description:
+            - Enable overlay IPv6 multicast support in VXLAN fabrics.
+            type: bool
+            default: false
+          first_hop_redundancy_protocol:
+            description:
+            - First hop redundancy protocol, HSRP or VRRP.
+            type: str
+            default: hsrp
+            choices: [ hsrp, vrrp ]
+          rendezvous_point_count:
+            description:
+            - Number of spines acting as Rendezvous-Points (RPs).
+            type: int
+            default: 2
+            choices: [ 2, 4 ]
+          rendezvous_point_loopback_id:
+            description:
+            - The rendezvous point loopback interface ID.
+            type: int
+            default: 254
+          rendezvous_point_mode:
+            description:
+            - Multicast rendezvous point mode. For IPv6 underlay, use C(asm) only.
+            type: str
+            default: asm
+            choices: [ asm, bidir ]
+          phantom_rendezvous_point_loopback_id1:
+            description:
+            - Underlay phantom rendezvous point loopback primary ID for PIM Bi-dir deployments.
+            type: int
+            default: 2
+          phantom_rendezvous_point_loopback_id2:
+            description:
+            - Underlay phantom rendezvous point loopback secondary ID for PIM Bi-dir deployments.
+            type: int
+            default: 3
+          phantom_rendezvous_point_loopback_id3:
+            description:
+            - Underlay phantom rendezvous point loopback tertiary ID for PIM Bi-dir deployments.
+            type: int
+            default: 4
+          phantom_rendezvous_point_loopback_id4:
+            description:
+            - Underlay phantom rendezvous point loopback quaternary ID for PIM Bi-dir deployments.
+            type: int
+            default: 5
+          l3vni_multicast_group:
+            description:
+            - Default underlay multicast group IPv4 address assigned for every overlay VRF.
+            type: str
+            default: "239.1.1.0"
+          l3_vni_ipv6_multicast_group:
+            description:
+            - Default underlay multicast group IPv6 address assigned for every overlay VRF.
+            type: str
+            default: "ff1e::"
+          ipv6_multicast_group_subnet:
+            description:
+            - IPv6 multicast address with prefix 112 to 128.
+            type: str
+            default: "ff1e::/121"
+          mvpn_vrf_route_import_id:
+            description:
+            - Enable MVPN VRI ID generation for tenant routed multicast with IPv4 underlay.
+            type: bool
+            default: true
+          mvpn_vrf_route_import_id_range:
+            description:
+            - MVPN VRI ID range (minimum 1, maximum 65535) for vPC, applicable when TRM is enabled
+              with IPv6 underlay, or O(config.management.mvpn_vrf_route_import_id) is enabled with IPv4 underlay.
+            type: str
+          vrf_route_import_id_reallocation:
+            description:
+            - One time VRI ID re-allocation based on MVPN VRI ID Range.
+            type: bool
+            default: false
+          target_subnet_mask:
+            description:
+            - Mask for underlay subnet IP range (30-31).
+            type: int
+            default: 30
+          anycast_gateway_mac:
+            description:
+            - Shared anycast gateway MAC address for all VTEPs in xxxx.xxxx.xxxx format.
+            type: str
+            default: 2020.0000.00aa
+          fabric_mtu:
+            description:
+            - Intra fabric interface MTU. Must be an even number (1500-9216).
+            type: int
+            default: 9216
+          l2_host_interface_mtu:
+            description:
+            - Layer 2 host interface MTU. Must be an even number (1500-9216).
+            type: int
+            default: 9216
+          l3_vni_no_vlan_default_option:
+            description:
+            - L3 VNI configuration without VLAN configuration. This value is propagated on VRF
+              creation as the default value of Enable L3VNI w/o VLAN in VRF.
+            type: bool
+            default: false
+          underlay_ipv6:
+            description:
+            - Enable IPv6 underlay. If not enabled, IPv4 underlay is used.
+            type: bool
+            default: false
+          static_underlay_ip_allocation:
+            description:
+            - Disable dynamic underlay IP address allocation.
+            type: bool
+            default: false
+          anycast_border_gateway_advertise_physical_ip:
+            description:
+            - Advertise Anycast Border Gateway PIP as VTEP.
+              Effective on MSD fabric Recalculate Config.
+            type: bool
+            default: false
+          sub_interface_dot1q_range:
+            description:
+            - Per aggregation dot1q range for VRF-Lite connectivity (minimum 2, maximum 4093).
+            type: str
+            default: "2-511"
+          vrf_lite_auto_config:
+            description:
+            - VRF Lite Inter-Fabric Connection Deployment Options.
+            - If C(back2BackAndToExternal) is selected, VRF Lite IFCs are auto created between
+              border devices of two Easy Fabrics, and between border devices in Easy Fabric and
+              edge routers in External Fabric.
+            type: str
+            default: manual
+            choices: [ manual, back2BackAndToExternal ]
+          vrf_lite_subnet_range:
+            description:
+            - Address range to assign P2P interfabric connections.
+            type: str
+            default: "10.33.0.0/16"
+          vrf_lite_subnet_target_mask:
+            description:
+            - VRF Lite subnet mask.
+            type: int
+            default: 30
+          auto_unique_vrf_lite_ip_prefix:
+            description:
+            - When enabled, IP prefix allocated to the VRF LITE IFC is not reused on VRF extension
+              over VRF LITE IFC. Instead, a unique IP subnet is allocated for each VRF extension.
+            type: bool
+            default: false
+          vpc_domain_id_range:
+            description:
+            - vPC domain ID range (minimum 1, maximum 1000) to use for new pairings.
+            type: str
+            default: "1-1000"
+          vpc_peer_link_vlan:
+            description:
+            - VLAN range (minimum 2, maximum 4094) for vPC Peer Link SVI.
+            type: str
+            default: "3600"
+          vpc_peer_link_enable_native_vlan:
+            description:
+            - Enable vPC peer link for native VLAN.
+            type: bool
+            default: false
+          vpc_peer_keep_alive_option:
+            description:
+            - Use vPC peer keep alive with loopback or management.
+            type: str
+            default: management
+            choices: [ loopback, management ]
+          vpc_auto_recovery_timer:
+            description:
+            - vPC auto recovery timer in seconds (240-3600).
+            type: int
+            default: 360
+          vpc_delay_restore_timer:
+            description:
+            - vPC delay restore timer in seconds (1-3600).
+            type: int
+            default: 150
+          vpc_peer_link_port_channel_id:
+            description:
+            - vPC peer link port channel ID (minimum 1, maximum 4096).
+            type: str
+            default: "500"
+          vpc_ipv6_neighbor_discovery_sync:
+            description:
+            - Enable IPv6 ND synchronization between vPC peers.
+            type: bool
+            default: true
+          vpc_layer3_peer_router:
+            description:
+            - Enable layer-3 peer-router on all leaf switches.
+            type: bool
+            default: true
+          vpc_tor_delay_restore_timer:
+            description:
+            - vPC delay restore timer for ToR switches in seconds.
+            type: int
+            default: 30
+          fabric_vpc_domain_id:
+            description:
+            - Enable the same vPC domain ID for all vPC pairs. Not recommended.
+            type: bool
+            default: false
+          shared_vpc_domain_id:
+            description:
+            - vPC domain ID to be used on all vPC pairs.
+            type: int
+            default: 1
+          fabric_vpc_qos:
+            description:
+            - QoS on spines for guaranteed delivery of vPC Fabric Peering communication.
+            type: bool
+            default: false
+          fabric_vpc_qos_policy_name:
+            description:
+            - QoS policy name. Should be the same on all spines.
+            type: str
+            default: spine_qos_for_fabric_vpc_peering
+          enable_peer_switch:
+            description:
+            - Enable the vPC peer-switch feature on ToR switches.
+            type: bool
+            default: false
+          per_vrf_loopback_auto_provision:
+            description:
+            - Auto provision an IPv4 loopback on a VTEP on VRF attachment.
+            - Enabling this option auto-provisions loopback on existing VRF attachments and also
+              when Edit, QuickAttach, or Multiattach actions are performed.
+            type: bool
+            default: false
+          per_vrf_loopback_ip_range:
+            description:
+            - Prefix pool to assign IPv4 addresses to loopbacks on VTEPs on a per VRF basis.
+            type: str
+            default: "10.5.0.0/22"
+          per_vrf_loopback_auto_provision_ipv6:
+            description:
+            - Auto provision an IPv6 loopback on a VTEP on VRF attachment.
+            type: bool
+            default: false
+          per_vrf_loopback_ipv6_range:
+            description:
+            - Prefix pool to assign IPv6 addresses to loopbacks on VTEPs on a per VRF basis.
+            type: str
+            default: "fd00::a05:0/112"
+          vrf_template:
+            description:
+            - Default overlay VRF template for leafs.
+            type: str
+            default: Default_VRF_Universal
+          network_template:
+            description:
+            - Default overlay network template for leafs.
+            type: str
+            default: Default_Network_Universal
+          vrf_extension_template:
+            description:
+            - Default overlay VRF template for borders.
+            type: str
+            default: Default_VRF_Extension_Universal
+          network_extension_template:
+            description:
+            - Default overlay network template for borders.
+            type: str
+            default: Default_Network_Extension_Universal
+          performance_monitoring:
+            description:
+            - If enabled, switch metrics are collected through periodic SNMP polling.
+              Alternative to real-time telemetry.
+            type: bool
+            default: false
+          tenant_dhcp:
+            description:
+            - Enable tenant DHCP.
+            type: bool
+            default: true
+          advertise_physical_ip:
+            description:
+            - For primary VTEP IP advertisement as next-hop of prefix routes.
+            type: bool
+            default: false
+          advertise_physical_ip_on_border:
+            description:
+            - Enable advertise-pip on vPC borders and border gateways only.
+              Applicable only when vPC advertise-pip is not enabled.
+            type: bool
+            default: true
+          bgp_authentication:
+            description:
+            - Enable BGP authentication.
+            type: bool
+            default: false
+          bgp_authentication_key_type:
+            description:
+            - BGP key encryption type. 3 - 3DES, 6 - Cisco type 6, 7 - Cisco type 7.
+            type: str
+            default: 3des
+            choices: [ 3des, type6, type7 ]
+          bgp_authentication_key:
+            description:
+            - Encrypted BGP authentication key based on type.
+            type: str
+            default: ""
+          bfd:
+            description:
+            - Enable BFD. Valid for IPv4 underlay only.
+            type: bool
+            default: false
+          bfd_ibgp:
+            description:
+            - Enable BFD for iBGP.
+            type: bool
+            default: false
+          bfd_authentication:
+            description:
+            - Enable BFD authentication. Valid for P2P interfaces only.
+            type: bool
+            default: false
+          bfd_authentication_key_id:
+            description:
+            - BFD authentication key ID.
+            type: int
+            default: 100
+          bfd_authentication_key:
+            description:
+            - Encrypted SHA1 secret value.
+            type: str
+            default: ""
+          pim_hello_authentication:
+            description:
+            - Enable PIM hello authentication. Valid for IPv4 underlay only.
+            type: bool
+            default: false
+          pim_hello_authentication_key:
+            description:
+            - PIM hello authentication key. 3DES encrypted.
+            type: str
+            default: ""
+          nxapi:
+            description:
+            - Enable NX-API over HTTPS.
+            type: bool
+            default: true
+          nxapi_http:
+            description:
+            - Enable NX-API over HTTP.
+            type: bool
+            default: false
+          nxapi_https_port:
+            description:
+            - HTTPS port for NX-API (1-65535).
+            type: int
+            default: 443
+          nxapi_http_port:
+            description:
+            - HTTP port for NX-API (1-65535).
+            type: int
+            default: 80
+          day0_bootstrap:
+            description:
+            - Automatic IP assignment for POAP.
+            type: bool
+            default: false
+          bootstrap_subnet_collection:
+            description:
+            - List of IPv4 or IPv6 subnets to be used for bootstrap.
+            - When O(state=merged), omitting this option preserves the existing collection.
+            - When O(state=merged), providing this option replaces the entire collection with the supplied list.
+            - Under O(state=merged), entries in this list are not merged item-by-item.
+            - Under O(state=merged), removing one entry from the playbook removes it from the fabric, and setting an empty list clears the collection.
+            - When O(state=replaced), this option is also treated as the exact desired collection.
+            - When O(state=replaced), omitting this option resets the collection to its default empty value.
+            type: list
+            elements: dict
+            suboptions:
+              start_ip:
+                description:
+                - Starting IP address of the bootstrap range.
+                type: str
+                required: true
+              end_ip:
+                description:
+                - Ending IP address of the bootstrap range.
+                type: str
+                required: true
+              default_gateway:
+                description:
+                - Default gateway for the bootstrap subnet.
+                type: str
+                required: true
+              subnet_prefix:
+                description:
+                - Subnet prefix length (8-30).
+                type: int
+                required: true
+          local_dhcp_server:
+            description:
+            - Automatic IP assignment for POAP from local DHCP server.
+            type: bool
+            default: false
+          dhcp_protocol_version:
+            description:
+            - IP protocol version for local DHCP server.
+            type: str
+            default: dhcpv4
+            choices: [ dhcpv4, dhcpv6 ]
+          dhcp_start_address:
+            description:
+            - DHCP scope start address for switch POAP.
+            type: str
+            default: ""
+          dhcp_end_address:
+            description:
+            - DHCP scope end address for switch POAP.
+            type: str
+            default: ""
+          management_gateway:
+            description:
+            - Default gateway for management VRF on the switch.
+            type: str
+            default: ""
+          management_ipv4_prefix:
+            description:
+            - Switch management IP subnet prefix for IPv4.
+            type: int
+            default: 24
+          management_ipv6_prefix:
+            description:
+            - Switch management IP subnet prefix for IPv6.
+            type: int
+            default: 64
+          netflow_settings:
+            description:
+            - Netflow configuration settings.
+            type: dict
+            suboptions:
+              netflow:
+                description:
+                - Enable netflow collection.
+                type: bool
+                default: false
+              netflow_exporter_collection:
+                description:
+                - List of netflow exporters.
+                type: list
+                elements: dict
+                suboptions:
+                  exporter_name:
+                    description:
+                    - Name of the netflow exporter.
+                    type: str
+                    required: true
+                  exporter_ip:
+                    description:
+                    - IP address of the netflow collector.
+                    type: str
+                    required: true
+                  vrf:
+                    description:
+                    - VRF name for the exporter.
+                    type: str
+                    default: management
+                  source_interface_name:
+                    description:
+                    - Source interface name.
+                    type: str
+                    required: true
+                  udp_port:
+                    description:
+                    - UDP port for netflow export (1-65535).
+                    type: int
+              netflow_record_collection:
+                description:
+                - List of netflow records.
+                type: list
+                elements: dict
+                suboptions:
+                  record_name:
+                    description:
+                    - Name of the netflow record.
+                    type: str
+                    required: true
+                  record_template:
+                    description:
+                    - Template type for the record.
+                    type: str
+                    required: true
+                  layer2_record:
+                    description:
+                    - Enable layer 2 record fields.
+                    type: bool
+                    default: false
+              netflow_monitor_collection:
+                description:
+                - List of netflow monitors.
+                type: list
+                elements: dict
+                suboptions:
+                  monitor_name:
+                    description:
+                    - Name of the netflow monitor.
+                    type: str
+                    required: true
+                  record_name:
+                    description:
+                    - Associated record name.
+                    type: str
+                    required: true
+                  exporter1_name:
+                    description:
+                    - Primary exporter name.
+                    type: str
+                    required: true
+                  exporter2_name:
+                    description:
+                    - Secondary exporter name.
+                    type: str
+                    default: ""
+          real_time_backup:
+            description:
+            - Backup hourly only if there is any config deployment since last backup.
+            type: bool
+            default: false
+          scheduled_backup:
+            description:
+            - Enable backup at the specified time daily.
+            type: bool
+            default: false
+          scheduled_backup_time:
+            description:
+            - Time (UTC) in 24 hour format to take a daily backup if enabled (00:00 to 23:59).
+            type: str
+            default: ""
+          leaf_tor_id_range:
+            description:
+            - Use specific vPC/Port-channel ID range for leaf-tor pairings.
+            type: bool
+            default: false
+          leaf_tor_vpc_port_channel_id_range:
+            description:
+            - vPC/Port-channel ID range (minimum 1, maximum 4096), used for auto-allocating
+              vPC/Port-Channel IDs for leaf-tor pairings.
+            type: str
+            default: "1-499"
+          allow_vlan_on_leaf_tor_pairing:
+            description:
+            - Set trunk allowed VLAN to none or all for leaf-tor pairing port-channels.
+            type: str
+            default: none
+            choices: [ none, all ]
+          ntp_server_collection:
+            description:
+            - List of NTP server IPv4/IPv6 addresses and/or hostnames.
+            type: list
+            elements: str
+          ntp_server_vrf_collection:
+            description:
+            - NTP Server VRFs. One VRF for all NTP servers or a list of VRFs, one per NTP server.
+            type: list
+            elements: str
+          dns_collection:
+            description:
+            - List of IPv4 and IPv6 DNS addresses.
+            type: list
+            elements: str
+          dns_vrf_collection:
+            description:
+            - DNS Server VRFs. One VRF for all DNS servers or a list of VRFs, one per DNS server.
+            type: list
+            elements: str
+          syslog_server_collection:
+            description:
+            - List of syslog server IPv4/IPv6 addresses and/or hostnames.
+            type: list
+            elements: str
+          syslog_server_vrf_collection:
+            description:
+            - Syslog Server VRFs. One VRF for all syslog servers or a list of VRFs, one per syslog server.
+            type: list
+            elements: str
+          syslog_severity_collection:
+            description:
+            - List of syslog severity values, one per syslog server.
+            type: list
+            elements: int
+          banner:
+            description:
+            - Message of the Day (motd) banner. Delimiter char (very first char is delimiter char)
+              followed by message ending with delimiter.
+            type: str
+            default: ""
+          extra_config_leaf:
+            description:
+            - Additional CLIs added after interface configurations for all switches with a VTEP
+              unless they have some spine role.
+            type: str
+            default: ""
+          extra_config_spine:
+            description:
+            - Additional CLIs added after interface configurations for all switches with some spine role.
+            type: str
+            default: ""
+          extra_config_tor:
+            description:
+            - Additional CLIs added after interface configurations for all ToRs.
+            type: str
+            default: ""
+          extra_config_intra_fabric_links:
+            description:
+            - Additional CLIs for all intra-fabric links.
+            type: str
+            default: ""
+          extra_config_aaa:
+            description:
+            - AAA configurations.
+            type: str
+            default: ""
+          extra_config_nxos_bootstrap:
+            description:
+            - Additional CLIs required during device bootup/login e.g. AAA/Radius.
+            type: str
+            default: ""
+          aaa:
+            description:
+            - Include AAA configs from Manageability tab during device bootup.
+            type: bool
+            default: false
+          pre_interface_config_leaf:
+            description:
+            - Additional CLIs added before interface configurations for all switches with a VTEP
+              unless they have some spine role.
+            type: str
+            default: ""
+          pre_interface_config_spine:
+            description:
+            - Additional CLIs added before interface configurations for all switches with some spine role.
+            type: str
+            default: ""
+          pre_interface_config_tor:
+            description:
+            - Additional CLIs added before interface configurations for all ToRs.
+            type: str
+            default: ""
+          greenfield_debug_flag:
+            description:
+            - Allow switch configuration to be cleared without a reload when preserveConfig is set to false.
+            type: str
+            default: disable
+            choices: [ enable, disable ]
+          interface_statistics_load_interval:
+            description:
+            - Interface statistics load interval in seconds.
+            type: int
+            default: 10
+          nve_hold_down_timer:
+            description:
+            - NVE source interface hold-down time in seconds.
+            type: int
+            default: 180
+          next_generation_oam:
+            description:
+            - Enable the Next Generation (NG) OAM feature for all switches in the fabric
+              to aid in troubleshooting VXLAN EVPN fabrics.
+            type: bool
+            default: true
+          ngoam_south_bound_loop_detect:
+            description:
+            - Enable the Next Generation (NG) OAM southbound loop detection.
+            type: bool
+            default: false
+          ngoam_south_bound_loop_detect_probe_interval:
+            description:
+            - Next Generation (NG) OAM southbound loop detection probe interval in seconds.
+            type: int
+            default: 300
+          ngoam_south_bound_loop_detect_recovery_interval:
+            description:
+            - Next Generation (NG) OAM southbound loop detection recovery interval in seconds.
+            type: int
+            default: 600
+          strict_config_compliance_mode:
+            description:
+            - Enable bi-directional compliance checks to flag additional configs in the running
+              config that are not in the intent/expected config.
+            type: bool
+            default: false
+          advanced_ssh_option:
+            description:
+            - Enable AAA IP Authorization. Enable only when IP Authorization is enabled
+              in the AAA Server.
+            type: bool
+            default: false
+          copp_policy:
+            description:
+            - Fabric wide CoPP policy. Customized CoPP policy should be provided when C(manual) is selected.
+            type: str
+            default: strict
+            choices: [ dense, lenient, moderate, strict, manual ]
+          power_redundancy_mode:
+            description:
+            - Default power supply mode for NX-OS switches.
+            type: str
+            default: redundant
+            choices: [ redundant, combined, inputSrcRedundant ]
+          heartbeat_interval:
+            description:
+            - XConnect heartbeat interval for periodic link status checks.
+            type: int
+            default: 190
+          snmp_trap:
+            description:
+            - Configure ND as a receiver for SNMP traps.
+            type: bool
+            default: true
+          cdp:
+            description:
+            - Enable CDP on management interface.
+            type: bool
+            default: false
+          real_time_interface_statistics_collection:
+            description:
+            - Enable real time interface statistics collection. Valid for NX-OS only.
+            type: bool
+            default: false
+          tcam_allocation:
+            description:
+            - TCAM commands are automatically generated for VxLAN and vPC Fabric Peering when enabled.
+            type: bool
+            default: true
+          allow_smart_switch_onboarding:
+            description:
+            - Enable onboarding of smart switches to Hypershield for firewall service.
+            type: bool
+            default: false
+          default_queuing_policy:
+            description:
+            - Enable default queuing policies.
+            type: bool
+            default: false
+          default_queuing_policy_cloudscale:
+            description:
+            - Queuing policy for all 92xx, -EX, -FX, -FX2, -FX3, -GX series switches in the fabric.
+            type: str
+            default: queuing_policy_default_8q_cloudscale
+          default_queuing_policy_r_series:
+            description:
+            - Queueing policy for all Nexus R-series switches.
+            type: str
+            default: queuing_policy_default_r_series
+          default_queuing_policy_other:
+            description:
+            - Queuing policy for all other switches in the fabric.
+            type: str
+            default: queuing_policy_default_other
+          aiml_qos_policy:
+            description:
+            - Queuing policy based on predominant fabric link speed.
+              C(User-defined) allows for custom configuration.
+            type: str
+            default: 400G
+            choices: [ 800G, 400G, 100G, 25G, User-defined ]
+          roce_v2:
+            description:
+            - DSCP for RDMA traffic. Numeric (0-63) with ranges/comma, or named values
+              (af11, af12, af13, af21, af22, af23, af31, af32, af33, af41, af42, af43,
+              cs1, cs2, cs3, cs4, cs5, cs6, cs7, default, ef).
+            type: str
+            default: "26"
+          cnp:
+            description:
+            - DSCP value for Congestion Notification. Numeric (0-63) with ranges/comma, or named values
+              (af11, af12, af13, af21, af22, af23, af31, af32, af33, af41, af42, af43,
+              cs1, cs2, cs3, cs4, cs5, cs6, cs7, default, ef).
+            type: str
+            default: "48"
+          wred_min:
+            description:
+            - WRED minimum threshold in kbytes.
+            type: int
+            default: 950
+          wred_max:
+            description:
+            - WRED maximum threshold in kbytes.
+            type: int
+            default: 3000
+          wred_drop_probability:
+            description:
+            - WRED drop probability percentage.
+            type: int
+            default: 7
+          wred_weight:
+            description:
+            - Influences how quickly WRED reacts to queue depth changes.
+            type: int
+            default: 0
+          bandwidth_remaining:
+            description:
+            - Percentage of remaining bandwidth allocated to AI traffic queues.
+            type: int
+            default: 50
+          dlb:
+            description:
+            - Enables fabric-level Dynamic Load Balancing (DLB) configuration.
+              Inter-Switch-Links (ISL) will be configured as DLB interfaces.
+            type: bool
+            default: false
+          dlb_mode:
+            description:
+            - Select system-wide flowlet, per-packet (packet spraying) or policy driven mixed mode.
+              Mixed mode is supported on Silicon One (S1) platform only.
+            type: str
+            default: flowlet
+            choices: [ flowlet, per-packet, policy-driven-flowlet, policy-driven-per-packet, policy-driven-mixed-mode ]
+          dlb_mixed_mode_default:
+            description:
+            - Default load balancing mode for policy driven mixed mode DLB.
+            type: str
+            default: ecmp
+            choices: [ ecmp, flowlet, per-packet ]
+          flowlet_aging:
+            description:
+            - Flowlet aging timer in microseconds. Valid range depends on platform.
+              Cloud Scale (CS) 1-2000000 (default 500), Silicon One (S1) 1-1024 (default 256).
+            type: int
+            default: 1
+          flowlet_dscp:
+            description:
+            - DSCP values for flowlet load balancing. Numeric (0-63) with ranges/comma, or named values
+              (af11, af12, af13, af21, af22, af23, af31, af32, af33, af41, af42, af43,
+              cs1, cs2, cs3, cs4, cs5, cs6, cs7, default, ef).
+            type: str
+            default: ""
+          per_packet_dscp:
+            description:
+            - DSCP values for per-packet load balancing. Numeric (0-63) with ranges/comma, or named values
+              (af11, af12, af13, af21, af22, af23, af31, af32, af33, af41, af42, af43,
+              cs1, cs2, cs3, cs4, cs5, cs6, cs7, default, ef).
+            type: str
+            default: ""
+          ai_load_sharing:
+            description:
+            - Enable IP load sharing using source and destination address for AI workloads.
+            type: bool
+            default: false
+          priority_flow_control_watch_interval:
+            description:
+            - Acceptable values from 101 to 1000 (milliseconds).
+              Leave blank for system default (100ms).
+            type: int
+            default: 101
+          ptp:
+            description:
+            - Enable Precision Time Protocol (PTP).
+            type: bool
+            default: false
+          ptp_loopback_id:
+            description:
+            - Precision Time Protocol source loopback ID.
+            type: int
+            default: 0
+          ptp_domain_id:
+            description:
+            - Multiple independent PTP clocking subdomains on a single network.
+            type: int
+            default: 0
+          private_vlan:
+            description:
+            - Enable PVLAN on switches except spines and super spines.
+            type: bool
+            default: false
+          default_private_vlan_secondary_network_template:
+            description:
+            - Default PVLAN secondary network template.
+            type: str
+            default: Pvlan_Secondary_Network
+          macsec:
+            description:
+            - Enable MACsec in the fabric. MACsec fabric parameters are used for configuring
+              MACsec on a fabric link if MACsec is enabled on the link.
+            type: bool
+            default: false
+          macsec_cipher_suite:
+            description:
+            - Configure MACsec cipher suite.
+            type: str
+            default: GCM-AES-XPN-256
+            choices: [ GCM-AES-128, GCM-AES-256, GCM-AES-XPN-128, GCM-AES-XPN-256 ]
+          macsec_key_string:
+            description:
+            - MACsec primary key string. Cisco Type 7 encrypted octet string.
+            type: str
+            default: ""
+          macsec_algorithm:
+            description:
+            - MACsec primary cryptographic algorithm. AES_128_CMAC or AES_256_CMAC.
+            type: str
+            default: AES_128_CMAC
+            choices: [ AES_128_CMAC, AES_256_CMAC ]
+          macsec_fallback_key_string:
+            description:
+            - MACsec fallback key string. Cisco Type 7 encrypted octet string.
+            type: str
+            default: ""
+          macsec_fallback_algorithm:
+            description:
+            - MACsec fallback cryptographic algorithm. AES_128_CMAC or AES_256_CMAC.
+            type: str
+            default: AES_128_CMAC
+            choices: [ AES_128_CMAC, AES_256_CMAC ]
+          macsec_report_timer:
+            description:
+            - MACsec operational status periodic report timer in minutes.
+            type: int
+            default: 5
+          enable_dpu_pinning:
+            description:
+            - Enable pinning of VRFs and networks to specific DPUs on smart switches.
+            type: bool
+            default: false
+          connectivity_domain_name:
+            description:
+            - Domain name to connect to Hypershield.
+            type: str
+          hypershield_connectivity_proxy_server:
+            description:
+            - IPv4 address, IPv6 address, or DNS name of the proxy server for Hypershield communication.
+            type: str
+          hypershield_connectivity_proxy_server_port:
+            description:
+            - Proxy port number for communication with Hypershield.
+            type: int
+          hypershield_connectivity_source_intf:
+            description:
+            - Loopback interface on smart switch for communication with Hypershield.
+            type: str
+      telemetry_settings:
+        description:
+        - Telemetry configuration settings.
+        type: dict
+        suboptions:
+          flow_collection:
+            description:
+            - Flow collection settings.
+            type: dict
+            suboptions:
+              traffic_analytics:
+                description:
+                - Traffic analytics state.
+                type: str
+                default: enabled
+              traffic_analytics_scope:
+                description:
+                - Traffic analytics scope.
+                type: str
+                default: intraFabric
+              operating_mode:
+                description:
+                - Operating mode.
+                type: str
+                default: flowTelemetry
+              udp_categorization:
+                description:
+                - UDP categorization.
+                type: str
+                default: enabled
+          microburst:
+            description:
+            - Microburst detection settings.
+            type: dict
+            suboptions:
+              microburst:
+                description:
+                - Enable microburst detection.
+                type: bool
+                default: false
+              sensitivity:
+                description:
+                - Microburst sensitivity level.
+                type: str
+                default: low
+          analysis_settings:
+            description:
+            - Telemetry analysis settings.
+            type: dict
+            suboptions:
+              is_enabled:
+                description:
+                - Enable telemetry analysis.
+                type: bool
+                default: false
+          nas:
+            description:
+            - NAS telemetry configuration.
+            type: dict
+            suboptions:
+              server:
+                description:
+                - NAS server address.
+                type: str
+                default: ""
+              export_settings:
+                description:
+                - NAS export settings.
+                type: dict
+                suboptions:
+                  export_type:
+                    description:
+                    - Export type.
+                    type: str
+                    default: full
+                  export_format:
+                    description:
+                    - Export format.
+                    type: str
+                    default: json
+          energy_management:
+            description:
+            - Energy management settings.
+            type: dict
+            suboptions:
+              cost:
+                description:
+                - Energy cost per unit.
+                type: float
+                default: 1.2
+      external_streaming_settings:
+        description:
+        - External streaming settings.
+        type: dict
+        suboptions:
+          email:
+            description:
+            - Email streaming configuration.
+            type: list
+            elements: dict
+          message_bus:
+            description:
+            - Message bus configuration.
+            type: list
+            elements: dict
+          syslog:
+            description:
+            - Syslog streaming configuration.
+            type: dict
+          webhooks:
+            description:
+            - Webhook configuration.
+            type: list
+            elements: dict
+  state:
+    description:
+    - The desired state of the fabric resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new fabrics and update existing ones as defined in the configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the fabric configuration specified in the configuration.
+      Any settings not explicitly provided will revert to their defaults.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      Any fabric existing on ND but not present in the configuration will be deleted. Use with extra caution.
+    - Use O(state=deleted) to remove the fabrics specified in the configuration from the Cisco Nexus Dashboard.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+  config_actions:
+    description:
+    - Controls save and deploy behavior after fabric configuration is updated.
+    - Save writes pending configuration to the controller.
+    - Deploy pushes the saved configuration to switches.
+    - Skipped automatically when O(state=deleted) or when no changes are made.
+    type: dict
+    suboptions:
+      save:
+        description:
+        - Whether to save fabric configuration after changes.
+        type: bool
+        default: false
+      deploy:
+        description:
+        - Whether to deploy fabric configuration to switches after saving.
+        - Requires O(config_actions.save=true) when enabled.
+        type: bool
+        default: false
+      type:
+        description:
+        - Scope of the deploy operation.
+        - C(switch) deploys only to affected switches.
+        - C(global) deploys to all switches in the fabric.
+        type: str
+        default: switch
+        choices: [ switch, global ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard having version 4.2.0 or higher.
+- Only AI/ML Routed fabric type (C(aimlRouted)) is supported by this module.
+- When using O(state=replaced) with only required fields, all optional management settings revert to their defaults.
+- O(config.management.site_id) defaults to the value of O(config.management.bgp_asn) if not provided.
+- The default O(config.management.vpc_peer_keep_alive_option) for Routed fabrics is C(management), unlike iBGP fabrics.
+"""
+
+EXAMPLES = r"""
+- name: Create an AI/ML Routed fabric using state merged (with auto ASN allocation)
+  cisco.nd.nd_manage_fabric_ai_routed:
+    state: merged
+    config:
+      - fabric_name: my_ai_ebgp_fabric
+        location:
+          latitude: 37.7749
+          longitude: -122.4194
+        license_tier: premier
+        alert_suspend: disabled
+        security_domain: all
+        telemetry_collection: false
+        management:
+          bgp_asn_auto_allocation: true
+          bgp_asn_range: "65000-65535"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.00aa"
+          performance_monitoring: false
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.1.0/25"
+          auto_generate_multicast_group_address: false
+          underlay_multicast_group_address_limit: 128
+          tenant_routed_multicast: false
+          rendezvous_point_count: 2
+          rendezvous_point_loopback_id: 254
+          vpc_peer_link_vlan: "3600"
+          vpc_peer_link_enable_native_vlan: false
+          vpc_peer_keep_alive_option: management
+          vpc_auto_recovery_timer: 360
+          vpc_delay_restore_timer: 150
+          vpc_peer_link_port_channel_id: "500"
+          advertise_physical_ip: false
+          vpc_domain_id_range: "1-1000"
+          bgp_loopback_id: 0
+          nve_loopback_id: 1
+          vrf_template: Default_VRF_Universal
+          network_template: Default_Network_Universal
+          vrf_extension_template: Default_VRF_Extension_Universal
+          network_extension_template: Default_Network_Extension_Universal
+          l3_vni_no_vlan_default_option: false
+          fabric_mtu: 9216
+          l2_host_interface_mtu: 9216
+          tenant_dhcp: true
+          nxapi: false
+          nxapi_https_port: 443
+          nxapi_http: false
+          nxapi_http_port: 80
+          snmp_trap: true
+          anycast_border_gateway_advertise_physical_ip: false
+          greenfield_debug_flag: disable
+          tcam_allocation: true
+          real_time_interface_statistics_collection: false
+          interface_statistics_load_interval: 10
+          bgp_loopback_ip_range: "10.2.0.0/22"
+          nve_loopback_ip_range: "10.3.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.254.0/24"
+          intra_fabric_subnet_range: "10.4.0.0/16"
+          l2_vni_range: "30000-49000"
+          l3_vni_range: "50000-59000"
+          network_vlan_range: "2300-2999"
+          vrf_vlan_range: "2000-2299"
+          sub_interface_dot1q_range: "2-511"
+          vrf_lite_auto_config: manual
+          vrf_lite_subnet_range: "10.33.0.0/16"
+          vrf_lite_subnet_target_mask: 30
+          auto_unique_vrf_lite_ip_prefix: false
+          per_vrf_loopback_auto_provision: true
+          per_vrf_loopback_ip_range: "10.5.0.0/22"
+          banner: ""
+          day0_bootstrap: false
+          local_dhcp_server: false
+          dhcp_protocol_version: dhcpv4
+          dhcp_start_address: ""
+          dhcp_end_address: ""
+          management_gateway: ""
+          management_ipv4_prefix: 24
+  register: result
+
+- name: Create an AI/ML Routed fabric with a static BGP ASN
+  cisco.nd.nd_manage_fabric_ai_routed:
+    state: merged
+    config:
+      - fabric_name: my_ai_ebgp_fabric_static
+        management:
+          bgp_asn: "65001"
+          bgp_asn_auto_allocation: false
+          site_id: "65001"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.00aa"
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.1.0/25"
+          bgp_loopback_ip_range: "10.2.0.0/22"
+          nve_loopback_ip_range: "10.3.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.254.0/24"
+          intra_fabric_subnet_range: "10.4.0.0/16"
+          l2_vni_range: "30000-49000"
+          l3_vni_range: "50000-59000"
+          network_vlan_range: "2300-2999"
+          vrf_vlan_range: "2000-2299"
+  register: result
+
+- name: Update specific fields on an existing AI/ML Routed fabric using state merged (partial update)
+  cisco.nd.nd_manage_fabric_ai_routed:
+    state: merged
+    config:
+      - fabric_name: my_ai_ebgp_fabric
+        management:
+          bgp_asn_range: "65100-65199"
+          anycast_gateway_mac: "2020.0000.00bb"
+          performance_monitoring: true
+  register: result
+
+- name: Create or fully replace an AI/ML Routed fabric using state replaced
+  cisco.nd.nd_manage_fabric_ai_routed:
+    state: replaced
+    config:
+      - fabric_name: my_ai_ebgp_fabric
+        location:
+          latitude: 37.7749
+          longitude: -122.4194
+        license_tier: premier
+        alert_suspend: disabled
+        security_domain: all
+        telemetry_collection: false
+        management:
+          bgp_asn: "65004"
+          bgp_asn_auto_allocation: false
+          site_id: "65004"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.00dd"
+          performance_monitoring: true
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.3.0/25"
+          rendezvous_point_count: 4
+          rendezvous_point_loopback_id: 253
+          vpc_peer_link_vlan: "3700"
+          vpc_peer_keep_alive_option: management
+          vpc_auto_recovery_timer: 300
+          vpc_delay_restore_timer: 120
+          vpc_peer_link_port_channel_id: "600"
+          advertise_physical_ip: true
+          vpc_domain_id_range: "1-800"
+          fabric_mtu: 9000
+          l2_host_interface_mtu: 9000
+          tenant_dhcp: false
+          snmp_trap: false
+          anycast_border_gateway_advertise_physical_ip: true
+          greenfield_debug_flag: disable
+          tcam_allocation: false
+          real_time_interface_statistics_collection: true
+          interface_statistics_load_interval: 30
+          bgp_loopback_ip_range: "10.22.0.0/22"
+          nve_loopback_ip_range: "10.23.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.252.0/24"
+          intra_fabric_subnet_range: "10.24.0.0/16"
+          l2_vni_range: "40000-59000"
+          l3_vni_range: "60000-69000"
+          network_vlan_range: "2400-3099"
+          vrf_vlan_range: "2100-2399"
+          banner: "^ Managed by Ansible ^"
+  register: result
+
+- name: Replace fabric with only required fields (all optional settings revert to defaults)
+  cisco.nd.nd_manage_fabric_ai_routed:
+    state: replaced
+    config:
+      - fabric_name: my_ai_ebgp_fabric
+        management:
+          bgp_asn: "65004"
+          bgp_asn_auto_allocation: false
+          site_id: "65004"
+          banner: "^ Managed by Ansible ^"
+  register: result
+
+- name: Enforce exact fabric inventory using state overridden (deletes unlisted fabrics)
+  cisco.nd.nd_manage_fabric_ai_routed:
+    state: overridden
+    config:
+      - fabric_name: fabric_east
+        location:
+          latitude: 40.7128
+          longitude: -74.0060
+        license_tier: premier
+        alert_suspend: disabled
+        security_domain: all
+        telemetry_collection: false
+        management:
+          bgp_asn: "65010"
+          bgp_asn_auto_allocation: false
+          site_id: "65010"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.0010"
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.10.0/25"
+          bgp_loopback_ip_range: "10.10.0.0/22"
+          nve_loopback_ip_range: "10.11.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.10.0/24"
+          intra_fabric_subnet_range: "10.12.0.0/16"
+          l2_vni_range: "30000-49000"
+          l3_vni_range: "50000-59000"
+          network_vlan_range: "2300-2999"
+          vrf_vlan_range: "2000-2299"
+      - fabric_name: fabric_west
+        location:
+          latitude: 34.0522
+          longitude: -118.2437
+        license_tier: premier
+        alert_suspend: disabled
+        security_domain: all
+        telemetry_collection: false
+        management:
+          bgp_asn: "65020"
+          bgp_asn_auto_allocation: false
+          site_id: "65020"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.0020"
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.20.0/25"
+          bgp_loopback_ip_range: "10.20.0.0/22"
+          nve_loopback_ip_range: "10.21.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.20.0/24"
+          intra_fabric_subnet_range: "10.22.0.0/16"
+          l2_vni_range: "30000-49000"
+          l3_vni_range: "50000-59000"
+          network_vlan_range: "2300-2999"
+          vrf_vlan_range: "2000-2299"
+  register: result
+
+- name: Delete a specific AI/ML Routed fabric using state deleted
+  cisco.nd.nd_manage_fabric_ai_routed:
+    state: deleted
+    config:
+      - fabric_name: my_ai_ebgp_fabric
+  register: result
+
+- name: Delete multiple AI/ML Routed fabrics in a single task
+  cisco.nd.nd_manage_fabric_ai_routed:
+    state: deleted
+    config:
+      - fabric_name: fabric_east
+      - fabric_name: fabric_west
+      - fabric_name: fabric_old
+  register: result
+"""
+
+RETURN = r"""
+changed:
+    description: Whether the module made any changes.
+    type: bool
+    returned: always
+    sample: true
+before:
+    description:
+    - AI/ML Routed fabric configuration before changes.
+    - Queried from the controller and may contain read-only properties.
+    type: list
+    returned: always
+    sample: [{"fabric_name": "ai_ebgp_fabric", "management": {"bgp_asn": "65001"}}]
+after:
+    description:
+    - AI/ML Routed fabric configuration after changes.
+    - Refreshed from the controller after write operations.
+    type: list
+    returned: always
+    sample: [{"fabric_name": "ai_ebgp_fabric", "management": {"bgp_asn": "65002"}}]
+diff:
+    description: Configuration differences between before and after states.
+    type: list
+    returned: always
+    sample: [{"fabric_name": "ai_ebgp_fabric", "management": {"bgp_asn": "65002"}}]
+proposed:
+    description: Proposed configuration sent to the module.
+    type: list
+    returned: info or debug output_level
+    sample: [{"fabric_name": "ai_ebgp_fabric", "management": {"bgp_asn": "65002"}}]
+output_level:
+    description: The output level set for the module.
+    type: str
+    returned: always
+    sample: normal
+logs:
+    description: Debug log messages from module execution.
+    type: list
+    returned: debug output_level
+    sample: ["Starting state machine for merged state"]
+api_paths:
+    description: API endpoint paths used during operations.
+    type: list
+    returned: verbosity >= 2 (-vv)
+    sample: ["/api/v1/manage/fabrics/ai_ebgp_fabric"]
+api_verbs:
+    description: HTTP methods used during operations.
+    type: list
+    returned: verbosity >= 2 (-vv)
+    sample: ["PUT"]
+api_response:
+    description: Full API responses from the controller.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+    sample: [{"RETURN_CODE": 200, "MESSAGE": "Success"}]
+api_result:
+    description: Operation results from the controller.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+    sample: [{"success": true, "changed": true}]
+api_diff:
+    description: API-level differences for each operation.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+api_metadata:
+    description: Operation metadata with sequence and identifiers.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+api_payload:
+    description: Request payloads sent to the API.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ai_routed import FabricAiRoutedModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_ai_routed import ManageAiRoutedFabricOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+
+
+def main():
+    argument_spec = nd_argument_spec()
+    argument_spec.update(FabricAiRoutedModel.get_argument_spec())
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    require_pydantic(module)
+
+    # Parse and validate config_actions BEFORE any state mutation so invalid
+    # input fails deterministically on every run, including idempotent no-drift
+    # runs, and never mutates ND before failing.
+    config_actions = module.params.get("config_actions") or {}
+    save = config_actions.get("save", False)
+    deploy = config_actions.get("deploy", False)
+    deploy_type = config_actions.get("type", "switch")
+    state = module.params.get("state", "merged")
+
+    try:
+        ManageAiRoutedFabricOrchestrator.validate_config_actions(save=save, deploy=deploy, deploy_type=deploy_type)
+    except ValueError as e:
+        module.fail_json(msg=str(e))
+
+    nd_state_machine = None
+    try:
+        # Initialize StateMachine
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=ManageAiRoutedFabricOrchestrator,
+        )
+
+        # Manage state
+        nd_state_machine.manage_state()
+
+        # Execute config save/deploy actions via orchestrator mixin (only on real changes)
+        if state != "deleted" and len(nd_state_machine.sent) > 0:
+            fabric_names = []
+            for item in nd_state_machine.sent:
+                name = item.get_identifier_value()
+                if name and name not in fabric_names:
+                    fabric_names.append(name)
+            if fabric_names:
+                nd_state_machine.model_orchestrator.execute_config_actions(
+                    fabric_names=fabric_names,
+                    save=save,
+                    deploy=deploy,
+                    deploy_type=deploy_type,
+                )
+
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
+        module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
+
+    except NDStateMachineError as e:
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
+        output = nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results) if nd_state_machine else {}
+        module.fail_json(msg=str(e), **output)
+    except Exception as e:
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
+        output = nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results) if nd_state_machine else {}
+        module.fail_json(msg=f"Module execution failed: {str(e)}", **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/nd_manage_fabric_routed.py
+++ b/plugins/modules/nd_manage_fabric_routed.py
@@ -1,0 +1,1795 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Matt Tarkington (@mtarking)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: nd_manage_fabric_routed
+version_added: "2.0.0"
+short_description: Manage Routed fabrics on Cisco Nexus Dashboard
+description:
+- Manage Routed fabrics on Cisco Nexus Dashboard (ND).
+- It supports creating, updating, replacing, and deleting Routed fabrics.
+author:
+- Matt Tarkington (@mtarking)
+options:
+  config:
+    description:
+    - The list of Routed fabrics to configure.
+    type: list
+    elements: dict
+    suboptions:
+      fabric_name:
+        description:
+        - The name of the fabric.
+        - Only letters, numbers, underscores, and hyphens are allowed.
+        - The O(config.fabric_name) must be defined when creating, updating or deleting a fabric.
+        type: str
+        required: true
+      location:
+        description:
+        - The geographic location of the fabric.
+        type: dict
+        suboptions:
+          latitude:
+            description:
+            - Latitude coordinate of the fabric location (-90 to 90).
+            type: float
+            required: true
+          longitude:
+            description:
+            - Longitude coordinate of the fabric location (-180 to 180).
+            type: float
+            required: true
+      license_tier:
+        description:
+        - The license tier for the fabric.
+        type: str
+        default: essentials
+        choices: [ essentials, advantage, premier ]
+      alert_suspend:
+        description:
+        - The alert suspension state for the fabric.
+        type: str
+        default: disabled
+        choices: [ enabled, disabled ]
+      telemetry_collection:
+        description:
+        - Enable telemetry collection for the fabric.
+        type: bool
+        default: false
+      telemetry_collection_type:
+        description:
+        - The telemetry collection type.
+        type: str
+        default: inBand
+      telemetry_streaming_protocol:
+        description:
+        - The telemetry streaming protocol.
+        type: str
+        default: ipv4
+      telemetry_source_interface:
+        description:
+        - The telemetry source interface.
+        type: str
+        default: loopback0
+      telemetry_source_vrf:
+        description:
+        - The telemetry source VRF.
+        type: str
+        default: default
+      security_domain:
+        description:
+        - The security domain associated with the fabric.
+        type: str
+        default: all
+      management:
+        description:
+        - The Routed management configuration for the fabric.
+        type: dict
+        suboptions:
+          bgp_asn:
+            description:
+            - The BGP Autonomous System Number for the fabric.
+            - Must be a numeric value between 1 and 4294967295, or dotted notation (1-65535.0-65535).
+            type: str
+            required: true
+          bgp_asn_auto_allocation:
+            description:
+            - Enable automatic BGP ASN allocation from the O(config.management.bgp_asn_range) pool.
+            type: bool
+            default: true
+          bgp_asn_range:
+            description:
+            - The BGP ASN range to use for automatic ASN allocation (e.g. C(65000-65535)).
+            - Required when O(config.management.bgp_asn_auto_allocation) is C(true).
+            type: str
+          bgp_as_mode:
+            description:
+            - The BGP AS mode for the fabric.
+            - C(multiAS) assigns a unique AS number per leaf/border/border gateway (borders and border gateways may share ASN).
+            - C(sameTierAS) assigns the same AS number within a tier (leafs share one ASN, borders/border gateways share one ASN).
+            type: str
+            default: multiAS
+            choices: [ multiAS, sameTierAS ]
+          bgp_allow_as_in_num:
+            description:
+            - The number of occurrences of the local AS number allowed in the BGP AS-path.
+            type: int
+            default: 1
+          bgp_max_path:
+            description:
+            - The maximum number of BGP equal-cost paths.
+            type: int
+            default: 4
+          bgp_underlay_failure_protect:
+            description:
+            - Enable BGP underlay failure protection.
+            type: bool
+            default: false
+          auto_configure_ebgp_evpn_peering:
+            description:
+            - Automatically configure eBGP EVPN overlay peering between leaf and spine switches.
+            type: bool
+            default: true
+          allow_leaf_same_as:
+            description:
+            - Allow leaf switches to have the same BGP ASN even when AS mode is Multi-AS.
+            type: bool
+            default: false
+          assign_ipv4_to_loopback0:
+            description:
+            - In an IPv6 routed fabric or VXLAN EVPN fabric with IPv6 underlay, assign IPv4 address
+              used for BGP Router ID to the routing loopback interface.
+            type: bool
+            default: true
+          route_map_tag:
+            description:
+            - Tag for Route Map FABRIC-RMAP-REDIST-SUBNET. (Min 0, Max 4294967295).
+            type: int
+            default: 12345
+          disable_route_map_tag:
+            description:
+            - Disable match tag for Route Map FABRIC-RMAP-REDIST-SUBNET.
+            type: bool
+            default: false
+          leaf_bgp_as:
+            description:
+            - The BGP AS number for leaf switches.
+            - Autonomous system number 1-4294967295 or dotted notation 1-65535.0-65535.
+            type: str
+          border_bgp_as:
+            description:
+            - The BGP AS number for border switches.
+            - Autonomous system number 1-4294967295 or dotted notation 1-65535.0-65535.
+            type: str
+          super_spine_bgp_as:
+            description:
+            - The BGP AS number for super-spine switches.
+            - Autonomous system number 1-4294967295 or dotted notation 1-65535.0-65535.
+            type: str
+          site_id:
+            description:
+            - The site identifier for EVPN Multi-Site support.
+            - Defaults to the value of O(config.management.bgp_asn) if not provided.
+            type: str
+            default: ""
+          bgp_loopback_id:
+            description:
+            - The underlay routing loopback interface ID (0-1023).
+            type: int
+            default: 0
+          bgp_loopback_ip_range:
+            description:
+            - Typically Loopback0 IP address range.
+            type: str
+            default: "10.2.0.0/22"
+          bgp_loopback_ipv6_range:
+            description:
+            - Typically Loopback0 IPv6 address range.
+            type: str
+            default: "fd00::a02:0/119"
+          nve_loopback_id:
+            description:
+            - The underlay VTEP loopback ID associated with the NVE interface (0-1023).
+            type: int
+            default: 1
+          nve_loopback_ip_range:
+            description:
+            - Typically Loopback1 IP address range.
+            type: str
+            default: "10.3.0.0/22"
+          nve_loopback_ipv6_range:
+            description:
+            - Typically Loopback1 and Anycast Loopback IPv6 address range.
+            type: str
+            default: "fd00::a03:0/118"
+          anycast_loopback_id:
+            description:
+            - Underlay anycast loopback ID. Used for vPC peering in VXLANv6 fabrics.
+            type: int
+            default: 10
+          anycast_rendezvous_point_ip_range:
+            description:
+            - Anycast or Phantom RP IP address range.
+            type: str
+            default: "10.254.254.0/24"
+          ipv6_anycast_rendezvous_point_ip_range:
+            description:
+            - Anycast RP IPv6 address range.
+            type: str
+            default: "fd00::254:254:0/118"
+          intra_fabric_subnet_range:
+            description:
+            - Address range to assign numbered and peer link SVI IPs.
+            type: str
+            default: "10.4.0.0/16"
+          l2_vni_range:
+            description:
+            - Overlay network identifier range (minimum 1, maximum 16777214).
+            type: str
+            default: "30000-49000"
+          l3_vni_range:
+            description:
+            - Overlay VRF identifier range (minimum 1, maximum 16777214).
+            type: str
+            default: "50000-59000"
+          network_vlan_range:
+            description:
+            - Per switch overlay network VLAN range (minimum 2, maximum 4094).
+            type: str
+            default: "2300-2999"
+          vrf_vlan_range:
+            description:
+            - Per switch overlay VRF VLAN range (minimum 2, maximum 4094).
+            type: str
+            default: "2000-2299"
+          overlay_mode:
+            description:
+            - Overlay mode. VRF/Network configuration using config-profile or CLI.
+            type: str
+            default: cli
+            choices: [ cli, config-profile ]
+          replication_mode:
+            description:
+            - Replication mode for BUM traffic.
+            type: str
+            default: multicast
+            choices: [ multicast, ingress ]
+          multicast_group_subnet:
+            description:
+            - Multicast pool prefix between 8 to 30. A multicast group IPv4 from this pool
+              is used for BUM traffic for each overlay network.
+            type: str
+            default: "239.1.1.0/25"
+          auto_generate_multicast_group_address:
+            description:
+            - Generate a new multicast group address from the multicast pool using a round-robin approach.
+            type: bool
+            default: false
+          underlay_multicast_group_address_limit:
+            description:
+            - The maximum supported value is 128 for NX-OS version 10.2(1) or earlier
+              and 512 for versions above 10.2(1).
+            type: int
+            default: 128
+            choices: [ 128, 512 ]
+          tenant_routed_multicast:
+            description:
+            - Enable overlay IPv4 multicast support in VXLAN fabrics.
+            type: bool
+            default: false
+          tenant_routed_multicast_ipv6:
+            description:
+            - Enable overlay IPv6 multicast support in VXLAN fabrics.
+            type: bool
+            default: false
+          first_hop_redundancy_protocol:
+            description:
+            - First hop redundancy protocol, HSRP or VRRP.
+            type: str
+            default: hsrp
+            choices: [ hsrp, vrrp ]
+          rendezvous_point_count:
+            description:
+            - Number of spines acting as Rendezvous-Points (RPs).
+            type: int
+            default: 2
+            choices: [ 2, 4 ]
+          rendezvous_point_loopback_id:
+            description:
+            - The rendezvous point loopback interface ID.
+            type: int
+            default: 254
+          rendezvous_point_mode:
+            description:
+            - Multicast rendezvous point mode. For IPv6 underlay, use C(asm) only.
+            type: str
+            default: asm
+            choices: [ asm, bidir ]
+          phantom_rendezvous_point_loopback_id1:
+            description:
+            - Underlay phantom rendezvous point loopback primary ID for PIM Bi-dir deployments.
+            type: int
+            default: 2
+          phantom_rendezvous_point_loopback_id2:
+            description:
+            - Underlay phantom rendezvous point loopback secondary ID for PIM Bi-dir deployments.
+            type: int
+            default: 3
+          phantom_rendezvous_point_loopback_id3:
+            description:
+            - Underlay phantom rendezvous point loopback tertiary ID for PIM Bi-dir deployments.
+            type: int
+            default: 4
+          phantom_rendezvous_point_loopback_id4:
+            description:
+            - Underlay phantom rendezvous point loopback quaternary ID for PIM Bi-dir deployments.
+            type: int
+            default: 5
+          l3vni_multicast_group:
+            description:
+            - Default underlay multicast group IPv4 address assigned for every overlay VRF.
+            type: str
+            default: "239.1.1.0"
+          l3_vni_ipv6_multicast_group:
+            description:
+            - Default underlay multicast group IPv6 address assigned for every overlay VRF.
+            type: str
+            default: "ff1e::"
+          ipv6_multicast_group_subnet:
+            description:
+            - IPv6 multicast address with prefix 112 to 128.
+            type: str
+            default: "ff1e::/121"
+          mvpn_vrf_route_import_id:
+            description:
+            - Enable MVPN VRI ID generation for tenant routed multicast with IPv4 underlay.
+            type: bool
+            default: true
+          mvpn_vrf_route_import_id_range:
+            description:
+            - MVPN VRI ID range (minimum 1, maximum 65535) for vPC, applicable when TRM is enabled
+              with IPv6 underlay, or O(config.management.mvpn_vrf_route_import_id) is enabled with IPv4 underlay.
+            type: str
+          vrf_route_import_id_reallocation:
+            description:
+            - One time VRI ID re-allocation based on MVPN VRI ID Range.
+            type: bool
+            default: false
+          target_subnet_mask:
+            description:
+            - Mask for underlay subnet IP range (30-31).
+            type: int
+            default: 30
+          anycast_gateway_mac:
+            description:
+            - Shared anycast gateway MAC address for all VTEPs in xxxx.xxxx.xxxx format.
+            type: str
+            default: 2020.0000.00aa
+          fabric_mtu:
+            description:
+            - Intra fabric interface MTU. Must be an even number (1500-9216).
+            type: int
+            default: 9216
+          l2_host_interface_mtu:
+            description:
+            - Layer 2 host interface MTU. Must be an even number (1500-9216).
+            type: int
+            default: 9216
+          l3_vni_no_vlan_default_option:
+            description:
+            - L3 VNI configuration without VLAN configuration. This value is propagated on VRF
+              creation as the default value of Enable L3VNI w/o VLAN in VRF.
+            type: bool
+            default: false
+          underlay_ipv6:
+            description:
+            - Enable IPv6 underlay. If not enabled, IPv4 underlay is used.
+            type: bool
+            default: false
+          static_underlay_ip_allocation:
+            description:
+            - Disable dynamic underlay IP address allocation.
+            type: bool
+            default: false
+          anycast_border_gateway_advertise_physical_ip:
+            description:
+            - Advertise Anycast Border Gateway PIP as VTEP.
+              Effective on MSD fabric Recalculate Config.
+            type: bool
+            default: false
+          sub_interface_dot1q_range:
+            description:
+            - Per aggregation dot1q range for VRF-Lite connectivity (minimum 2, maximum 4093).
+            type: str
+            default: "2-511"
+          vrf_lite_auto_config:
+            description:
+            - VRF Lite Inter-Fabric Connection Deployment Options.
+            - If C(back2BackAndToExternal) is selected, VRF Lite IFCs are auto created between
+              border devices of two Easy Fabrics, and between border devices in Easy Fabric and
+              edge routers in External Fabric.
+            type: str
+            default: manual
+            choices: [ manual, back2BackAndToExternal ]
+          vrf_lite_subnet_range:
+            description:
+            - Address range to assign P2P interfabric connections.
+            type: str
+            default: "10.33.0.0/16"
+          vrf_lite_subnet_target_mask:
+            description:
+            - VRF Lite subnet mask.
+            type: int
+            default: 30
+          auto_unique_vrf_lite_ip_prefix:
+            description:
+            - When enabled, IP prefix allocated to the VRF LITE IFC is not reused on VRF extension
+              over VRF LITE IFC. Instead, a unique IP subnet is allocated for each VRF extension.
+            type: bool
+            default: false
+          vpc_domain_id_range:
+            description:
+            - vPC domain ID range (minimum 1, maximum 1000) to use for new pairings.
+            type: str
+            default: "1-1000"
+          vpc_peer_link_vlan:
+            description:
+            - VLAN range (minimum 2, maximum 4094) for vPC Peer Link SVI.
+            type: str
+            default: "3600"
+          vpc_peer_link_enable_native_vlan:
+            description:
+            - Enable vPC peer link for native VLAN.
+            type: bool
+            default: false
+          vpc_peer_keep_alive_option:
+            description:
+            - Use vPC peer keep alive with loopback or management.
+            type: str
+            default: management
+            choices: [ loopback, management ]
+          vpc_auto_recovery_timer:
+            description:
+            - vPC auto recovery timer in seconds (240-3600).
+            type: int
+            default: 360
+          vpc_delay_restore_timer:
+            description:
+            - vPC delay restore timer in seconds (1-3600).
+            type: int
+            default: 150
+          vpc_peer_link_port_channel_id:
+            description:
+            - vPC peer link port channel ID (minimum 1, maximum 4096).
+            type: str
+            default: "500"
+          vpc_ipv6_neighbor_discovery_sync:
+            description:
+            - Enable IPv6 ND synchronization between vPC peers.
+            type: bool
+            default: true
+          vpc_layer3_peer_router:
+            description:
+            - Enable layer-3 peer-router on all leaf switches.
+            type: bool
+            default: true
+          vpc_tor_delay_restore_timer:
+            description:
+            - vPC delay restore timer for ToR switches in seconds.
+            type: int
+            default: 30
+          fabric_vpc_domain_id:
+            description:
+            - Enable the same vPC domain ID for all vPC pairs. Not recommended.
+            type: bool
+            default: false
+          shared_vpc_domain_id:
+            description:
+            - vPC domain ID to be used on all vPC pairs.
+            type: int
+            default: 1
+          fabric_vpc_qos:
+            description:
+            - QoS on spines for guaranteed delivery of vPC Fabric Peering communication.
+            type: bool
+            default: false
+          fabric_vpc_qos_policy_name:
+            description:
+            - QoS policy name. Should be the same on all spines.
+            type: str
+            default: spine_qos_for_fabric_vpc_peering
+          enable_peer_switch:
+            description:
+            - Enable the vPC peer-switch feature on ToR switches.
+            type: bool
+            default: false
+          per_vrf_loopback_auto_provision:
+            description:
+            - Auto provision an IPv4 loopback on a VTEP on VRF attachment.
+            - Enabling this option auto-provisions loopback on existing VRF attachments and also
+              when Edit, QuickAttach, or Multiattach actions are performed.
+            type: bool
+            default: false
+          per_vrf_loopback_ip_range:
+            description:
+            - Prefix pool to assign IPv4 addresses to loopbacks on VTEPs on a per VRF basis.
+            type: str
+            default: "10.5.0.0/22"
+          per_vrf_loopback_auto_provision_ipv6:
+            description:
+            - Auto provision an IPv6 loopback on a VTEP on VRF attachment.
+            type: bool
+            default: false
+          per_vrf_loopback_ipv6_range:
+            description:
+            - Prefix pool to assign IPv6 addresses to loopbacks on VTEPs on a per VRF basis.
+            type: str
+            default: "fd00::a05:0/112"
+          vrf_template:
+            description:
+            - Default overlay VRF template for leafs.
+            type: str
+            default: Default_VRF_Universal
+          network_template:
+            description:
+            - Default overlay network template for leafs.
+            type: str
+            default: Default_Network_Universal
+          vrf_extension_template:
+            description:
+            - Default overlay VRF template for borders.
+            type: str
+            default: Default_VRF_Extension_Universal
+          network_extension_template:
+            description:
+            - Default overlay network template for borders.
+            type: str
+            default: Default_Network_Extension_Universal
+          performance_monitoring:
+            description:
+            - If enabled, switch metrics are collected through periodic SNMP polling.
+              Alternative to real-time telemetry.
+            type: bool
+            default: false
+          tenant_dhcp:
+            description:
+            - Enable tenant DHCP.
+            type: bool
+            default: true
+          advertise_physical_ip:
+            description:
+            - For primary VTEP IP advertisement as next-hop of prefix routes.
+            type: bool
+            default: false
+          advertise_physical_ip_on_border:
+            description:
+            - Enable advertise-pip on vPC borders and border gateways only.
+              Applicable only when vPC advertise-pip is not enabled.
+            type: bool
+            default: true
+          bgp_authentication:
+            description:
+            - Enable BGP authentication.
+            type: bool
+            default: false
+          bgp_authentication_key_type:
+            description:
+            - BGP key encryption type. 3 - 3DES, 6 - Cisco type 6, 7 - Cisco type 7.
+            type: str
+            default: 3des
+            choices: [ 3des, type6, type7 ]
+          bgp_authentication_key:
+            description:
+            - Encrypted BGP authentication key based on type.
+            type: str
+            default: ""
+          bfd:
+            description:
+            - Enable BFD. Valid for IPv4 underlay only.
+            type: bool
+            default: false
+          bfd_ibgp:
+            description:
+            - Enable BFD for iBGP.
+            type: bool
+            default: false
+          bfd_authentication:
+            description:
+            - Enable BFD authentication. Valid for P2P interfaces only.
+            type: bool
+            default: false
+          bfd_authentication_key_id:
+            description:
+            - BFD authentication key ID.
+            type: int
+            default: 100
+          bfd_authentication_key:
+            description:
+            - Encrypted SHA1 secret value.
+            type: str
+            default: ""
+          pim_hello_authentication:
+            description:
+            - Enable PIM hello authentication. Valid for IPv4 underlay only.
+            type: bool
+            default: false
+          pim_hello_authentication_key:
+            description:
+            - PIM hello authentication key. 3DES encrypted.
+            type: str
+            default: ""
+          nxapi:
+            description:
+            - Enable NX-API over HTTPS.
+            type: bool
+            default: true
+          nxapi_http:
+            description:
+            - Enable NX-API over HTTP.
+            type: bool
+            default: false
+          nxapi_https_port:
+            description:
+            - HTTPS port for NX-API (1-65535).
+            type: int
+            default: 443
+          nxapi_http_port:
+            description:
+            - HTTP port for NX-API (1-65535).
+            type: int
+            default: 80
+          day0_bootstrap:
+            description:
+            - Automatic IP assignment for POAP.
+            type: bool
+            default: false
+          bootstrap_subnet_collection:
+            description:
+            - List of IPv4 or IPv6 subnets to be used for bootstrap.
+            - When O(state=merged), omitting this option preserves the existing collection.
+            - When O(state=merged), providing this option replaces the entire collection with the supplied list.
+            - Under O(state=merged), entries in this list are not merged item-by-item.
+            - Under O(state=merged), removing one entry from the playbook removes it from the fabric, and setting an empty list clears the collection.
+            - When O(state=replaced), this option is also treated as the exact desired collection.
+            - When O(state=replaced), omitting this option resets the collection to its default empty value.
+            type: list
+            elements: dict
+            suboptions:
+              start_ip:
+                description:
+                - Starting IP address of the bootstrap range.
+                type: str
+                required: true
+              end_ip:
+                description:
+                - Ending IP address of the bootstrap range.
+                type: str
+                required: true
+              default_gateway:
+                description:
+                - Default gateway for the bootstrap subnet.
+                type: str
+                required: true
+              subnet_prefix:
+                description:
+                - Subnet prefix length (8-30).
+                type: int
+                required: true
+          local_dhcp_server:
+            description:
+            - Automatic IP assignment for POAP from local DHCP server.
+            type: bool
+            default: false
+          dhcp_protocol_version:
+            description:
+            - IP protocol version for local DHCP server.
+            type: str
+            default: dhcpv4
+            choices: [ dhcpv4, dhcpv6 ]
+          dhcp_start_address:
+            description:
+            - DHCP scope start address for switch POAP.
+            type: str
+            default: ""
+          dhcp_end_address:
+            description:
+            - DHCP scope end address for switch POAP.
+            type: str
+            default: ""
+          management_gateway:
+            description:
+            - Default gateway for management VRF on the switch.
+            type: str
+            default: ""
+          management_ipv4_prefix:
+            description:
+            - Switch management IP subnet prefix for IPv4.
+            type: int
+            default: 24
+          management_ipv6_prefix:
+            description:
+            - Switch management IP subnet prefix for IPv6.
+            type: int
+            default: 64
+          netflow_settings:
+            description:
+            - Netflow configuration settings.
+            type: dict
+            suboptions:
+              netflow:
+                description:
+                - Enable netflow collection.
+                type: bool
+                default: false
+              netflow_exporter_collection:
+                description:
+                - List of netflow exporters.
+                type: list
+                elements: dict
+                suboptions:
+                  exporter_name:
+                    description:
+                    - Name of the netflow exporter.
+                    type: str
+                    required: true
+                  exporter_ip:
+                    description:
+                    - IP address of the netflow collector.
+                    type: str
+                    required: true
+                  vrf:
+                    description:
+                    - VRF name for the exporter.
+                    type: str
+                    default: management
+                  source_interface_name:
+                    description:
+                    - Source interface name.
+                    type: str
+                    required: true
+                  udp_port:
+                    description:
+                    - UDP port for netflow export (1-65535).
+                    type: int
+              netflow_record_collection:
+                description:
+                - List of netflow records.
+                type: list
+                elements: dict
+                suboptions:
+                  record_name:
+                    description:
+                    - Name of the netflow record.
+                    type: str
+                    required: true
+                  record_template:
+                    description:
+                    - Template type for the record.
+                    type: str
+                    required: true
+                  layer2_record:
+                    description:
+                    - Enable layer 2 record fields.
+                    type: bool
+                    default: false
+              netflow_monitor_collection:
+                description:
+                - List of netflow monitors.
+                type: list
+                elements: dict
+                suboptions:
+                  monitor_name:
+                    description:
+                    - Name of the netflow monitor.
+                    type: str
+                    required: true
+                  record_name:
+                    description:
+                    - Associated record name.
+                    type: str
+                    required: true
+                  exporter1_name:
+                    description:
+                    - Primary exporter name.
+                    type: str
+                    required: true
+                  exporter2_name:
+                    description:
+                    - Secondary exporter name.
+                    type: str
+                    default: ""
+          real_time_backup:
+            description:
+            - Backup hourly only if there is any config deployment since last backup.
+            type: bool
+          scheduled_backup:
+            description:
+            - Enable backup at the specified time daily.
+            type: bool
+          scheduled_backup_time:
+            description:
+            - Time (UTC) in 24 hour format to take a daily backup if enabled (00:00 to 23:59).
+            type: str
+            default: ""
+          leaf_tor_id_range:
+            description:
+            - Use specific vPC/Port-channel ID range for leaf-tor pairings.
+            type: bool
+            default: false
+          leaf_tor_vpc_port_channel_id_range:
+            description:
+            - vPC/Port-channel ID range (minimum 1, maximum 4096), used for auto-allocating
+              vPC/Port-Channel IDs for leaf-tor pairings.
+            type: str
+            default: "1-499"
+          allow_vlan_on_leaf_tor_pairing:
+            description:
+            - Set trunk allowed VLAN to none or all for leaf-tor pairing port-channels.
+            type: str
+            default: none
+            choices: [ none, all ]
+          ntp_server_collection:
+            description:
+            - List of NTP server IPv4/IPv6 addresses and/or hostnames.
+            type: list
+            elements: str
+          ntp_server_vrf_collection:
+            description:
+            - NTP Server VRFs. One VRF for all NTP servers or a list of VRFs, one per NTP server.
+            type: list
+            elements: str
+          dns_collection:
+            description:
+            - List of IPv4 and IPv6 DNS addresses.
+            type: list
+            elements: str
+          dns_vrf_collection:
+            description:
+            - DNS Server VRFs. One VRF for all DNS servers or a list of VRFs, one per DNS server.
+            type: list
+            elements: str
+          syslog_server_collection:
+            description:
+            - List of syslog server IPv4/IPv6 addresses and/or hostnames.
+            type: list
+            elements: str
+          syslog_server_vrf_collection:
+            description:
+            - Syslog Server VRFs. One VRF for all syslog servers or a list of VRFs, one per syslog server.
+            type: list
+            elements: str
+          syslog_severity_collection:
+            description:
+            - List of syslog severity values, one per syslog server.
+            type: list
+            elements: int
+          banner:
+            description:
+            - Message of the Day (motd) banner. Delimiter char (very first char is delimiter char)
+              followed by message ending with delimiter.
+            type: str
+            default: ""
+          extra_config_leaf:
+            description:
+            - Additional CLIs added after interface configurations for all switches with a VTEP
+              unless they have some spine role.
+            type: str
+            default: ""
+          extra_config_spine:
+            description:
+            - Additional CLIs added after interface configurations for all switches with some spine role.
+            type: str
+            default: ""
+          extra_config_tor:
+            description:
+            - Additional CLIs added after interface configurations for all ToRs.
+            type: str
+            default: ""
+          extra_config_intra_fabric_links:
+            description:
+            - Additional CLIs for all intra-fabric links.
+            type: str
+            default: ""
+          extra_config_aaa:
+            description:
+            - AAA configurations.
+            type: str
+            default: ""
+          extra_config_nxos_bootstrap:
+            description:
+            - Additional CLIs required during device bootup/login e.g. AAA/Radius.
+            type: str
+            default: ""
+          aaa:
+            description:
+            - Include AAA configs from Manageability tab during device bootup.
+            type: bool
+            default: false
+          pre_interface_config_leaf:
+            description:
+            - Additional CLIs added before interface configurations for all switches with a VTEP
+              unless they have some spine role.
+            type: str
+            default: ""
+          pre_interface_config_spine:
+            description:
+            - Additional CLIs added before interface configurations for all switches with some spine role.
+            type: str
+            default: ""
+          pre_interface_config_tor:
+            description:
+            - Additional CLIs added before interface configurations for all ToRs.
+            type: str
+            default: ""
+          greenfield_debug_flag:
+            description:
+            - Allow switch configuration to be cleared without a reload when preserveConfig is set to false.
+            type: str
+            default: disable
+            choices: [ enable, disable ]
+          interface_statistics_load_interval:
+            description:
+            - Interface statistics load interval in seconds.
+            type: int
+            default: 10
+          nve_hold_down_timer:
+            description:
+            - NVE source interface hold-down time in seconds.
+            type: int
+            default: 180
+          next_generation_oam:
+            description:
+            - Enable the Next Generation (NG) OAM feature for all switches in the fabric
+              to aid in troubleshooting VXLAN EVPN fabrics.
+            type: bool
+            default: true
+          ngoam_south_bound_loop_detect:
+            description:
+            - Enable the Next Generation (NG) OAM southbound loop detection.
+            type: bool
+            default: false
+          ngoam_south_bound_loop_detect_probe_interval:
+            description:
+            - Next Generation (NG) OAM southbound loop detection probe interval in seconds.
+            type: int
+            default: 300
+          ngoam_south_bound_loop_detect_recovery_interval:
+            description:
+            - Next Generation (NG) OAM southbound loop detection recovery interval in seconds.
+            type: int
+            default: 600
+          strict_config_compliance_mode:
+            description:
+            - Enable bi-directional compliance checks to flag additional configs in the running
+              config that are not in the intent/expected config.
+            type: bool
+            default: false
+          advanced_ssh_option:
+            description:
+            - Enable AAA IP Authorization. Enable only when IP Authorization is enabled
+              in the AAA Server.
+            type: bool
+            default: false
+          copp_policy:
+            description:
+            - Fabric wide CoPP policy. Customized CoPP policy should be provided when C(manual) is selected.
+            type: str
+            default: strict
+            choices: [ dense, lenient, moderate, strict, manual ]
+          power_redundancy_mode:
+            description:
+            - Default power supply mode for NX-OS switches.
+            type: str
+            default: redundant
+            choices: [ redundant, combined, inputSrcRedundant ]
+          heartbeat_interval:
+            description:
+            - XConnect heartbeat interval for periodic link status checks.
+            type: int
+            default: 190
+          snmp_trap:
+            description:
+            - Configure ND as a receiver for SNMP traps.
+            type: bool
+            default: true
+          cdp:
+            description:
+            - Enable CDP on management interface.
+            type: bool
+            default: false
+          real_time_interface_statistics_collection:
+            description:
+            - Enable real time interface statistics collection. Valid for NX-OS only.
+            type: bool
+            default: false
+          tcam_allocation:
+            description:
+            - TCAM commands are automatically generated for VxLAN and vPC Fabric Peering when enabled.
+            type: bool
+            default: true
+          allow_smart_switch_onboarding:
+            description:
+            - Enable onboarding of smart switches to Hypershield for firewall service.
+            type: bool
+            default: false
+          default_queuing_policy:
+            description:
+            - Enable default queuing policies.
+            type: bool
+            default: false
+          default_queuing_policy_cloudscale:
+            description:
+            - Queuing policy for all 92xx, -EX, -FX, -FX2, -FX3, -GX series switches in the fabric.
+            type: str
+            default: queuing_policy_default_8q_cloudscale
+          default_queuing_policy_r_series:
+            description:
+            - Queueing policy for all Nexus R-series switches.
+            type: str
+            default: queuing_policy_default_r_series
+          default_queuing_policy_other:
+            description:
+            - Queuing policy for all other switches in the fabric.
+            type: str
+            default: queuing_policy_default_other
+          aiml_qos:
+            description:
+            - Configures QoS and Queuing Policies specific to N9K Cloud Scale (CS) and
+              Silicon One (S1) switch fabric for AI network workloads.
+            type: bool
+            default: false
+          aiml_qos_policy:
+            description:
+            - Queuing policy based on predominant fabric link speed.
+              C(User-defined) allows for custom configuration.
+            type: str
+            default: 400G
+            choices: [ 800G, 400G, 100G, 25G, User-defined ]
+          roce_v2:
+            description:
+            - DSCP for RDMA traffic. Numeric (0-63) with ranges/comma, or named values
+              (af11, af12, af13, af21, af22, af23, af31, af32, af33, af41, af42, af43,
+              cs1, cs2, cs3, cs4, cs5, cs6, cs7, default, ef).
+            type: str
+            default: "26"
+          cnp:
+            description:
+            - DSCP value for Congestion Notification. Numeric (0-63) with ranges/comma, or named values
+              (af11, af12, af13, af21, af22, af23, af31, af32, af33, af41, af42, af43,
+              cs1, cs2, cs3, cs4, cs5, cs6, cs7, default, ef).
+            type: str
+            default: "48"
+          wred_min:
+            description:
+            - WRED minimum threshold in kbytes.
+            type: int
+            default: 950
+          wred_max:
+            description:
+            - WRED maximum threshold in kbytes.
+            type: int
+            default: 3000
+          wred_drop_probability:
+            description:
+            - WRED drop probability percentage.
+            type: int
+            default: 7
+          wred_weight:
+            description:
+            - Influences how quickly WRED reacts to queue depth changes.
+            type: int
+            default: 0
+          bandwidth_remaining:
+            description:
+            - Percentage of remaining bandwidth allocated to AI traffic queues.
+            type: int
+            default: 50
+          dlb:
+            description:
+            - Enables fabric-level Dynamic Load Balancing (DLB) configuration.
+              Inter-Switch-Links (ISL) will be configured as DLB interfaces.
+            type: bool
+            default: false
+          dlb_mode:
+            description:
+            - Select system-wide flowlet, per-packet (packet spraying) or policy driven mixed mode.
+              Mixed mode is supported on Silicon One (S1) platform only.
+            type: str
+            default: flowlet
+            choices: [ flowlet, per-packet, policy-driven-flowlet, policy-driven-per-packet, policy-driven-mixed-mode ]
+          dlb_mixed_mode_default:
+            description:
+            - Default load balancing mode for policy driven mixed mode DLB.
+            type: str
+            default: ecmp
+            choices: [ ecmp, flowlet, per-packet ]
+          flowlet_aging:
+            description:
+            - Flowlet aging timer in microseconds. Valid range depends on platform.
+              Cloud Scale (CS) 1-2000000 (default 500), Silicon One (S1) 1-1024 (default 256).
+            type: int
+          flowlet_dscp:
+            description:
+            - DSCP values for flowlet load balancing. Numeric (0-63) with ranges/comma, or named values
+              (af11, af12, af13, af21, af22, af23, af31, af32, af33, af41, af42, af43,
+              cs1, cs2, cs3, cs4, cs5, cs6, cs7, default, ef).
+            type: str
+            default: ""
+          per_packet_dscp:
+            description:
+            - DSCP values for per-packet load balancing. Numeric (0-63) with ranges/comma, or named values
+              (af11, af12, af13, af21, af22, af23, af31, af32, af33, af41, af42, af43,
+              cs1, cs2, cs3, cs4, cs5, cs6, cs7, default, ef).
+            type: str
+            default: ""
+          ai_load_sharing:
+            description:
+            - Enable IP load sharing using source and destination address for AI workloads.
+            type: bool
+            default: false
+          priority_flow_control_watch_interval:
+            description:
+            - Acceptable values from 101 to 1000 (milliseconds).
+              Leave blank for system default (100ms).
+            type: int
+          ptp:
+            description:
+            - Enable Precision Time Protocol (PTP).
+            type: bool
+            default: false
+          ptp_loopback_id:
+            description:
+            - Precision Time Protocol source loopback ID.
+            type: int
+            default: 0
+          ptp_domain_id:
+            description:
+            - Multiple independent PTP clocking subdomains on a single network.
+            type: int
+            default: 0
+          private_vlan:
+            description:
+            - Enable PVLAN on switches except spines and super spines.
+            type: bool
+            default: false
+          default_private_vlan_secondary_network_template:
+            description:
+            - Default PVLAN secondary network template.
+            type: str
+            default: Pvlan_Secondary_Network
+          macsec:
+            description:
+            - Enable MACsec in the fabric. MACsec fabric parameters are used for configuring
+              MACsec on a fabric link if MACsec is enabled on the link.
+            type: bool
+            default: false
+          macsec_cipher_suite:
+            description:
+            - Configure MACsec cipher suite.
+            type: str
+            default: GCM-AES-XPN-256
+            choices: [ GCM-AES-128, GCM-AES-256, GCM-AES-XPN-128, GCM-AES-XPN-256 ]
+          macsec_key_string:
+            description:
+            - MACsec primary key string. Cisco Type 7 encrypted octet string.
+            type: str
+            default: ""
+          macsec_algorithm:
+            description:
+            - MACsec primary cryptographic algorithm. AES_128_CMAC or AES_256_CMAC.
+            type: str
+            default: AES_128_CMAC
+            choices: [ AES_128_CMAC, AES_256_CMAC ]
+          macsec_fallback_key_string:
+            description:
+            - MACsec fallback key string. Cisco Type 7 encrypted octet string.
+            type: str
+            default: ""
+          macsec_fallback_algorithm:
+            description:
+            - MACsec fallback cryptographic algorithm. AES_128_CMAC or AES_256_CMAC.
+            type: str
+            default: AES_128_CMAC
+            choices: [ AES_128_CMAC, AES_256_CMAC ]
+          macsec_report_timer:
+            description:
+            - MACsec operational status periodic report timer in minutes.
+            type: int
+            default: 5
+          enable_dpu_pinning:
+            description:
+            - Enable pinning of VRFs and networks to specific DPUs on smart switches.
+            type: bool
+            default: false
+          connectivity_domain_name:
+            description:
+            - Domain name to connect to Hypershield.
+            type: str
+          hypershield_connectivity_proxy_server:
+            description:
+            - IPv4 address, IPv6 address, or DNS name of the proxy server for Hypershield communication.
+            type: str
+          hypershield_connectivity_proxy_server_port:
+            description:
+            - Proxy port number for communication with Hypershield.
+            type: int
+          hypershield_connectivity_source_intf:
+            description:
+            - Loopback interface on smart switch for communication with Hypershield.
+            type: str
+      telemetry_settings:
+        description:
+        - Telemetry configuration settings.
+        type: dict
+        suboptions:
+          flow_collection:
+            description:
+            - Flow collection settings.
+            type: dict
+            suboptions:
+              traffic_analytics:
+                description:
+                - Traffic analytics state.
+                type: str
+                default: enabled
+              traffic_analytics_scope:
+                description:
+                - Traffic analytics scope.
+                type: str
+                default: intraFabric
+              operating_mode:
+                description:
+                - Operating mode.
+                type: str
+                default: flowTelemetry
+              udp_categorization:
+                description:
+                - UDP categorization.
+                type: str
+                default: enabled
+          microburst:
+            description:
+            - Microburst detection settings.
+            type: dict
+            suboptions:
+              microburst:
+                description:
+                - Enable microburst detection.
+                type: bool
+                default: false
+              sensitivity:
+                description:
+                - Microburst sensitivity level.
+                type: str
+                default: low
+          analysis_settings:
+            description:
+            - Telemetry analysis settings.
+            type: dict
+            suboptions:
+              is_enabled:
+                description:
+                - Enable telemetry analysis.
+                type: bool
+                default: false
+          nas:
+            description:
+            - NAS telemetry configuration.
+            type: dict
+            suboptions:
+              server:
+                description:
+                - NAS server address.
+                type: str
+                default: ""
+              export_settings:
+                description:
+                - NAS export settings.
+                type: dict
+                suboptions:
+                  export_type:
+                    description:
+                    - Export type.
+                    type: str
+                    default: full
+                  export_format:
+                    description:
+                    - Export format.
+                    type: str
+                    default: json
+          energy_management:
+            description:
+            - Energy management settings.
+            type: dict
+            suboptions:
+              cost:
+                description:
+                - Energy cost per unit.
+                type: float
+                default: 1.2
+      external_streaming_settings:
+        description:
+        - External streaming settings.
+        type: dict
+        suboptions:
+          email:
+            description:
+            - Email streaming configuration.
+            type: list
+            elements: dict
+          message_bus:
+            description:
+            - Message bus configuration.
+            type: list
+            elements: dict
+          syslog:
+            description:
+            - Syslog streaming configuration.
+            type: dict
+          webhooks:
+            description:
+            - Webhook configuration.
+            type: list
+            elements: dict
+  state:
+    description:
+    - The desired state of the fabric resources on the Cisco Nexus Dashboard.
+    - Use O(state=merged) to create new fabrics and update existing ones as defined in the configuration.
+      Resources on ND that are not specified in the configuration will be left unchanged.
+    - Use O(state=replaced) to replace the fabric configuration specified in the configuration.
+      Any settings not explicitly provided will revert to their defaults.
+    - Use O(state=overridden) to enforce the configuration as the single source of truth.
+      Any fabric existing on ND but not present in the configuration will be deleted. Use with extra caution.
+    - Use O(state=deleted) to remove the fabrics specified in the configuration from the Cisco Nexus Dashboard.
+    type: str
+    default: merged
+    choices: [ merged, replaced, overridden, deleted ]
+  config_actions:
+    description:
+    - Controls save and deploy behavior after fabric configuration is updated.
+    - Save writes pending configuration to the controller.
+    - Deploy pushes the saved configuration to switches.
+    - Skipped automatically when O(state=deleted) or when no changes are made.
+    type: dict
+    suboptions:
+      save:
+        description:
+        - Whether to save fabric configuration after changes.
+        type: bool
+        default: false
+      deploy:
+        description:
+        - Whether to deploy fabric configuration to switches after saving.
+        - Requires O(config_actions.save=true) when enabled.
+        type: bool
+        default: false
+      type:
+        description:
+        - Scope of the deploy operation.
+        - C(switch) deploys only to affected switches.
+        - C(global) deploys to all switches in the fabric.
+        type: str
+        default: switch
+        choices: [ switch, global ]
+extends_documentation_fragment:
+- cisco.nd.modules
+- cisco.nd.check_mode
+notes:
+- This module is only supported on Nexus Dashboard having version 4.2.0 or higher.
+- Only Routed fabric type (C(routed)) is supported by this module.
+- When using O(state=replaced) with only required fields, all optional management settings revert to their defaults.
+- O(config.management.site_id) defaults to the value of O(config.management.bgp_asn) if not provided.
+- The default O(config.management.vpc_peer_keep_alive_option) for Routed fabrics is C(management), unlike iBGP fabrics.
+"""
+
+EXAMPLES = r"""
+- name: Create a Routed fabric using state merged (with auto ASN allocation)
+  cisco.nd.nd_manage_fabric_routed:
+    state: merged
+    config:
+      - fabric_name: my_ebgp_fabric
+        location:
+          latitude: 37.7749
+          longitude: -122.4194
+        license_tier: premier
+        alert_suspend: disabled
+        security_domain: all
+        telemetry_collection: false
+        management:
+          bgp_asn_auto_allocation: true
+          bgp_asn_range: "65000-65535"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.00aa"
+          performance_monitoring: false
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.1.0/25"
+          auto_generate_multicast_group_address: false
+          underlay_multicast_group_address_limit: 128
+          tenant_routed_multicast: false
+          rendezvous_point_count: 2
+          rendezvous_point_loopback_id: 254
+          vpc_peer_link_vlan: "3600"
+          vpc_peer_link_enable_native_vlan: false
+          vpc_peer_keep_alive_option: management
+          vpc_auto_recovery_timer: 360
+          vpc_delay_restore_timer: 150
+          vpc_peer_link_port_channel_id: "500"
+          advertise_physical_ip: false
+          vpc_domain_id_range: "1-1000"
+          bgp_loopback_id: 0
+          nve_loopback_id: 1
+          vrf_template: Default_VRF_Universal
+          network_template: Default_Network_Universal
+          vrf_extension_template: Default_VRF_Extension_Universal
+          network_extension_template: Default_Network_Extension_Universal
+          l3_vni_no_vlan_default_option: false
+          fabric_mtu: 9216
+          l2_host_interface_mtu: 9216
+          tenant_dhcp: true
+          nxapi: false
+          nxapi_https_port: 443
+          nxapi_http: false
+          nxapi_http_port: 80
+          snmp_trap: true
+          anycast_border_gateway_advertise_physical_ip: false
+          greenfield_debug_flag: disable
+          tcam_allocation: true
+          real_time_interface_statistics_collection: false
+          interface_statistics_load_interval: 10
+          bgp_loopback_ip_range: "10.2.0.0/22"
+          nve_loopback_ip_range: "10.3.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.254.0/24"
+          intra_fabric_subnet_range: "10.4.0.0/16"
+          l2_vni_range: "30000-49000"
+          l3_vni_range: "50000-59000"
+          network_vlan_range: "2300-2999"
+          vrf_vlan_range: "2000-2299"
+          sub_interface_dot1q_range: "2-511"
+          vrf_lite_auto_config: manual
+          vrf_lite_subnet_range: "10.33.0.0/16"
+          vrf_lite_subnet_target_mask: 30
+          auto_unique_vrf_lite_ip_prefix: false
+          per_vrf_loopback_auto_provision: true
+          per_vrf_loopback_ip_range: "10.5.0.0/22"
+          banner: ""
+          day0_bootstrap: false
+          local_dhcp_server: false
+          dhcp_protocol_version: dhcpv4
+          dhcp_start_address: ""
+          dhcp_end_address: ""
+          management_gateway: ""
+          management_ipv4_prefix: 24
+  register: result
+
+- name: Create a Routed fabric with a static BGP ASN
+  cisco.nd.nd_manage_fabric_routed:
+    state: merged
+    config:
+      - fabric_name: my_ebgp_fabric_static
+        management:
+          bgp_asn: "65001"
+          bgp_asn_auto_allocation: false
+          site_id: "65001"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.00aa"
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.1.0/25"
+          bgp_loopback_ip_range: "10.2.0.0/22"
+          nve_loopback_ip_range: "10.3.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.254.0/24"
+          intra_fabric_subnet_range: "10.4.0.0/16"
+          l2_vni_range: "30000-49000"
+          l3_vni_range: "50000-59000"
+          network_vlan_range: "2300-2999"
+          vrf_vlan_range: "2000-2299"
+  register: result
+
+- name: Update specific fields on an existing Routed fabric using state merged (partial update)
+  cisco.nd.nd_manage_fabric_routed:
+    state: merged
+    config:
+      - fabric_name: my_ebgp_fabric
+        management:
+          bgp_asn_range: "65100-65199"
+          anycast_gateway_mac: "2020.0000.00bb"
+          performance_monitoring: true
+  register: result
+
+- name: Create or fully replace a Routed fabric using state replaced
+  cisco.nd.nd_manage_fabric_routed:
+    state: replaced
+    config:
+      - fabric_name: my_ebgp_fabric
+        location:
+          latitude: 37.7749
+          longitude: -122.4194
+        license_tier: premier
+        alert_suspend: disabled
+        security_domain: all
+        telemetry_collection: false
+        management:
+          bgp_asn: "65004"
+          bgp_asn_auto_allocation: false
+          site_id: "65004"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.00dd"
+          performance_monitoring: true
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.3.0/25"
+          rendezvous_point_count: 3
+          rendezvous_point_loopback_id: 253
+          vpc_peer_link_vlan: "3700"
+          vpc_peer_keep_alive_option: management
+          vpc_auto_recovery_timer: 300
+          vpc_delay_restore_timer: 120
+          vpc_peer_link_port_channel_id: "600"
+          advertise_physical_ip: true
+          vpc_domain_id_range: "1-800"
+          fabric_mtu: 9000
+          l2_host_interface_mtu: 9000
+          tenant_dhcp: false
+          snmp_trap: false
+          anycast_border_gateway_advertise_physical_ip: true
+          greenfield_debug_flag: disable
+          tcam_allocation: false
+          real_time_interface_statistics_collection: true
+          interface_statistics_load_interval: 30
+          bgp_loopback_ip_range: "10.22.0.0/22"
+          nve_loopback_ip_range: "10.23.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.252.0/24"
+          intra_fabric_subnet_range: "10.24.0.0/16"
+          l2_vni_range: "40000-59000"
+          l3_vni_range: "60000-69000"
+          network_vlan_range: "2400-3099"
+          vrf_vlan_range: "2100-2399"
+          banner: "^ Managed by Ansible ^"
+  register: result
+
+- name: Replace fabric with only required fields (all optional settings revert to defaults)
+  cisco.nd.nd_manage_fabric_routed:
+    state: replaced
+    config:
+      - fabric_name: my_ebgp_fabric
+        management:
+          bgp_asn: "65004"
+          bgp_asn_auto_allocation: false
+          site_id: "65004"
+          banner: "^ Managed by Ansible ^"
+  register: result
+
+- name: Enforce exact fabric inventory using state overridden (deletes unlisted fabrics)
+  cisco.nd.nd_manage_fabric_routed:
+    state: overridden
+    config:
+      - fabric_name: fabric_east
+        location:
+          latitude: 40.7128
+          longitude: -74.0060
+        license_tier: premier
+        alert_suspend: disabled
+        security_domain: all
+        telemetry_collection: false
+        management:
+          bgp_asn: "65010"
+          bgp_asn_auto_allocation: false
+          site_id: "65010"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.0010"
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.10.0/25"
+          bgp_loopback_ip_range: "10.10.0.0/22"
+          nve_loopback_ip_range: "10.11.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.10.0/24"
+          intra_fabric_subnet_range: "10.12.0.0/16"
+          l2_vni_range: "30000-49000"
+          l3_vni_range: "50000-59000"
+          network_vlan_range: "2300-2999"
+          vrf_vlan_range: "2000-2299"
+      - fabric_name: fabric_west
+        location:
+          latitude: 34.0522
+          longitude: -118.2437
+        license_tier: premier
+        alert_suspend: disabled
+        security_domain: all
+        telemetry_collection: false
+        management:
+          bgp_asn: "65020"
+          bgp_asn_auto_allocation: false
+          site_id: "65020"
+          bgp_as_mode: multiAS
+          target_subnet_mask: 30
+          anycast_gateway_mac: "2020.0000.0020"
+          replication_mode: multicast
+          multicast_group_subnet: "239.1.20.0/25"
+          bgp_loopback_ip_range: "10.20.0.0/22"
+          nve_loopback_ip_range: "10.21.0.0/22"
+          anycast_rendezvous_point_ip_range: "10.254.20.0/24"
+          intra_fabric_subnet_range: "10.22.0.0/16"
+          l2_vni_range: "30000-49000"
+          l3_vni_range: "50000-59000"
+          network_vlan_range: "2300-2999"
+          vrf_vlan_range: "2000-2299"
+  register: result
+
+- name: Delete a specific Routed fabric using state deleted
+  cisco.nd.nd_manage_fabric_routed:
+    state: deleted
+    config:
+      - fabric_name: my_ebgp_fabric
+  register: result
+
+- name: Delete multiple Routed fabrics in a single task
+  cisco.nd.nd_manage_fabric_routed:
+    state: deleted
+    config:
+      - fabric_name: fabric_east
+      - fabric_name: fabric_west
+      - fabric_name: fabric_old
+  register: result
+"""
+
+RETURN = r"""
+changed:
+    description: Whether the module made any changes.
+    type: bool
+    returned: always
+    sample: true
+before:
+    description:
+    - Routed fabric configuration before changes.
+    - Queried from the controller and may contain read-only properties.
+    type: list
+    returned: always
+    sample: [{"fabric_name": "fabric_east", "management": {"bgp_asn": "65001"}}]
+after:
+    description:
+    - Routed fabric configuration after changes.
+    - Refreshed from the controller after write operations.
+    type: list
+    returned: always
+    sample: [{"fabric_name": "fabric_east", "management": {"bgp_asn": "65002"}}]
+diff:
+    description: Configuration differences between before and after states.
+    type: list
+    returned: always
+    sample: [{"fabric_name": "fabric_east", "management": {"bgp_asn": "65002"}}]
+proposed:
+    description: Proposed configuration sent to the module.
+    type: list
+    returned: info or debug output_level
+    sample: [{"fabric_name": "fabric_east", "management": {"bgp_asn": "65002"}}]
+output_level:
+    description: The output level set for the module.
+    type: str
+    returned: always
+    sample: normal
+logs:
+    description: Debug log messages from module execution.
+    type: list
+    returned: debug output_level
+    sample: ["Starting state machine for merged state"]
+api_paths:
+    description: API endpoint paths used during operations.
+    type: list
+    returned: verbosity >= 2 (-vv)
+    sample: ["/api/v1/manage/fabrics/fabric_east"]
+api_verbs:
+    description: HTTP methods used during operations.
+    type: list
+    returned: verbosity >= 2 (-vv)
+    sample: ["PUT"]
+api_response:
+    description: Full API responses from the controller.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+    sample: [{"RETURN_CODE": 200, "MESSAGE": "Success"}]
+api_result:
+    description: Operation results from the controller.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+    sample: [{"success": true, "changed": true}]
+api_diff:
+    description: API-level differences for each operation.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+api_metadata:
+    description: Operation metadata with sequence and identifiers.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+api_payload:
+    description: Request payloads sent to the API.
+    type: list
+    returned: verbosity >= 3 (-vvv)
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.nd.plugins.module_utils.nd import nd_argument_spec
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_routed import FabricRoutedModel
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.manage_fabric_routed import ManageRoutedFabricOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
+
+
+def main():
+    argument_spec = nd_argument_spec()
+    argument_spec.update(FabricRoutedModel.get_argument_spec())
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    require_pydantic(module)
+
+    # Parse and validate config_actions BEFORE any state mutation so invalid
+    # input fails deterministically on every run, including idempotent no-drift
+    # runs, and never mutates ND before failing.
+    config_actions = module.params.get("config_actions") or {}
+    save = config_actions.get("save", False)
+    deploy = config_actions.get("deploy", False)
+    deploy_type = config_actions.get("type", "switch")
+    state = module.params.get("state", "merged")
+
+    try:
+        ManageRoutedFabricOrchestrator.validate_config_actions(save=save, deploy=deploy, deploy_type=deploy_type)
+    except ValueError as e:
+        module.fail_json(msg=str(e))
+
+    nd_state_machine = None
+    try:
+        # Initialize StateMachine
+        nd_state_machine = NDStateMachine(
+            module=module,
+            model_orchestrator=ManageRoutedFabricOrchestrator,
+        )
+
+        # Manage state
+        nd_state_machine.manage_state()
+
+        # Execute config save/deploy actions via orchestrator mixin (only on real changes)
+        if state != "deleted" and len(nd_state_machine.sent) > 0:
+            fabric_names = []
+            for item in nd_state_machine.sent:
+                name = item.get_identifier_value()
+                if name and name not in fabric_names:
+                    fabric_names.append(name)
+            if fabric_names:
+                nd_state_machine.model_orchestrator.execute_config_actions(
+                    fabric_names=fabric_names,
+                    save=save,
+                    deploy=deploy,
+                    deploy_type=deploy_type,
+                )
+
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
+        module.exit_json(**nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results))
+
+    except NDStateMachineError as e:
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
+        output = nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results) if nd_state_machine else {}
+        module.fail_json(msg=str(e), **output)
+    except Exception as e:
+        verbosity = module._verbosity if hasattr(module, "_verbosity") else 0
+        output = nd_state_machine.output.format_with_verbosity(verbosity, nd_state_machine.results) if nd_state_machine else {}
+        module.fail_json(msg=f"Module execution failed: {str(e)}", **output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/nd_manage_fabric/tasks/fabric_ai_routed.yaml
+++ b/tests/integration/targets/nd_manage_fabric/tasks/fabric_ai_routed.yaml
@@ -1,0 +1,246 @@
+---
+# Test code for the ND modules
+# Copyright: (c) 2026, Cisco Systems
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+#############################################################################
+# CLEANUP - Ensure clean state before tests
+#############################################################################
+- name: Clean up any existing test fabrics before starting tests
+  cisco.nd.nd_manage_fabric_ai_routed:
+    <<: *nd_info
+    state: deleted
+    config:
+      - fabric_name: "{{ ai_routed_test_fabric_merged }}"
+      - fabric_name: "{{ ai_routed_test_fabric_replaced }}"
+      - fabric_name: "{{ ai_routed_test_fabric_deleted }}"
+  tags: always
+
+#############################################################################
+# TEST 1: STATE MERGED - Create fabric using merged state
+#############################################################################
+- name: "TEST 1a: Create AI Routed fabric using state merged (first run)"
+  cisco.nd.nd_manage_fabric_ai_routed:
+    <<: *nd_info
+    state: merged
+    config:
+      - "{{ {'fabric_name': ai_routed_test_fabric_merged} | combine(fabric_config_ai_routed) }}"
+  register: merged_result_1
+  tags: [test_merged, test_merged_create]
+
+- name: "TEST 1a: Verify fabric was created using merged state"
+  assert:
+    that:
+      - merged_result_1 is changed
+      - merged_result_1 is not failed
+    fail_msg: "AI Routed fabric creation with state merged failed"
+    success_msg: "AI Routed fabric successfully created with state merged"
+  tags: [test_merged, test_merged_create]
+
+- name: "TEST 1b: Create fabric using state merged (second run - idempotency test)"
+  cisco.nd.nd_manage_fabric_ai_routed:
+    <<: *nd_info
+    state: merged
+    config:
+      - "{{ {'fabric_name': ai_routed_test_fabric_merged} | combine(fabric_config_ai_routed) }}"
+  register: merged_result_2
+  tags: [test_merged, test_merged_idempotent]
+
+- name: "TEST 1b: Verify merged state is idempotent"
+  assert:
+    that:
+      - merged_result_2 is not changed
+      - merged_result_2 is not failed
+    fail_msg: "Merged state is not idempotent - should not change when run twice with same config"
+    success_msg: "Merged state is idempotent - no changes on second run"
+  tags: [test_merged, test_merged_idempotent]
+
+- name: "TEST 1c: Update fabric using state merged (modify existing)"
+  cisco.nd.nd_manage_fabric_ai_routed:
+    <<: *nd_info
+    state: merged
+    config:
+      - fabric_name: "{{ ai_routed_test_fabric_merged }}"
+        management:
+          anycast_gateway_mac: "2020.0000.00bb"
+          performance_monitoring: true
+  register: merged_result_3
+  tags: [test_merged, test_merged_update]
+
+- name: "TEST 1c: Verify fabric was updated using merged state"
+  assert:
+    that:
+      - merged_result_3 is changed
+      - merged_result_3 is not failed
+    fail_msg: "AI Routed fabric update with state merged failed"
+    success_msg: "AI Routed fabric successfully updated with state merged"
+  tags: [test_merged, test_merged_update]
+
+#############################################################################
+# VALIDATION: Query merged fabric and validate fabric type + AI QoS enabled
+#############################################################################
+- name: "VALIDATION: Authenticate with ND to get token"
+  ansible.builtin.uri:
+    url: "https://{{ ansible_host }}:{{ ansible_httpapi_port | default(443) }}/login"
+    method: POST
+    headers:
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      domain: "{{ ansible_httpapi_login_domain | default('local') }}"
+      userName: "{{ ansible_user }}"
+      userPasswd: "{{ ansible_password }}"
+    validate_certs: false
+    return_content: true
+    status_code:
+      - 200
+  register: nd_auth_response
+  tags: [test_merged, test_merged_validation]
+  delegate_to: localhost
+
+- name: "VALIDATION: Query merged fabric configuration from ND"
+  ansible.builtin.uri:
+    url: "https://{{ ansible_host }}:{{ ansible_httpapi_port | default(443) }}/api/v1/manage/fabrics/{{ ai_routed_test_fabric_merged }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ nd_auth_response.json.jwttoken }}"
+      Content-Type: "application/json"
+    validate_certs: false
+    return_content: true
+    status_code:
+      - 200
+      - 404
+  register: merged_fabric_query
+  tags: [test_merged, test_merged_validation]
+  delegate_to: localhost
+
+- name: "VALIDATION: Parse fabric configuration response"
+  set_fact:
+    merged_fabric_config: "{{ merged_fabric_query.json }}"
+  tags: [test_merged, test_merged_validation]
+
+- name: "VALIDATION: Verify fabric type is aimlRouted and AI QoS is enabled"
+  assert:
+    that:
+      - merged_fabric_config.management.type == "aimlRouted"
+      - merged_fabric_config.management.aimlQos == true
+      - merged_fabric_config.management.anycastGatewayMac == "2020.0000.00bb"
+      - merged_fabric_config.management.performanceMonitoring == true
+    fail_msg: >-
+      AI Routed fabric validation failed.
+      type: {{ merged_fabric_config.management.type }} (expected aimlRouted),
+      aimlQos: {{ merged_fabric_config.management.aimlQos }} (expected true),
+      anycastGatewayMac: {{ merged_fabric_config.management.anycastGatewayMac }} (expected 2020.0000.00bb),
+      performanceMonitoring: {{ merged_fabric_config.management.performanceMonitoring }} (expected true)
+    success_msg: "AI Routed fabric type and AI QoS validated"
+  tags: [test_merged, test_merged_validation]
+
+#############################################################################
+# TEST 2: STATE REPLACED - Create and manage fabric using replaced state
+#############################################################################
+- name: "TEST 2a: Create AI Routed fabric using state replaced (first run)"
+  cisco.nd.nd_manage_fabric_ai_routed:
+    <<: *nd_info
+    state: replaced
+    config:
+      - "{{ {'fabric_name': ai_routed_test_fabric_replaced} | combine(fabric_config_ai_routed) }}"
+  register: replaced_result_1
+  tags: [test_replaced, test_replaced_create]
+
+- name: "TEST 2a: Verify fabric was created using replaced state"
+  assert:
+    that:
+      - replaced_result_1 is changed
+      - replaced_result_1 is not failed
+    fail_msg: "AI Routed fabric creation with state replaced failed"
+    success_msg: "AI Routed fabric successfully created with state replaced"
+  tags: [test_replaced, test_replaced_create]
+
+- name: "TEST 2b: Create fabric using state replaced (second run - idempotency test)"
+  cisco.nd.nd_manage_fabric_ai_routed:
+    <<: *nd_info
+    state: replaced
+    config:
+      - "{{ {'fabric_name': ai_routed_test_fabric_replaced} | combine(fabric_config_ai_routed) }}"
+  register: replaced_result_2
+  tags: [test_replaced, test_replaced_idempotent]
+
+- name: "TEST 2b: Verify replaced state is idempotent"
+  assert:
+    that:
+      - replaced_result_2 is not changed
+      - replaced_result_2 is not failed
+    fail_msg: "Replaced state is not idempotent - should not change when run twice with same config"
+    success_msg: "Replaced state is idempotent - no changes on second run"
+  tags: [test_replaced, test_replaced_idempotent]
+
+#############################################################################
+# TEST 3: STATE OVERRIDDEN - Enforce exact inventory (deletes unlisted fabrics)
+#############################################################################
+- name: "TEST 3a: Override inventory to a single fabric (deletes others)"
+  cisco.nd.nd_manage_fabric_ai_routed:
+    <<: *nd_info
+    state: overridden
+    config:
+      - "{{ {'fabric_name': ai_routed_test_fabric_merged} | combine(fabric_config_ai_routed) }}"
+  register: overridden_result_1
+  tags: [test_overridden]
+
+- name: "TEST 3a: Verify overridden state changed inventory"
+  assert:
+    that:
+      - overridden_result_1 is changed
+      - overridden_result_1 is not failed
+    fail_msg: "AI Routed fabric overridden state failed"
+    success_msg: "AI Routed fabric inventory enforced with overridden state"
+  tags: [test_overridden]
+
+#############################################################################
+# TEST 4: STATE DELETED - Delete fabrics
+#############################################################################
+- name: "TEST 4a: Delete the remaining fabric using state deleted"
+  cisco.nd.nd_manage_fabric_ai_routed:
+    <<: *nd_info
+    state: deleted
+    config:
+      - fabric_name: "{{ ai_routed_test_fabric_merged }}"
+  register: deleted_result_1
+  tags: [test_deleted]
+
+- name: "TEST 4a: Verify fabric was deleted"
+  assert:
+    that:
+      - deleted_result_1 is changed
+      - deleted_result_1 is not failed
+    fail_msg: "AI Routed fabric deletion with state deleted failed"
+    success_msg: "AI Routed fabric successfully deleted with state deleted"
+  tags: [test_deleted]
+
+- name: "TEST 4b: Delete the same fabric again (idempotency test)"
+  cisco.nd.nd_manage_fabric_ai_routed:
+    <<: *nd_info
+    state: deleted
+    config:
+      - fabric_name: "{{ ai_routed_test_fabric_merged }}"
+  register: deleted_result_2
+  tags: [test_deleted]
+
+- name: "TEST 4b: Verify delete is idempotent"
+  assert:
+    that:
+      - deleted_result_2 is not changed
+      - deleted_result_2 is not failed
+    fail_msg: "Deleted state is not idempotent - should not change when fabric already absent"
+    success_msg: "Deleted state is idempotent - no changes when fabric already absent"
+  tags: [test_deleted]

--- a/tests/integration/targets/nd_manage_fabric/tasks/fabric_routed.yaml
+++ b/tests/integration/targets/nd_manage_fabric/tasks/fabric_routed.yaml
@@ -1,0 +1,244 @@
+---
+# Test code for the ND modules
+# Copyright: (c) 2026, Cisco Systems
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have a Nexus Dashboard host, username and password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: ansible_host, ansible_user and ansible_password.'
+  when: ansible_host is not defined or ansible_user is not defined or ansible_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    nd_info: &nd_info
+      output_level: '{{ api_key_output_level | default("debug") }}'
+
+#############################################################################
+# CLEANUP - Ensure clean state before tests
+#############################################################################
+- name: Clean up any existing test fabrics before starting tests
+  cisco.nd.nd_manage_fabric_routed:
+    <<: *nd_info
+    state: deleted
+    config:
+      - fabric_name: "{{ routed_test_fabric_merged }}"
+      - fabric_name: "{{ routed_test_fabric_replaced }}"
+      - fabric_name: "{{ routed_test_fabric_deleted }}"
+  tags: always
+
+#############################################################################
+# TEST 1: STATE MERGED - Create fabric using merged state
+#############################################################################
+- name: "TEST 1a: Create Routed fabric using state merged (first run)"
+  cisco.nd.nd_manage_fabric_routed:
+    <<: *nd_info
+    state: merged
+    config:
+      - "{{ {'fabric_name': routed_test_fabric_merged} | combine(fabric_config_routed) }}"
+  register: merged_result_1
+  tags: [test_merged, test_merged_create]
+
+- name: "TEST 1a: Verify fabric was created using merged state"
+  assert:
+    that:
+      - merged_result_1 is changed
+      - merged_result_1 is not failed
+    fail_msg: "Routed fabric creation with state merged failed"
+    success_msg: "Routed fabric successfully created with state merged"
+  tags: [test_merged, test_merged_create]
+
+- name: "TEST 1b: Create fabric using state merged (second run - idempotency test)"
+  cisco.nd.nd_manage_fabric_routed:
+    <<: *nd_info
+    state: merged
+    config:
+      - "{{ {'fabric_name': routed_test_fabric_merged} | combine(fabric_config_routed) }}"
+  register: merged_result_2
+  tags: [test_merged, test_merged_idempotent]
+
+- name: "TEST 1b: Verify merged state is idempotent"
+  assert:
+    that:
+      - merged_result_2 is not changed
+      - merged_result_2 is not failed
+    fail_msg: "Merged state is not idempotent - should not change when run twice with same config"
+    success_msg: "Merged state is idempotent - no changes on second run"
+  tags: [test_merged, test_merged_idempotent]
+
+- name: "TEST 1c: Update fabric using state merged (modify existing)"
+  cisco.nd.nd_manage_fabric_routed:
+    <<: *nd_info
+    state: merged
+    config:
+      - fabric_name: "{{ routed_test_fabric_merged }}"
+        management:
+          anycast_gateway_mac: "2020.0000.00bb"
+          performance_monitoring: true
+  register: merged_result_3
+  tags: [test_merged, test_merged_update]
+
+- name: "TEST 1c: Verify fabric was updated using merged state"
+  assert:
+    that:
+      - merged_result_3 is changed
+      - merged_result_3 is not failed
+    fail_msg: "Routed fabric update with state merged failed"
+    success_msg: "Routed fabric successfully updated with state merged"
+  tags: [test_merged, test_merged_update]
+
+#############################################################################
+# VALIDATION: Query merged fabric and validate fabric type + changed fields
+#############################################################################
+- name: "VALIDATION: Authenticate with ND to get token"
+  ansible.builtin.uri:
+    url: "https://{{ ansible_host }}:{{ ansible_httpapi_port | default(443) }}/login"
+    method: POST
+    headers:
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      domain: "{{ ansible_httpapi_login_domain | default('local') }}"
+      userName: "{{ ansible_user }}"
+      userPasswd: "{{ ansible_password }}"
+    validate_certs: false
+    return_content: true
+    status_code:
+      - 200
+  register: nd_auth_response
+  tags: [test_merged, test_merged_validation]
+  delegate_to: localhost
+
+- name: "VALIDATION: Query merged fabric configuration from ND"
+  ansible.builtin.uri:
+    url: "https://{{ ansible_host }}:{{ ansible_httpapi_port | default(443) }}/api/v1/manage/fabrics/{{ routed_test_fabric_merged }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ nd_auth_response.json.jwttoken }}"
+      Content-Type: "application/json"
+    validate_certs: false
+    return_content: true
+    status_code:
+      - 200
+      - 404
+  register: merged_fabric_query
+  tags: [test_merged, test_merged_validation]
+  delegate_to: localhost
+
+- name: "VALIDATION: Parse fabric configuration response"
+  set_fact:
+    merged_fabric_config: "{{ merged_fabric_query.json }}"
+  tags: [test_merged, test_merged_validation]
+
+- name: "VALIDATION: Verify fabric type is routed and changed properties applied"
+  assert:
+    that:
+      - merged_fabric_config.management.type == "routed"
+      - merged_fabric_config.management.anycastGatewayMac == "2020.0000.00bb"
+      - merged_fabric_config.management.performanceMonitoring == true
+    fail_msg: >-
+      Routed fabric validation failed.
+      type: {{ merged_fabric_config.management.type }} (expected routed),
+      anycastGatewayMac: {{ merged_fabric_config.management.anycastGatewayMac }} (expected 2020.0000.00bb),
+      performanceMonitoring: {{ merged_fabric_config.management.performanceMonitoring }} (expected true)
+    success_msg: "Routed fabric type and changed properties validated"
+  tags: [test_merged, test_merged_validation]
+
+#############################################################################
+# TEST 2: STATE REPLACED - Create and manage fabric using replaced state
+#############################################################################
+- name: "TEST 2a: Create Routed fabric using state replaced (first run)"
+  cisco.nd.nd_manage_fabric_routed:
+    <<: *nd_info
+    state: replaced
+    config:
+      - "{{ {'fabric_name': routed_test_fabric_replaced} | combine(fabric_config_routed) }}"
+  register: replaced_result_1
+  tags: [test_replaced, test_replaced_create]
+
+- name: "TEST 2a: Verify fabric was created using replaced state"
+  assert:
+    that:
+      - replaced_result_1 is changed
+      - replaced_result_1 is not failed
+    fail_msg: "Routed fabric creation with state replaced failed"
+    success_msg: "Routed fabric successfully created with state replaced"
+  tags: [test_replaced, test_replaced_create]
+
+- name: "TEST 2b: Create fabric using state replaced (second run - idempotency test)"
+  cisco.nd.nd_manage_fabric_routed:
+    <<: *nd_info
+    state: replaced
+    config:
+      - "{{ {'fabric_name': routed_test_fabric_replaced} | combine(fabric_config_routed) }}"
+  register: replaced_result_2
+  tags: [test_replaced, test_replaced_idempotent]
+
+- name: "TEST 2b: Verify replaced state is idempotent"
+  assert:
+    that:
+      - replaced_result_2 is not changed
+      - replaced_result_2 is not failed
+    fail_msg: "Replaced state is not idempotent - should not change when run twice with same config"
+    success_msg: "Replaced state is idempotent - no changes on second run"
+  tags: [test_replaced, test_replaced_idempotent]
+
+#############################################################################
+# TEST 3: STATE OVERRIDDEN - Enforce exact inventory (deletes unlisted fabrics)
+#############################################################################
+- name: "TEST 3a: Override inventory to a single fabric (deletes others)"
+  cisco.nd.nd_manage_fabric_routed:
+    <<: *nd_info
+    state: overridden
+    config:
+      - "{{ {'fabric_name': routed_test_fabric_merged} | combine(fabric_config_routed) }}"
+  register: overridden_result_1
+  tags: [test_overridden]
+
+- name: "TEST 3a: Verify overridden state changed inventory"
+  assert:
+    that:
+      - overridden_result_1 is changed
+      - overridden_result_1 is not failed
+    fail_msg: "Routed fabric overridden state failed"
+    success_msg: "Routed fabric inventory enforced with overridden state"
+  tags: [test_overridden]
+
+#############################################################################
+# TEST 4: STATE DELETED - Delete fabrics
+#############################################################################
+- name: "TEST 4a: Delete the remaining fabric using state deleted"
+  cisco.nd.nd_manage_fabric_routed:
+    <<: *nd_info
+    state: deleted
+    config:
+      - fabric_name: "{{ routed_test_fabric_merged }}"
+  register: deleted_result_1
+  tags: [test_deleted]
+
+- name: "TEST 4a: Verify fabric was deleted"
+  assert:
+    that:
+      - deleted_result_1 is changed
+      - deleted_result_1 is not failed
+    fail_msg: "Routed fabric deletion with state deleted failed"
+    success_msg: "Routed fabric successfully deleted with state deleted"
+  tags: [test_deleted]
+
+- name: "TEST 4b: Delete the same fabric again (idempotency test)"
+  cisco.nd.nd_manage_fabric_routed:
+    <<: *nd_info
+    state: deleted
+    config:
+      - fabric_name: "{{ routed_test_fabric_merged }}"
+  register: deleted_result_2
+  tags: [test_deleted]
+
+- name: "TEST 4b: Verify delete is idempotent"
+  assert:
+    that:
+      - deleted_result_2 is not changed
+      - deleted_result_2 is not failed
+    fail_msg: "Deleted state is not idempotent - should not change when fabric already absent"
+    success_msg: "Deleted state is idempotent - no changes when fabric already absent"
+  tags: [test_deleted]

--- a/tests/integration/targets/nd_manage_fabric/tasks/main.yaml
+++ b/tests/integration/targets/nd_manage_fabric/tasks/main.yaml
@@ -13,3 +13,9 @@
 
 - name: Run nd_manage_fabric AI eBGP VXLAN tests
   ansible.builtin.include_tasks: fabric_ai_ebgp.yaml
+
+- name: Run nd_manage_fabric Routed tests
+  ansible.builtin.include_tasks: fabric_routed.yaml
+
+- name: Run nd_manage_fabric AI Routed tests
+  ansible.builtin.include_tasks: fabric_ai_routed.yaml

--- a/tests/integration/targets/nd_manage_fabric/vars/main.yaml
+++ b/tests/integration/targets/nd_manage_fabric/vars/main.yaml
@@ -25,6 +25,16 @@ ai_ebgp_test_fabric_replaced: "ai_ebgp_test_fabric_replaced"
 ai_ebgp_test_fabric_deleted: "ai_ebgp_test_fabric_deleted"
 ai_ebgp_test_fabric_config_actions: "ai_ebgp_test_fabric_config_actions"
 
+routed_test_fabric_merged: "routed_test_fabric_merged"
+routed_test_fabric_replaced: "routed_test_fabric_replaced"
+routed_test_fabric_deleted: "routed_test_fabric_deleted"
+routed_test_fabric_config_actions: "routed_test_fabric_config_actions"
+
+ai_routed_test_fabric_merged: "ai_routed_test_fabric_merged"
+ai_routed_test_fabric_replaced: "ai_routed_test_fabric_replaced"
+ai_routed_test_fabric_deleted: "ai_routed_test_fabric_deleted"
+ai_routed_test_fabric_config_actions: "ai_routed_test_fabric_config_actions"
+
 # Common fabric configuration for all tests
 # common_fabric_config:
 fabric_config_ibgp:
@@ -522,6 +532,11 @@ fabric_config_ai_ibgp:
     dhcp_end_address: ""
     management_gateway: ""
     management_ipv4_prefix: 24
+
+# Routed fabrics share management properties with eBGP VXLAN fabrics; the module
+# injects the fabric type, so the eBGP configs are reused for the routed tests.
+fabric_config_routed: "{{ fabric_config_ebgp }}"
+fabric_config_ai_routed: "{{ fabric_config_ai_ebgp }}"
 
 # Common AI eBGP VXLAN fabric configuration for all AI eBGP tests
 # Uses aimlVxlanEbgp type which shares management properties with vxlanEbgp

--- a/tests/unit/module_utils/models/test_manage_fabric_routed.py
+++ b/tests/unit/module_utils/models/test_manage_fabric_routed.py
@@ -1,0 +1,107 @@
+# Copyright: (c) 2026, Matt Tarkington (@mtarking)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for Routed and AI/ML Routed fabric models."""
+
+from __future__ import absolute_import, annotations, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from pydantic import ValidationError
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.enums import FabricTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_routed import (
+    FabricRoutedModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.manage_fabric.manage_fabric_ai_routed import (
+    FabricAiRoutedModel,
+)
+
+
+def test_manage_fabric_routed_00010() -> None:
+    """
+    # Summary
+
+    Verify the Routed fabric model applies the routed type discriminator and
+    propagates the fabric name and site_id defaults.
+    """
+    model = FabricRoutedModel(
+        fabric_name="routed_fabric",
+        management={"type": "routed", "bgp_asn": "65001"},
+    )
+
+    assert model._fabric_type == FabricTypeEnum.ROUTED
+    assert model.management is not None
+    assert model.management.type == FabricTypeEnum.ROUTED
+    assert model.management.name == "routed_fabric"
+    assert model.management.site_id == "65001"
+    assert model.telemetry_collection is False
+
+
+def test_manage_fabric_routed_00020() -> None:
+    """
+    # Summary
+
+    Verify the AI Routed fabric model inherits the routed base behavior and
+    forces aiml_qos to True.
+    """
+    model = FabricAiRoutedModel(
+        fabric_name="ai_routed_fabric",
+        management={"type": "aimlRouted", "bgp_asn": "65002"},
+    )
+
+    assert model._fabric_type == FabricTypeEnum.AIML_ROUTED
+    assert model.management is not None
+    assert model.management.type == "aimlRouted"
+    assert model.management.name == "ai_routed_fabric"
+    assert model.management.site_id == "65002"
+    assert model.management.aiml_qos is True
+    assert model.telemetry_collection is False
+
+
+def test_manage_fabric_routed_00030() -> None:
+    """
+    # Summary
+
+    Verify aiml_qos is not exposed in the AI Routed model argument spec.
+    """
+    spec = FabricAiRoutedModel.get_argument_spec()
+
+    def contains_option(node: dict, key: str) -> bool:
+        if not isinstance(node, dict):
+            return False
+        options = node.get("options")
+        if isinstance(options, dict):
+            if key in options:
+                return True
+            for child in options.values():
+                if isinstance(child, dict) and contains_option(child, key):
+                    return True
+        elements = node.get("elements")
+        if isinstance(elements, dict) and contains_option(elements, key):
+            return True
+        return False
+
+    assert contains_option(spec, "aiml_qos") is False
+
+
+def test_manage_fabric_routed_00040() -> None:
+    """
+    # Summary
+
+    Verify aiml_qos is locked to True on the AI Routed model and cannot be
+    overridden to a non-True value, including via a wire payload.
+    """
+    with pytest.raises(ValidationError):
+        FabricAiRoutedModel(
+            fabric_name="ai_routed_fabric",
+            management={"type": "aimlRouted", "bgp_asn": "65002", "aiml_qos": False},
+        )
+
+    with pytest.raises(ValidationError):
+        FabricAiRoutedModel(
+            fabric_name="ai_routed_fabric",
+            management={"type": "aimlRouted", "bgp_asn": "65002", "aimlQos": False},
+        )


### PR DESCRIPTION
## Related Issue(s)

Closes #314

## Proposed Changes

Adds two new ND fabric modules for **Routed** fabrics, built on the pydantic model +
state-machine architecture:

- **`nd_manage_fabric_routed`** — standalone Routed fabric management (fabric type `routed`)
- **`nd_manage_fabric_ai_routed`** — AI/ML Routed fabric management (fabric type `aimlRouted`),
  subclassed from the routed base with AI QoS always enabled (frozen `aiml_qos`)

Per the OpenAPI spec (`docs/openapi/4.2.1/manage.json`), `routed`/`aimlRouted` share
byte-for-byte identical property schemas with `vxlanEbgp`/`aimlVxlanEbgp` — only the
`type` discriminator differs — so the routed models mirror the eBGP VXLAN implementation.

New/changed files:
- `plugins/module_utils/models/manage_fabric/manage_fabric_routed.py` — `RoutedManagementModel`, `FabricRoutedModel`
- `plugins/module_utils/models/manage_fabric/manage_fabric_ai_routed.py` — `AimlRoutedManagementModel`, `FabricAiRoutedModel`
- `plugins/module_utils/orchestrators/manage_fabric_routed.py` — `ManageRoutedFabricOrchestrator`
- `plugins/module_utils/orchestrators/manage_fabric_ai_routed.py` — `ManageAiRoutedFabricOrchestrator`
- `plugins/modules/nd_manage_fabric_routed.py`, `plugins/modules/nd_manage_fabric_ai_routed.py`
- `plugins/module_utils/models/manage_fabric/enums.py` — added `FabricTypeEnum.ROUTED` / `AIML_ROUTED`
- `plugins/module_utils/models/manage_fabric/constants.py` — wired `ROUTED` into pool/pattern/string maps
- `tests/unit/module_utils/models/test_manage_fabric_routed.py`
- `tests/integration/targets/nd_manage_fabric/tasks/fabric_routed.yaml`, `fabric_ai_routed.yaml` (+ `main.yaml`/`vars/main.yaml` wiring)
- `changelogs/fragments/add_nd_manage_fabric_routed.yml`

## Test Notes

- Unit tests: `python -m pytest tests/unit/module_utils/models/test_manage_fabric_routed.py`
  → 4 passed. Covers routed model type/identity, AI routed `aiml_qos=True`, `aiml_qos`
  exclusion from argspec, and the locked/frozen `aiml_qos` field rejecting `False`.
- Integration tests added under `tests/integration/targets/nd_manage_fabric/` covering
  `merged` (create/idempotent/update), `replaced` (create/idempotent), `overridden`, and
  `deleted` (delete/idempotent), plus live API validation of `management.type`
  (`routed` / `aimlRouted`) and `aimlQos == true` for the AI variant.
- YAML validated for all new/modified integration files.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infa
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers