### PR TITLE
nd_interface_*: finalize controller-accepted mutations on the failure path

### DIFF
--- a/changelogs/fragments/interface_finalize_accepted_intent.yml
+++ b/changelogs/fragments/interface_finalize_accepted_intent.yml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - >-
+    nd_interface_* - when a task with ``config_actions.deploy`` set to ``true`` fails after the controller has already
+    accepted some of the requested interface changes, deploy that accepted subset and name it in the failure message instead
+    of leaving it staged but undeployed. A retry previously classified those interfaces as unchanged and never deployed them,
+    so controller intent and switch running state stayed divergent even after a successful retry. The failure-path finalizer
+    introduced for ``nd_interface_loopback`` is now shared (``finalize_accepted_intent`` in ``base_interface.py``) and
+    adopted by all ten ``nd_interface_*`` modules.

--- a/changelogs/fragments/interface_finalize_accepted_intent.yml
+++ b/changelogs/fragments/interface_finalize_accepted_intent.yml
@@ -1,9 +1,0 @@
----
-bugfixes:
-  - >-
-    nd_interface_* - when a task with ``config_actions.deploy`` set to ``true`` fails after the controller has already
-    accepted some of the requested interface changes, deploy that accepted subset and name it in the failure message instead
-    of leaving it staged but undeployed. A retry previously classified those interfaces as unchanged and never deployed them,
-    so controller intent and switch running state stayed divergent even after a successful retry. The failure-path finalizer
-    introduced for ``nd_interface_loopback`` is now shared (``finalize_accepted_intent`` in ``base_interface.py``) and
-    adopted by all ten ``nd_interface_*`` modules.

--- a/plugins/module_utils/orchestrators/base_interface.py
+++ b/plugins/module_utils/orchestrators/base_interface.py
@@ -71,7 +71,8 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         Initialize mutable private state after Pydantic model construction. Pydantic disallows `Field()` on
         underscore-prefixed names, so these are set here to ensure each instance gets its own container: the
-        deploy/remove queues and the per-switch interface cache read by `_switch_interfaces`.
+        deploy/remove queues, the `_deploy_attempted` stage flag read by `deploy_accepted_mutations`, and the per-switch interface
+        cache read by `_switch_interfaces`.
 
         ## Raises
 
@@ -79,6 +80,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         """
         self._pending_deploys: list[tuple[str, str]] = []
         self._pending_removes: list[tuple[str, str]] = []
+        self._deploy_attempted: bool = False
         self._switch_interfaces_cache: dict[str, dict[str, dict]] = {}
 
     def apply_config_actions(self, params: Mapping[str, Any]) -> bool:
@@ -409,14 +411,18 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         When `deploy` is `False`, returns `None` without making any API call.
 
+        Sets `_deploy_attempted` before sending so that, if this request fails, the failure-path finalizer
+        (`deploy_accepted_mutations`) does not resubmit the identical deployment (PR #547 review).
+
         ## Raises
 
         ### RuntimeError
 
-        - If the deploy API request fails.
+        - If the deploy API request fails. The queue is retained.
         """
         if not self.deploy or not self._pending_deploys:
             return None
+        self._deploy_attempted = True
         try:
             result = self._deploy_interfaces(self._pending_deploys)
             self._pending_deploys = []
@@ -442,8 +448,9 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         exactly one that was not accepted.
 
         Returns the deployed `(interface_name, switch_id)` pairs so the caller can name them in the failure report. Returns an
-        empty list without any API call when `deploy` is `False` (staged intent is the documented contract in that case) or when
-        no accepted-mutation pairs are queued.
+        empty list without any API call when `deploy` is `False` (staged intent is the documented contract in that case), when
+        the normal `deploy_pending` request was already attempted (a failed normal deploy is reported by its own error and must not
+        be resubmitted — PR #547 review), or when no accepted-mutation pairs are queued.
 
         ## Raises
 
@@ -451,7 +458,7 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         - If the failure-path deploy API request fails. The accepted pairs remain queued in that case.
         """
-        if not self.deploy:
+        if not self.deploy or self._deploy_attempted:
             return []
         unsent = self._unsent_delete_pairs()
         accepted = [pair for pair in self._pending_deploys if pair not in unsent]
@@ -528,6 +535,38 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
         payload = {"interfaces": [{"interfaceName": name, "switchId": switch_id} for name, switch_id in pairs]}
         return self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
 
+    def _accepted_multistatus_pairs(self) -> set[tuple[str, str]]:
+        """
+        # Summary
+
+        Return the `(interface_name, switch_id)` pair (name lower-cased) of every `DATA.results[]` item in the most recent response
+        whose `status` is exactly `success` (case/whitespace-tolerant). The pair-keyed counterpart of `_accepted_multistatus_names`
+        for the bulk endpoints whose 207 items carry `interfaceName` and `switchId` (`interfaceActions/remove`), so the same name on
+        two switches is told apart. Only an exact `success` is trusted (vault: `multi-status-207-status-field-inconsistent`; issue
+        #397). Returns an empty set when the last response was not a 207 or carries no `results[]` envelope.
+
+        ## Raises
+
+        None
+        """
+        if self.rest_send.return_code != 207:
+            return set()
+        data = self.rest_send.response_current.get("DATA")
+        results = data.get("results") if isinstance(data, dict) else None
+        if not isinstance(results, list):
+            return set()
+        accepted: set[tuple[str, str]] = set()
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("status") or "").strip().lower() != "success":
+                continue
+            name = item.get("interfaceName")
+            switch_id = item.get("switchId")
+            if isinstance(name, str) and name.strip() and isinstance(switch_id, str) and switch_id.strip():
+                accepted.add((name.strip().lower(), switch_id.strip()))
+        return accepted
+
     def remove_pending(self) -> ResponseType | None:
         """
         # Summary
@@ -536,20 +575,39 @@ class NDBaseInterfaceOrchestrator(NDBaseOrchestrator[ModelType]):
 
         Returns `None` without making any API call if the queue is empty.
 
+        The endpoint answers HTTP 207 with an independent `results[]` status per interface, so one removal can succeed while another
+        is rejected. On a failed request, the pairs the response reports as an exact `success` (`_accepted_multistatus_pairs`) are
+        dequeued — their removal IS on the controller, and the module's failure-path finalizer (`deploy_accepted_mutations`) must
+        ship it rather than strand it staged, where a retry would no longer find the interface and never deploy it (PR #547 review).
+        Rejected, status-less, and unknown-status pairs stay queued as unsent. The response is consulted only when the request
+        recorded a new one: a sender exception leaves the previous response in place (issue #554), which must not be mistaken for
+        this request's result.
+
         ## Raises
 
         ### RuntimeError
 
-        - If the remove API request fails.
+        - If the remove API request fails. The message names the pairs the controller rejected and, for a mixed 207, the pairs it
+          accepted from the same request (whose deploy stays queued).
         """
         if not self._pending_removes:
             return None
+        submitted = list(self._pending_removes)
+        recorded = len(self.rest_send.responses)
         try:
             result = self._remove_interfaces()
             self._pending_removes = []
             return result
         except Exception as e:
-            raise RuntimeError(f"Bulk remove failed for interfaces {self._pending_removes}: {e}") from e
+            accepted: list[tuple[str, str]] = []
+            if len(self.rest_send.responses) > recorded:
+                accepted_pairs = self._accepted_multistatus_pairs()
+                accepted = [pair for pair in submitted if (pair[0].lower(), pair[1]) in accepted_pairs]
+                self._pending_removes = [pair for pair in self._pending_removes if pair not in accepted]
+            msg = f"Bulk remove failed for interfaces {self._pending_removes}: {e}"
+            if accepted:
+                msg += f" The controller accepted the removal of {accepted} from the same request; their deploy stays queued."
+            raise RuntimeError(msg) from e
 
     def _remove_interfaces(self) -> ResponseType:
         """

--- a/plugins/modules/nd_interface_ethernet_access.py
+++ b/plugins/modules/nd_interface_ethernet_access.py
@@ -268,6 +268,9 @@ options:
         - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes, that
+          accepted subset is still deployed and is named in the failure message, so a failed task does not leave accepted
+          changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -422,7 +425,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import EthernetAccessInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import EthernetAccessInterfaceOrchestrator
 
 
@@ -622,6 +625,7 @@ def main() -> None:
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -630,6 +634,7 @@ def main() -> None:
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_ethernet_trunk_host.py
+++ b/plugins/modules/nd_interface_ethernet_trunk_host.py
@@ -285,6 +285,9 @@ options:
         - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes, that
+          accepted subset is still deployed and is named in the failure message, so a failed task does not leave accepted
+          changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -564,7 +567,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import EthernetTrunkHostInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import EthernetTrunkHostInterfaceOrchestrator
 
 
@@ -764,6 +767,7 @@ def main() -> None:
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -772,6 +776,7 @@ def main() -> None:
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_loopback.py
+++ b/plugins/modules/nd_interface_loopback.py
@@ -700,41 +700,8 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.loopback_interface import LoopbackInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.loopback_interface import LoopbackInterfaceOrchestrator
-
-
-def _finalize_accepted_intent(nd_state_machine: NDStateMachine | None, module: AnsibleModule, module_log: logging.Logger) -> str:
-    """
-    # Summary
-
-    Failure-path finalizer (PR #403 review): when the module fails after some mutations succeeded, deploy the already-accepted
-    subset via `deploy_accepted_mutations` so it does not remain staged-but-undeployed. Without this, a retry classifies the
-    accepted interfaces as unchanged and never deploys them, so controller intent and switch running state stay divergent even
-    after a successful retry.
-
-    Returns a sentence to append to the failure message naming what was finalized (or reporting that finalization itself
-    failed). Returns an empty string when there is nothing to do: check mode (no mutations were sent), `deploy: false`
-    (staged intent is the documented contract), no accepted mutations queued, or the failure preceded orchestrator creation.
-
-    ## Raises
-
-    None (a finalization failure is folded into the returned message so it cannot mask the original error).
-    """
-    if nd_state_machine is None or module.check_mode:
-        return ""
-    orchestrator = nd_state_machine.model_orchestrator
-    if not isinstance(orchestrator, NDBaseInterfaceOrchestrator):
-        return ""
-    try:
-        deployed = orchestrator.deploy_accepted_mutations()
-    except Exception as deploy_error:  # pylint: disable=broad-except
-        module_log.exception("Failure-path deploy of accepted mutations failed")
-        return f" NOTE: the controller accepted some interface changes before the failure and deploying them also failed; they remain staged: {deploy_error}"
-    if not deployed:
-        return ""
-    names = ", ".join(sorted(f"{name} (switchId {switch_id})" for name, switch_id in deployed))
-    return f" NOTE: before the failure, the controller had already accepted changes for interface(s) [{names}]; those changes were deployed."
 
 
 def main():
@@ -795,7 +762,7 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
-        error_msg += _finalize_accepted_intent(nd_state_machine, module, module_log)
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -804,7 +771,7 @@ def main():
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
-        error_msg += _finalize_accepted_intent(nd_state_machine, module, module_log)
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -224,6 +224,9 @@ options:
         - When V(true), all queued port-channel changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the port-channels modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes, that
+          accepted subset is still deployed and is named in the failure message, so a failed task does not leave accepted
+          changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -465,7 +468,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_ch
 )
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_access_interface import (
     PortChannelAccessInterfaceOrchestrator,
 )
@@ -524,6 +527,7 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -532,6 +536,7 @@ def main():
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_port_channel_trunk_host.py
+++ b/plugins/modules/nd_interface_port_channel_trunk_host.py
@@ -294,6 +294,9 @@ options:
         - When V(true), all queued port-channel changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the port-channels modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes, that
+          accepted subset is still deployed and is named in the failure message, so a failed task does not leave accepted
+          changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -550,7 +553,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_ch
 )
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_trunk_host_interface import (
     PortChannelTrunkHostInterfaceOrchestrator,
 )
@@ -609,6 +612,7 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -617,6 +621,7 @@ def main():
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -153,6 +153,9 @@ options:
         - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the subinterfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes, that
+          accepted subset is still deployed and is named in the failure message, so a failed task does not leave accepted
+          changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -402,7 +405,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_managed_interface import SubinterfaceManagedInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_managed_interface import SubinterfaceManagedInterfaceOrchestrator
 
 
@@ -464,6 +467,7 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -476,6 +476,7 @@ def main():
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_subinterface_unmanaged.py
+++ b/plugins/modules/nd_interface_subinterface_unmanaged.py
@@ -307,6 +307,7 @@ def main():
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_subinterface_unmanaged.py
+++ b/plugins/modules/nd_interface_subinterface_unmanaged.py
@@ -61,6 +61,9 @@ options:
         - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the subinterfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes, that
+          accepted subset is still deployed and is named in the failure message, so a failed task does not leave accepted
+          changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -233,7 +236,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.subinterface_unmanaged_interface import SubinterfaceUnmanagedInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.subinterface_unmanaged_interface import SubinterfaceUnmanagedInterfaceOrchestrator
 
 
@@ -295,6 +298,7 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -223,6 +223,9 @@ options:
         - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes, that
+          accepted subset is still deployed and is named in the failure message, so a failed task does not leave accepted
+          changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -535,7 +538,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat im
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.svi_interface import SviInterfaceModel
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.svi_interface import SviInterfaceOrchestrator
 
 
@@ -602,6 +605,7 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -614,6 +614,7 @@ def main():
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_vpc_access.py
+++ b/plugins/modules/nd_interface_vpc_access.py
@@ -281,6 +281,9 @@ options:
         - When V(true), all queued vPC interface changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the vPC interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes, that
+          accepted subset is still deployed and is named in the failure message, so a failed task does not leave accepted
+          changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -543,7 +546,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_acc
 )
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_access_interface import (
     AccessVpcHostInterfaceOrchestrator,
 )
@@ -602,6 +605,7 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -610,6 +614,7 @@ def main():
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_vpc_trunk_host.py
+++ b/plugins/modules/nd_interface_vpc_trunk_host.py
@@ -324,6 +324,9 @@ options:
         - When V(true), all queued vPC interface changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the vPC interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes, that
+          accepted subset is still deployed and is named in the failure message, so a failed task does not leave accepted
+          changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -611,7 +614,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.vpc_tru
 )
 from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
 from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.vpc_trunk_host_interface import (
     TrunkVpcHostInterfaceOrchestrator,
 )
@@ -670,6 +673,7 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -678,6 +682,7 @@ def main():
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
@@ -286,5 +286,113 @@
         "DATA": {
             "error": "boom"
         }
+    },
+    "test_base_interface_00671a": {
+        "TEST_NOTES": [
+            "deploy_pending failure that precedes deploy_accepted_mutations: POST interfaceActions/deploy returns 500; the finalizer must NOT resubmit"
+        ],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/deploy",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {
+            "error": "boom"
+        }
+    },
+    "test_base_interface_00730a": {
+        "TEST_NOTES": [
+            "remove_pending mixed 207: loopback10 on switch A succeeds, loopback10 on switch B and loopback20 on switch A fail (vault: multi-status-207-status-field-inconsistent)"
+        ],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/remove",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {
+                    "switchId": "FDO12345ABC",
+                    "switchName": "SW-A",
+                    "interfaceName": "loopback10",
+                    "status": "success",
+                    "message": "Interface deleted successfully"
+                },
+                {
+                    "switchId": "FDO12345ABD",
+                    "switchName": "SW-B",
+                    "interfaceName": "loopback10",
+                    "status": "Failed",
+                    "message": "Invalid Interface"
+                },
+                {
+                    "switchId": "FDO12345ABC",
+                    "switchName": "SW-A",
+                    "interfaceName": "loopback20",
+                    "status": "failed",
+                    "message": "Interface delete failed due to configuration error"
+                }
+            ]
+        }
+    },
+    "test_base_interface_00740a": {
+        "TEST_NOTES": [
+            "remove_pending 207 with untrusted statuses: only an exact (case/whitespace-tolerant) 'success' is accepted; 'error', a missing status, a non-dict item, and a pair that was never submitted are all ignored"
+        ],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/remove",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {
+                    "switchId": "FDO12345ABC",
+                    "interfaceName": "Loopback10",
+                    "status": " Success ",
+                    "message": "Interface deleted successfully"
+                },
+                {
+                    "switchId": "FDO12345ABC",
+                    "interfaceName": "loopback20",
+                    "status": "error",
+                    "message": "Interface delete failed"
+                },
+                {
+                    "switchId": "FDO12345ABC",
+                    "interfaceName": "loopback30",
+                    "message": "no status key"
+                },
+                {
+                    "switchId": "FDO12345ABC",
+                    "interfaceName": "loopback99",
+                    "status": "success",
+                    "message": "never submitted"
+                },
+                "not-a-dict"
+            ]
+        }
+    },
+    "test_base_interface_00750a": {
+        "TEST_NOTES": [
+            "remove_pending happy 207 (every item exact success) consumed by the FIRST remove in the test; the SECOND remove then raises from the sender before any response is recorded, leaving this 207 stale in response_current (issue #554)"
+        ],
+        "RETURN_CODE": 207,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/remove",
+        "MESSAGE": "Multi-Status",
+        "DATA": {
+            "results": [
+                {
+                    "switchId": "FDO12345ABC",
+                    "interfaceName": "loopback10",
+                    "status": "success",
+                    "message": "Interface deleted successfully"
+                },
+                {
+                    "switchId": "FDO12345ABD",
+                    "interfaceName": "loopback10",
+                    "status": "success",
+                    "message": "Interface deleted successfully"
+                }
+            ]
+        }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_base_interface.json
@@ -262,5 +262,29 @@
                 }
             ]
         }
+    },
+    "test_base_interface_00684a": {
+        "TEST_NOTES": [
+            "finalize_accepted_intent success: POST interfaceActions/deploy succeeds for the queued mutation-backed pairs"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/deploy",
+        "MESSAGE": "OK",
+        "DATA": {
+            "status": "ok"
+        }
+    },
+    "test_base_interface_00685a": {
+        "TEST_NOTES": [
+            "finalize_accepted_intent failure: POST interfaceActions/deploy returns 500; the message must report staged intent and the queue must be retained"
+        ],
+        "RETURN_CODE": 500,
+        "METHOD": "POST",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/interfaceActions/deploy",
+        "MESSAGE": "Internal Server Error",
+        "DATA": {
+            "error": "boom"
+        }
     }
 }

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, annotations, division, print_function
 __metaclass__ = type  # pylint: disable=invalid-name
 
 import inspect
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -36,7 +37,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
 )
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.fabric_context import FabricContext
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
 from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import ResponseHandler
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 from ansible_collections.cisco.nd.tests.unit.module_utils.common_utils import does_not_raise
@@ -842,6 +843,209 @@ def test_base_interface_00670() -> None:
     with pytest.raises(RuntimeError, match=match):
         instance.deploy_accepted_mutations()
 
+    assert instance._pending_deploys == [("loopback10", "FDO12345ABC")]
+
+
+# =============================================================================
+# Test: finalize_accepted_intent (module-side failure-path helper)
+# =============================================================================
+
+
+def test_base_interface_00680() -> None:
+    """
+    # Summary
+
+    Verify `finalize_accepted_intent` returns an empty string when the failure preceded orchestrator creation (`orchestrator`
+    is `None`).
+
+    ## Test
+
+    - `orchestrator` is None
+    - The returned string is empty
+
+    ## Classes and Methods
+
+    - finalize_accepted_intent()
+    """
+    with does_not_raise():
+        result = finalize_accepted_intent(None, False, logging.getLogger("test"))
+
+    assert result == ""
+
+
+def test_base_interface_00681() -> None:
+    """
+    # Summary
+
+    Verify `finalize_accepted_intent` returns an empty string without any API call in check mode, even with `deploy` enabled
+    and mutation-backed pairs queued (no mutations were sent in check mode, so there is nothing accepted to finalize).
+
+    ## Test
+
+    - `deploy` is enabled and one pair is queued
+    - `check_mode` is True
+    - No API call is made (the response generator is never consulted)
+    - The returned string is empty and the queue is untouched
+
+    ## Classes and Methods
+
+    - finalize_accepted_intent()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance.deploy = True
+    instance._queue_deploy("loopback10", "FDO12345ABC")
+
+    with does_not_raise():
+        result = finalize_accepted_intent(instance, True, logging.getLogger("test"))
+
+    assert result == ""
+    assert instance._pending_deploys == [("loopback10", "FDO12345ABC")]
+    assert rest_send.committed_payload is None
+
+
+def test_base_interface_00682() -> None:
+    """
+    # Summary
+
+    Verify `finalize_accepted_intent` returns an empty string when the orchestrator is not an `NDBaseInterfaceOrchestrator`
+    (a non-interface orchestrator has no deploy queue to finalize).
+
+    ## Test
+
+    - `orchestrator` is a `SimpleNamespace` stand-in
+    - The returned string is empty
+
+    ## Classes and Methods
+
+    - finalize_accepted_intent()
+    """
+    with does_not_raise():
+        result = finalize_accepted_intent(SimpleNamespace(deploy=True), False, logging.getLogger("test"))  # type: ignore[arg-type]
+
+    assert result == ""
+
+
+def test_base_interface_00683() -> None:
+    """
+    # Summary
+
+    Verify `finalize_accepted_intent` returns an empty string without any API call when `deploy` is False, even with
+    mutation-backed pairs queued (staged intent is the documented contract for `deploy: false`).
+
+    ## Test
+
+    - `deploy` is False (the default) and one pair is queued
+    - No API call is made
+    - The returned string is empty and the queue is untouched
+
+    ## Classes and Methods
+
+    - finalize_accepted_intent()
+    - NDBaseInterfaceOrchestrator.deploy_accepted_mutations()
+    """
+
+    def responses():
+        yield {}
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance._queue_deploy("loopback10", "FDO12345ABC")
+
+    with does_not_raise():
+        result = finalize_accepted_intent(instance, False, logging.getLogger("test"))
+
+    assert result == ""
+    assert instance._pending_deploys == [("loopback10", "FDO12345ABC")]
+    assert rest_send.committed_payload is None
+
+
+def test_base_interface_00684() -> None:
+    """
+    # Summary
+
+    Verify `finalize_accepted_intent` deploys the accepted pairs and returns a NOTE sentence naming them in sorted order.
+
+    ## Test
+
+    - `deploy` is enabled and two mutation-backed pairs are queued (out of sorted order)
+    - POST is issued to `/api/v1/manage/fabrics/fabric_1/interfaceActions/deploy` with both pairs
+    - The returned sentence names both pairs, sorted, and says they were deployed
+    - `_pending_deploys` is empty afterwards
+
+    ## Classes and Methods
+
+    - finalize_accepted_intent()
+    - NDBaseInterfaceOrchestrator.deploy_accepted_mutations()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance.deploy = True
+    instance._queue_deploy("loopback20", "FDO12345ABD")
+    instance._queue_deploy("loopback10", "FDO12345ABC")
+
+    with does_not_raise():
+        result = finalize_accepted_intent(instance, False, logging.getLogger("test"))
+
+    assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/interfaceActions/deploy"
+    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert result == (
+        " NOTE: before the failure, the controller had already accepted changes for interface(s) "
+        "[loopback10 (switchId FDO12345ABC), loopback20 (switchId FDO12345ABD)]; those changes were deployed."
+    )
+    assert instance._pending_deploys == []
+
+
+def test_base_interface_00685(caplog: pytest.LogCaptureFixture) -> None:
+    """
+    # Summary
+
+    Verify `finalize_accepted_intent` folds a failure-path deploy error into the returned sentence (so it cannot mask the
+    original module error), logs it, and leaves the accepted pairs queued.
+
+    ## Test
+
+    - `deploy` is enabled and one mutation-backed pair is queued
+    - POST returns 500
+    - The returned sentence reports the changes remain staged and carries the `RuntimeError` text
+    - The failure is logged at ERROR level and `_pending_deploys` still contains the pair
+
+    ## Classes and Methods
+
+    - finalize_accepted_intent()
+    - NDBaseInterfaceOrchestrator.deploy_accepted_mutations()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance.deploy = True
+    instance._queue_deploy("loopback10", "FDO12345ABC")
+
+    log = logging.getLogger("test_base_interface_00685")
+    with caplog.at_level(logging.ERROR, logger=log.name):
+        with does_not_raise():
+            result = finalize_accepted_intent(instance, False, log)
+
+    assert result.startswith(" NOTE: the controller accepted some interface changes before the failure and deploying them also failed; they remain staged: ")
+    assert "Failure-path deploy failed for accepted interfaces [('loopback10', 'FDO12345ABC')]" in result
+    assert "Failure-path deploy of accepted mutations failed" in caplog.text
     assert instance._pending_deploys == [("loopback10", "FDO12345ABC")]
 
 

--- a/tests/unit/module_utils/orchestrators/test_base_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_base_interface.py
@@ -846,6 +846,48 @@ def test_base_interface_00670() -> None:
     assert instance._pending_deploys == [("loopback10", "FDO12345ABC")]
 
 
+def test_base_interface_00671() -> None:
+    """
+    # Summary
+
+    Verify `deploy_accepted_mutations` issues no API call and returns an empty list once `deploy_pending` has already attempted the
+    normal deployment and failed: the retained queue is the failed deployment itself, not accepted-but-undeployed intent, so the
+    failure-path finalizer must not resubmit it (PR #547 review).
+
+    ## Test
+
+    - `deploy` is enabled and one pair is queued
+    - `deploy_pending` POSTs to `interfaceActions/deploy`, receives 500, and raises `RuntimeError` with the queue retained
+    - `deploy_accepted_mutations` returns an empty list
+    - Exactly one response was recorded (no second deploy request); the queue is still retained
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.deploy_pending()
+    - NDBaseInterfaceOrchestrator.deploy_accepted_mutations()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance.deploy = True
+    instance._queue_deploy("loopback10", "FDO12345ABC")
+
+    with pytest.raises(RuntimeError, match=r"Bulk deploy failed"):
+        instance.deploy_pending()
+
+    with does_not_raise():
+        result = instance.deploy_accepted_mutations()
+
+    assert result == []
+    assert len(rest_send.responses) == 1
+    assert instance._pending_deploys == [("loopback10", "FDO12345ABC")]
+
+
 # =============================================================================
 # Test: finalize_accepted_intent (module-side failure-path helper)
 # =============================================================================
@@ -1160,6 +1202,137 @@ def test_base_interface_00720() -> None:
         instance.remove_pending()
 
     assert instance._pending_removes == [("loopback10", "FDO12345ABC")]
+
+
+def test_base_interface_00730() -> None:
+    """
+    # Summary
+
+    Verify `remove_pending` reconciles a mixed HTTP 207 from `interfaceActions/remove`: the pairs the controller reports as an exact
+    `success` are dequeued (their removal IS on the controller, so the failure-path finalizer must still deploy them) while the
+    rejected pairs stay queued, and the raised message names both sets. Matching is on the `(interfaceName, switchId)` pair, so
+    the same interface name on two switches is told apart (PR #547 review).
+
+    ## Test
+
+    - Three pairs are queued: loopback10 on switch A, loopback10 on switch B, loopback20 on switch A
+    - POST returns 207: loopback10/A `success`, loopback10/B `Failed`, loopback20/A `failed`
+    - `RuntimeError` matches `Bulk remove failed` and names the accepted pair
+    - `_pending_removes` retains only loopback10/B and loopback20/A, in queue order
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.remove_pending()
+    - NDBaseInterfaceOrchestrator._accepted_multistatus_pairs()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance._queue_remove("loopback10", "FDO12345ABC")
+    instance._queue_remove("loopback10", "FDO12345ABD")
+    instance._queue_remove("loopback20", "FDO12345ABC")
+
+    match = (
+        r"Bulk remove failed for interfaces \[\('loopback10', 'FDO12345ABD'\), \('loopback20', 'FDO12345ABC'\)\]"
+        r".*accepted the removal of \[\('loopback10', 'FDO12345ABC'\)\]"
+    )
+    with pytest.raises(RuntimeError, match=match):
+        instance.remove_pending()
+
+    assert instance._pending_removes == [("loopback10", "FDO12345ABD"), ("loopback20", "FDO12345ABC")]
+
+
+def test_base_interface_00740() -> None:
+    """
+    # Summary
+
+    Verify `remove_pending` trusts only an exact (case/whitespace-tolerant) `success` item status when reconciling a 207 and
+    ignores everything else: `error`, a missing `status` key, a non-dict item, and a `success` for a pair that was never submitted
+    (vault: `multi-status-207-status-field-inconsistent`).
+
+    ## Test
+
+    - Three pairs are queued: loopback10, loopback20, loopback30, all on switch A
+    - POST returns 207: `Loopback10` ` Success ` (case and whitespace differ), loopback20 `error`, loopback30 without a status key,
+      an unsubmitted loopback99 `success`, and a bare string item
+    - `RuntimeError` matches `Bulk remove failed`
+    - Only loopback10 is dequeued; loopback20 and loopback30 remain queued
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.remove_pending()
+    - NDBaseInterfaceOrchestrator._accepted_multistatus_pairs()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance._queue_remove("loopback10", "FDO12345ABC")
+    instance._queue_remove("loopback20", "FDO12345ABC")
+    instance._queue_remove("loopback30", "FDO12345ABC")
+
+    with pytest.raises(RuntimeError, match=r"Bulk remove failed"):
+        instance.remove_pending()
+
+    assert instance._pending_removes == [("loopback20", "FDO12345ABC"), ("loopback30", "FDO12345ABC")]
+
+
+def test_base_interface_00750() -> None:
+    """
+    # Summary
+
+    Verify `remove_pending` does not reconcile against a stale response: when the sender raises before any response is recorded,
+    `response_current` still holds the previous request's all-success 207, and none of its pairs may be dequeued from the new
+    request (issue #554 freshness requirement).
+
+    ## Test
+
+    - First call: loopback10 on switches A and B are queued; POST returns an all-success 207; the queue is cleared
+    - The same two pairs are re-queued and the sender is set to raise `ValueError` from `commit`
+    - Second call: `RuntimeError` matches `Bulk remove failed` and does not claim any accepted removal
+    - Both pairs remain queued; still exactly one response was recorded
+
+    ## Classes and Methods
+
+    - NDBaseInterfaceOrchestrator.remove_pending()
+    - NDBaseInterfaceOrchestrator._accepted_multistatus_pairs()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_base_interface(f"{method_name}a")
+
+    gen_responses = ResponseGenerator(responses())
+    rest_send = _build_rest_send(gen_responses)
+    instance = _StubInterfaceOrchestrator(rest_send=rest_send)
+    instance._queue_remove("loopback10", "FDO12345ABC")
+    instance._queue_remove("loopback10", "FDO12345ABD")
+
+    with does_not_raise():
+        instance.remove_pending()
+    assert instance._pending_removes == []
+    assert rest_send.return_code == 207
+
+    instance._queue_remove("loopback10", "FDO12345ABC")
+    instance._queue_remove("loopback10", "FDO12345ABD")
+    rest_send.sender.raise_method = "commit"
+    rest_send.sender.raise_exception = ValueError("simulated transport failure")
+
+    with pytest.raises(RuntimeError, match=r"Bulk remove failed") as exc_info:
+        instance.remove_pending()
+
+    assert "accepted the removal" not in str(exc_info.value)
+    assert instance._pending_removes == [("loopback10", "FDO12345ABC"), ("loopback10", "FDO12345ABD")]
+    assert len(rest_send.responses) == 1
 
 
 # =============================================================================

--- a/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
+++ b/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
@@ -1,0 +1,338 @@
+# Copyright: (c) 2026, Allen Robel (@allenrobel)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests verifying every `nd_interface_*` module finalizes controller-accepted mutations on its failure path.
+
+When a module fails after the controller has already accepted some interface mutations (for example a later grouped create is
+rejected), the accepted subset would otherwise remain staged-but-undeployed: a retry classifies those interfaces as unchanged and
+never re-queues their deploy. Each module's `except` handlers must therefore call `finalize_accepted_intent`, which deploys the
+accepted subset (honoring `config_actions.deploy` and check mode) and names it in the failure message. These tests drive each
+module's `main()` with stand-ins for `AnsibleModule` and `NDStateMachine` so the handlers themselves are exercised.
+"""
+
+# pylint: disable=invalid-name
+# pylint: disable=line-too-long
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-few-public-methods
+# pylint: disable=unused-argument
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesDelete,
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+
+# Modules carrying both the `NDStateMachineError` handler and the broad `Exception` fallback handler.
+TWO_HANDLER_MODULES = (
+    "nd_interface_ethernet_access",
+    "nd_interface_ethernet_trunk_host",
+    "nd_interface_loopback",
+    "nd_interface_port_channel_access",
+    "nd_interface_port_channel_trunk_host",
+    "nd_interface_vpc_access",
+    "nd_interface_vpc_trunk_host",
+)
+
+# Modules carrying only the `NDStateMachineError` handler (the missing broad handler is tracked by issue #379).
+ONE_HANDLER_MODULES = (
+    "nd_interface_subinterface_managed",
+    "nd_interface_subinterface_unmanaged",
+    "nd_interface_svi",
+)
+
+INTERFACE_MODULES = TWO_HANDLER_MODULES + ONE_HANDLER_MODULES
+
+ACCEPTED_PAIR = ("Ethernet1/1", "FDO12345ABC")
+ACCEPTED_NOTE = " NOTE: before the failure, the controller had already accepted changes for interface(s) [Ethernet1/1 (switchId FDO12345ABC)]; those changes were deployed."
+
+
+class _FailJson(Exception):
+    """
+    # Summary
+
+    Raised by the `AnsibleModule` stand-in's `fail_json` so the test can capture the failure keyword arguments.
+
+    ## Raises
+
+    None
+    """
+
+
+class _ExitJson(Exception):
+    """
+    # Summary
+
+    Raised by the `AnsibleModule` stand-in's `exit_json`; reaching it means the module did not fail as the test expected.
+
+    ## Raises
+
+    None
+    """
+
+
+class _FakeAnsibleModule:
+    """
+    # Summary
+
+    Minimal `AnsibleModule` stand-in for driving `main()`: carries `params` and `check_mode`, and turns `fail_json` / `exit_json`
+    into exceptions.
+
+    ## Raises
+
+    None
+    """
+
+    def __init__(self, *, deploy: bool, check_mode: bool, **kwargs: Any) -> None:
+        self.params: dict[str, Any] = {
+            "config": [],
+            "state": "merged",
+            "config_actions": {"deploy": deploy},
+            "output_level": "normal",
+        }
+        self.check_mode = check_mode
+
+    def fail_json(self, **kwargs: Any) -> None:
+        """
+        # Summary
+
+        Capture the failure keyword arguments.
+
+        ## Raises
+
+        ### _FailJson
+
+        - Always, carrying `kwargs`
+        """
+        raise _FailJson(kwargs)
+
+    def exit_json(self, **kwargs: Any) -> None:
+        """
+        # Summary
+
+        Signal an unexpected success exit.
+
+        ## Raises
+
+        ### _ExitJson
+
+        - Always
+        """
+        raise _ExitJson(kwargs)
+
+
+class _RecordingOrchestrator(NDBaseInterfaceOrchestrator):
+    """
+    # Summary
+
+    Concrete `NDBaseInterfaceOrchestrator` whose `_deploy_interfaces` records the deployed pairs instead of calling the controller.
+
+    ## Raises
+
+    None
+    """
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+
+    def model_post_init(self, __context) -> None:
+        super().model_post_init(__context)
+        self._deployed: list[list[tuple[str, str]]] = []  # pylint: disable=attribute-defined-outside-init
+
+    def _deploy_interfaces(self, pairs: list[tuple[str, str]]) -> dict[str, Any]:
+        """
+        # Summary
+
+        Record `pairs` instead of sending `interfaceActions/deploy`.
+
+        ## Raises
+
+        None
+        """
+        self._deployed.append(list(pairs))
+        return {"RETURN_CODE": 200, "MESSAGE": "OK", "DATA": {}}
+
+
+class _FakeStateMachine:
+    """
+    # Summary
+
+    `NDStateMachine` stand-in: builds a `_RecordingOrchestrator` with one controller-accepted pair queued for deploy, then raises
+    the configured exception from `manage_state` to simulate a later operation failing.
+
+    ## Raises
+
+    None
+    """
+
+    failure: Exception = NDStateMachineError("later operation failed")
+    last_instance: _FakeStateMachine | None = None
+
+    def __init__(self, module: Any, model_orchestrator: Any) -> None:
+        self.model_orchestrator = _RecordingOrchestrator(rest_send=RestSend({"check_mode": False, "fabric_name": "fabric_1"}))
+        self.model_orchestrator._queue_deploy(*ACCEPTED_PAIR)
+        self.output = SimpleNamespace(format=lambda: {})
+        type(self).last_instance = self
+
+    def manage_state(self) -> None:
+        """
+        # Summary
+
+        Raise the configured failure after the accepted pair has been queued.
+
+        ## Raises
+
+        ### Exception
+
+        - Always, the class-level `failure`
+        """
+        raise self.failure
+
+
+def _run_main(
+    monkeypatch: pytest.MonkeyPatch, module_name: str, *, failure: Exception, deploy: bool = True, check_mode: bool = False
+) -> tuple[dict[str, Any], _RecordingOrchestrator]:
+    """
+    # Summary
+
+    Drive `module_name.main()` with the stand-ins and return the captured `fail_json` kwargs plus the orchestrator the module used.
+
+    ## Raises
+
+    ### AssertionError
+
+    - If `main()` did not call `fail_json`
+    """
+    module = importlib.import_module(f"ansible_collections.cisco.nd.plugins.modules.{module_name}")
+
+    class _StateMachine(_FakeStateMachine):
+        pass
+
+    _StateMachine.failure = failure
+    monkeypatch.setattr(module, "AnsibleModule", lambda **kwargs: _FakeAnsibleModule(deploy=deploy, check_mode=check_mode, **kwargs))
+    monkeypatch.setattr(module, "NDStateMachine", _StateMachine)
+    monkeypatch.setattr(module, "require_pydantic", lambda module: None)
+    monkeypatch.setattr(module, "setup_logging", lambda module: None)
+
+    with pytest.raises(_FailJson) as exc_info:
+        module.main()
+    assert _StateMachine.last_instance is not None
+    return exc_info.value.args[0], _StateMachine.last_instance.model_orchestrator
+
+
+@pytest.mark.parametrize("module_name", INTERFACE_MODULES)
+def test_nd_interface_finalize_accepted_intent_00000(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
+    """
+    # Summary
+
+    Verify the `NDStateMachineError` handler of each interface module deploys the controller-accepted pair and names it in the
+    failure message.
+
+    ## Test
+
+    - `config_actions.deploy` is true and one accepted pair is queued when `manage_state` raises `NDStateMachineError`
+    - `fail_json` is called with the original error plus the accepted-interface NOTE
+    - The orchestrator deployed exactly the accepted pair, once
+
+    ## Classes and Methods
+
+    - nd_interface_*.main()
+    - finalize_accepted_intent()
+    """
+    kwargs, orchestrator = _run_main(monkeypatch, module_name, failure=NDStateMachineError("later operation failed"))
+
+    assert kwargs["msg"] == f"Module execution failed: later operation failed{ACCEPTED_NOTE}"
+    assert orchestrator._deployed == [[ACCEPTED_PAIR]]
+    assert orchestrator._pending_deploys == []
+
+
+@pytest.mark.parametrize("module_name", TWO_HANDLER_MODULES)
+def test_nd_interface_finalize_accepted_intent_00010(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
+    """
+    # Summary
+
+    Verify the broad `Exception` handler of each two-handler interface module also deploys the controller-accepted pair and
+    names it in the failure message.
+
+    ## Test
+
+    - `config_actions.deploy` is true and one accepted pair is queued when `manage_state` raises a plain `RuntimeError`
+    - `fail_json` is called with the original error plus the accepted-interface NOTE
+    - The orchestrator deployed exactly the accepted pair, once
+
+    ## Classes and Methods
+
+    - nd_interface_*.main()
+    - finalize_accepted_intent()
+    """
+    kwargs, orchestrator = _run_main(monkeypatch, module_name, failure=RuntimeError("unexpected"))
+
+    assert kwargs["msg"] == f"Module failed: unexpected{ACCEPTED_NOTE}"
+    assert orchestrator._deployed == [[ACCEPTED_PAIR]]
+
+
+@pytest.mark.parametrize("module_name", INTERFACE_MODULES)
+def test_nd_interface_finalize_accepted_intent_00020(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
+    """
+    # Summary
+
+    Verify the failure path honors `config_actions.deploy: false`: the accepted pair stays staged and the message carries no NOTE.
+
+    ## Test
+
+    - `config_actions.deploy` is false and one accepted pair is queued when `manage_state` raises `NDStateMachineError`
+    - `fail_json` is called with only the original error
+    - No deploy was issued and the pair remains queued
+
+    ## Classes and Methods
+
+    - nd_interface_*.main()
+    - finalize_accepted_intent()
+    """
+    kwargs, orchestrator = _run_main(monkeypatch, module_name, failure=NDStateMachineError("later operation failed"), deploy=False)
+
+    assert kwargs["msg"] == "Module execution failed: later operation failed"
+    assert orchestrator._deployed == []
+    assert orchestrator._pending_deploys == [ACCEPTED_PAIR]
+
+
+@pytest.mark.parametrize("module_name", INTERFACE_MODULES)
+def test_nd_interface_finalize_accepted_intent_00030(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
+    """
+    # Summary
+
+    Verify the failure path issues no deploy in check mode (no mutations were sent, so nothing was accepted).
+
+    ## Test
+
+    - Check mode is on, `config_actions.deploy` is true, and one pair is queued when `manage_state` raises `NDStateMachineError`
+    - `fail_json` is called with only the original error
+    - No deploy was issued
+
+    ## Classes and Methods
+
+    - nd_interface_*.main()
+    - finalize_accepted_intent()
+    """
+    kwargs, orchestrator = _run_main(monkeypatch, module_name, failure=NDStateMachineError("later operation failed"), check_mode=True)
+
+    assert kwargs["msg"] == "Module execution failed: later operation failed"
+    assert orchestrator._deployed == []

--- a/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
+++ b/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
@@ -59,7 +59,10 @@ ONE_HANDLER_MODULES = (
 INTERFACE_MODULES = TWO_HANDLER_MODULES + ONE_HANDLER_MODULES
 
 ACCEPTED_PAIR = ("Ethernet1/1", "FDO12345ABC")
-ACCEPTED_NOTE = " NOTE: before the failure, the controller had already accepted changes for interface(s) [Ethernet1/1 (switchId FDO12345ABC)]; those changes were deployed."
+ACCEPTED_NOTE = (
+    " NOTE: before the failure, the controller had already accepted changes for interface(s) "
+    "[Ethernet1/1 (switchId FDO12345ABC)]; those changes were deployed."
+)
 
 
 class _FailJson(Exception):

--- a/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
+++ b/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import importlib
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
@@ -161,17 +161,23 @@ class _RecordingOrchestrator(NDBaseInterfaceOrchestrator):
         super().model_post_init(__context)
         self._deployed: list[list[tuple[str, str]]] = []  # pylint: disable=attribute-defined-outside-init
 
+    deploy_failure: ClassVar[Exception | None] = None
+
     def _deploy_interfaces(self, pairs: list[tuple[str, str]]) -> dict[str, Any]:
         """
         # Summary
 
-        Record `pairs` instead of sending `interfaceActions/deploy`.
+        Record `pairs` instead of sending `interfaceActions/deploy`, then raise the class-level `deploy_failure` if one is set.
 
         ## Raises
 
-        None
+        ### Exception
+
+        - The class-level `deploy_failure`, when set (simulates a rejected deploy request)
         """
         self._deployed.append(list(pairs))
+        if self.deploy_failure is not None:
+            raise self.deploy_failure
         return {"RETURN_CODE": 200, "MESSAGE": "OK", "DATA": {}}
 
 
@@ -187,11 +193,15 @@ class _FakeStateMachine:
     None
     """
 
-    failure: Exception = NDStateMachineError("later operation failed")
+    failure: Exception | None = NDStateMachineError("later operation failed")
+    deploy_failure: Exception | None = None
     last_instance: _FakeStateMachine | None = None
 
     def __init__(self, module: Any, model_orchestrator: Any) -> None:
-        self.model_orchestrator = _RecordingOrchestrator(rest_send=RestSend({"check_mode": False, "fabric_name": "fabric_1"}))
+        class _Orchestrator(_RecordingOrchestrator):
+            deploy_failure = self.deploy_failure
+
+        self.model_orchestrator = _Orchestrator(rest_send=RestSend({"check_mode": False, "fabric_name": "fabric_1"}))
         self.model_orchestrator._queue_deploy(*ACCEPTED_PAIR)
         self.output = SimpleNamespace(format=lambda: {})
         type(self).last_instance = self
@@ -200,24 +210,32 @@ class _FakeStateMachine:
         """
         # Summary
 
-        Raise the configured failure after the accepted pair has been queued.
+        Raise the configured failure after the accepted pair has been queued; return normally when `failure` is `None`.
 
         ## Raises
 
         ### Exception
 
-        - Always, the class-level `failure`
+        - The class-level `failure`, when set
         """
-        raise self.failure
+        if self.failure is not None:
+            raise self.failure
 
 
-def _run_main(
-    monkeypatch: pytest.MonkeyPatch, module_name: str, *, failure: Exception, deploy: bool = True, check_mode: bool = False
+def _run_main(  # pylint: disable=too-many-arguments
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    *,
+    failure: Exception | None,
+    deploy: bool = True,
+    check_mode: bool = False,
+    deploy_failure: Exception | None = None,
 ) -> tuple[dict[str, Any], _RecordingOrchestrator]:
     """
     # Summary
 
     Drive `module_name.main()` with the stand-ins and return the captured `fail_json` kwargs plus the orchestrator the module used.
+    `failure` is raised from `manage_state` (`None` lets it succeed); `deploy_failure` is raised from the orchestrator's deploy request.
 
     ## Raises
 
@@ -231,6 +249,7 @@ def _run_main(
         pass
 
     _StateMachine.failure = failure
+    _StateMachine.deploy_failure = deploy_failure
     monkeypatch.setattr(module, "AnsibleModule", lambda **kwargs: _FakeAnsibleModule(deploy=deploy, check_mode=check_mode, **kwargs))
     monkeypatch.setattr(module, "NDStateMachine", _StateMachine)
     monkeypatch.setattr(module, "require_pydantic", lambda module: None)
@@ -340,3 +359,32 @@ def test_nd_interface_finalize_accepted_intent_00030(monkeypatch: pytest.MonkeyP
 
     assert kwargs["msg"] == "Module execution failed: later operation failed"
     assert orchestrator._deployed == []
+
+
+@pytest.mark.parametrize("module_name", TWO_HANDLER_MODULES)
+def test_nd_interface_finalize_accepted_intent_00040(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
+    """
+    # Summary
+
+    Verify that when the normal `deploy_pending` request itself fails, the broad handler's finalizer does not resubmit the same
+    deployment: exactly one deploy request is made, the message reports the deploy failure without an accepted-interface NOTE,
+    and the pair stays queued (PR #547 review).
+
+    ## Test
+
+    - `config_actions.deploy` is true, `manage_state` succeeds, and the deploy request raises `RuntimeError`
+    - `fail_json` is called with the wrapped `Bulk deploy failed` message only
+    - The orchestrator issued exactly one deploy request, for the queued pair
+
+    ## Classes and Methods
+
+    - nd_interface_*.main()
+    - finalize_accepted_intent()
+    - NDBaseInterfaceOrchestrator.deploy_pending()
+    - NDBaseInterfaceOrchestrator.deploy_accepted_mutations()
+    """
+    kwargs, orchestrator = _run_main(monkeypatch, module_name, failure=None, deploy_failure=RuntimeError("deploy rejected"))
+
+    assert kwargs["msg"] == f"Module failed: Bulk deploy failed for interfaces [{ACCEPTED_PAIR!r}]: deploy rejected"
+    assert orchestrator._deployed == [[ACCEPTED_PAIR]]
+    assert orchestrator._pending_deploys == [ACCEPTED_PAIR]

--- a/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
+++ b/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
@@ -38,26 +38,21 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
 from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
 
-# Modules carrying both the `NDStateMachineError` handler and the broad `Exception` fallback handler.
-TWO_HANDLER_MODULES = (
+# Every interface module carries both the `NDStateMachineError` handler and the broad `Exception` fallback handler (the svi and
+# subinterface modules gained the broad handler in PR #551, issue #379).
+INTERFACE_MODULES = (
     "nd_interface_ethernet_access",
     "nd_interface_ethernet_routed",
     "nd_interface_ethernet_trunk_host",
     "nd_interface_loopback",
     "nd_interface_port_channel_access",
     "nd_interface_port_channel_trunk_host",
-    "nd_interface_vpc_access",
-    "nd_interface_vpc_trunk_host",
-)
-
-# Modules carrying only the `NDStateMachineError` handler (the missing broad handler is tracked by issue #379).
-ONE_HANDLER_MODULES = (
     "nd_interface_subinterface_managed",
     "nd_interface_subinterface_unmanaged",
     "nd_interface_svi",
+    "nd_interface_vpc_access",
+    "nd_interface_vpc_trunk_host",
 )
-
-INTERFACE_MODULES = TWO_HANDLER_MODULES + ONE_HANDLER_MODULES
 
 ACCEPTED_PAIR = ("Ethernet1/1", "FDO12345ABC")
 ACCEPTED_NOTE = (
@@ -287,12 +282,12 @@ def test_nd_interface_finalize_accepted_intent_00000(monkeypatch: pytest.MonkeyP
     assert orchestrator._pending_deploys == []
 
 
-@pytest.mark.parametrize("module_name", TWO_HANDLER_MODULES)
+@pytest.mark.parametrize("module_name", INTERFACE_MODULES)
 def test_nd_interface_finalize_accepted_intent_00010(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
     """
     # Summary
 
-    Verify the broad `Exception` handler of each two-handler interface module also deploys the controller-accepted pair and
+    Verify the broad `Exception` handler of each interface module also deploys the controller-accepted pair and
     names it in the failure message.
 
     ## Test
@@ -361,7 +356,7 @@ def test_nd_interface_finalize_accepted_intent_00030(monkeypatch: pytest.MonkeyP
     assert orchestrator._deployed == []
 
 
-@pytest.mark.parametrize("module_name", TWO_HANDLER_MODULES)
+@pytest.mark.parametrize("module_name", INTERFACE_MODULES)
 def test_nd_interface_finalize_accepted_intent_00040(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
     """
     # Summary

--- a/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
+++ b/tests/unit/modules/test_nd_interface_finalize_accepted_intent.py
@@ -41,6 +41,7 @@ from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import Res
 # Modules carrying both the `NDStateMachineError` handler and the broad `Exception` fallback handler.
 TWO_HANDLER_MODULES = (
     "nd_interface_ethernet_access",
+    "nd_interface_ethernet_routed",
     "nd_interface_ethernet_trunk_host",
     "nd_interface_loopback",
     "nd_interface_port_channel_access",


### PR DESCRIPTION
## Related Issue(s)

Closes #546

## Proposed Changes

- Lift the `nd_interface_loopback`-private failure-path helper into `plugins/module_utils/orchestrators/base_interface.py` as `finalize_accepted_intent(orchestrator, check_mode, module_log)`. The signature is orchestrator-shaped so the orchestrator layer keeps no dependency on `NDStateMachine`.
- Call it from every `except` handler in all ten `nd_interface_*` modules and append its NOTE sentence to the failure message. Behavior is unchanged for loopback; the nine siblings gain the fix: when a task with `config_actions.deploy: true` fails after the controller has already accepted some mutations, the accepted subset is deployed and named instead of being left staged-but-undeployed (where a retry would classify it as unchanged and never deploy it).
- `nd_interface_svi` and the two `nd_interface_subinterface_*` modules carry only the `NDStateMachineError` handler, so they get the call there; their missing broad handler is #379 and should call the finalizer when it lands.
- Docs: carry the loopback `config_actions.deploy` sentence about the accepted subset over to the nine siblings.

Review round (mikewiebe, 2026-09-09), both fixed orchestrator-side in `base_interface.py` so the module wrappers are unchanged:

- **Mixed 207 on `interfaceActions/remove`** ("Reconcile mixed-207 removes and skip the finalizer after a failed normal deploy"): the remove queue was cleared only on whole-request success, so on a 207 with one `success` and one `Failed` item the accepted removal stayed queued, was classified as unsent by `_unsent_delete_pairs`, and was excluded from the failure-path deploy. `remove_pending` now snapshots the response count before the request; on failure it reads the response only if a new one was recorded (a sender exception leaves the previous response in place, #554), dequeues the pairs reported as an exact `success` matched on `(interfaceName, switchId)` (new `_accepted_multistatus_pairs`, the pair-keyed counterpart of `_accepted_multistatus_names`), leaves rejected / status-less / unknown pairs queued, and names the accepted pairs in the raised message.
- **Failed normal deploy resubmitted by the finalizer** (same commit): `deploy_pending` retains its queue on failure and runs inside the same `try` as the broad handler's finalizer, which then sent the identical deploy again. `deploy_pending` now sets a `_deploy_attempted` stage flag before sending and `deploy_accepted_mutations` returns early once the normal deploy has been attempted. This was already reachable on `develop` through loopback and routed; the fix covers all eleven modules.
- Dropped the changelog fragment: this repo's changelog is generated from squash-commit subjects by the release script (`changelog-generation.yml`), which never reads `changelogs/fragments/`.

This PR builds on the `NDBaseInterfaceOrchestrator.deploy_accepted_mutations` finalizer that landed with #403 (merged to `develop` 2026-09-02). It was originally stacked on that branch; it is now based directly on `develop`.

## Test Notes

- New `tests/unit/module_utils/orchestrators/test_base_interface.py` 00680–00685: `finalize_accepted_intent` with `None` orchestrator, check mode, non-interface orchestrator, `deploy: false`, success (sorted NOTE, queue drained), and failure-path deploy error (folded into the message, logged, queue retained).
- New `tests/unit/modules/test_nd_interface_finalize_accepted_intent.py`: parametrized over all eleven `nd_interface_*` modules (routed included, since it already carries the shared helper from #550), drives each `main()` with `AnsibleModule` / `NDStateMachine` stand-ins and asserts the `NDStateMachineError` handler (all eleven) and the broad handler (the eight that have one) deploy the accepted pair and name it, and that `deploy: false` and check mode issue no deploy.
- Review-round tests (`test_base_interface.py`): 00671 `deploy_pending` fails with 500, then `deploy_accepted_mutations` makes no request and retains the queue; 00730 mixed 207 with `loopback10` on two switches (only the `success` pair dequeued, both rejected pairs retained in order, message names both sets); 00740 untrusted item statuses (` Success ` accepted case/whitespace-tolerantly; `error`, missing `status`, a non-dict item, and an unsubmitted pair ignored); 00750 stale-response guard (an all-success 207 from a prior remove, then a sender exception on the next remove dequeues nothing). Removing the freshness guard makes 00750 fail, so it is load-bearing.
- Review-round module-boundary test 00040 across the eight two-handler modules: `manage_state` succeeds, the normal deploy raises, `fail_json` carries only the `Bulk deploy failed` message, and exactly one deploy request was made.
- Full unit suite: 4657 passed in the nd-dev machine.
- `ndtest --test validate-modules`, `ndtest --test pylint`, and `ndtest --test pep8` pass for all touched modules and the test files (`ndtest --test pylint` re-run on the three files touched by the review round).
- black / isort / pylint / mypy clean on the changed files (mypy's three pre-existing `ModelType` attribute errors in `base_interface.py` are unchanged).
- CI: the first `develop`-based run (after #403 merged) passed the full unit-test matrix, Black, lint, and build/import. The two Sanity jobs flagged one pep8 E501 (a 172-character string literal in the new test file) that the stacked configuration had hidden, since CI does not run on non-`develop`-based PRs. Fixed in the "Wrap ACCEPTED_NOTE literal to satisfy CI pep8 E501" commit; no behavior change. The run on the current head ("Drop the changelog fragment; this repo's changelog is generated from commit subjects") is fully green: all 56 checks pass, Integration Tests skipped as usual.
- Not lab-run: the loopback two-run convergence probe in the (now merged) #403 thread is the live evidence for the shared code path; the sibling adoption is a one-line call into the same base-class method. The mixed-207 remove reconciliation is unit-tested against the spec's `multiDeleteResponse` shape and the vault's observed `Failed` status; it has not been reproduced on the lab.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved (branch is directly on `develop` at #548's squash commit `67197ec9`)
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5ogXuT7RjKHTF8Ty5RXpL
https://claude.ai/code/session_01GtjGrZGWEtY2dfDPuVVfkb
