### PR TITLE
nd_interface_port_channel_*: member-already-in-use preflight

### DIFF
--- a/changelogs/fragments/port_channel_member_preflight.yml
+++ b/changelogs/fragments/port_channel_member_preflight.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - nd_interface_port_channel_access, nd_interface_port_channel_trunk_host - fail fast with a validation error naming the
+    member and its current owner when a port-channel lists a member ethernet already belonging to a different port-channel,
+    instead of surfacing the controller's opaque mid-run HTTP 500 (https://github.com/CiscoDevNet/ansible-nd/issues/369).

--- a/changelogs/fragments/port_channel_member_preflight.yml
+++ b/changelogs/fragments/port_channel_member_preflight.yml
@@ -1,5 +1,0 @@
----
-bugfixes:
-  - nd_interface_port_channel_access, nd_interface_port_channel_trunk_host - fail fast with a validation error naming the
-    member and its current owner when a port-channel lists a member ethernet already belonging to a different port-channel,
-    instead of surfacing the controller's opaque mid-run HTTP 500 (https://github.com/CiscoDevNet/ansible-nd/issues/369).

--- a/plugins/module_utils/orchestrators/port_channel_base.py
+++ b/plugins/module_utils/orchestrators/port_channel_base.py
@@ -19,6 +19,8 @@ Inherits shared interface lifecycle operations (deploy queuing, fabric validatio
 resolution) from `NDBaseInterfaceOrchestrator` and adds port-channel-specific functionality:
 - Standard remove-based deletion (port-channels are virtual interfaces and are deletable)
 - Fabric-wide `query_all()` filtered by `interfaceType: "portChannel"` and per-type policy filtering
+- A member-already-in-use `preflight()` that rejects, before any write, a port-channel whose member ethernet is
+  already owned by a different port-channel (issue #369)
 
 Member ethernet interfaces are not managed by this orchestrator — the port-channel policy is the
 single source of truth for member configuration via the `ports` list. Member field restrictions
@@ -28,6 +30,7 @@ on standalone ethernet modules are enforced separately by the ethernet orchestra
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
@@ -67,6 +70,7 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
 
     - Via `validate_prerequisites` if the fabric does not exist or is in deployment-freeze mode.
     - Via `_resolve_switch_id` if no switch matches the given IP in the fabric.
+    - Via `preflight` if a proposed member ethernet is already owned by a different port-channel.
     - Via `create` if the create API request fails.
     - Via `update` if the update API request fails.
     - Via `remove_pending` if the bulk remove API request fails.
@@ -223,6 +227,144 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
             self._queue_remove(model_instance.interface_name, switch_id)
             self._queue_deploy(model_instance.interface_name, switch_id)
 
+    def preflight(self, model_instances: Sequence[ModelType]) -> None:
+        """
+        # Summary
+
+        Run the inherited capability preflight, then reject any proposed port-channel whose member ethernet is already
+        owned by a different port-channel (issue #369). Invoked by `NDStateMachine.manage_state` for merged/replaced/
+        overridden before any mutation, including in `--check` mode.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Propagated from `NDBaseInterfaceOrchestrator.preflight` (capability preflight).
+        - Via `_validate_members_available` if any proposed member is owned by another port-channel.
+        """
+        super().preflight(model_instances)
+        self._validate_members_available(model_instances)
+
+    @staticmethod
+    def _policy_of(iface: dict) -> dict:
+        """
+        # Summary
+
+        Return the `configData.networkOS.policy` dict of an interface record, or `{}` when any level is missing.
+
+        ## Raises
+
+        None
+        """
+        return iface.get("configData", {}).get("networkOS", {}).get("policy", {}) or {}
+
+    def _member_owners(self, switch_id: str) -> dict[str, str]:
+        """
+        # Summary
+
+        Return `{member_name_lower: owning_port_channel_name}` for every member ethernet on `switch_id`, derived from the
+        `ports` list of every `portChannel` record in the switch's unfiltered inventory -- regardless of policy type, so a
+        member of an unmanaged port-channel flavor (e.g. `vpcPeerlinkPo`) is still seen as owned. A member whose own intent
+        `policyType` ends in `Member` but that no port-channel record lists is mapped to its policy type (e.g.
+        `accessPoMember`) so it is still treated as owned, with the owner reported as unknown.
+
+        Membership is read from ND intent, not `operData.portChannelId`: ND rejects a conflicting create against intent even
+        when the owning port-channel has never been deployed (`operData.portChannelId` is still `-1`).
+
+        ## Raises
+
+        ### RuntimeError
+
+        - Via `_switch_interfaces` if the interface-list API request fails with a non-404 status.
+        """
+        inventory = self._switch_interfaces(switch_id)
+        owners: dict[str, str] = {}
+        for iface in inventory.values():
+            if iface.get("interfaceType") != "portChannel":
+                continue
+            for member in self._policy_of(iface).get("ports") or []:
+                if isinstance(member, str) and member:
+                    owners[member.lower()] = iface.get("interfaceName", "")
+        for name, iface in inventory.items():
+            policy_type = self._policy_of(iface).get("policyType")
+            if name not in owners and isinstance(policy_type, str) and policy_type.endswith("Member"):
+                owners[name] = f"unknown port-channel (member policyType {policy_type})"
+        return owners
+
+    def _validate_members_available(self, model_instances: Sequence[ModelType]) -> None:
+        """
+        # Summary
+
+        Fail fast when a proposed port-channel claims a member ethernet that ND intent already assigns to a different
+        port-channel, or that another port-channel in the same task also claims. ND rejects the first case at create with
+        an opaque flat HTTP 500 (`Member port <Eth> is a member of <po>, remove <Eth> from <po> first`) after any earlier
+        items in the batch have already been accepted; ND would accept the first claimant in the second case and reject the
+        second the same way. A member already owned by the port-channel under management is allowed so an idempotent
+        re-apply passes. Hard-fails in `--check` mode too: membership comes from the standard interfaces GET, so the
+        dry-run answer is reliable.
+
+        Reads the unfiltered per-switch inventory via `_member_owners`, which the state machine's initial `query_all` has
+        already cached for every switch in the config, so no additional requests are issued for merged/replaced/overridden.
+
+        Moving a member between two port-channels in one task (remove from A, add to B) is out of scope and reported as a
+        conflict: ND checks the create against current intent before the update to A is applied.
+
+        ## Raises
+
+        ### RuntimeError
+
+        - If any proposed member is owned by a different port-channel in ND intent.
+        - If two proposed port-channels on the same switch claim the same member.
+        - Via `_resolve_switch_id` if a `switch_ip` does not match any switch in the fabric.
+        - Via `_member_owners` if the interface-list API request fails.
+        """
+        # TODO(4.2.1) port-channel-member-conflict-returns-500
+        # ND rejects a conflicting member with a flat HTTP 500 {code, message} envelope (no results[]) that masquerades as a
+        # transient server error, after any earlier interfaces in the same POST batch were already accepted. This preflight
+        # predicts the conflict from intent so the module fails before any write. Keep it even once ND returns a 4xx: it still
+        # prevents partial acceptance of earlier batch items.
+        conflicts: list[str] = []
+        claimed: dict[tuple[str, str], str] = {}
+        for model_instance in model_instances:
+            ports = self._proposed_members(model_instance)
+            if not ports:
+                continue
+            switch_ip = model_instance.switch_ip
+            po_name = model_instance.interface_name
+            owners = self._member_owners(self._resolve_switch_id(switch_ip))
+            for member in ports:
+                key = member.lower()
+                owner = owners.get(key)
+                if owner and owner.lower() != po_name.lower():
+                    conflicts.append(f"(switch_ip={switch_ip}, port-channel={po_name}, member={member}, current owner={owner})")
+                prior = claimed.get((switch_ip, key))
+                if prior and prior.lower() != po_name.lower():
+                    conflicts.append(f"(switch_ip={switch_ip}, member={member} claimed by both {prior} and {po_name} in this task)")
+                claimed.setdefault((switch_ip, key), po_name)
+        if conflicts:
+            raise RuntimeError(
+                f"Cannot configure port-channel member(s) already in use in fabric '{self.fabric_name}': {', '.join(conflicts)}. "
+                "Remove each member from its current port-channel first."
+            )
+
+    @staticmethod
+    def _proposed_members(model_instance: ModelType) -> list[str]:
+        """
+        # Summary
+
+        Return the member interface names a proposed port-channel claims (`config_data.network_os.policy.ports`), or `[]`
+        when the item carries no policy or no `ports` (e.g. a `merged` update that leaves membership untouched).
+
+        ## Raises
+
+        None
+        """
+        config_data = getattr(model_instance, "config_data", None)
+        network_os = getattr(config_data, "network_os", None) if config_data is not None else None
+        policy = getattr(network_os, "policy", None) if network_os is not None else None
+        ports = getattr(policy, "ports", None) if policy is not None else None
+        return [port for port in ports or [] if isinstance(port, str) and port]
+
     def query_one(self, model_instance: ModelType, **kwargs) -> ResponseType:
         """
         # Summary
@@ -255,6 +397,10 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
 
+        Each switch's interface list is read through the shared `_switch_interfaces` cache, so the unfiltered inventory
+        (including member ethernets and port-channels of other policy types) stays available to `preflight` without a
+        second fetch.
+
         Each returned interface dict is enriched with a `switch_ip` field so that the model can be constructed
         with the composite identifier `(switch_ip, interface_name)`.
 
@@ -271,9 +417,7 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
             self.validate_prerequisites()
             all_port_channels = []
             for switch_ip, switch_id in self._switches_to_query().items():
-                api_endpoint = self._configure_endpoint(self.query_all_endpoint(), switch_sn=switch_id)
-                result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, not_found_ok=True)
-                interfaces = result.get("interfaces", []) or [] if isinstance(result, dict) else []
+                interfaces = list(self._switch_interfaces(switch_id).values())
                 port_channels = [iface for iface in interfaces if iface.get("interfaceType") == "portChannel"]
                 managed = [
                     iface for iface in port_channels if iface.get("configData", {}).get("networkOS", {}).get("policy", {}).get("policyType") in managed_types

--- a/plugins/module_utils/orchestrators/port_channel_base.py
+++ b/plugins/module_utils/orchestrators/port_channel_base.py
@@ -279,16 +279,20 @@ class PortChannelBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         """
         inventory = self._switch_interfaces(switch_id)
         owners: dict[str, str] = {}
-        for iface in inventory.values():
-            if iface.get("interfaceType") != "portChannel":
-                continue
-            for member in self._policy_of(iface).get("ports") or []:
-                if isinstance(member, str) and member:
-                    owners[member.lower()] = iface.get("interfaceName", "")
         for name, iface in inventory.items():
-            policy_type = self._policy_of(iface).get("policyType")
-            if name not in owners and isinstance(policy_type, str) and policy_type.endswith("Member"):
-                owners[name] = f"unknown port-channel (member policyType {policy_type})"
+            policy = self._policy_of(iface)
+            policy_type = policy.get("policyType")
+
+            # A member-typed ethernet defaults to an unknown owner; setdefault never overwrites an explicit owner already
+            # recorded from a port-channel seen earlier in the inventory.
+            if isinstance(policy_type, str) and policy_type.endswith("Member"):
+                owners.setdefault(name, f"unknown port-channel (member policyType {policy_type})")
+
+            # A port-channel's `ports` list names the explicit owner, replacing any unknown default recorded above or later.
+            if iface.get("interfaceType") == "portChannel":
+                for member in policy.get("ports") or []:
+                    if isinstance(member, str) and member:
+                        owners[member.lower()] = iface.get("interfaceName", "")
         return owners
 
     def _validate_members_available(self, model_instances: Sequence[ModelType]) -> None:

--- a/plugins/modules/nd_interface_port_channel_access.py
+++ b/plugins/modules/nd_interface_port_channel_access.py
@@ -20,6 +20,8 @@ description:
   O(config[].config_data.network_os.policy.ports) and inherit access-mode configuration from the port-channel policy.
 - Member interface field mutability is restricted while members of a port-channel; only description, admin_state, and
   extra_config can be modified on members via the C(nd_interface_ethernet_access) module.
+- A port-channel that lists a member ethernet already belonging to a different port-channel is rejected before any
+  change is made (also in check mode); remove the member from its current port-channel first.
 author:
 - Allen Robel (@allenrobel)
 options:

--- a/plugins/modules/nd_interface_port_channel_trunk_host.py
+++ b/plugins/modules/nd_interface_port_channel_trunk_host.py
@@ -20,6 +20,8 @@ description:
   O(config[].config_data.network_os.policy.ports) and inherit trunk-mode configuration from the port-channel policy.
 - Member interface field mutability is restricted while members of a port-channel; only description, admin_state, and
   extra_config can be modified on members via the C(nd_interface_ethernet_trunk_host) module.
+- A port-channel that lists a member ethernet already belonging to a different port-channel is rejected before any
+  change is made (also in check mode); remove the member from its current port-channel first.
 author:
 - Allen Robel (@allenrobel)
 options:

--- a/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_access_interface.json
@@ -602,5 +602,1378 @@
         "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
         "MESSAGE": "OK",
         "DATA": {"status": "ok"}
+    },
+    "test_port_channel_access_orchestrator_00900a": {
+        "TEST_NOTES": [
+            "preflight free member passes: switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00900b": {
+        "TEST_NOTES": [
+            "preflight free member passes: interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00910a": {
+        "TEST_NOTES": [
+            "preflight cross-PO conflict (same-family owners): switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00910b": {
+        "TEST_NOTES": [
+            "preflight cross-PO conflict (same-family owners): interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00920a": {
+        "TEST_NOTES": [
+            "preflight cross-type conflict (vpcPeerlinkPo owner): switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00920b": {
+        "TEST_NOTES": [
+            "preflight cross-type conflict (vpcPeerlinkPo owner): interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00930a": {
+        "TEST_NOTES": [
+            "preflight idempotent re-apply (member owned by the PO under management): switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00930b": {
+        "TEST_NOTES": [
+            "preflight idempotent re-apply (member owned by the PO under management): interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00940a": {
+        "TEST_NOTES": [
+            "preflight hard-fails in check mode: switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00940b": {
+        "TEST_NOTES": [
+            "preflight hard-fails in check mode: interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00950a": {
+        "TEST_NOTES": [
+            "preflight intra-task duplicate member claim: switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00950b": {
+        "TEST_NOTES": [
+            "preflight intra-task duplicate member claim: interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00960a": {
+        "TEST_NOTES": [
+            "preflight after query_all issues no extra request: fabric summary (validate_prerequisites)"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/summary",
+        "MESSAGE": "OK",
+        "DATA": {
+            "fabricName": "fabric_1",
+            "fabricStatus": "healthy"
+        }
+    },
+    "test_port_channel_access_orchestrator_00960b": {
+        "TEST_NOTES": [
+            "preflight after query_all issues no extra request: switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00960c": {
+        "TEST_NOTES": [
+            "preflight after query_all issues no extra request: interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00970a": {
+        "TEST_NOTES": [
+            "preflight orphan *Member policy type with no owning port-channel record: switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_access_orchestrator_00970b": {
+        "TEST_NOTES": [
+            "preflight orphan *Member policy type with no owning port-channel record: interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
     }
 }

--- a/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_trunk_host_interface.json
+++ b/tests/unit/module_utils/fixtures/fixture_data/test_port_channel_trunk_host_interface.json
@@ -335,5 +335,345 @@
                 }
             ]
         }
+    },
+    "test_port_channel_trunk_host_orchestrator_00900a": {
+        "TEST_NOTES": [
+            "preflight free member passes: switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_trunk_host_orchestrator_00900b": {
+        "TEST_NOTES": [
+            "preflight free member passes: interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
+    },
+    "test_port_channel_trunk_host_orchestrator_00910a": {
+        "TEST_NOTES": [
+            "preflight cross-PO conflict: switches list"
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches",
+        "MESSAGE": "OK",
+        "DATA": {
+            "switches": [
+                {
+                    "fabricManagementIp": "192.168.1.1",
+                    "switchId": "FDO11111AAA"
+                }
+            ]
+        }
+    },
+    "test_port_channel_trunk_host_orchestrator_00910b": {
+        "TEST_NOTES": [
+            "preflight cross-PO conflict: interfaces list",
+            "Member-conflict inventory (issue #369): port-channel501/accessPoHost owns Ethernet1/1, port-channel502/trunkPoHost owns Ethernet1/3, port-channel500/vpcPeerlinkPo (unmanaged type) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, Ethernet1/36 is an accessPoMember with no owning port-channel record. Every operData.portChannelId is -1 (owners are intent-only, undeployed)."
+        ],
+        "RETURN_CODE": 200,
+        "METHOD": "GET",
+        "REQUEST_PATH": "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces",
+        "MESSAGE": "OK",
+        "DATA": {
+            "interfaces": [
+                {
+                    "interfaceName": "port-channel500",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerlinkPo",
+                                "ports": [
+                                    "Ethernet1/2"
+                                ],
+                                "allowedVlans": "all"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel501",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoHost",
+                                "ports": [
+                                    "Ethernet1/1"
+                                ],
+                                "accessVlan": 100,
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "port-channel502",
+                    "interfaceType": "portChannel",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoHost",
+                                "ports": [
+                                    "Ethernet1/3"
+                                ],
+                                "allowedVlans": "1-100",
+                                "portChannelMode": "active"
+                            }
+                        }
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/1",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/2",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "vpcPeerLinkMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/3",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/35",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "trunk",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "trunkHost",
+                                "allowedVlans": "1-100"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "trunk",
+                        "portChannelId": -1
+                    }
+                },
+                {
+                    "interfaceName": "Ethernet1/36",
+                    "interfaceType": "ethernet",
+                    "configData": {
+                        "mode": "access",
+                        "networkOS": {
+                            "networkOSType": "nx-os",
+                            "policy": {
+                                "policyType": "accessPoMember"
+                            }
+                        }
+                    },
+                    "operData": {
+                        "mode": "access",
+                        "portChannelId": -1
+                    }
+                }
+            ]
+        }
     }
 }

--- a/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py
@@ -60,11 +60,13 @@ def _build_rest_send(
     fabric_name: str = "fabric_1",
     state: str | None = None,
     config: list[dict] | None = None,
+    check_mode: bool = False,
 ) -> RestSend:
     """Build a RestSend wired to the file-based Sender and the real ResponseHandler.
 
     `state` and `config` populate `rest_send.params` so `query_all`'s `_switches_to_query` scoping
-    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised.
+    (fabric-wide for `overridden`, config-scoped otherwise) can be exercised. `check_mode` drives
+    `rest_send.check_mode` so the member-availability preflight's check-mode behavior can be exercised.
     """
     sender = Sender()
     sender.ansible_module = MockAnsibleModule()
@@ -75,7 +77,7 @@ def _build_rest_send(
     response_handler.verb = HttpVerbEnum.GET
     response_handler.commit()
 
-    params: dict = {"check_mode": False, "fabric_name": fabric_name}
+    params: dict = {"check_mode": check_mode, "fabric_name": fabric_name}
     if state is not None:
         params["state"] = state
     if config is not None:
@@ -104,13 +106,16 @@ def _build_pc_model(
     switch_ip: str = "192.168.1.1",
     interface_name: str = "port-channel501",
     include_config: bool = True,
+    ports: list[str] | None = None,
 ) -> PortChannelAccessInterfaceModel:
-    """Build a minimal `PortChannelAccessInterfaceModel` instance for CRUD tests."""
+    """Build a minimal `PortChannelAccessInterfaceModel` instance for CRUD tests. `ports` defaults to `["Ethernet1/1"]`."""
     kwargs: dict = {"switch_ip": switch_ip, "interface_name": interface_name}
     if include_config:
         kwargs["config_data"] = PortChannelAccessConfigDataModel(
             network_os=PortChannelAccessNetworkOSModel(
-                policy=PortChannelAccessPolicyModel(admin_state=True, access_vlan=100, port_channel_mode="active", ports=["Ethernet1/1"]),
+                policy=PortChannelAccessPolicyModel(
+                    admin_state=True, access_vlan=100, port_channel_mode="active", ports=ports if ports is not None else ["Ethernet1/1"]
+                ),
             ),
         )
     return PortChannelAccessInterfaceModel(**kwargs)
@@ -967,3 +972,254 @@ def test_port_channel_access_orchestrator_00800() -> None:
         instance.create(model)
 
     assert instance._pending_deploys == [("port-channel501", "FDO11111AAA")]
+
+
+# =============================================================================
+# Test: preflight -- member-already-in-use (issue #369)
+#
+# Shared inventory for switch FDO11111AAA (see fixture TEST_NOTES): port-channel501 (accessPoHost) owns
+# Ethernet1/1, port-channel502 (trunkPoHost) owns Ethernet1/3, port-channel500 (vpcPeerlinkPo, a type this
+# orchestrator does NOT manage) owns Ethernet1/2, Ethernet1/35 is a free trunkHost, and Ethernet1/36 carries
+# an accessPoMember policy type with no owning port-channel record. Every operData.portChannelId is -1
+# (owners are intent-only), which is exactly why membership must be read from intent rather than operData.
+# =============================================================================
+
+
+def _preflight_orchestrator(method_name: str, check_mode: bool = False) -> PortChannelAccessInterfaceOrchestrator:
+    """Build an orchestrator whose responses are the switches list (a) then the member-conflict inventory (b)."""
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+
+    rest_send = _build_rest_send(ResponseGenerator(responses()), state="merged", check_mode=check_mode)
+    return PortChannelAccessInterfaceOrchestrator(rest_send=rest_send)
+
+
+def test_port_channel_access_orchestrator_00900() -> None:
+    """
+    # Summary
+
+    Verify `preflight` passes when every proposed member is free (case (a) in issue #369).
+
+    ## Test
+
+    - Proposed port-channel701 claims Ethernet1/35, whose intent policyType is trunkHost and which no port-channel record lists
+    - `preflight` does not raise
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.preflight()
+    - PortChannelBaseOrchestrator._validate_members_available()
+    """
+    method_name = inspect.stack()[0][3]
+    instance = _preflight_orchestrator(method_name)
+    model = _build_pc_model(interface_name="port-channel701", ports=["Ethernet1/35"])
+
+    with does_not_raise():
+        instance.preflight([model])
+
+
+def test_port_channel_access_orchestrator_00910() -> None:
+    """
+    # Summary
+
+    Verify `preflight` rejects members owned by a different port-channel, naming each member and its current owner,
+    and aggregates every offender into one message (case (b) in issue #369).
+
+    ## Test
+
+    - Proposed port-channel702 claims Ethernet1/1 (owned by port-channel501/accessPoHost) and Ethernet1/3 (owned by port-channel502/trunkPoHost)
+    - `preflight` raises RuntimeError naming both members and both owners
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.preflight()
+    - PortChannelBaseOrchestrator._validate_members_available()
+    """
+    method_name = inspect.stack()[0][3]
+    instance = _preflight_orchestrator(method_name)
+    model = _build_pc_model(interface_name="port-channel702", ports=["Ethernet1/1", "Ethernet1/3"])
+
+    with pytest.raises(RuntimeError) as exc_info:
+        instance.preflight([model])
+
+    message = str(exc_info.value)
+    assert "port-channel702" in message
+    assert "Ethernet1/1" in message and "port-channel501" in message
+    assert "Ethernet1/3" in message and "port-channel502" in message
+    assert "192.168.1.1" in message
+
+
+def test_port_channel_access_orchestrator_00920() -> None:
+    """
+    # Summary
+
+    Verify `preflight` reads membership from the unfiltered inventory: a member owned by a port-channel of a policy type this
+    orchestrator does not manage (vpcPeerlinkPo) is still a conflict (case (c) in issue #369).
+
+    ## Test
+
+    - Proposed port-channel702 claims Ethernet1/2 (owned by port-channel500/vpcPeerlinkPo, which query_all would filter out)
+    - `preflight` raises RuntimeError naming Ethernet1/2 and port-channel500
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.preflight()
+    - PortChannelBaseOrchestrator._validate_members_available()
+    """
+    method_name = inspect.stack()[0][3]
+    instance = _preflight_orchestrator(method_name)
+    model = _build_pc_model(interface_name="port-channel702", ports=["Ethernet1/2"])
+
+    with pytest.raises(RuntimeError, match=r"Ethernet1/2.*port-channel500"):
+        instance.preflight([model])
+
+
+def test_port_channel_access_orchestrator_00930() -> None:
+    """
+    # Summary
+
+    Verify `preflight` allows a member already owned by the port-channel under management, so an idempotent re-apply of
+    `merged` passes (case (d) in issue #369). Member names are compared case-insensitively.
+
+    ## Test
+
+    - Proposed port-channel501 claims ethernet1/1, which port-channel501 already owns in intent
+    - `preflight` does not raise
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.preflight()
+    - PortChannelBaseOrchestrator._validate_members_available()
+    """
+    method_name = inspect.stack()[0][3]
+    instance = _preflight_orchestrator(method_name)
+    model = _build_pc_model(interface_name="port-channel501", ports=["ethernet1/1"])
+
+    with does_not_raise():
+        instance.preflight([model])
+
+
+def test_port_channel_access_orchestrator_00940() -> None:
+    """
+    # Summary
+
+    Verify `preflight` hard-fails on a member conflict even in check mode (case (e) in issue #369). Unlike the capability
+    preflight, which downgrades to a warning in check mode, membership comes from the standard interfaces GET.
+
+    ## Test
+
+    - rest_send.check_mode is True
+    - Proposed port-channel702 claims Ethernet1/1 (owned by port-channel501)
+    - `preflight` raises RuntimeError
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.preflight()
+    - PortChannelBaseOrchestrator._validate_members_available()
+    """
+    method_name = inspect.stack()[0][3]
+    instance = _preflight_orchestrator(method_name, check_mode=True)
+    assert instance.rest_send.check_mode is True
+    model = _build_pc_model(interface_name="port-channel702", ports=["Ethernet1/1"])
+
+    with pytest.raises(RuntimeError, match=r"Ethernet1/1.*port-channel501"):
+        instance.preflight([model])
+
+
+def test_port_channel_access_orchestrator_00950() -> None:
+    """
+    # Summary
+
+    Verify `preflight` rejects two proposed port-channels on the same switch that both claim the same free member. ND would
+    accept the first create and reject the second with the same opaque 500, so the conflict is caught before any write.
+
+    ## Test
+
+    - Proposed port-channel701 and port-channel702 both claim Ethernet1/35 (free in ND)
+    - `preflight` raises RuntimeError naming Ethernet1/35 and both port-channels
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.preflight()
+    - PortChannelBaseOrchestrator._validate_members_available()
+    """
+    method_name = inspect.stack()[0][3]
+    instance = _preflight_orchestrator(method_name)
+    first = _build_pc_model(interface_name="port-channel701", ports=["Ethernet1/35"])
+    second = _build_pc_model(interface_name="port-channel702", ports=["Ethernet1/35"])
+
+    with pytest.raises(RuntimeError) as exc_info:
+        instance.preflight([first, second])
+
+    message = str(exc_info.value)
+    assert "Ethernet1/35" in message
+    assert "port-channel701" in message and "port-channel702" in message
+
+
+def test_port_channel_access_orchestrator_00960() -> None:
+    """
+    # Summary
+
+    Verify `preflight` issues no additional request after `query_all` has already fetched the switch's interfaces: both
+    read the shared `_switch_interfaces` cache (CLAUDE.md performance rule -- fetch each resource at most once per run).
+
+    ## Test
+
+    - `query_all` (state merged, config scoped to 192.168.1.1) consumes summary (a), switches (b), interfaces (c)
+    - No further responses are queued; the response generator is exhausted
+    - `preflight` for a free member does not raise (an extra GET would exhaust the generator and raise)
+    - `_switch_interfaces_cache` holds the unfiltered inventory for FDO11111AAA
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.query_all()
+    - PortChannelBaseOrchestrator.preflight()
+    - NDBaseInterfaceOrchestrator._switch_interfaces()
+    """
+    method_name = inspect.stack()[0][3]
+
+    def responses():
+        yield responses_pc_access(f"{method_name}a")
+        yield responses_pc_access(f"{method_name}b")
+        yield responses_pc_access(f"{method_name}c")
+
+    config = [{"switch_ip": "192.168.1.1", "interface_name": "port-channel701"}]
+    instance = _build_orchestrator(ResponseGenerator(responses()), state="merged", config=config)
+
+    with does_not_raise():
+        result = instance.query_all()
+        instance.preflight([_build_pc_model(interface_name="port-channel701", ports=["Ethernet1/35"])])
+
+    # query_all still returns only the managed accessPoHost port-channels...
+    assert [iface["interfaceName"] for iface in result] == ["port-channel501"]
+    # ...while the cache retains the unfiltered inventory the preflight reads.
+    assert set(instance._switch_interfaces_cache) == {"FDO11111AAA"}
+    assert "ethernet1/2" in instance._switch_interfaces_cache["FDO11111AAA"]
+    assert "port-channel500" in instance._switch_interfaces_cache["FDO11111AAA"]
+
+
+def test_port_channel_access_orchestrator_00970() -> None:
+    """
+    # Summary
+
+    Verify `preflight` rejects a member whose intent policyType ends in `Member` even when no port-channel record on the
+    switch lists it, reporting the owner as unknown rather than treating the member as free.
+
+    ## Test
+
+    - Proposed port-channel702 claims Ethernet1/36 (policyType accessPoMember, listed by no port-channel record)
+    - `preflight` raises RuntimeError naming Ethernet1/36 and its accessPoMember policy type
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.preflight()
+    - PortChannelBaseOrchestrator._validate_members_available()
+    """
+    method_name = inspect.stack()[0][3]
+    instance = _preflight_orchestrator(method_name)
+    model = _build_pc_model(interface_name="port-channel702", ports=["Ethernet1/36"])
+
+    with pytest.raises(RuntimeError, match=r"Ethernet1/36.*accessPoMember"):
+        instance.preflight([model])

--- a/tests/unit/module_utils/orchestrators/test_port_channel_trunk_host_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_port_channel_trunk_host_interface.py
@@ -31,7 +31,10 @@ import inspect
 import pytest
 from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.port_channel_trunk_host_interface import (
+    PortChannelTrunkHostConfigDataModel,
     PortChannelTrunkHostInterfaceModel,
+    PortChannelTrunkHostNetworkOSModel,
+    PortChannelTrunkHostPolicyModel,
 )
 from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.port_channel_trunk_host_interface import (
     PortChannelTrunkHostInterfaceOrchestrator,
@@ -379,3 +382,81 @@ def test_port_channel_trunk_host_orchestrator_00440() -> None:
     assert len(result) == 1
     assert result[0]["interfaceName"] == "port-channel501"
     assert result[0]["switchIp"] == "192.168.1.1"
+
+
+# =============================================================================
+# Test: preflight -- member-already-in-use (issue #369)
+#
+# The full case matrix lives in test_port_channel_access_interface.py (00900-00970); the check is implemented once in
+# PortChannelBaseOrchestrator. These two tests confirm the trunk-host orchestrator inherits it.
+# =============================================================================
+
+
+def _build_trunk_model(interface_name: str, ports: list[str], switch_ip: str = "192.168.1.1") -> PortChannelTrunkHostInterfaceModel:
+    """Build a minimal `PortChannelTrunkHostInterfaceModel` claiming `ports` as members."""
+    return PortChannelTrunkHostInterfaceModel(
+        switch_ip=switch_ip,
+        interface_name=interface_name,
+        config_data=PortChannelTrunkHostConfigDataModel(
+            network_os=PortChannelTrunkHostNetworkOSModel(
+                policy=PortChannelTrunkHostPolicyModel(admin_state=True, allowed_vlans="1-100", port_channel_mode="active", ports=ports),
+            ),
+        ),
+    )
+
+
+def _preflight_orchestrator(method_name: str) -> PortChannelTrunkHostInterfaceOrchestrator:
+    """Build an orchestrator whose responses are the switches list (a) then the member-conflict inventory (b)."""
+
+    def responses():
+        yield responses_pc_trunk_host(f"{method_name}a")
+        yield responses_pc_trunk_host(f"{method_name}b")
+
+    return _build_orchestrator(ResponseGenerator(responses()), state="merged")
+
+
+def test_port_channel_trunk_host_orchestrator_00900() -> None:
+    """
+    # Summary
+
+    Verify the inherited `preflight` passes when every proposed member is free.
+
+    ## Test
+
+    - Proposed port-channel701 claims Ethernet1/35 (free trunkHost)
+    - `preflight` does not raise
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.preflight()
+    - PortChannelBaseOrchestrator._validate_members_available()
+    """
+    method_name = inspect.stack()[0][3]
+    instance = _preflight_orchestrator(method_name)
+
+    with does_not_raise():
+        instance.preflight([_build_trunk_model("port-channel701", ["Ethernet1/35"])])
+
+
+def test_port_channel_trunk_host_orchestrator_00910() -> None:
+    """
+    # Summary
+
+    Verify the inherited `preflight` rejects a member owned by a different port-channel, including one of the access flavor
+    this orchestrator does not manage, naming the member and its owner.
+
+    ## Test
+
+    - Proposed port-channel702 claims Ethernet1/1 (owned by port-channel501/accessPoHost)
+    - `preflight` raises RuntimeError naming Ethernet1/1 and port-channel501
+
+    ## Classes and Methods
+
+    - PortChannelBaseOrchestrator.preflight()
+    - PortChannelBaseOrchestrator._validate_members_available()
+    """
+    method_name = inspect.stack()[0][3]
+    instance = _preflight_orchestrator(method_name)
+
+    with pytest.raises(RuntimeError, match=r"Ethernet1/1.*port-channel501"):
+        instance.preflight([_build_trunk_model("port-channel702", ["Ethernet1/1"])])


### PR DESCRIPTION
## Related Issue(s)

Closes #369

## Proposed Changes

Add a client-side member-already-in-use preflight to the port-channel orchestrators (`nd_interface_port_channel_access`, `nd_interface_port_channel_trunk_host`), per the design agreed in #369.

ND 4.2.1 rejects a port-channel create whose `ports` member already belongs to another port-channel with a flat HTTP 500 `{code, message}` envelope (no `results[]`) -- a permanent 409-class conflict dressed as a server error (vault: `port-channel-member-conflict-returns-500`). Today that surfaces mid-run as `Create failed for <po>: ...`, after any earlier interfaces in the same POST batch were already accepted. The module now fails fast with a validation error naming each offending member and its current owner, before any write, in check mode too.

- **`PortChannelBaseOrchestrator.query_all`** now reads each switch's inventory through the shared `NDBaseInterfaceOrchestrator._switch_interfaces` cache (mirroring the ethernet/loopback/SVI orchestrators). No behavior change; it was the last orchestrator still issuing its own per-switch `_request`. This warms the cache with the **unfiltered** records during the state machine's initial `query_all`.
- **`PortChannelBaseOrchestrator.preflight`** override: runs the inherited capability preflight, then `_validate_members_available`. Because it reads the same cache, it issues **zero additional requests** for merged/replaced/overridden.
  - Owners are derived from every `portChannel` record's `ports` list regardless of policy type, so a member of an unmanaged flavor (e.g. `Ethernet1/2` owned by `port-channel500`/`vpcPeerlinkPo`) is still a conflict -- the filtered `before` view would miss it.
  - Membership is read from **intent**, not `operData.portChannelId` (which stays `-1` until the owner is deployed; ND still rejects the conflict).
  - A member whose own `policyType` ends in `Member` but that no port-channel record lists is treated as owned (owner reported as unknown) rather than free.
  - A member already owned by the port-channel under management passes (idempotent re-apply). Two proposed port-channels on one switch claiming the same member also fail (ND would accept the first and 500 on the second).
  - Hard-fails in `--check` mode: unlike the capability preflight (unpublished endpoint), this data comes from the standard interfaces GET.
  - Intra-task re-home (remove from A, add to B in one config) stays out of scope per the issue and is reported as a conflict.
- Workaround site carries `TODO(4.2.1) port-channel-member-conflict-returns-500`.
- Module `description` gets one line stating the fail-fast behavior; changelog fragment added.
- Not done: the optional "aside" in #369 about wiring the capability `interface_type`/`interface_mode` ClassVars for port-channels.

## Test Notes

- New unit tests in `tests/unit/module_utils/orchestrators/test_port_channel_access_interface.py` (00900-00970): free member passes; cross-PO conflict aggregates every offender naming member + owner; cross-type (`vpcPeerlinkPo`) owner conflicts; same-PO re-apply passes (case-insensitive); check mode still fails; intra-task duplicate claim fails; `query_all` then `preflight` consumes no extra response (generator exhaustion would raise) and the cache retains the unfiltered inventory; orphan `*Member` policy type fails. `test_port_channel_trunk_host_interface.py` 00900-00910 confirm inheritance.
- Full unit suite: 4205 passed (`ndpytest tests/unit/`).
- `ndtest --test pylint` / `--test validate-modules` on the changed plugin files pass; `ndblack`, `ndisort` clean; `ndmypy` error count on `port_channel_base.py` unchanged from develop (pre-existing `NDBaseModel` attr-defined pattern noted at the top of the file).
- Not lab-run: the conflict shape itself was lab-verified on 2026-06-30 (issue body / vault note); the preflight is exercised against that recorded shape in unit tests.

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LpZPyFp9vCBb1mH97CXj4