### PR TITLE
nd_interface_svi, nd_interface_subinterface_*: add broad exception handler in main()

### DIFF
--- a/changelogs/fragments/379_broad_exception_handler.yml
+++ b/changelogs/fragments/379_broad_exception_handler.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - nd_interface_svi, nd_interface_subinterface_managed, nd_interface_subinterface_unmanaged - add the broad fallback exception
+    handler in ``main()`` so unhandled exceptions (e.g. model validation errors) are reported via ``fail_json`` with the module's
+    structured output instead of a raw traceback, matching the sibling interface modules (https://github.com/CiscoDevNet/ansible-nd/issues/379).

--- a/changelogs/fragments/379_broad_exception_handler.yml
+++ b/changelogs/fragments/379_broad_exception_handler.yml
@@ -1,5 +1,0 @@
----
-bugfixes:
-  - nd_interface_svi, nd_interface_subinterface_managed, nd_interface_subinterface_unmanaged - add the broad fallback exception
-    handler in ``main()`` so unhandled exceptions (e.g. model validation errors) are reported via ``fail_json`` with the module's
-    structured output instead of a raw traceback, matching the sibling interface modules (https://github.com/CiscoDevNet/ansible-nd/issues/379).

--- a/plugins/modules/nd_interface_subinterface_managed.py
+++ b/plugins/modules/nd_interface_subinterface_managed.py
@@ -468,6 +468,14 @@ def main():
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
 
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
 
 if __name__ == "__main__":
     main()

--- a/plugins/modules/nd_interface_subinterface_unmanaged.py
+++ b/plugins/modules/nd_interface_subinterface_unmanaged.py
@@ -299,6 +299,14 @@ def main():
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
 
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
 
 if __name__ == "__main__":
     main()

--- a/plugins/modules/nd_interface_svi.py
+++ b/plugins/modules/nd_interface_svi.py
@@ -606,6 +606,14 @@ def main():
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
 
+    except Exception as e:  # pylint: disable=broad-except
+        module_log.exception("Unhandled exception during module execution")
+        output = nd_state_machine.output.format() if nd_state_machine else {}
+        error_msg = f"Module failed: {str(e)}"
+        if module.params.get("output_level") == "debug":
+            error_msg += f"\nTraceback:\n{traceback.format_exc()}"
+        module.fail_json(msg=error_msg, **output)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Related Issue(s)

Closes #379

## Proposed Changes

- Add the standard broad ``except Exception`` fallback handler after the existing ``NDStateMachineError`` handler in
  ``nd_interface_svi``, ``nd_interface_subinterface_managed``, and ``nd_interface_subinterface_unmanaged``.
  The handler body is identical to the one every sibling ``NDStateMachine``-based module already carries
  (e.g. ``nd_interface_loopback.main()``), so the existing docstring contract
  (``None (catches all exceptions and calls module.fail_json)``) now holds.
- Add a ``bugfixes`` changelog fragment.

⚠️ **Merge-ordering note (PR #547):** #547 adds a ``finalize_accepted_intent(...)`` line to *both* handlers in the
compliant interface modules. The new broad handlers introduced here do not have that line because it does not exist
on develop yet. Whichever of #547 / this PR lands second must add that one line to the new broad handler in each of the
three modules during rebase — git will not do it automatically.

## Test Notes

- ``black``, ``isort``, and ``ansible-test sanity --test pylint`` pass on the three modules; ``yamllint`` sanity passes on the fragment.
- ``pylint`` (wrapper) output is byte-identical before/after the change (all findings pre-existing).
- ``mypy`` reports only the pre-existing unresolvable ``ansible.module_utils.basic`` import present on develop.
- Unit tests referencing these modules (``test_nd_interface_deploy_default.py``, ``test_nd_state_machine.py``) pass (20 tests).

## Cisco Nexus Dashboard Version

4.2.1

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers