### PR TITLE
nd_interface_ethernet_*: support safe updates to port-channel and vPC members

### DIFF
--- a/changelogs/fragments/iface-004-port-channel-member-updates.yml
+++ b/changelogs/fragments/iface-004-port-channel-member-updates.yml
@@ -1,0 +1,18 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+bugfixes:
+  - >-
+    nd_interface_ethernet_access, nd_interface_ethernet_trunk_host, and
+    nd_interface_ethernet_routed - recognize authentic accessPoMember,
+    accessVpcPoMember, poMember, vpcMember, l3PoMember, and iosXeL3PoMember
+    controller policies and safely update admin_state, description, and
+    extra_config with state=merged while preserving port-channel or vPC
+    membership. Member validation rejects abbreviated membership or
+    interface-context commands and requires a compatible parent policy, mode,
+    and network OS. vPC validation compares the literal shared peer
+    configuration returned in both parent echoes, validates both switches from
+    cached inventories, and uses one reusable pair proof without a GET per
+    member. Unrecognized nested member configuration fails closed instead of
+    being silently omitted from the full PUT
+    (https://github.com/CiscoDevNet/ansible-nd/issues/533#iface-004).

--- a/plugins/module_utils/interface_membership.py
+++ b/plugins/module_utils/interface_membership.py
@@ -1,0 +1,1074 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Controller-independent ethernet membership ownership validation.
+
+``EthernetMembershipIndex`` consumes interface inventories that have already been
+fetched and cached by an orchestrator.  It never sends a REST request.  This keeps
+membership validation reusable by both the standalone ethernet orchestrators and
+the interface aggregator without adding a per-interface discovery cost.
+
+The index deliberately fails closed.  A member update is safe only when its exact
+member-policy descriptor agrees with one unambiguous parent, the configured and
+operational port-channel identities do not conflict, and every required parent
+membership reference is internally consistent.  vPC members additionally require
+reciprocal evidence from both peers' cached inventories.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, TypeAlias
+
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_member_interface import (
+    MemberPolicyDescriptor,
+    MemberPolicyDisposition,
+    classify_member_policy,
+    get_member_policy_descriptor,
+    normalize_port_channel_id,
+    parse_member_interface_response,
+    policy_type_from_interface_record,
+)
+
+MemberKey: TypeAlias = tuple[str, str]
+InterfaceRecord: TypeAlias = Mapping[str, Any]
+SwitchInventory: TypeAlias = Mapping[str, InterfaceRecord]
+InterfaceInventories: TypeAlias = Mapping[str, SwitchInventory]
+
+VpcParentSignature: TypeAlias = tuple[
+    str,
+    str,
+    str,
+    tuple[Any, ...],
+]
+_LOCAL_PARENT_MEMBER_FIELDS = (
+    "ports",
+    "peer1MemberPorts",
+    "peer2MemberPorts",
+)
+
+
+class MembershipValidationError(ValueError):
+    """Raised when cached inventory cannot prove one safe member owner."""
+
+
+class MissingPeerInventoryError(MembershipValidationError):
+    """Raised when pair-aware validation needs a peer inventory not yet cached."""
+
+    def __init__(self, peer_switch_id: str) -> None:
+        self.peer_switch_id = peer_switch_id
+        super().__init__(f"Pair-aware membership validation requires cached interface inventory " f"for peer switch {peer_switch_id!r}")
+
+
+class MissingPeerIdentityError(MembershipValidationError):
+    """Raised when a vPC parent omits its peer and cached evidence is insufficient."""
+
+    def __init__(self, switch_id: str, parent_name: str) -> None:
+        self.switch_id = switch_id
+        self.parent_name = parent_name
+        super().__init__(
+            f"Pair-aware membership validation cannot resolve the peer for vPC "
+            f"parent {parent_name!r} on switch {switch_id!r} from cached inventory "
+            "or pair evidence"
+        )
+
+
+@dataclass(frozen=True)
+class IndexedEthernetMember:
+    """One member-policy interface found in the supplied inventories."""
+
+    switch_id: str
+    interface_name: str
+    policy_type: str
+    disposition: MemberPolicyDisposition
+    descriptor: MemberPolicyDescriptor | None
+    record: InterfaceRecord
+
+    @property
+    def key(self) -> MemberKey:
+        """Return the canonical index key."""
+
+        return self.switch_id, self.interface_name.lower()
+
+
+@dataclass(frozen=True)
+class MemberOwner:
+    """Validated parent metadata for one member on one switch."""
+
+    switch_id: str
+    interface_name: str
+    interface_type: str
+    policy_type: str
+    port_channel_id: int
+    claim_fields: tuple[str, ...]
+    record: InterfaceRecord
+
+
+@dataclass(frozen=True)
+class ValidatedMemberOwnership:
+    """Proof that a member's cached ownership is safe for an in-place update."""
+
+    member: IndexedEthernetMember
+    owner: MemberOwner
+    configured_port_channel_id: int
+    operational_port_channel_id: int | None
+    peer_owner: MemberOwner | None = None
+    peer_members: tuple[IndexedEthernetMember, ...] = ()
+    pair_validated: bool = False
+
+
+@dataclass(frozen=True)
+class _ParentClaim:
+    """Internal representation of a parent record that names a member."""
+
+    switch_id: str
+    interface_name: str
+    interface_type: str
+    policy_type: str | None
+    claim_fields: tuple[str, ...]
+    record: InterfaceRecord
+
+
+@dataclass(frozen=True)
+class _VpcParentCopy:
+    """One valid, literal vPC parent signature used for O(1) peer inference."""
+
+    switch_id: str
+    signature: VpcParentSignature
+    record: InterfaceRecord
+
+
+@dataclass(frozen=True)
+class _VpcParentSlot:
+    """One literal peer slot from a vPC parent's pair-wide configuration."""
+
+    number: int
+    port_channel_id: int
+    member_names: frozenset[str]
+    fingerprint: tuple[Any, ...]
+
+    @property
+    def member_field(self) -> str:
+        """Return the ND policy key that names this slot's members."""
+
+        return f"peer{self.number}MemberPorts"
+
+
+@dataclass(frozen=True)
+class _ValidatedVpcSlotMember:
+    """One vPC member whose configured, operational, and parent evidence agrees."""
+
+    member: IndexedEthernetMember
+    configured_port_channel_id: int
+    operational_port_channel_id: int | None
+
+
+@dataclass(frozen=True)
+class _ValidatedVpcParentPair:
+    """Cached pair-wide ownership proof for every member of one vPC parent."""
+
+    results: Mapping[MemberKey, ValidatedMemberOwnership]
+
+
+class EthernetMembershipIndex:
+    """Index and validate ethernet members from already-cached inventories.
+
+    ``inventories`` has the same shape as the interface orchestrator cache:
+    ``{switch_id: {lower_interface_name: raw_interface_record}}``.  The mapping
+    keys are treated as lookup hints; canonical keys come from each record's
+    ``interfaceName`` and the enclosing switch serial.
+    """
+
+    def __init__(
+        self,
+        inventories: InterfaceInventories,
+        *,
+        peer_switch_ids: Mapping[str, str] | None = None,
+    ) -> None:
+        self._inventories: dict[str, dict[str, InterfaceRecord]] = {}
+        self._members: dict[MemberKey, IndexedEthernetMember] = {}
+        self._vpc_members_by_parent: dict[MemberKey, tuple[IndexedEthernetMember, ...]] = {}
+        self._claims: dict[MemberKey, tuple[_ParentClaim, ...]] = {}
+        self._peer_switch_ids = self._normalize_peer_switch_ids(peer_switch_ids)
+        self._vpc_parents_by_signature: dict[VpcParentSignature, tuple[_VpcParentCopy, ...]] = {}
+        self._vpc_peer_cache: dict[tuple[str, str], str] = {}
+        self._vpc_pair_validation_cache: dict[tuple[tuple[str, str], str, str], _ValidatedVpcParentPair] = {}
+        self._validation_cache: dict[MemberKey, ValidatedMemberOwnership] = {}
+        self._build(inventories)
+
+    @property
+    def members(self) -> Mapping[MemberKey, IndexedEthernetMember]:
+        """Return the indexed member records keyed by serial and lower-case name."""
+
+        return MappingProxyType(self._members)
+
+    @property
+    def member_keys(self) -> tuple[MemberKey, ...]:
+        """Return canonical member keys in deterministic order."""
+
+        return tuple(sorted(self._members))
+
+    def get_member(self, switch_id: str, interface_name: str) -> IndexedEthernetMember | None:
+        """Return one indexed member, or ``None`` for a non-member/missing record."""
+
+        return self._members.get(self._key(switch_id, interface_name))
+
+    def require_member(self, switch_id: str, interface_name: str) -> IndexedEthernetMember:
+        """Return one indexed member or raise a closed ownership error."""
+
+        member = self.get_member(switch_id, interface_name)
+        if member is None:
+            raise MembershipValidationError(f"Interface {interface_name!r} on switch {switch_id!r} is not an " "indexed ethernet member")
+        return member
+
+    def validate(self, switch_id: str, interface_name: str) -> ValidatedMemberOwnership:
+        """Validate and return ownership proof for one indexed member.
+
+        Standalone port-channel membership requires only the target switch's
+        inventory.  A vPC member requires both peer inventories and raises
+        ``MissingPeerInventoryError`` with the exact missing serial when the
+        orchestrator must populate another cached inventory before retrying.
+        """
+
+        key = self._key(switch_id, interface_name)
+        cached = self._validation_cache.get(key)
+        if cached is not None:
+            return cached
+
+        member = self.require_member(switch_id, interface_name)
+        descriptor = member.descriptor
+        if descriptor is None:
+            raise MembershipValidationError(
+                f"Interface {interface_name!r} on switch {switch_id!r} uses " f"protected or unsupported member policy {member.policy_type!r}"
+            )
+
+        if descriptor.pair_aware:
+            claim = self._require_vpc_parent_claim(member)
+            result = self._validate_vpc_pair(member=member, claim=claim)
+        else:
+            configured_id, operational_id = self._member_port_channel_ids(member)
+            claim = self._require_single_claim(member)
+            owner = self._validate_parent_claim(
+                member,
+                claim,
+                configured_id,
+                local_member_field=descriptor.parent_member_fields[0],
+            )
+            result = ValidatedMemberOwnership(
+                member=member,
+                owner=owner,
+                configured_port_channel_id=configured_id,
+                operational_port_channel_id=operational_id,
+            )
+        self._validation_cache[key] = result
+        return result
+
+    def _build(self, inventories: InterfaceInventories) -> None:
+        if not isinstance(inventories, Mapping):
+            raise TypeError("inventories must be a mapping keyed by switch serial")
+
+        for switch_id, inventory in inventories.items():
+            if not isinstance(switch_id, str) or not switch_id:
+                raise MembershipValidationError(f"Inventory switch identifier must be a non-empty string; got {switch_id!r}")
+            if not isinstance(inventory, Mapping):
+                raise TypeError(f"Inventory for switch {switch_id!r} must be a mapping keyed by interface name")
+
+            normalized_inventory: dict[str, InterfaceRecord] = {}
+            for record in inventory.values():
+                if not isinstance(record, Mapping):
+                    raise TypeError(f"Interface inventory entry for switch {switch_id!r} must be a mapping")
+                interface_name = record.get("interfaceName")
+                if not isinstance(interface_name, str) or not interface_name:
+                    raise MembershipValidationError(f"Interface inventory entry for switch {switch_id!r} lacks a valid interfaceName")
+                record_switch_id = record.get("switchId")
+                if record_switch_id is not None and record_switch_id != switch_id:
+                    raise MembershipValidationError(
+                        f"Interface {interface_name!r} is stored under switch {switch_id!r} " f"but its record declares switchId {record_switch_id!r}"
+                    )
+
+                normalized_name = interface_name.lower()
+                if normalized_name in normalized_inventory:
+                    raise MembershipValidationError(
+                        f"Inventory for switch {switch_id!r} contains duplicate interface " f"name {interface_name!r} after case normalization"
+                    )
+                normalized_inventory[normalized_name] = record
+
+                policy_type = policy_type_from_interface_record(record)
+                disposition = classify_member_policy(policy_type)
+                if disposition == MemberPolicyDisposition.NOT_MEMBER:
+                    continue
+                if not isinstance(policy_type, str) or not policy_type:
+                    raise MembershipValidationError(
+                        f"Interface {interface_name!r} on switch {switch_id!r} " "was classified as an ethernet member without a valid policyType"
+                    )
+                member = IndexedEthernetMember(
+                    switch_id=switch_id,
+                    interface_name=interface_name,
+                    policy_type=policy_type,
+                    disposition=disposition,
+                    descriptor=get_member_policy_descriptor(policy_type),
+                    record=record,
+                )
+                if member.key in self._members:
+                    raise MembershipValidationError(f"Duplicate member index key {member.key!r}")
+                self._members[member.key] = member
+            self._inventories[switch_id] = normalized_inventory
+        self._build_vpc_member_index()
+        self._build_parent_claims()
+        self._build_vpc_parent_index()
+
+    def _build_vpc_member_index(self) -> None:
+        """Index supported physical vPC members by switch and parent once.
+
+        ND also labels the parent-side ``portChannel`` record with policies such as
+        ``trunkVpcMember`` and ``accessVpcMember``.  Those protected records are not
+        physical members and must not contaminate a vPC parent's member set.
+        """
+
+        mutable: dict[MemberKey, list[IndexedEthernetMember]] = {}
+        for member in self._members.values():
+            descriptor = member.descriptor
+            if member.record.get("interfaceType") != "ethernet" or descriptor is None or not descriptor.pair_aware:
+                continue
+            policy = self._policy(member.record)
+            parent_name = policy.get("primaryInterface") if policy is not None else None
+            if not isinstance(parent_name, str) or not parent_name:
+                continue
+            mutable.setdefault((member.switch_id, parent_name.lower()), []).append(member)
+        self._vpc_members_by_parent = {key: tuple(sorted(members, key=lambda item: item.interface_name.lower())) for key, members in mutable.items()}
+
+    def _build_parent_claims(self) -> None:
+        """Index every parent membership reference once for constant-time lookups."""
+
+        mutable_claims: dict[MemberKey, list[_ParentClaim]] = {}
+        for switch_id, inventory in self._inventories.items():
+            for record in inventory.values():
+                policy = self._policy(record)
+                if policy is None:
+                    continue
+                claim_fields_by_member: dict[str, list[str]] = {}
+                for field in _LOCAL_PARENT_MEMBER_FIELDS:
+                    for member_name in self._normalized_member_names(policy.get(field)):
+                        claim_fields_by_member.setdefault(member_name, []).append(field)
+                if not claim_fields_by_member:
+                    continue
+
+                parent_name = record.get("interfaceName")
+                interface_type = record.get("interfaceType")
+                if not isinstance(parent_name, str) or not isinstance(interface_type, str):
+                    raise MembershipValidationError(f"A parent membership record on switch {switch_id!r} lacks " "interfaceName or interfaceType")
+                policy_type = policy_type_from_interface_record(record)
+                for member_name, claim_fields in claim_fields_by_member.items():
+                    key = (switch_id, member_name)
+                    mutable_claims.setdefault(key, []).append(
+                        _ParentClaim(
+                            switch_id=switch_id,
+                            interface_name=parent_name,
+                            interface_type=interface_type,
+                            policy_type=policy_type,
+                            claim_fields=tuple(claim_fields),
+                            record=record,
+                        )
+                    )
+        self._claims = {key: tuple(claims) for key, claims in mutable_claims.items()}
+
+    def _build_vpc_parent_index(self) -> None:
+        """Index valid literal parent signatures once for constant-time peer inference."""
+
+        mutable: dict[VpcParentSignature, list[_VpcParentCopy]] = {}
+        for switch_id, inventory in self._inventories.items():
+            for record in inventory.values():
+                signature = self._optional_vpc_parent_signature(record)
+                if signature is None:
+                    continue
+                mutable.setdefault(signature, []).append(
+                    _VpcParentCopy(
+                        switch_id=switch_id,
+                        signature=signature,
+                        record=record,
+                    )
+                )
+        self._vpc_parents_by_signature = {signature: tuple(copies) for signature, copies in mutable.items()}
+
+    @staticmethod
+    def _normalize_peer_switch_ids(
+        peer_switch_ids: Mapping[str, str] | None,
+    ) -> dict[str, str]:
+        """Validate optional authoritative vPC pair evidence and fail closed."""
+
+        if peer_switch_ids is None:
+            return {}
+        if not isinstance(peer_switch_ids, Mapping):
+            raise TypeError("peer_switch_ids must be a mapping of switch serials")
+        normalized: dict[str, str] = {}
+        owners_by_peer: dict[str, str] = {}
+        for switch_id, peer_switch_id in peer_switch_ids.items():
+            if not isinstance(switch_id, str) or not switch_id:
+                raise MembershipValidationError(f"Pair evidence has invalid switch identifier {switch_id!r}")
+            if not isinstance(peer_switch_id, str) or not peer_switch_id:
+                raise MembershipValidationError(f"Pair evidence for switch {switch_id!r} has invalid peer " f"identifier {peer_switch_id!r}")
+            if switch_id == peer_switch_id:
+                raise MembershipValidationError(f"Pair evidence for switch {switch_id!r} points to itself")
+            prior_owner = owners_by_peer.get(peer_switch_id)
+            if prior_owner is not None and prior_owner != switch_id:
+                raise MembershipValidationError(f"Pair evidence assigns peer {peer_switch_id!r} to both " f"{prior_owner!r} and {switch_id!r}")
+            owners_by_peer[peer_switch_id] = switch_id
+            normalized[switch_id] = peer_switch_id
+        for switch_id, peer_switch_id in normalized.items():
+            reciprocal = normalized.get(peer_switch_id)
+            if reciprocal is not None and reciprocal != switch_id:
+                raise MembershipValidationError(f"Pair evidence for {switch_id!r} and {peer_switch_id!r} " "is not reciprocal")
+        return normalized
+
+    @classmethod
+    def _optional_vpc_parent_signature(cls, record: InterfaceRecord) -> VpcParentSignature | None:
+        """Return a literal signature for a structurally valid vPC parent.
+
+        ND preserves peer1/peer2 meaning in both switch-scoped echoes.  The record
+        switchId and policy peerSwitchId reverse, but peer1*/peer2* fields do not.
+        """
+
+        if record.get("interfaceType") != "vpc":
+            return None
+        parent_name = record.get("interfaceName")
+        policy = cls._policy(record)
+        if not isinstance(parent_name, str) or not parent_name or policy is None:
+            return None
+        policy_type = policy.get("policyType")
+        if not isinstance(policy_type, str):
+            return None
+        try:
+            peer1_id = normalize_port_channel_id(policy.get("peer1PortChannelId"))
+            peer2_id = normalize_port_channel_id(policy.get("peer2PortChannelId"))
+        except ValueError:
+            return None
+        peer1_members = cls._normalized_member_names(policy.get("peer1MemberPorts"))
+        peer2_members = cls._normalized_member_names(policy.get("peer2MemberPorts"))
+        if peer1_id is None or peer2_id is None or not peer1_members or not peer2_members:
+            return None
+        fingerprint = cls._vpc_parent_fingerprint(record)
+        if fingerprint is None:
+            return None
+        return (parent_name.lower(), "vpc", policy_type, fingerprint)
+
+    def _required_vpc_parent_signature(self, record: InterfaceRecord, switch_id: str, parent_name: str) -> VpcParentSignature:
+        """Return one target parent's literal signature with precise errors."""
+
+        policy_type = policy_type_from_interface_record(record)
+        if record.get("interfaceType") != "vpc" or not isinstance(policy_type, str):
+            raise MembershipValidationError(f"Interface {parent_name!r} on switch {switch_id!r} is not a " "valid vPC parent")
+        self._required_policy_port_channel_id(record, "peer1PortChannelId", parent_name=parent_name, switch_id=switch_id)
+        self._required_policy_port_channel_id(record, "peer2PortChannelId", parent_name=parent_name, switch_id=switch_id)
+        self._required_vpc_member_names(record, "peer1MemberPorts", switch_id, parent_name)
+        self._required_vpc_member_names(record, "peer2MemberPorts", switch_id, parent_name)
+        fingerprint = self._vpc_parent_fingerprint(record)
+        if fingerprint is None:
+            raise MembershipValidationError(f"vPC parent {parent_name!r} on switch {switch_id!r} lacks valid configData")
+        return (parent_name.lower(), "vpc", policy_type, fingerprint)
+
+    @classmethod
+    def _vpc_parent_fingerprint(cls, record: InterfaceRecord) -> tuple[Any, ...] | None:
+        """Return hashable pair-comparable configData with only echo metadata removed."""
+
+        config_data = record.get("configData")
+        if not isinstance(config_data, Mapping):
+            return None
+        frozen = cls._freeze_vpc_value(config_data)
+        return frozen if isinstance(frozen, tuple) else None
+
+    @classmethod
+    def _freeze_vpc_value(cls, value: Any, *, field_name: str = "") -> Any:
+        """Freeze JSON-like data while normalizing only vPC member-list presentation."""
+
+        if isinstance(value, Mapping):
+            ignored = {"switchId", "peerSwitchId", "policyId"}
+            return tuple(
+                sorted((key, cls._freeze_vpc_value(item, field_name=key)) for key, item in value.items() if isinstance(key, str) and key not in ignored)
+            )
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            if field_name.endswith("MemberPorts") and all(isinstance(item, str) for item in value):
+                return tuple(sorted(item.strip().lower() for item in value))
+            return tuple(cls._freeze_vpc_value(item) for item in value)
+        return value
+
+    def _infer_vpc_peer_switch_id(self, switch_id: str, parent_name: str, record: InterfaceRecord) -> str | None:
+        """Infer one peer from an identical literal cached parent signature."""
+
+        signature = self._required_vpc_parent_signature(record, switch_id, parent_name)
+        candidates: set[str] = set()
+        for copy in self._vpc_parents_by_signature.get(signature, ()):
+            if copy.switch_id == switch_id:
+                continue
+            candidate_policy = self._required_policy(copy.record)
+            declared_peer = candidate_policy.get("peerSwitchId")
+            if declared_peer not in (None, ""):
+                if not isinstance(declared_peer, str) or declared_peer != switch_id:
+                    continue
+            candidates.add(copy.switch_id)
+        if len(candidates) > 1:
+            raise MembershipValidationError(
+                f"Cannot resolve peer for vPC parent {parent_name!r} on switch "
+                f"{switch_id!r}: reciprocal cached parent evidence is ambiguous "
+                f"across {sorted(candidates)!r}"
+            )
+        return next(iter(candidates), None)
+
+    def _resolve_vpc_peer_switch_id(self, switch_id: str, parent_name: str, record: InterfaceRecord) -> str:
+        """Resolve a vPC peer without guessing, caching one result per parent copy."""
+
+        cache_key = (switch_id, parent_name.lower())
+        cached = self._vpc_peer_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        policy = self._required_policy(record)
+        raw_declared = policy.get("peerSwitchId")
+        if raw_declared in (None, ""):
+            declared_peer = None
+        elif not isinstance(raw_declared, str):
+            raise MembershipValidationError(f"vPC parent {parent_name!r} on switch {switch_id!r} has invalid " f"peerSwitchId {raw_declared!r}")
+        else:
+            declared_peer = raw_declared
+
+        mapped_peer = self._peer_switch_ids.get(switch_id)
+        if declared_peer is not None and mapped_peer is not None and declared_peer != mapped_peer:
+            raise MembershipValidationError(
+                f"vPC parent {parent_name!r} on switch {switch_id!r} declares "
+                f"peerSwitchId {declared_peer!r}, but authoritative pair evidence "
+                f"resolves {mapped_peer!r}"
+            )
+
+        peer_switch_id = declared_peer or mapped_peer
+        if peer_switch_id is None:
+            peer_switch_id = self._infer_vpc_peer_switch_id(switch_id, parent_name, record)
+        if peer_switch_id is None:
+            raise MissingPeerIdentityError(switch_id, parent_name)
+        if peer_switch_id == switch_id:
+            raise MembershipValidationError(f"vPC parent {parent_name!r} on switch {switch_id!r} resolves " "itself as peerSwitchId")
+        self._vpc_peer_cache[cache_key] = peer_switch_id
+        return peer_switch_id
+
+    @staticmethod
+    def _key(switch_id: str, interface_name: str) -> MemberKey:
+        if not isinstance(switch_id, str) or not switch_id:
+            raise ValueError("switch_id must be a non-empty string")
+        if not isinstance(interface_name, str) or not interface_name:
+            raise ValueError("interface_name must be a non-empty string")
+        return switch_id, interface_name.lower()
+
+    def _member_port_channel_ids(self, member: IndexedEthernetMember) -> tuple[int, int | None]:
+        try:
+            model = parse_member_interface_response(member.record)
+            configured_id = model.normalized_port_channel_id
+            operational_id = normalize_port_channel_id(self._mapping(member.record.get("operData")).get("portChannelId"))
+        except (TypeError, ValueError) as exc:
+            raise MembershipValidationError(f"Cannot validate member {member.interface_name!r} on switch " f"{member.switch_id!r}: {exc}") from exc
+
+        if configured_id is None:
+            raise MembershipValidationError(
+                f"Member {member.interface_name!r} on switch {member.switch_id!r} " "does not declare a valid configured portChannelId"
+            )
+        if operational_id is not None and operational_id != configured_id:
+            raise MembershipValidationError(
+                f"Member {member.interface_name!r} on switch {member.switch_id!r} "
+                f"has configured port-channel ID {configured_id} but operational ID "
+                f"{operational_id}"
+            )
+        return configured_id, operational_id
+
+    def _claims_for(self, switch_id: str, interface_name: str) -> tuple[_ParentClaim, ...]:
+        if switch_id not in self._inventories:
+            raise MembershipValidationError(f"No cached interface inventory exists for switch {switch_id!r}")
+        return self._claims.get(self._key(switch_id, interface_name), ())
+
+    def _require_single_claim(self, member: IndexedEthernetMember) -> _ParentClaim:
+        descriptor = member.descriptor
+        if descriptor is None:
+            raise MembershipValidationError(
+                f"Interface {member.interface_name!r} on switch {member.switch_id!r} uses " f"protected or unsupported member policy {member.policy_type!r}"
+            )
+        claims = self._claims_for(member.switch_id, member.interface_name)
+        if not claims:
+            raise MembershipValidationError(
+                f"Member {member.interface_name!r} on switch {member.switch_id!r} " "is orphaned: no parent membership list contains it"
+            )
+        if len(claims) != 1:
+            owners = ", ".join(f"{claim.interface_name} ({claim.policy_type})" for claim in claims)
+            raise MembershipValidationError(f"Member {member.interface_name!r} on switch {member.switch_id!r} " f"has multiple parent owners: {owners}")
+        return claims[0]
+
+    def _require_vpc_parent_claim(
+        self,
+        member: IndexedEthernetMember,
+        *,
+        expected_parent_name: str | None = None,
+        expected_member_field: str | None = None,
+    ) -> _ParentClaim:
+        """Require exactly one compatible vPC parent claim for a physical member."""
+
+        policy = self._required_policy(member.record)
+        parent_name = policy.get("primaryInterface")
+        if not isinstance(parent_name, str) or not parent_name:
+            raise MembershipValidationError(f"vPC member {member.interface_name!r} on switch {member.switch_id!r} " "lacks a valid primaryInterface")
+        claims = self._claims_for(member.switch_id, member.interface_name)
+        if not claims:
+            raise MembershipValidationError(
+                f"vPC member {member.interface_name!r} on switch {member.switch_id!r} is orphaned: " "no parent membership list contains it"
+            )
+        if len(claims) != 1:
+            owners = ", ".join(f"{claim.interface_name} ({claim.policy_type})" for claim in claims)
+            raise MembershipValidationError(f"vPC member {member.interface_name!r} on switch {member.switch_id!r} " f"has multiple parent owners: {owners}")
+        claim = claims[0]
+        descriptor = member.descriptor
+        if descriptor is None or not descriptor.pair_aware:
+            raise MembershipValidationError(
+                f"Interface {member.interface_name!r} on switch {member.switch_id!r} " "does not use a supported pair-aware member policy"
+            )
+        if claim.interface_type != descriptor.parent_interface_type:
+            raise MembershipValidationError(
+                f"vPC member {member.interface_name!r} on switch {member.switch_id!r} is claimed by "
+                f"interface type {claim.interface_type!r}; expected {descriptor.parent_interface_type!r}"
+            )
+        if claim.policy_type not in descriptor.parent_policy_types:
+            raise MembershipValidationError(
+                f"vPC member policy {member.policy_type!r} on {member.interface_name!r} is claimed by "
+                f"incompatible parent policy {claim.policy_type!r}; expected one of {descriptor.parent_policy_types!r}"
+            )
+        if claim.interface_name.lower() != parent_name.lower():
+            raise MembershipValidationError(
+                f"vPC member {member.interface_name!r} on switch {member.switch_id!r} declares "
+                f"primaryInterface {parent_name!r}, but its sole parent claim is {claim.interface_name!r}"
+            )
+        if expected_parent_name is not None and claim.interface_name.lower() != expected_parent_name.lower():
+            raise MembershipValidationError(
+                f"vPC member {member.interface_name!r} on switch {member.switch_id!r} is claimed by "
+                f"parent {claim.interface_name!r}; expected {expected_parent_name!r}"
+            )
+        if expected_member_field is not None and expected_member_field not in claim.claim_fields:
+            raise MembershipValidationError(
+                f"vPC parent {claim.interface_name!r} on switch {member.switch_id!r} does not contain "
+                f"member {member.interface_name!r} in assigned field {expected_member_field!r}"
+            )
+        return claim
+
+    @staticmethod
+    def _validate_parent_envelope(
+        descriptor: MemberPolicyDescriptor,
+        record: InterfaceRecord,
+        *,
+        switch_id: str,
+        parent_name: str,
+    ) -> None:
+        """Require the parent's structural mode and network OS to match its policy."""
+
+        config_data = record.get("configData")
+        if not isinstance(config_data, Mapping):
+            raise MembershipValidationError(f"Parent {parent_name!r} on switch {switch_id!r} lacks valid configData")
+        actual_mode = config_data.get("mode")
+        if actual_mode != descriptor.parent_wire_mode:
+            raise MembershipValidationError(
+                f"Parent {parent_name!r} on switch {switch_id!r} has mode {actual_mode!r}; "
+                f"expected {descriptor.parent_wire_mode!r} for member policy {descriptor.policy_type!r}"
+            )
+        network_os = config_data.get("networkOS")
+        if not isinstance(network_os, Mapping):
+            raise MembershipValidationError(f"Parent {parent_name!r} on switch {switch_id!r} lacks valid networkOS data")
+        actual_network_os = network_os.get("networkOSType")
+        if actual_network_os != descriptor.parent_network_os:
+            raise MembershipValidationError(
+                f"Parent {parent_name!r} on switch {switch_id!r} has networkOSType {actual_network_os!r}; "
+                f"expected {descriptor.parent_network_os!r} for member policy {descriptor.policy_type!r}"
+            )
+
+    def _validate_parent_claim(
+        self,
+        member: IndexedEthernetMember,
+        claim: _ParentClaim,
+        member_port_channel_id: int,
+        *,
+        local_member_field: str,
+    ) -> MemberOwner:
+        descriptor = member.descriptor
+        if descriptor is None:
+            raise MembershipValidationError(
+                f"Interface {member.interface_name!r} on switch {member.switch_id!r} " f"uses protected or unsupported member policy {member.policy_type!r}"
+            )
+        if claim.interface_type != descriptor.parent_interface_type:
+            raise MembershipValidationError(
+                f"Member {member.interface_name!r} on switch {member.switch_id!r} "
+                f"is claimed by interface type {claim.interface_type!r}; expected "
+                f"{descriptor.parent_interface_type!r}"
+            )
+        if claim.policy_type not in descriptor.parent_policy_types:
+            raise MembershipValidationError(
+                f"Member policy {member.policy_type!r} on {member.interface_name!r} "
+                f"is claimed by incompatible parent policy {claim.policy_type!r}; "
+                f"expected one of {descriptor.parent_policy_types!r}"
+            )
+        self._validate_parent_envelope(
+            descriptor,
+            claim.record,
+            switch_id=member.switch_id,
+            parent_name=claim.interface_name,
+        )
+        if local_member_field not in claim.claim_fields:
+            raise MembershipValidationError(
+                f"Parent {claim.interface_name!r} on switch {member.switch_id!r} "
+                f"does not contain member {member.interface_name!r} in required field "
+                f"{local_member_field!r}"
+            )
+
+        parent_id = self._standalone_parent_port_channel_id(claim)
+        if parent_id != member_port_channel_id:
+            raise MembershipValidationError(
+                f"Member {member.interface_name!r} on switch {member.switch_id!r} "
+                f"declares port-channel ID {member_port_channel_id}, but parent "
+                f"{claim.interface_name!r} resolves to ID {parent_id}"
+            )
+
+        return MemberOwner(
+            switch_id=member.switch_id,
+            interface_name=claim.interface_name,
+            interface_type=claim.interface_type,
+            policy_type=claim.policy_type,
+            port_channel_id=parent_id,
+            claim_fields=claim.claim_fields,
+            record=claim.record,
+        )
+
+    def _standalone_parent_port_channel_id(self, claim: _ParentClaim) -> int:
+        try:
+            name_id = normalize_port_channel_id(claim.interface_name)
+            policy = self._policy(claim.record) or {}
+            configured_id = normalize_port_channel_id(policy.get("portChannelId"))
+        except ValueError as exc:
+            raise MembershipValidationError(
+                f"Cannot resolve port-channel identity for parent " f"{claim.interface_name!r} on switch {claim.switch_id!r}: {exc}"
+            ) from exc
+        if name_id is None:
+            raise MembershipValidationError(
+                f"Parent {claim.interface_name!r} on switch {claim.switch_id!r} " "does not have a valid port-channel interface name"
+            )
+        if configured_id is not None and configured_id != name_id:
+            raise MembershipValidationError(
+                f"Parent {claim.interface_name!r} on switch {claim.switch_id!r} " f"has name ID {name_id} but policy portChannelId {configured_id}"
+            )
+        return name_id
+
+    def _validate_vpc_pair(
+        self,
+        member: IndexedEthernetMember,
+        claim: _ParentClaim,
+    ) -> ValidatedMemberOwnership:
+        descriptor = member.descriptor
+        if descriptor is None or not descriptor.pair_aware:
+            raise MembershipValidationError(
+                f"Interface {member.interface_name!r} on switch {member.switch_id!r} " f"does not use a supported pair-aware member policy"
+            )
+        self._validate_vpc_parent_record(
+            descriptor,
+            claim.record,
+            switch_id=member.switch_id,
+            parent_name=claim.interface_name,
+        )
+        peer_switch_id = self._resolve_vpc_peer_switch_id(member.switch_id, claim.interface_name, claim.record)
+        if peer_switch_id not in self._inventories:
+            raise MissingPeerInventoryError(peer_switch_id)
+
+        pair_ids = tuple(sorted((member.switch_id, peer_switch_id)))
+        cache_key = (pair_ids, claim.interface_name.lower(), member.policy_type)
+        cached_pair = self._vpc_pair_validation_cache.get(cache_key)
+        if cached_pair is not None:
+            cached_result = cached_pair.results.get(member.key)
+            if cached_result is None:
+                raise MembershipValidationError(
+                    f"vPC member {member.interface_name!r} on switch {member.switch_id!r} " f"is not owned by validated parent {claim.interface_name!r}"
+                )
+            return cached_result
+
+        peer_parent_record = self._inventories[peer_switch_id].get(claim.interface_name.lower())
+        if peer_parent_record is None:
+            raise MembershipValidationError(f"Peer switch {peer_switch_id!r} does not contain vPC parent copy " f"{claim.interface_name!r}")
+        peer_parent_name = peer_parent_record.get("interfaceName")
+        if not isinstance(peer_parent_name, str) or peer_parent_name.lower() != claim.interface_name.lower():
+            raise MembershipValidationError(
+                f"Peer parent record for {claim.interface_name!r} on switch {peer_switch_id!r} " f"has invalid interfaceName {peer_parent_name!r}"
+            )
+        self._validate_vpc_parent_record(
+            descriptor,
+            peer_parent_record,
+            switch_id=peer_switch_id,
+            parent_name=peer_parent_name,
+        )
+        reciprocal_peer_id = self._resolve_vpc_peer_switch_id(peer_switch_id, peer_parent_name, peer_parent_record)
+        if reciprocal_peer_id != member.switch_id:
+            raise MembershipValidationError(
+                f"vPC parent copies are not reciprocal: {claim.interface_name!r} on "
+                f"switch {peer_switch_id!r} resolves peerSwitchId "
+                f"{reciprocal_peer_id!r}, expected {member.switch_id!r}"
+            )
+
+        local_signature = self._required_vpc_parent_signature(claim.record, member.switch_id, claim.interface_name)
+        peer_signature = self._required_vpc_parent_signature(peer_parent_record, peer_switch_id, peer_parent_name)
+        if local_signature != peer_signature:
+            raise MembershipValidationError(
+                f"vPC parent copies for {claim.interface_name!r} have inconsistent literal configured data; "
+                "ND peer1/peer2 fields must retain the same meaning in both switch echoes"
+            )
+
+        slots = self._vpc_parent_slots(claim.record, member.switch_id, claim.interface_name)
+        orientations = (
+            {pair_ids[0]: slots[0], pair_ids[1]: slots[1]},
+            {pair_ids[0]: slots[1], pair_ids[1]: slots[0]},
+        )
+        valid_orientations: list[tuple[dict[str, _VpcParentSlot], dict[str, tuple[_ValidatedVpcSlotMember, ...]]]] = []
+        orientation_errors: list[str] = []
+        for orientation in orientations:
+            try:
+                validated_by_switch = {
+                    switch_id: self._validate_vpc_members_for_parent(
+                        switch_id=switch_id,
+                        member_names=slot.member_names,
+                        expected_policy_type=member.policy_type,
+                        expected_parent_name=claim.interface_name,
+                        expected_port_channel_id=slot.port_channel_id,
+                        expected_member_field=slot.member_field,
+                    )
+                    for switch_id, slot in orientation.items()
+                }
+                valid_orientations.append((orientation, validated_by_switch))
+            except MembershipValidationError as exc:
+                orientation_errors.append(str(exc))
+
+        if not valid_orientations:
+            raise MembershipValidationError(
+                f"Cannot map literal peer1/peer2 slots for vPC parent {claim.interface_name!r} "
+                f"onto switches {list(pair_ids)!r}: {'; '.join(orientation_errors)}"
+            )
+        if len(valid_orientations) > 1 and slots[0].fingerprint != slots[1].fingerprint:
+            raise MembershipValidationError(
+                f"Cannot unambiguously map non-equivalent peer1/peer2 slots for vPC parent " f"{claim.interface_name!r} onto switches {list(pair_ids)!r}"
+            )
+
+        orientation, validated_by_switch = valid_orientations[0]
+        parent_records = {member.switch_id: claim.record, peer_switch_id: peer_parent_record}
+        owners = {
+            switch_id: MemberOwner(
+                switch_id=switch_id,
+                interface_name=str(parent_records[switch_id].get("interfaceName")),
+                interface_type="vpc",
+                policy_type=str(policy_type_from_interface_record(parent_records[switch_id])),
+                port_channel_id=slot.port_channel_id,
+                claim_fields=(slot.member_field,),
+                record=parent_records[switch_id],
+            )
+            for switch_id, slot in orientation.items()
+        }
+        results: dict[MemberKey, ValidatedMemberOwnership] = {}
+        for switch_id, validated_members in validated_by_switch.items():
+            other_switch_id = pair_ids[1] if switch_id == pair_ids[0] else pair_ids[0]
+            peer_members = tuple(item.member for item in validated_by_switch[other_switch_id])
+            for validated_member in validated_members:
+                result = ValidatedMemberOwnership(
+                    member=validated_member.member,
+                    owner=owners[switch_id],
+                    configured_port_channel_id=validated_member.configured_port_channel_id,
+                    operational_port_channel_id=validated_member.operational_port_channel_id,
+                    peer_owner=owners[other_switch_id],
+                    peer_members=peer_members,
+                    pair_validated=True,
+                )
+                results[validated_member.member.key] = result
+
+        proof = _ValidatedVpcParentPair(results=MappingProxyType(results))
+        self._vpc_pair_validation_cache[cache_key] = proof
+        self._validation_cache.update(results)
+        target = results.get(member.key)
+        if target is None:
+            raise MembershipValidationError(
+                f"vPC member {member.interface_name!r} on switch {member.switch_id!r} is not in the "
+                f"validated local slot for parent {claim.interface_name!r}"
+            )
+        return target
+
+    def _validate_vpc_parent_record(
+        self,
+        descriptor: MemberPolicyDescriptor,
+        record: InterfaceRecord,
+        *,
+        switch_id: str,
+        parent_name: str,
+    ) -> None:
+        """Validate one vPC parent copy without assigning its literal peer slot."""
+
+        if record.get("interfaceType") != descriptor.parent_interface_type:
+            raise MembershipValidationError(
+                f"vPC parent {parent_name!r} on switch {switch_id!r} has interface type "
+                f"{record.get('interfaceType')!r}; expected {descriptor.parent_interface_type!r}"
+            )
+        policy_type = policy_type_from_interface_record(record)
+        if policy_type not in descriptor.parent_policy_types:
+            raise MembershipValidationError(
+                f"vPC parent {parent_name!r} on switch {switch_id!r} uses incompatible policy "
+                f"{policy_type!r}; expected one of {descriptor.parent_policy_types!r}"
+            )
+        self._validate_parent_envelope(descriptor, record, switch_id=switch_id, parent_name=parent_name)
+
+    def _vpc_parent_slots(self, record: InterfaceRecord, switch_id: str, parent_name: str) -> tuple[_VpcParentSlot, _VpcParentSlot]:
+        """Return the two literal, pair-wide peer slots from one coherent parent copy."""
+
+        policy = self._required_policy(record)
+        slots = []
+        for number in (1, 2):
+            slots.append(
+                _VpcParentSlot(
+                    number=number,
+                    port_channel_id=self._required_policy_port_channel_id(
+                        record,
+                        f"peer{number}PortChannelId",
+                        parent_name=parent_name,
+                        switch_id=switch_id,
+                    ),
+                    member_names=self._required_vpc_member_names(
+                        record,
+                        f"peer{number}MemberPorts",
+                        switch_id,
+                        parent_name,
+                    ),
+                    fingerprint=tuple(
+                        sorted(
+                            (key[5:], self._freeze_vpc_value(value, field_name=key))
+                            for key, value in policy.items()
+                            if isinstance(key, str) and key.startswith(f"peer{number}") and len(key) > 5
+                        )
+                    ),
+                )
+            )
+        return slots[0], slots[1]
+
+    def _validate_vpc_members_for_parent(
+        self,
+        *,
+        switch_id: str,
+        member_names: frozenset[str],
+        expected_policy_type: str,
+        expected_parent_name: str,
+        expected_port_channel_id: int,
+        expected_member_field: str,
+    ) -> tuple[_ValidatedVpcSlotMember, ...]:
+        actual_members = self._vpc_members_by_parent.get((switch_id, expected_parent_name.lower()), ())
+        actual_names = frozenset(item.interface_name.lower() for item in actual_members)
+        if actual_names != member_names:
+            missing = sorted(member_names - actual_names)
+            unlisted = sorted(actual_names - member_names)
+            raise MembershipValidationError(
+                f"vPC parent {expected_parent_name!r} on switch {switch_id!r} has member-set "
+                f"mismatch for this slot: missing={missing!r}, unlisted={unlisted!r}"
+            )
+
+        validated: list[_ValidatedVpcSlotMember] = []
+        for slot_member in actual_members:
+            if slot_member.policy_type != expected_policy_type:
+                raise MembershipValidationError(
+                    f"vPC member {slot_member.interface_name!r} on switch "
+                    f"{switch_id!r} uses policy {slot_member.policy_type!r}; expected "
+                    f"{expected_policy_type!r}"
+                )
+            self._require_vpc_parent_claim(
+                slot_member,
+                expected_parent_name=expected_parent_name,
+                expected_member_field=expected_member_field,
+            )
+            configured_id, operational_id = self._member_port_channel_ids(slot_member)
+            if configured_id != expected_port_channel_id:
+                raise MembershipValidationError(
+                    f"vPC member {slot_member.interface_name!r} on switch "
+                    f"{switch_id!r} declares port-channel ID {configured_id}; "
+                    f"expected {expected_port_channel_id}"
+                )
+            self._validate_primary_interface(slot_member, expected_parent_name)
+            validated.append(
+                _ValidatedVpcSlotMember(
+                    member=slot_member,
+                    configured_port_channel_id=configured_id,
+                    operational_port_channel_id=operational_id,
+                )
+            )
+        return tuple(validated)
+
+    @staticmethod
+    def _validate_primary_interface(member: IndexedEthernetMember, expected_parent_name: str) -> None:
+        policy = EthernetMembershipIndex._required_policy(member.record)
+        primary_interface = policy.get("primaryInterface")
+        if not isinstance(primary_interface, str) or (primary_interface.lower() != expected_parent_name.lower()):
+            raise MembershipValidationError(
+                f"vPC member {member.interface_name!r} on switch {member.switch_id!r} "
+                f"declares primaryInterface {primary_interface!r}; expected "
+                f"{expected_parent_name!r}"
+            )
+
+    @staticmethod
+    def _required_policy_port_channel_id(
+        record: InterfaceRecord,
+        field: str,
+        *,
+        parent_name: str,
+        switch_id: str,
+    ) -> int:
+        policy = EthernetMembershipIndex._required_policy(record)
+        try:
+            port_channel_id = normalize_port_channel_id(policy.get(field))
+        except ValueError as exc:
+            raise MembershipValidationError(f"vPC parent {parent_name!r} on switch {switch_id!r} has invalid " f"{field}: {exc}") from exc
+        if port_channel_id is None:
+            raise MembershipValidationError(f"vPC parent {parent_name!r} on switch {switch_id!r} lacks valid " f"{field}")
+        return port_channel_id
+
+    @staticmethod
+    def _required_vpc_member_names(
+        record: InterfaceRecord,
+        field: str,
+        switch_id: str,
+        parent_name: str,
+    ) -> frozenset[str]:
+        policy = EthernetMembershipIndex._required_policy(record)
+        raw_names = policy.get(field)
+        names = EthernetMembershipIndex._normalized_member_names(raw_names)
+        if not names:
+            raise MembershipValidationError(f"vPC parent {parent_name!r} on switch {switch_id!r} lacks a " f"non-empty {field} list")
+        return names
+
+    @staticmethod
+    def _normalized_member_names(value: object) -> frozenset[str]:
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+            return frozenset()
+        names: set[str] = set()
+        for name in value:
+            if isinstance(name, str) and name.strip():
+                names.add(name.strip().lower())
+        return frozenset(names)
+
+    @staticmethod
+    def _mapping(value: object) -> Mapping[str, Any]:
+        return value if isinstance(value, Mapping) else {}
+
+    @staticmethod
+    def _policy(record: InterfaceRecord) -> Mapping[str, Any] | None:
+        config_data = record.get("configData")
+        if not isinstance(config_data, Mapping):
+            return None
+        network_os = config_data.get("networkOS")
+        if not isinstance(network_os, Mapping):
+            return None
+        policy = network_os.get("policy")
+        return policy if isinstance(policy, Mapping) else None
+
+    @staticmethod
+    def _required_policy(record: InterfaceRecord) -> Mapping[str, Any]:
+        policy = EthernetMembershipIndex._policy(record)
+        if policy is None:
+            raise MembershipValidationError(f"Interface {record.get('interfaceName')!r} lacks a valid policy mapping")
+        return policy

--- a/plugins/module_utils/models/interfaces/ethernet_member_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_member_interface.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar, Literal, Mapping
+from typing import ClassVar, Literal, Mapping, Union
 
 from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
     Field,
@@ -218,7 +218,13 @@ class AccessVpcPoMemberPolicyModel(AccessPoMemberPolicyModel):
     primary_interface: str | None = Field(default=None, alias="primaryInterface", description="Owning vPC interface")
 
 
-NexusMemberPolicyModel = PoMemberPolicyModel | AccessPoMemberPolicyModel | L3PoMemberPolicyModel | VpcMemberPolicyModel | AccessVpcPoMemberPolicyModel
+NexusMemberPolicyModel = Union[
+    PoMemberPolicyModel,
+    AccessPoMemberPolicyModel,
+    L3PoMemberPolicyModel,
+    VpcMemberPolicyModel,
+    AccessVpcPoMemberPolicyModel,
+]
 
 
 class NexusEthernetMemberNetworkOSModel(NDNestedModel):

--- a/plugins/module_utils/models/interfaces/ethernet_member_interface.py
+++ b/plugins/module_utils/models/interfaces/ethernet_member_interface.py
@@ -1,0 +1,670 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Internal models and policy metadata for safe ethernet port-channel member updates.
+
+The public ethernet modules own host policies, while an attached physical port uses a
+different controller policy (for example ``poMember``).  Serializing that record through
+a host-policy model changes its policy discriminator and can detach the port.  This module
+therefore models the member records exactly and offers a narrow, non-mutating overlay for
+the three properties the controller permits the ethernet modules to manage in-place.
+
+This is an internal serialization layer, not an Ansible argument-spec model.  Ownership
+and parent-consistency checks remain the orchestrator's responsibility.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import ClassVar, Literal, Mapping
+
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    Field,
+    model_validator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    FecEnum,
+    LacpRateEnum,
+    PortChannelModeEnum,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import (
+    AllowedVlans,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.policy_base import (
+    InterfacePolicyStrictBase,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.nested import (
+    NDNestedModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.types import (
+    AsciiDescription,
+)
+
+SAFE_MEMBER_UPDATE_FIELDS = frozenset({"admin_state", "description", "extra_config"})
+"""Python field names that may be changed without replacing a member policy."""
+
+_SAFE_MEMBER_UPDATE_ALIASES = {
+    "adminState": "admin_state",
+    "description": "description",
+    "extraConfig": "extra_config",
+}
+
+_EXTRA_CONFIG_COMMAND_SEPARATOR = re.compile(r"[;\r\n]+")
+_PORT_CHANNEL_ID = re.compile(r"^(?:port-?channel)?\s*(\d+)$", re.IGNORECASE)
+
+
+class MemberPolicyDisposition(str, Enum):
+    """Safety classification used by ethernet orchestrators before planning a mutation."""
+
+    SUPPORTED = "supported"
+    PAIR_AWARE = "pair_aware"
+    PROTECTED = "protected"
+    NOT_MEMBER = "not_member"
+
+
+@dataclass(frozen=True)
+class MemberPolicyDescriptor:
+    """Static relationship between a member policy and its owning parent policy."""
+
+    policy_type: str
+    family: Literal["access", "trunk", "routed"]
+    network_os: Literal["nx-os", "ios-xe"]
+    wire_mode: Literal["access", "trunk", "routed"]
+    parent_interface_type: Literal["portChannel", "vpc"]
+    parent_policy_types: tuple[str, ...]
+    parent_wire_mode: Literal["access", "trunk", "routed"]
+    parent_network_os: Literal["nx-os", "ios-xe"]
+    parent_member_fields: tuple[str, ...] = ("ports",)
+    pair_aware: bool = False
+
+    @property
+    def disposition(self) -> MemberPolicyDisposition:
+        """Return the validation level required before this member may be updated."""
+
+        if self.pair_aware:
+            return MemberPolicyDisposition.PAIR_AWARE
+        return MemberPolicyDisposition.SUPPORTED
+
+
+class EthernetMemberModelError(ValueError):
+    """Base exception for member classification, parsing, and safe-overlay failures."""
+
+
+class UnsupportedMemberPolicyError(EthernetMemberModelError):
+    """Raised when a record is not one of the explicitly modeled member policies."""
+
+
+class UnsafeMemberUpdateError(EthernetMemberModelError):
+    """Raised when a requested overlay could alter policy family or membership."""
+
+
+class UnmodeledMemberConfigurationError(EthernetMemberModelError):
+    """Raised when a full member PUT would silently discard nested configuration."""
+
+
+class NexusPortChannelMemberPolicyBase(InterfacePolicyStrictBase):
+    """Fields declared by the common NX-OS member templates."""
+
+    port_channel_id: str = Field(
+        alias="portChannelId",
+        min_length=1,
+        description="Owning port-channel identifier",
+    )
+    port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode")
+    cdp: bool | None = Field(default=None, alias="cdp", description="Enable CDP")
+    lacp_port_priority: int | None = Field(
+        default=None,
+        alias="lacpPortPriority",
+        ge=1,
+        le=65535,
+        description="LACP port priority",
+    )
+    lacp_rate: LacpRateEnum | None = Field(default=None, alias="lacpRate", description="LACP packet rate")
+    description: AsciiDescription = Field(
+        default=None,
+        alias="description",
+        max_length=254,
+        description="Interface description",
+    )
+    debounce_timer: int | None = Field(
+        default=None,
+        alias="debounceTimer",
+        ge=0,
+        le=20000,
+        description="Link-down debounce timer",
+    )
+    debounce_linkup_timer: int | None = Field(
+        default=None,
+        alias="debounceLinkupTimer",
+        ge=1000,
+        le=10000,
+        description="Link-up debounce timer",
+    )
+    fec: FecEnum | None = Field(default=None, alias="fec", description="Forward error correction mode")
+    extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional interface CLI")
+
+
+class PoMemberPolicyModel(NexusPortChannelMemberPolicyBase):
+    """NX-OS standalone trunk port-channel member (``poMember``)."""
+
+    policy_type: Literal["poMember"] = Field(alias="policyType")
+    allowed_vlans: AllowedVlans = Field(default=None, alias="allowedVlans", description="Allowed VLANs")
+
+
+class AccessPoMemberPolicyModel(NexusPortChannelMemberPolicyBase):
+    """NX-OS standalone access port-channel member (``accessPoMember``)."""
+
+    policy_type: Literal["accessPoMember"] = Field(alias="policyType")
+
+
+class L3PoMemberPolicyModel(InterfacePolicyStrictBase):
+    """NX-OS standalone routed port-channel member (``l3PoMember``)."""
+
+    policy_type: Literal["l3PoMember"] = Field(alias="policyType")
+    port_channel_id: str = Field(
+        alias="portChannelId",
+        min_length=1,
+        description="Owning port-channel identifier",
+    )
+    port_channel_mode: PortChannelModeEnum | None = Field(default=None, alias="portChannelMode", description="Port-channel mode")
+    description: AsciiDescription = Field(
+        default=None,
+        alias="description",
+        max_length=254,
+        description="Interface description",
+    )
+    fec: FecEnum | None = Field(default=None, alias="fec", description="Forward error correction mode")
+    extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional interface CLI")
+
+
+class IosXeL3PoMemberPolicyModel(InterfacePolicyStrictBase):
+    """IOS-XE standalone routed port-channel member (``iosXeL3PoMember``)."""
+
+    policy_type: Literal["iosXeL3PoMember"] = Field(alias="policyType")
+    port_channel_id: str = Field(
+        alias="portChannelId",
+        min_length=1,
+        description="Owning port-channel identifier",
+    )
+    port_channel_mode: Literal["on", "active", "passive", "auto", "desirable"] | None = Field(
+        default=None,
+        alias="portChannelMode",
+        description="LACP or PAgP port-channel mode",
+    )
+    description: str | None = Field(
+        default=None,
+        alias="description",
+        max_length=200,
+        description="Interface description",
+    )
+    extra_config: str | None = Field(default=None, alias="extraConfig", description="Additional interface CLI")
+
+
+class VpcMemberPolicyModel(PoMemberPolicyModel):
+    """NX-OS trunk vPC member; updates require proof from both peers."""
+
+    policy_type: Literal["vpcMember"] = Field(alias="policyType")
+    primary_interface: str | None = Field(default=None, alias="primaryInterface", description="Owning vPC interface")
+
+
+class AccessVpcPoMemberPolicyModel(AccessPoMemberPolicyModel):
+    """NX-OS access vPC member; updates require proof from both peers."""
+
+    policy_type: Literal["accessVpcPoMember"] = Field(alias="policyType")
+    primary_interface: str | None = Field(default=None, alias="primaryInterface", description="Owning vPC interface")
+
+
+NexusMemberPolicyModel = PoMemberPolicyModel | AccessPoMemberPolicyModel | L3PoMemberPolicyModel | VpcMemberPolicyModel | AccessVpcPoMemberPolicyModel
+
+
+class NexusEthernetMemberNetworkOSModel(NDNestedModel):
+    """NX-OS container for an exactly modeled member policy."""
+
+    network_os_type: Literal["nx-os"] = Field(alias="networkOSType")
+    policy: NexusMemberPolicyModel = Field(alias="policy", discriminator="policy_type")
+
+
+class IosXeEthernetMemberNetworkOSModel(NDNestedModel):
+    """IOS-XE container for an exactly modeled member policy."""
+
+    network_os_type: Literal["ios-xe"] = Field(alias="networkOSType")
+    policy: IosXeL3PoMemberPolicyModel = Field(alias="policy")
+
+
+class EthernetMemberConfigDataModel(NDNestedModel):
+    """Configuration envelope shared by the supported member records."""
+
+    mode: Literal["access", "trunk", "routed"] = Field(alias="mode")
+    network_os: NexusEthernetMemberNetworkOSModel | IosXeEthernetMemberNetworkOSModel = Field(
+        alias="networkOS",
+        discriminator="network_os_type",
+    )
+
+
+class EthernetMemberInterfaceModel(NDBaseModel):
+    """Response-tolerant, payload-exact model for an existing ethernet member."""
+
+    identifiers: ClassVar[list[str] | None] = ["interface_name"]
+    identifier_strategy: ClassVar[Literal["single", "composite", "hierarchical", "singleton"] | None] = "single"
+    payload_exclude_fields: ClassVar[set[str]] = {"switch_ip"}
+
+    switch_ip: str | None = Field(default=None, alias="switchIp")
+    switch_id: str | None = Field(default=None, alias="switchId")
+    interface_name: str = Field(alias="interfaceName", min_length=1)
+    interface_type: Literal["ethernet"] = Field(default="ethernet", alias="interfaceType")
+    config_data: EthernetMemberConfigDataModel = Field(alias="configData")
+
+    @property
+    def policy(self):
+        """Return the concrete member policy branch."""
+
+        return self.config_data.network_os.policy
+
+    @property
+    def policy_type(self) -> str:
+        """Return the exact controller policy discriminator."""
+
+        return self.policy.policy_type
+
+    @property
+    def descriptor(self) -> MemberPolicyDescriptor:
+        """Return static family and parent metadata for this member policy."""
+
+        descriptor = get_member_policy_descriptor(self.policy_type)
+        if descriptor is None:  # Defensive: the discriminated model should make this unreachable.
+            raise UnsupportedMemberPolicyError(f"Unsupported ethernet member policyType {self.policy_type!r}")
+        return descriptor
+
+    @property
+    def normalized_port_channel_id(self) -> int | None:
+        """Return the member's owning port-channel number in canonical integer form."""
+
+        return normalize_port_channel_id(self.policy.port_channel_id)
+
+    @model_validator(mode="after")
+    def validate_policy_envelope(self):
+        """Ensure the wire mode and network OS agree with the exact policy descriptor."""
+
+        descriptor = self.descriptor
+        actual_network_os = self.config_data.network_os.network_os_type
+        if actual_network_os != descriptor.network_os:
+            raise ValueError(f"policyType {self.policy_type!r} requires networkOSType {descriptor.network_os!r}; " f"got {actual_network_os!r}")
+        if self.config_data.mode != descriptor.wire_mode:
+            raise ValueError(f"policyType {self.policy_type!r} requires wire mode {descriptor.wire_mode!r}; " f"got {self.config_data.mode!r}")
+        return self
+
+
+MEMBER_POLICY_DESCRIPTORS: dict[str, MemberPolicyDescriptor] = {
+    "poMember": MemberPolicyDescriptor(
+        policy_type="poMember",
+        family="trunk",
+        network_os="nx-os",
+        wire_mode="trunk",
+        parent_interface_type="portChannel",
+        parent_policy_types=("trunkPoHost",),
+        parent_wire_mode="trunk",
+        parent_network_os="nx-os",
+    ),
+    # Captured ND inventory reports accessPoMember intent with wire mode access.  Operational
+    # data can independently report mode trunk after the interface joins the port-channel.
+    "accessPoMember": MemberPolicyDescriptor(
+        policy_type="accessPoMember",
+        family="access",
+        network_os="nx-os",
+        wire_mode="access",
+        parent_interface_type="portChannel",
+        parent_policy_types=("accessPoHost",),
+        parent_wire_mode="access",
+        parent_network_os="nx-os",
+    ),
+    "l3PoMember": MemberPolicyDescriptor(
+        policy_type="l3PoMember",
+        family="routed",
+        network_os="nx-os",
+        wire_mode="routed",
+        parent_interface_type="portChannel",
+        parent_policy_types=("l3Po",),
+        parent_wire_mode="routed",
+        parent_network_os="nx-os",
+    ),
+    "iosXeL3PoMember": MemberPolicyDescriptor(
+        policy_type="iosXeL3PoMember",
+        family="routed",
+        network_os="ios-xe",
+        wire_mode="routed",
+        parent_interface_type="portChannel",
+        parent_policy_types=("iosXeL3PortChannel",),
+        parent_wire_mode="routed",
+        parent_network_os="ios-xe",
+    ),
+    "vpcMember": MemberPolicyDescriptor(
+        policy_type="vpcMember",
+        family="trunk",
+        network_os="nx-os",
+        wire_mode="trunk",
+        parent_interface_type="vpc",
+        parent_policy_types=("trunkVpcHost",),
+        parent_wire_mode="trunk",
+        parent_network_os="nx-os",
+        parent_member_fields=("peer1MemberPorts", "peer2MemberPorts"),
+        pair_aware=True,
+    ),
+    "accessVpcPoMember": MemberPolicyDescriptor(
+        policy_type="accessVpcPoMember",
+        family="access",
+        network_os="nx-os",
+        wire_mode="access",
+        parent_interface_type="vpc",
+        parent_policy_types=("accessVpcHost",),
+        parent_wire_mode="access",
+        parent_network_os="nx-os",
+        parent_member_fields=("peer1MemberPorts", "peer2MemberPorts"),
+        pair_aware=True,
+    ),
+}
+"""Exact, modeled member-policy registry consumed by ethernet orchestrators."""
+
+
+# Fail closed for every currently known internal, fabric-owned, specialized, or unsupported
+# member template.  An unknown policy ending in "Member" is also protected by
+# classify_member_policy(), so a new controller template cannot become writable by accident.
+PROTECTED_MEMBER_POLICY_TYPES = frozenset(
+    {
+        "accessVpcMember",
+        "csrMultisiteIfcMember",
+        "dataBrokerPoMember",
+        "dot1qTunnelPoMember",
+        "dot1qTunnelVpcMember",
+        "dot1qTunnelVpcPoMember",
+        "fexPoMember",
+        "iosXeAccessPoMember",
+        "iosXeInternalL3PoMember",
+        "iosXeStackwiseLinkMember",
+        "iosXeTrunkPoMember",
+        "ipfmAccessPoMember",
+        "ipfmTrunkPoMember",
+        "l2DciLinkMember",
+        "l3PoMemberInternal",
+        "multiSiteLinkMember",
+        "pvlanPoMember",
+        "pvlanVpcMember",
+        "trunkVpcMember",
+        "uplinkPoMember",
+        "vpcPeerLinkMember",
+        "vpcUplinkMember",
+        "vrfLiteLinkMember",
+    }
+)
+
+
+_RESPONSE_ONLY_POLICY_FIELDS: dict[str, Mapping[str, type[object]]] = {
+    "accessPoMember": {"ptp": bool, "portMode": str},
+    "poMember": {"ptp": bool},
+    "accessVpcPoMember": {"ptp": bool},
+    "vpcMember": {"ptp": bool},
+    "l3PoMember": {"ptp": bool},
+}
+"""Qualified controller echoes that may be discarded before a member PUT."""
+
+
+def get_member_policy_descriptor(policy_type: object) -> MemberPolicyDescriptor | None:
+    """Return exact metadata for a modeled member policy, otherwise ``None``."""
+
+    if not isinstance(policy_type, str):
+        return None
+    return MEMBER_POLICY_DESCRIPTORS.get(policy_type)
+
+
+def classify_member_policy(policy_type: object) -> MemberPolicyDisposition:
+    """Classify a policy without ever treating an unknown member template as writable."""
+
+    descriptor = get_member_policy_descriptor(policy_type)
+    if descriptor is not None:
+        return descriptor.disposition
+    if isinstance(policy_type, str) and (policy_type in PROTECTED_MEMBER_POLICY_TYPES or policy_type.endswith("Member")):
+        return MemberPolicyDisposition.PROTECTED
+    return MemberPolicyDisposition.NOT_MEMBER
+
+
+def is_member_policy(policy_type: object) -> bool:
+    """Return whether the policy is modeled or conservatively recognized as a member."""
+
+    return classify_member_policy(policy_type) != MemberPolicyDisposition.NOT_MEMBER
+
+
+def is_supported_member_policy(policy_type: object, *, include_pair_aware: bool = False) -> bool:
+    """Return whether safe overlays are modeled, optionally including pair-aware policies."""
+
+    disposition = classify_member_policy(policy_type)
+    if disposition == MemberPolicyDisposition.SUPPORTED:
+        return True
+    return include_pair_aware and disposition == MemberPolicyDisposition.PAIR_AWARE
+
+
+def normalize_port_channel_id(value: object) -> int | None:
+    """Normalize integer and ``Port-channelN`` identities; operational ``-1`` means unset.
+
+    Valid configured identities are 1 through 4096. ``None``, an empty string, and ND's
+    documented integer/string ``-1`` sentinel return ``None``. Zero and every other
+    negative value are invalid rather than alternate unset sentinels, so ownership
+    validation cannot silently accept malformed operational evidence.
+    """
+
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"Invalid port-channel identifier {value!r}")
+    if isinstance(value, int):
+        if value == -1:
+            return None
+        number = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if stripped in {"", "-1"}:
+            return None
+        match = _PORT_CHANNEL_ID.fullmatch(stripped)
+        if not match:
+            raise ValueError(f"Invalid port-channel identifier {value!r}")
+        number = int(match.group(1))
+    else:
+        raise ValueError(f"Invalid port-channel identifier {value!r}")
+    if not 1 <= number <= 4096:
+        raise ValueError(f"Port-channel identifier {number} must be in the range 1..4096")
+    return number
+
+
+def policy_type_from_interface_record(record: Mapping[str, object]) -> str | None:
+    """Read ``configData.networkOS.policy.policyType`` from an interface record."""
+
+    config_data = record.get("configData")
+    if not isinstance(config_data, Mapping):
+        return None
+    network_os = config_data.get("networkOS")
+    if not isinstance(network_os, Mapping):
+        return None
+    policy = network_os.get("policy")
+    if not isinstance(policy, Mapping):
+        return None
+    policy_type = policy.get("policyType")
+    return policy_type if isinstance(policy_type, str) else None
+
+
+def _declared_field_aliases(model: object) -> frozenset[str]:
+    """Return one Pydantic model's complete wire-key set."""
+
+    model_fields = getattr(type(model), "model_fields", None)
+    if not isinstance(model_fields, Mapping):
+        raise UnmodeledMemberConfigurationError(f"Cannot inspect declared fields for member model {type(model).__name__}")
+    return frozenset(str(getattr(field, "alias", None) or name) for name, field in model_fields.items())
+
+
+def _validate_nested_member_configuration(
+    record: Mapping[str, object],
+    model: EthernetMemberInterfaceModel,
+) -> None:
+    """Fail closed when model reconstruction would drop unclassified config intent.
+
+    Top-level inventory metadata is response-only by construction. Nested configData,
+    networkOS, and policy mappings form the full PUT body, so every key there must be
+    modeled or explicitly qualified as a response-only controller echo.
+    """
+
+    config_data = record.get("configData")
+    if not isinstance(config_data, Mapping):
+        raise UnmodeledMemberConfigurationError("Member record lacks a valid configData mapping")
+    network_os = config_data.get("networkOS")
+    if not isinstance(network_os, Mapping):
+        raise UnmodeledMemberConfigurationError("Member record lacks a valid configData.networkOS mapping")
+    policy = network_os.get("policy")
+    if not isinstance(policy, Mapping):
+        raise UnmodeledMemberConfigurationError("Member record lacks a valid configData.networkOS.policy mapping")
+
+    checks = (
+        ("configData", config_data, model.config_data, {}),
+        ("configData.networkOS", network_os, model.config_data.network_os, {}),
+        (
+            "configData.networkOS.policy",
+            policy,
+            model.policy,
+            _RESPONSE_ONLY_POLICY_FIELDS.get(model.policy_type, {}),
+        ),
+    )
+    violations: list[str] = []
+    for path, raw_mapping, nested_model, response_only in checks:
+        for key in set(raw_mapping) - _declared_field_aliases(nested_model):
+            expected_type = response_only.get(key) if isinstance(key, str) else None
+            if expected_type is None or not isinstance(raw_mapping[key], expected_type):
+                violations.append(f"{path}.{key!s}")
+    if violations:
+        raise UnmodeledMemberConfigurationError(
+            f"Cannot safely update member policy {model.policy_type!r}: unclassified or malformed nested "
+            f"configuration fields would be omitted from the full PUT: {sorted(violations)!r}"
+        )
+
+
+def parse_member_interface_response(
+    record: Mapping[str, object],
+) -> EthernetMemberInterfaceModel:
+    """Parse a modeled member response while stripping controller-only fields.
+
+    Protected and unknown member policies are rejected with their safety classification in
+    the error. Qualified response-only echoes such as NX-OS ``ptp`` and top-level inventory
+    metadata are discarded. Any other unmodeled nested configuration fails closed.
+    """
+
+    policy_type = policy_type_from_interface_record(record)
+    disposition = classify_member_policy(policy_type)
+    if disposition not in {
+        MemberPolicyDisposition.SUPPORTED,
+        MemberPolicyDisposition.PAIR_AWARE,
+    }:
+        raise UnsupportedMemberPolicyError(f"Cannot model ethernet member policyType {policy_type!r}; classification is {disposition.value!r}")
+    model = EthernetMemberInterfaceModel.from_response(dict(record))
+    _validate_nested_member_configuration(record, model)
+    return model
+
+
+def _is_cli_abbreviation(token: str, command: str, minimum_length: int) -> bool:
+    """Return whether token is a conservative, ordinary CLI abbreviation."""
+
+    return len(token) >= minimum_length and command.startswith(token)
+
+
+def _extra_config_command_changes_membership(command: str) -> bool:
+    """Classify one normalized interface CLI command without executing it."""
+
+    tokens = command.casefold().split()
+    if not tokens:
+        return False
+
+    first = tokens[0]
+    if _is_cli_abbreviation(first, "exit", 2) or _is_cli_abbreviation(first, "end", 2):
+        return True
+    if _is_cli_abbreviation(first, "default-interface", len("default-i")):
+        return True
+
+    command_index = 0
+    if first == "no" or _is_cli_abbreviation(first, "default", 3):
+        command_index = 1
+    if command_index < len(tokens):
+        candidate = tokens[command_index]
+        if _is_cli_abbreviation(candidate, "channel-group", 2):
+            return True
+        if _is_cli_abbreviation(candidate, "interface", 3):
+            return True
+
+    if first == "do":
+        command_index = 1
+    else:
+        command_index = 0
+    return command_index < len(tokens) and _is_cli_abbreviation(tokens[command_index], "configure", 4)
+
+
+def _extra_config_changes_membership(extra_config: str) -> bool:
+    """Reject membership commands and attempts to escape the interface context.
+
+    NX-OS accepts newlines, carriage returns, and semicolons as command boundaries.
+    Inspect every command segment so a safe-looking prefix cannot hide a later
+    channel-group/default-interface operation. Ordinary NX-OS abbreviations are
+    treated the same as their full commands. Context-changing commands are also
+    rejected because subsequent text could target the parent or another interface.
+    """
+    for segment in _EXTRA_CONFIG_COMMAND_SEPARATOR.split(extra_config):
+        command = segment.strip()
+        if not command or command.startswith("!"):
+            continue
+        if _extra_config_command_changes_membership(command):
+            return True
+    return False
+
+
+def normalize_safe_member_updates(updates: Mapping[str, object]) -> dict[str, object]:
+    """Normalize safe snake/camel-case update keys and reject membership-changing CLI."""
+
+    normalized: dict[str, object] = {}
+    for supplied_key, value in updates.items():
+        key = _SAFE_MEMBER_UPDATE_ALIASES.get(supplied_key, supplied_key)
+        if key not in SAFE_MEMBER_UPDATE_FIELDS:
+            raise UnsafeMemberUpdateError(f"Port-channel members may update only {sorted(SAFE_MEMBER_UPDATE_FIELDS)}; got {supplied_key!r}")
+        if key in normalized:
+            raise UnsafeMemberUpdateError(f"Member update supplies {key!r} more than once")
+        normalized[key] = value
+
+    extra_config = normalized.get("extra_config")
+    if isinstance(extra_config, str) and _extra_config_changes_membership(extra_config):
+        raise UnsafeMemberUpdateError("extra_config for an attached member must not change channel-group membership or default the interface")
+    return normalized
+
+
+def build_member_update_payload(
+    member: Mapping[str, object] | EthernetMemberInterfaceModel,
+    updates: Mapping[str, object],
+    *,
+    switch_id: str | None = None,
+    pair_validated: bool = False,
+) -> dict[str, object]:
+    """Return a member-preserving PUT payload with only safe requested fields overlaid.
+
+    The supplied model/record is never mutated.  Pair-aware vPC policies additionally require
+    the caller to attest that both peer records and their common parent were validated.
+    """
+
+    model = member if isinstance(member, EthernetMemberInterfaceModel) else parse_member_interface_response(member)
+    descriptor = model.descriptor
+    if descriptor.pair_aware and not pair_validated:
+        raise UnsafeMemberUpdateError(f"policyType {descriptor.policy_type!r} requires pair-aware ownership validation before update")
+
+    normalized_updates = normalize_safe_member_updates(updates)
+    updated = model.model_copy(deep=True)
+    for field_name, value in normalized_updates.items():
+        setattr(updated.policy, field_name, value)
+
+    payload = updated.to_payload()
+    resolved_switch_id = switch_id if switch_id is not None else updated.switch_id
+    if resolved_switch_id is not None:
+        payload["switchId"] = resolved_switch_id
+    return payload

--- a/plugins/module_utils/orchestrators/ethernet_access_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_access_interface.py
@@ -15,11 +15,15 @@ from __future__ import annotations
 from typing import ClassVar, Type
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import AccessHostPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    AccessHostPolicyTypeEnum,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import (
     EthernetAccessInterfaceModel,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import EthernetBaseOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import (
+    EthernetBaseOrchestrator,
+)
 
 
 class EthernetAccessInterfaceOrchestrator(EthernetBaseOrchestrator):
@@ -39,6 +43,7 @@ class EthernetAccessInterfaceOrchestrator(EthernetBaseOrchestrator):
     """
 
     model_class: ClassVar[Type[NDBaseModel]] = EthernetAccessInterfaceModel
+    MEMBER_FAMILY: ClassVar[str] = "access"
 
     def _managed_policy_types(self) -> set[str]:
         """
@@ -51,3 +56,10 @@ class EthernetAccessInterfaceOrchestrator(EthernetBaseOrchestrator):
         None
         """
         return {e.value for e in AccessHostPolicyTypeEnum}
+
+    def query_all(self, model_instance: NDBaseModel | None = None, **kwargs):
+        """Return access hosts plus named compatible member planning projections."""
+        result = super().query_all(model_instance=model_instance, **kwargs)
+        if not isinstance(result, list):
+            return result
+        return self._append_named_member_projections(result)

--- a/plugins/module_utils/orchestrators/ethernet_base.py
+++ b/plugins/module_utils/orchestrators/ethernet_base.py
@@ -27,11 +27,18 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import ClassVar
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import NDEndpointBaseModel
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_fabrics_switches_vpc_pair import (
+    EpVpcPairGet,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
     EpManageInterfacesGet,
     EpManageInterfacesListGet,
@@ -39,12 +46,41 @@ from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manag
     EpManageInterfacesPost,
     EpManageInterfacesPut,
 )
+from ansible_collections.cisco.nd.plugins.module_utils.interface_membership import (
+    EthernetMembershipIndex,
+    MissingPeerInventoryError,
+    MissingPeerIdentityError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import InterfaceDefaultConfig
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_member_interface import (
+    MemberPolicyDisposition,
+    build_member_update_payload,
+    classify_member_policy,
+    get_member_policy_descriptor,
+    normalize_safe_member_updates,
+    parse_member_interface_response,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import (
+    InterfaceDefaultConfig,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
+    NDBaseInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
 
 ModelType = NDBaseModel
+
+
+@dataclass(frozen=True)
+class MemberUpdateIntent:
+    """Original caller intent retained while the state machine merges a planning projection."""
+
+    requested_state: str
+    effective_state: str
+    requested_fields: frozenset[str]
+    requested_values: dict[str, Any]
 
 
 class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
@@ -92,7 +128,23 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
     # template body (InterfaceDefaultConfig), which resets the interface and drops it from type-specific query filters.
     delete_bulk_endpoint: type[NDEndpointBaseModel] | None = EpManageInterfacesNormalize
 
-    PORT_CHANNEL_MODIFIABLE_FIELDS: ClassVar[set[str]] = {"description", "admin_state", "extra_config"}
+    PORT_CHANNEL_MODIFIABLE_FIELDS: ClassVar[set[str]] = {
+        "description",
+        "admin_state",
+        "extra_config",
+    }
+    MEMBER_FAMILY: ClassVar[str] = ""
+    MEMBER_PLANNING_SHAPES: ClassVar[dict[tuple[str, str], tuple[str, str]]] = {
+        ("access", "nx-os"): ("access", "accessHost"),
+        ("trunk", "nx-os"): ("trunk", "trunkHost"),
+        ("routed", "nx-os"): ("routed", "routedHost"),
+        ("routed", "ios-xe"): ("routed", "iosXeRoutedHost"),
+    }
+    MEMBER_SAFE_FIELD_ALIASES: ClassVar[dict[str, str]] = {
+        "admin_state": "adminState",
+        "description": "description",
+        "extra_config": "extraConfig",
+    }
 
     # Policy types a create/update may OVERWRITE on an existing interface: the host-facing ethernet policy types a user can create
     # through the ND 4.2.1 create-side OpenAPI discriminators (`createInterfaceEthernet{Trunk,Access,Routed,Pvlan,Dot1qTunnel,
@@ -143,6 +195,12 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         super().model_post_init(__context)
         self._pending_normalizes: list[tuple[str, str]] = []
         self._pending_resets: list[tuple[str, str]] = []
+        self._member_records: dict[tuple[str, str], dict] = {}
+        self._member_intents: dict[tuple[str, str], MemberUpdateIntent] = {}
+        self._validated_member_ownership: dict[tuple[str, str], Any] = {}
+        self._membership_index_cache = None
+        self._membership_index_inventory_switches: frozenset[str] = frozenset()
+        self._member_peer_serial_cache: dict[str, str] = {}
 
     def _managed_policy_types(self) -> set[str]:
         """
@@ -226,6 +284,390 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         """
         return self._switch_interfaces(switch_id).get(interface_name.lower())
 
+    def _canonical_task_interface_name(self, switch_ip: str, interface_name: str) -> str:
+        """Normalize a task interface name through the concrete host model.
+
+        Discovery runs before the state machine creates its proposed collection, but member
+        projections must still match abbreviations such as e1/24 and gi3 to the controller's
+        canonical names. Identifier-only construction invokes the same field validator used
+        later by planning.
+        """
+        try:
+            identity = self.model_class.from_config(
+                {"switch_ip": switch_ip, "interface_name": interface_name},
+                context={"state": "deleted"},
+            )
+            return identity.interface_name
+        except Exception:  # Invalid input is reported by normal proposed-model validation.
+            return interface_name
+
+    def _named_member_targets(self) -> set[tuple[str, str]]:
+        """Return canonical (switch_ip, lower_name) targets explicitly named by the task."""
+        targets: set[tuple[str, str]] = set()
+        params = self.rest_send.params if self.rest_send and self.rest_send.params else {}
+        for item in params.get("config") or []:
+            if not isinstance(item, dict):
+                continue
+            switch_ip = item.get("switch_ip")
+            interface_name = item.get("interface_name")
+            if not isinstance(switch_ip, str) or not isinstance(interface_name, str):
+                continue
+            canonical = self._canonical_task_interface_name(switch_ip, interface_name)
+            targets.add((switch_ip, canonical.lower()))
+        return targets
+
+    def _member_planning_projection(self, member_record: dict, switch_ip: str) -> dict:
+        """Return a host-shaped, read-only planning projection for one authentic member.
+
+        The state machine can only compare instances of the public host model. Projecting the
+        member's identity and three safe properties lets it classify a named member as UPDATE,
+        while the untouched authentic record remains in _member_records for payload
+        construction. Membership metadata is deliberately absent from this projection.
+        """
+        member = parse_member_interface_response(member_record)
+        descriptor = member.descriptor
+        shape = self.MEMBER_PLANNING_SHAPES.get((descriptor.family, descriptor.network_os))
+        if shape is None:
+            raise RuntimeError(
+                f"No host planning shape is registered for member policy '{descriptor.policy_type}' " f"({descriptor.family}/{descriptor.network_os})."
+            )
+        mode, projected_policy_type = shape
+        projected_policy: dict[str, Any] = {"policyType": projected_policy_type}
+        for field_name, alias in self.MEMBER_SAFE_FIELD_ALIASES.items():
+            value = getattr(member.policy, field_name, None)
+            # A defaults-only routed response may echo description as an empty string,
+            # while the public routed-host input model accepts only non-empty descriptions.
+            if descriptor.family == "routed" and field_name == "description" and value == "":
+                continue
+            if value is not None:
+                projected_policy[alias] = value
+        return {
+            "switchIp": switch_ip,
+            "interfaceName": member.interface_name,
+            "interfaceType": "ethernet",
+            "configData": {
+                "mode": mode,
+                "networkOS": {
+                    "networkOSType": descriptor.network_os,
+                    "policy": projected_policy,
+                },
+            },
+        }
+
+    def _append_named_member_projections(self, result: list[dict]) -> list[dict]:
+        """Append compatible real members explicitly named by a mutating task.
+
+        Omitted members never enter the public host-family scope, including under overridden.
+        Gathered remains host-only. Concrete orchestrators call this after their normal
+        default-interface filters so a safe-only projection is never discarded as a default.
+        """
+        params = self.rest_send.params if self.rest_send and self.rest_send.params else {}
+        if params.get("state") == "gathered" or not self.MEMBER_FAMILY:
+            return result
+        named = self._named_member_targets()
+        if not named:
+            return result
+
+        projected = list(result)
+        projected_keys = {(item.get("switchIp"), str(item.get("interfaceName", "")).lower()) for item in projected if isinstance(item, dict)}
+        for switch_ip, switch_id in self._switches_to_query().items():
+            for lower_name, record in self._switch_interfaces(switch_id).items():
+                task_key = (switch_ip, lower_name)
+                if task_key not in named or task_key in projected_keys:
+                    continue
+                policy_type = self._existing_policy_type(record)
+                disposition = classify_member_policy(policy_type)
+                descriptor = get_member_policy_descriptor(policy_type)
+                if descriptor is not None and descriptor.family == self.MEMBER_FAMILY:
+                    member_key = (switch_id, lower_name)
+                    self._member_records[member_key] = record
+                    projected.append(self._member_planning_projection(record, switch_ip))
+                    projected_keys.add(task_key)
+                    continue
+                # A delete cannot safely normalize any member policy, including a
+                # protected or wrong-family one. Add identity only so the generic
+                # delete planner routes it through preflight_delete, which inspects
+                # the authentic cached record and fails before a write.
+                if params.get("state") == "deleted" and disposition != MemberPolicyDisposition.NOT_MEMBER:
+                    projected.append(
+                        {
+                            "switchIp": switch_ip,
+                            "interfaceName": record.get("interfaceName"),
+                            "interfaceType": "ethernet",
+                        }
+                    )
+                    projected_keys.add(task_key)
+        return projected
+
+    @staticmethod
+    def _requested_member_updates(
+        model_instance: ModelType,
+    ) -> tuple[frozenset[str], dict[str, Any]]:
+        """Extract exactly the policy fields explicitly supplied by the caller."""
+        config_data = getattr(model_instance, "config_data", None)
+        network_os = getattr(config_data, "network_os", None)
+        policy = getattr(network_os, "policy", None)
+        if policy is None:
+            return frozenset(), {}
+        requested_fields = frozenset(field for field in policy.model_fields_set if field != "policy_type")
+        requested_values = {field: getattr(policy, field) for field in requested_fields}
+        return requested_fields, requested_values
+
+    @staticmethod
+    def _member_key(switch_id: str, interface_name: str) -> tuple[str, str]:
+        """Return the canonical key shared by member records, intents, and ownership."""
+        return switch_id, interface_name.lower()
+
+    def _cache_member_peer_switch_id(
+        self,
+        switch_id: str,
+        peer_switch_id: str,
+        *,
+        source: str,
+    ) -> str:
+        """Validate and cache one reciprocal vPC switch-pair relationship."""
+        if not isinstance(peer_switch_id, str) or not peer_switch_id:
+            raise RuntimeError(f"{source} for switch {switch_id!r} is missing a valid " f"peerSwitchId; received {peer_switch_id!r}.")
+        if peer_switch_id == switch_id:
+            raise RuntimeError(f"{source} for switch {switch_id!r} points to itself.")
+
+        cached_peer = self._member_peer_serial_cache.get(switch_id)
+        if cached_peer is not None and cached_peer != peer_switch_id:
+            raise RuntimeError(f"Conflicting vPC pair evidence for switch {switch_id!r}: " f"{cached_peer!r} and {peer_switch_id!r}.")
+        reciprocal = self._member_peer_serial_cache.get(peer_switch_id)
+        if reciprocal is not None and reciprocal != switch_id:
+            raise RuntimeError(f"Cached vPC pair evidence for peer {peer_switch_id!r} resolves " f"{reciprocal!r}, not {switch_id!r}.")
+        for owner, peer in self._member_peer_serial_cache.items():
+            if peer == peer_switch_id and owner != switch_id:
+                raise RuntimeError(f"Cached vPC pair evidence assigns peer {peer_switch_id!r} " f"to both {owner!r} and {switch_id!r}.")
+
+        self._member_peer_serial_cache[switch_id] = peer_switch_id
+        self._member_peer_serial_cache[peer_switch_id] = switch_id
+        return peer_switch_id
+
+    def _resolve_member_peer_switch_id(self, switch_id: str) -> str:
+        """Resolve one omitted vPC peer through the established cached pair endpoint."""
+
+        cached = self._member_peer_serial_cache.get(switch_id)
+        if cached is not None:
+            return cached
+        endpoint = EpVpcPairGet()
+        endpoint.fabric_name = self.fabric_name
+        endpoint.switch_id = switch_id
+        result = self._request(
+            path=endpoint.path,
+            verb=endpoint.verb,
+            not_found_ok=True,
+        )
+        if not isinstance(result, dict) or not result:
+            raise RuntimeError(f"Cannot resolve the vPC peer for switch {switch_id!r}: the " "vpcPair endpoint returned no pair evidence.")
+        record_switch_id = result.get("switchId")
+        if record_switch_id not in (None, switch_id):
+            raise RuntimeError(f"vPC pair evidence requested for switch {switch_id!r} declares " f"switchId {record_switch_id!r}.")
+        peer_switch_id = result.get("peerSwitchId")
+        if not isinstance(peer_switch_id, str) or not peer_switch_id:
+            raise RuntimeError(f"vPC pair evidence for switch {switch_id!r} is missing a valid " f"peerSwitchId; received {result!r}.")
+        return self._cache_member_peer_switch_id(
+            switch_id,
+            peer_switch_id,
+            source="vPC pair endpoint evidence",
+        )
+
+    @staticmethod
+    def _interface_policy(record: dict[str, Any]) -> dict[str, Any] | None:
+        """Return one interface record's policy mapping when its envelope is valid."""
+        config_data = record.get("configData")
+        if not isinstance(config_data, dict):
+            return None
+        network_os = config_data.get("networkOS")
+        if not isinstance(network_os, dict):
+            return None
+        policy = network_os.get("policy")
+        return policy if isinstance(policy, dict) else None
+
+    def _pair_aware_member_parent(
+        self,
+        switch_id: str,
+        member_record: dict[str, Any],
+    ) -> tuple[str, dict[str, Any], dict[str, Any]] | None:
+        """Return a compatible cached vPC parent for one named member routing hint."""
+        policy = self._interface_policy(member_record)
+        if policy is None:
+            return None
+        descriptor = get_member_policy_descriptor(policy.get("policyType"))
+        if descriptor is None or not descriptor.pair_aware:
+            return None
+        parent_name = policy.get("primaryInterface")
+        if not isinstance(parent_name, str) or not parent_name:
+            return None
+        parent_record = self._switch_interfaces_cache.get(switch_id, {}).get(parent_name.lower())
+        if not isinstance(parent_record, dict):
+            return None
+        parent_policy = self._interface_policy(parent_record)
+        parent_config = parent_record.get("configData")
+        parent_network_os = parent_config.get("networkOS") if isinstance(parent_config, dict) else None
+        if (
+            parent_record.get("interfaceType") != descriptor.parent_interface_type
+            or not isinstance(parent_policy, dict)
+            or parent_policy.get("policyType") not in descriptor.parent_policy_types
+            or not isinstance(parent_network_os, dict)
+            or parent_config.get("mode") != descriptor.parent_wire_mode
+            or parent_network_os.get("networkOSType") != descriptor.parent_network_os
+        ):
+            return None
+        return parent_name, parent_record, parent_policy
+
+    def _prefetch_named_member_peer_inventories(self) -> None:
+        """Prefetch every unique vPC peer needed by explicitly named members.
+
+        Pair relationships are all resolved and checked before any peer inventory
+        request. This lets one membership index validate arbitrarily many pairs and
+        also keeps conflicting or malformed pair evidence fail-closed before writes.
+        """
+        pairs: set[frozenset[str]] = set()
+        seen_parents: set[tuple[str, str]] = set()
+        for (switch_id, _member_name), member_record in sorted(self._member_records.items()):
+            parent = self._pair_aware_member_parent(switch_id, member_record)
+            if parent is None:
+                continue
+            parent_name, _parent_record, parent_policy = parent
+            parent_key = (switch_id, parent_name.lower())
+            if parent_key in seen_parents:
+                continue
+            seen_parents.add(parent_key)
+
+            peer_switch_id = parent_policy.get("peerSwitchId")
+            if peer_switch_id in (None, ""):
+                peer_switch_id = self._resolve_member_peer_switch_id(switch_id)
+            else:
+                peer_switch_id = self._cache_member_peer_switch_id(
+                    switch_id,
+                    peer_switch_id,
+                    source=f"vPC parent {parent_name!r}",
+                )
+            pairs.add(frozenset((switch_id, peer_switch_id)))
+
+        for pair in sorted(tuple(sorted(pair)) for pair in pairs):
+            for switch_id in pair:
+                if switch_id not in self._switch_interfaces_cache:
+                    self._switch_interfaces(switch_id)
+
+    def _membership_index(self) -> EthernetMembershipIndex:
+        """Return the index built from cached inventories and vPC pair evidence."""
+        inventory_switches = frozenset(self._switch_interfaces_cache)
+        if self._membership_index_cache is not None and inventory_switches != self._membership_index_inventory_switches:
+            # Direct orchestrator callers can load another switch after an earlier
+            # safe PUT. The PUT itself does not invalidate ownership, but an index
+            # predating a newly cached inventory cannot validate that switch.
+            self._membership_index_cache = None
+        if self._membership_index_cache is None:
+            self._prefetch_named_member_peer_inventories()
+            self._membership_index_cache = EthernetMembershipIndex(
+                self._switch_interfaces_cache,
+                peer_switch_ids=self._member_peer_serial_cache,
+            )
+            self._membership_index_inventory_switches = frozenset(self._switch_interfaces_cache)
+        return self._membership_index_cache
+
+    def _validate_member_ownership(self, switch_id: str, interface_name: str):
+        """Validate ownership with at most one cached pair and peer-inventory GET."""
+        try:
+            try:
+                return self._membership_index().validate(switch_id, interface_name)
+            except MissingPeerIdentityError as exc:
+                # A schema-valid parent echo may omit peerSwitchId. Reuse the
+                # vPC modules' authoritative per-switch vpcPair endpoint and
+                # retain both orientations so every member of the pair shares it.
+                self._resolve_member_peer_switch_id(exc.switch_id)
+                self._membership_index_cache = None
+                return self._membership_index().validate(switch_id, interface_name)
+        except MissingPeerInventoryError as exc:
+            # The per-switch interface cache guarantees one peer inventory GET,
+            # shared by every later member in the same module invocation.
+            self._switch_interfaces(exc.peer_switch_id)
+            self._membership_index_cache = None
+            return self._membership_index().validate(switch_id, interface_name)
+
+    @staticmethod
+    def _desired_network_os(model_instance: ModelType) -> str | None:
+        """Return the public host model's requested network OS discriminator."""
+        config_data = getattr(model_instance, "config_data", None)
+        network_os = getattr(config_data, "network_os", None)
+        return getattr(network_os, "network_os_type", None)
+
+    def _prepare_member_intent(self, model_instance: ModelType, existing_data: dict | None) -> bool:
+        """Validate a real member target and retain its original explicit safe-field intent.
+
+        Returns True only for an exact supported member policy. Unknown, protected,
+        wrong-family, replacement-state, and ambiguous ownership cases fail closed.
+        """
+        policy_type = self._existing_policy_type(existing_data)
+        disposition = classify_member_policy(policy_type)
+        if disposition == MemberPolicyDisposition.NOT_MEMBER:
+            return False
+        if existing_data is None:
+            raise AssertionError("Member classification requires an existing interface record")
+
+        descriptor = get_member_policy_descriptor(policy_type)
+        if descriptor is None:
+            raise RuntimeError(
+                f"Interface {model_instance.interface_name} on switch {model_instance.switch_ip} "
+                f"uses protected or unsupported member policy '{policy_type}'."
+            )
+        if descriptor.family != self.MEMBER_FAMILY:
+            raise RuntimeError(
+                f"Interface {model_instance.interface_name} uses member policy '{policy_type}' "
+                f"from the '{descriptor.family}' family; the '{self.MEMBER_FAMILY}' ethernet "
+                f"module cannot modify it."
+            )
+
+        desired_network_os = self._desired_network_os(model_instance)
+        if desired_network_os is not None and desired_network_os != descriptor.network_os:
+            raise RuntimeError(
+                f"Interface {model_instance.interface_name} uses member policy '{policy_type}' "
+                f"for network OS '{descriptor.network_os}', but the task requested "
+                f"'{desired_network_os}'."
+            )
+
+        state = self.rest_send.params.get("state") if self.rest_send and self.rest_send.params else None
+        if state != "merged":
+            raise RuntimeError(
+                f"Interface {model_instance.interface_name} uses port-channel member policy "
+                f"'{policy_type}'. Standalone ethernet modules support member-safe updates only "
+                f"with state: merged; requested state: {state}."
+            )
+
+        requested_fields, requested_values = self._requested_member_updates(model_instance)
+        non_safe = requested_fields - self.PORT_CHANNEL_MODIFIABLE_FIELDS
+        if non_safe:
+            raise RuntimeError(
+                f"Interface {model_instance.interface_name} is a port-channel member. "
+                f"The following explicitly requested fields cannot be modified: "
+                f"{sorted(non_safe)}. Only these fields can be modified: "
+                f"{sorted(self.PORT_CHANNEL_MODIFIABLE_FIELDS)}."
+            )
+        # Performs value normalization and rejects membership-changing extra_config.
+        requested_values = normalize_safe_member_updates(requested_values)
+
+        switch_id = self._resolve_switch_id(model_instance.switch_ip)
+        key = self._member_key(switch_id, model_instance.interface_name)
+        # query_all() already records every named member for state-machine use.
+        # Direct update() callers reach this method without that discovery pass;
+        # register the authentic record now so peer prefetch precedes index build.
+        self._member_records[key] = existing_data
+        ownership = self._validate_member_ownership(switch_id, model_instance.interface_name)
+        if descriptor.pair_aware and not ownership.pair_validated:
+            raise RuntimeError(f"Pair-aware ownership validation did not complete for vPC member " f"{model_instance.interface_name}.")
+
+        self._validated_member_ownership[key] = ownership
+        self._member_intents[key] = MemberUpdateIntent(
+            requested_state=state,
+            effective_state="merged",
+            requested_fields=requested_fields,
+            requested_values=requested_values,
+        )
+        return True
+
     def _check_port_channel_restrictions(self, model_instance: ModelType, existing_data: dict | None = None) -> None:
         """
         # Summary
@@ -254,6 +696,14 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         port_channel_id = self._existing_port_channel_id(existing_data)
         if port_channel_id is None:
             return
+        policy_type = self._existing_policy_type(existing_data)
+        if classify_member_policy(policy_type) == MemberPolicyDisposition.NOT_MEMBER:
+            raise RuntimeError(
+                f"Interface {model_instance.interface_name} has operational port-channel "
+                f"membership {port_channel_id}, but its configured policy is "
+                f"'{policy_type}'. Refusing a host-policy write because membership evidence "
+                f"is inconsistent; reconcile the parent port-channel first."
+            )
 
         if model_instance.config_data is None:
             return
@@ -340,6 +790,24 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         - If the existing wire policy type is not in `CONVERTIBLE_POLICY_TYPES`.
         """
         existing_type = self._existing_policy_type(existing_data)
+        disposition = classify_member_policy(existing_type)
+        if disposition != MemberPolicyDisposition.NOT_MEMBER:
+            if get_member_policy_descriptor(existing_type) is None:
+                raise RuntimeError(
+                    f"Interface {model_instance.interface_name} on switch {model_instance.switch_ip} is owned by the fabric "
+                    f"(system policy '{existing_type}'). Refusing to overwrite it with policy "
+                    f"'{self._desired_policy_type(model_instance)}'. Only explicitly supported user-owned member policies "
+                    f"can use the dedicated member-safe update path."
+                )
+            switch_id = self._resolve_switch_id(model_instance.switch_ip)
+            key = self._member_key(switch_id, model_instance.interface_name)
+            if key in self._validated_member_ownership:
+                return
+            raise RuntimeError(
+                f"Interface {model_instance.interface_name} on switch "
+                f"{model_instance.switch_ip} uses member policy '{existing_type}', but "
+                f"the dedicated member ownership and safe-field checks have not passed."
+            )
         if existing_type is None or existing_type in self.CONVERTIBLE_POLICY_TYPES:
             return
         raise RuntimeError(
@@ -390,8 +858,10 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         for model_instance in model_instances:
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             existing_data = self._existing_interface(model_instance.interface_name, switch_id)
+            member_target = self._prepare_member_intent(model_instance, existing_data)
             self._check_fabric_ownership(model_instance, existing_data)
-            self._check_port_channel_restrictions(model_instance, existing_data)
+            if not member_target:
+                self._check_port_channel_restrictions(model_instance, existing_data)
 
     def preflight_delete(self, model_instances: Sequence[ModelType]) -> None:
         """
@@ -461,6 +931,21 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
 
         - If the existing wire state shows the interface is a port-channel member.
         """
+        policy_type = self._existing_policy_type(existing_data)
+        disposition = classify_member_policy(policy_type)
+        if disposition != MemberPolicyDisposition.NOT_MEMBER:
+            configured_id = None
+            if get_member_policy_descriptor(policy_type) is not None and existing_data is not None:
+                try:
+                    configured_id = parse_member_interface_response(existing_data).normalized_port_channel_id
+                except ValueError:
+                    configured_id = None
+            owner = f"port-channel {configured_id}" if configured_id is not None else f"member policy '{policy_type}'"
+            raise RuntimeError(
+                f"Interface {model_instance.interface_name} is a member of {owner}. "
+                f"Refusing to normalize a port-channel member (this would strip its "
+                f"channel-group membership). Remove it from the parent first."
+            )
         port_channel_id = self._existing_port_channel_id(existing_data)
         if port_channel_id is not None:
             raise RuntimeError(
@@ -684,6 +1169,13 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         try:
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             existing_data = kwargs.get("existing_data") or self._existing_interface(model_instance.interface_name, switch_id)
+            existing_policy_type = self._existing_policy_type(existing_data)
+            if classify_member_policy(existing_policy_type) != MemberPolicyDisposition.NOT_MEMBER:
+                raise RuntimeError(
+                    f"Interface {model_instance.interface_name} already exists with member "
+                    f"policy '{existing_policy_type}'; a member must never be sent through "
+                    f"the create endpoint."
+                )
             self._check_fabric_ownership(model_instance, existing_data)
             self._check_port_channel_restrictions(model_instance, existing_data)
             api_endpoint = self._configure_endpoint(self.create_endpoint(), switch_sn=switch_id)
@@ -695,6 +1187,45 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
             return result
         except Exception as e:
             raise RuntimeError(f"Create failed for {model_instance.get_identifier_value()}: {e}") from e
+
+    def _update_member(self, model_instance: ModelType, switch_id: str, existing_data: dict) -> ResponseType:
+        """PUT a validated member-policy payload without changing its membership.
+
+        The original explicit caller fields were captured in preflight before the state
+        machine merged its host-shaped planning projection. Direct orchestrator callers are
+        also safe: when no intent exists yet, the same validation is performed here.
+        """
+        key = self._member_key(switch_id, model_instance.interface_name)
+        if key not in self._member_intents:
+            self._prepare_member_intent(model_instance, existing_data)
+        self._check_fabric_ownership(model_instance, existing_data)
+
+        intent = self._member_intents.get(key)
+        ownership = self._validated_member_ownership.get(key)
+        if intent is None or ownership is None:
+            raise RuntimeError(f"Member-safe intent or ownership proof is missing for " f"{model_instance.interface_name} on switch {switch_id}.")
+        api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
+        api_endpoint.set_identifiers(model_instance.interface_name)
+        payload = build_member_update_payload(
+            existing_data,
+            intent.requested_values,
+            switch_id=switch_id,
+            pair_validated=bool(ownership.pair_validated),
+        )
+        result = self._request(path=api_endpoint.path, verb=api_endpoint.verb, data=payload)
+
+        # Keep discovery coherent without a post-write GET. Only configData changed; retain
+        # operational evidence and other response metadata from the cached record.
+        updated_record = deepcopy(existing_data)
+        updated_record["switchId"] = switch_id
+        updated_record["configData"] = deepcopy(payload["configData"])
+        self._switch_interfaces_cache[switch_id][model_instance.interface_name.lower()] = updated_record
+        self._member_records[key] = updated_record
+        # The safe overlay cannot change member policy, primaryInterface, port-channel
+        # identity, or parent membership lists. Retain the cached ownership index and
+        # its proofs across later member PUTs in this invocation.
+        self._queue_deploy(model_instance.interface_name, switch_id)
+        return result
 
     def update(self, model_instance: ModelType, **kwargs) -> ResponseType:
         """
@@ -718,6 +1249,11 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         try:
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             existing_data = kwargs.get("existing_data") or self._existing_interface(model_instance.interface_name, switch_id)
+            existing_policy_type = self._existing_policy_type(existing_data)
+            if get_member_policy_descriptor(existing_policy_type) is not None:
+                if existing_data is None:
+                    raise AssertionError("Member update requires existing interface data")
+                return self._update_member(model_instance, switch_id, existing_data)
             self._check_fabric_ownership(model_instance, existing_data)
             self._check_port_channel_restrictions(model_instance, existing_data)
             api_endpoint = self._configure_endpoint(self.update_endpoint(), switch_sn=switch_id)
@@ -802,6 +1338,13 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
             for model_instance in model_instances:
                 switch_id = self._resolve_switch_id(model_instance.switch_ip)
                 existing_data = kwargs.get("existing_data") or self._existing_interface(model_instance.interface_name, switch_id)
+                existing_policy_type = self._existing_policy_type(existing_data)
+                if classify_member_policy(existing_policy_type) != MemberPolicyDisposition.NOT_MEMBER:
+                    raise RuntimeError(
+                        f"Interface {model_instance.interface_name} already exists with member "
+                        f"policy '{existing_policy_type}'; a member must never be sent through "
+                        f"the bulk create endpoint."
+                    )
                 self._check_fabric_ownership(model_instance, existing_data)
                 self._check_port_channel_restrictions(model_instance, existing_data)
                 payload = model_instance.to_payload()
@@ -891,14 +1434,17 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         for model_instance in model_instances:
             switch_id = self._resolve_switch_id(model_instance.switch_ip)
             existing_data = kwargs.get("existing_data") or self._existing_interface(model_instance.interface_name, switch_id)
+            policy_type = self._existing_policy_type(existing_data)
+            member_disposition = classify_member_policy(policy_type)
             port_channel_id = self._existing_port_channel_id(existing_data)
-            if port_channel_id is not None:
+            if member_disposition != MemberPolicyDisposition.NOT_MEMBER or port_channel_id is not None:
                 if state == "overridden":
+                    owner = port_channel_id if port_channel_id is not None else policy_type
                     logger.info(
-                        "Skipping port-channel member %s on switch %s (member of port-channel %s) during state:overridden",
+                        "Skipping port-channel member %s on switch %s (owner %s) during state:overridden",
                         model_instance.interface_name,
                         model_instance.switch_ip,
-                        port_channel_id,
+                        owner,
                     )
                     continue
                 self._check_port_channel_delete_restriction(model_instance, existing_data)
@@ -938,9 +1484,9 @@ class EthernetBaseOrchestrator(NDBaseInterfaceOrchestrator[ModelType]):
         The set of switches queried is determined by `_switches_to_query`: fabric-wide for `state: overridden`,
         and limited to switches named in the user config for all other states.
 
-        Port-channel member interfaces are included in the results (they exist on the switch and need to be visible
-        for port-channel restriction checks in `create` / `update`). `delete_bulk` skips PC members when invoked
-        under `state: overridden` so fabric-wide convergence does not detach interfaces from their port-channels.
+        Compatible port-channel members are projected into mutating-state results only when explicitly named by
+        the task. Omitted members remain outside family and overridden scope, and gathered remains host-only.
+        `delete_bulk` also skips members so fabric-wide convergence cannot detach them from their port-channels.
 
         Runs `validate_prerequisites` on first call to ensure the fabric exists and is modifiable before returning any data.
 

--- a/plugins/module_utils/orchestrators/ethernet_routed_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_routed_interface.py
@@ -21,7 +21,9 @@ import logging
 from collections.abc import Sequence
 from typing import ClassVar
 
-from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_links import EpManageLinksListGet
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_links import (
+    EpManageLinksListGet,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
     EthernetRoutedPolicyTypeEnum,
@@ -33,9 +35,15 @@ from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.etherne
     XeEthernetRoutedPolicyModel,
     normalize_ethernet_interface_name,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.policy_base import InterfacePolicyStrictBase
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import EthernetBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.policy_base import (
+    InterfacePolicyStrictBase,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import (
+    EthernetBaseOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +122,7 @@ class EthernetRoutedInterfaceOrchestrator(EthernetBaseOrchestrator):
     """
 
     model_class: ClassVar[type[NDBaseModel]] = EthernetRoutedInterfaceModel
+    MEMBER_FAMILY: ClassVar[str] = "routed"
 
     # TODO(4.2.1) capable-switches-empty-for-ethernet-on-vxlan
     # Deliberate opt-OUT of the capability preflight (both ClassVars ""): the unpublished capableSwitches
@@ -281,7 +290,10 @@ class EthernetRoutedInterfaceOrchestrator(EthernetBaseOrchestrator):
             "switchId": switch_id,
             "configData": {
                 "mode": "routed",
-                "networkOS": {"networkOSType": "ios-xe", "policy": {"policyType": "iosXeRoutedHost", "adminState": True}},
+                "networkOS": {
+                    "networkOSType": "ios-xe",
+                    "policy": {"policyType": "iosXeRoutedHost", "adminState": True},
+                },
             },
         }
 
@@ -446,7 +458,10 @@ class EthernetRoutedInterfaceOrchestrator(EthernetBaseOrchestrator):
         policy_cls = _POLICY_MODELS.get(policy_type)
         if policy_cls is None:
             return None
-        return {**policy_cls.reverse_diff_defaults, **_ND_INJECTED_READ_KEY_DEFAULTS.get(policy_type, {})}
+        return {
+            **policy_cls.reverse_diff_defaults,
+            **_ND_INJECTED_READ_KEY_DEFAULTS.get(policy_type, {}),
+        }
 
     @staticmethod
     def _is_unconfigured_default(iface: dict) -> bool:
@@ -542,7 +557,7 @@ class EthernetRoutedInterfaceOrchestrator(EthernetBaseOrchestrator):
         result = [iface for iface in result if in_scope(iface)]
         if state == "overridden":
             result = [iface for iface in result if not self._is_ios_xe(iface) or (iface.get("switchIp"), iface.get("interfaceName")) in named]
-        return result
+        return self._append_named_member_projections(result)
 
     @staticmethod
     def _is_ios_xe(iface: dict) -> bool:

--- a/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
+++ b/plugins/module_utils/orchestrators/ethernet_trunk_host_interface.py
@@ -15,13 +15,21 @@ from __future__ import annotations
 from typing import ClassVar
 
 from ansible_collections.cisco.nd.plugins.module_utils.models.base import NDBaseModel
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import TrunkHostPolicyTypeEnum
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.enums import (
+    TrunkHostPolicyTypeEnum,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import (
     EthernetTrunkHostInterfaceModel,
 )
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import InterfaceDefaultConfig
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import EthernetBaseOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import ResponseType
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.interface_default_config import (
+    InterfaceDefaultConfig,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_base import (
+    EthernetBaseOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.types import (
+    ResponseType,
+)
 
 
 class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
@@ -48,6 +56,7 @@ class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
     """
 
     model_class: ClassVar[type[NDBaseModel]] = EthernetTrunkHostInterfaceModel
+    MEMBER_FAMILY: ClassVar[str] = "trunk"
 
     def _managed_policy_types(self) -> set[str]:
         """
@@ -117,4 +126,5 @@ class EthernetTrunkHostInterfaceOrchestrator(EthernetBaseOrchestrator):
         result = super().query_all(model_instance=model_instance, **kwargs)
         if not isinstance(result, list):
             return result
-        return [iface for iface in result if not self._is_unconfigured_default(iface)]
+        filtered = [iface for iface in result if not self._is_unconfigured_default(iface)]
+        return self._append_named_member_projections(filtered)

--- a/plugins/modules/nd_interface_ethernet_access.py
+++ b/plugins/modules/nd_interface_ethernet_access.py
@@ -4,7 +4,11 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -15,9 +19,10 @@ description:
 - Manage ethernet accessHost interfaces on Cisco Nexus Dashboard.
 - It supports creating, updating, and deleting accessHost interface configurations on switches within a fabric.
 - Multiple interfaces can share the same configuration via the O(config[].interface_names) list.
-- Interfaces that are port-channel members have restricted mutability; only O(config[].config_data.network_os.policy.description),
-  O(config[].config_data.network_os.policy.admin_state), and O(config[].config_data.network_os.policy.extra_config)
-  can be modified on port-channel member interfaces.
+- An NX-OS ethernet interface carrying the C(accessPoMember) or C(accessVpcPoMember) policy can be updated with
+  O(state=merged) without changing its port-channel or vPC membership. Only O(config[].config_data.network_os.policy.admin_state),
+  O(config[].config_data.network_os.policy.description), and O(config[].config_data.network_os.policy.extra_config)
+  may be supplied for such a member.
 author:
 - Allen Robel (@allenrobel)
 options:
@@ -126,6 +131,10 @@ options:
                   extra_config:
                     description:
                     - Additional CLI configuration commands to apply to the interface.
+                    - For a C(accessPoMember) or C(accessVpcPoMember) interface, membership-changing and
+                      interface-context commands are rejected. This includes C(channel-group), C(no channel-group),
+                      C(default interface), C(default-interface), C(interface), C(exit), C(end), and
+                      C(configure terminal), including their ordinary CLI abbreviations.
                     type: str
                   fec:
                     description:
@@ -268,6 +277,9 @@ options:
         - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes,
+          that accepted subset is still deployed and is named in the failure message, so a failed task does not leave
+          accepted changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -277,13 +289,20 @@ options:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
     - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
       Resources on ND that are not specified in the configuration will be left unchanged.
-    - Use O(state=replaced) to replace the resources specified in the configuration.
+      For C(accessPoMember) and C(accessVpcPoMember), this is the only supported state and only the three documented
+      member-safe fields may be supplied; all other modeled configurable member-policy fields and membership values
+      are preserved.
+    - Use O(state=replaced) to replace the resources specified in the configuration. An explicitly named
+      C(accessPoMember) or C(accessVpcPoMember) is rejected; use O(state=merged) for its member-safe fields.
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       The resources on ND will be modified to exactly match the configuration.
       Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
+      Omitted member interfaces remain outside the managed C(accessHost) scope, while an explicitly named
+      C(accessPoMember) or C(accessVpcPoMember) is rejected.
     - Use O(state=deleted) to reset the specified interfaces to their fabric default configuration via the
       C(interfaceActions/normalize) API. Physical ethernet interfaces cannot be truly deleted from a switch;
-      this operation is the API equivalent of the NX-OS C(default interface) CLI command.
+      this operation is the API equivalent of the NX-OS C(default interface) CLI command. An explicitly named
+      C(accessPoMember) or C(accessVpcPoMember) is rejected because normalization would change its membership.
     type: str
     default: merged
     choices: [ merged, replaced, overridden, deleted ]
@@ -292,9 +311,35 @@ extends_documentation_fragment:
 - cisco.nd.check_mode
 notes:
 - This module is only supported on Nexus Dashboard.
-- This module manages NX-OS ethernet accessHost interfaces only (interface_type C(ethernet), mode C(access), network_os_type C(nx-os),
-  policy_type C(accessHost)). These values are hardcoded by the module and are not user-configurable.
-- Interfaces that are port-channel members have restricted mutability.
+- This module manages NX-OS ethernet C(accessHost) interfaces (interface_type C(ethernet), mode C(access),
+  network_os_type C(nx-os), policy_type C(accessHost)). These structural values are not user-configurable.
+- Explicitly named C(accessPoMember) and C(accessVpcPoMember) interfaces are also supported under O(state=merged),
+  but only for C(admin_state), C(description), and C(extra_config). The update retains the authentic member policy,
+  owning identifier and mode, and every other modeled configurable member-policy field. Qualified controller
+  response-only echoes are not replayed; any unrecognized nested configuration field fails closed before mutation
+  so a full PUT cannot silently discard future intent.
+- C(accessPoMember) configured intent has mode C(access), even when operational data reports mode C(trunk) after
+  the physical interface joins the port-channel.
+- Manage a C(accessPoMember) parent and its C(ports) membership with
+  M(cisco.nd.nd_interface_port_channel_access). Manage a C(accessVpcPoMember) parent and peer membership with
+  M(cisco.nd.nd_interface_vpc_access). This module never attaches, detaches, or reparents an ethernet member.
+- Before updating C(accessPoMember), the module requires exactly one compatible access port-channel parent on the
+  same switch. The parent must list the member, the member's configured port-channel identifier must match that
+  parent, the parent's configured policy, mode, and network OS must be compatible, and any present positive
+  operational identifier must also agree. Orphaned, multiply claimed, incompatible, or conflicting evidence fails
+  closed before mutation.
+- ND returns literal identical C(peer1*) and C(peer2*) configured values in both vPC parent echoes; only the
+  C(switchId) and C(peerSwitchId) orientation swaps. Before updating C(accessVpcPoMember), the module compares that
+  shared configured state and validates the parent policy, mode, network OS, member policies, member lists,
+  port-channel identifiers, C(primaryInterface), peer identities, and unambiguous ownership on both switches using
+  cached inventories. Missing or inconsistent evidence fails closed before any interface mutation.
+- Pair-aware validation creates one cached pair proof shared by all requested members of the same vPC. Resolving
+  that proof can add one C(/vpcPair) GET when peer identity is not already known and one cached interface-inventory
+  GET when the peer inventory has not already been read. It never adds a GET per member.
+- C(accessVpcMember), peer-link members, uplink members, internal routed members, and other fabric-owned or system
+  member policies remain protected and are rejected before mutation.
+- With O(config_actions.deploy=false), a successful member update remains staged on the controller. With
+  O(config_actions.deploy=true), the changed member is included in the module's final interface deployment call.
 """
 
 EXAMPLES = r"""
@@ -406,9 +451,134 @@ EXAMPLES = r"""
     config_actions:
       deploy: false
     state: merged
+
+- name: Update safe properties on an existing access port-channel member
+  # The access port-channel and its Ethernet1/24 membership already exist.
+  # Membership-changing commands are not permitted in extra_config.
+  cisco.nd.nd_interface_ethernet_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_names:
+          - Ethernet1/24
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: Access port-channel member managed by Ansible
+              extra_config: "logging event link-status"
+    config_actions:
+      deploy: false
+    state: merged
+
+- name: Update one member of an existing access vPC after reciprocal peer validation
+  # The vPC parent and both peer memberships already exist. The peer inventory is
+  # validated, but only the explicitly named Ethernet1/24 interface is updated.
+  cisco.nd.nd_interface_ethernet_access:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_names:
+          - Ethernet1/24
+        config_data:
+          network_os:
+            policy:
+              description: Access vPC member managed by Ansible
+    config_actions:
+      deploy: false
+    state: merged
 """
 
 RETURN = r"""
+changed:
+  description: Whether the module changed, or in check mode would change, the fabric configuration.
+  returned: always
+  type: bool
+  sample: true
+output_level:
+  description: The output verbosity level in effect for the run, echoing the O(output_level) parameter.
+  returned: always
+  type: str
+  sample: normal
+before:
+  description:
+  - The existing managed access interface configurations before the module ran, normalized to one item per
+    interface with singular C(interface_name), rather than grouped by O(config[].interface_names).
+  - For O(state=merged), O(state=replaced), and O(state=deleted), it includes all managed access interfaces on every
+    switch named in O(config), not only the explicitly named interfaces. For O(state=overridden), it is fabric-wide.
+  - An empty list when no matching access interface configuration existed in that query scope.
+  - For a supported C(accessPoMember) or C(accessVpcPoMember) update, the entry is a host-shaped planning/reporting
+    projection containing the member identity and safe fields. It uses C(accessHost) as the reporting policy and
+    omits the authentic member discriminator, owning identifier, and membership metadata. It does not represent a
+    policy conversion.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/1
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          access_vlan: 100
+after:
+  description:
+  - The resulting managed access interface configurations in the same per-interface query scope and singular
+    C(interface_name) format as C(before).
+  - In check mode, the configuration that would result had the module run outside of check mode.
+  - An interface reset to its fabric default by O(state=deleted) or O(state=overridden) leaves the managed access
+    scope and is absent from this list.
+  - For a supported member update, the entry is the resulting host-shaped safe-field projection. The authentic member
+    policy and parent membership remain unchanged on the controller but are not included in this output projection.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/1
+    config_data:
+      network_os:
+        policy:
+          admin_state: true
+          access_vlan: 200
+diff:
+  description:
+  - Reserved for the per-interface difference between C(before) and C(after).
+  - Currently always an empty list for this module family; compare C(before) and C(after) directly.
+  returned: always
+  type: list
+  elements: dict
+  sample: []
+proposed:
+  description: The configuration the module proposed to apply, before reconciliation with the controller.
+  returned: when O(output_level) is V(info) or V(debug)
+  type: list
+  elements: dict
+  sample:
+  - switch_ip: 192.168.1.1
+    interface_name: Ethernet1/1
+    config_data:
+      network_os:
+        policy:
+          access_vlan: 200
+logs:
+  description:
+  - Reserved for internal diagnostic log messages collected during the run.
+  - Currently always an empty list for this module family; use the C(ND_LOGGING_CONFIG) file-based logging
+    described in the collection docs instead.
+  returned: when O(output_level) is V(debug)
+  type: list
+  elements: str
+  sample: []
+msg:
+  description:
+  - A human-readable error message, present only when the module fails.
+  - When O(config_actions.deploy=true) and the controller accepted some changes before the failure, the message
+    names the interfaces whose accepted changes were deployed, or reports that deploying them also failed.
+  returned: on failure
+  type: str
+  sample: "Configuration error: ..."
 """
 
 import copy
@@ -416,14 +586,30 @@ import logging
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import EthernetAccessInterfaceModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import EthernetAccessInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_access_interface import (
+    EthernetAccessInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import (
+    config_actions_spec,
+    nd_argument_spec,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
+    NDBaseInterfaceOrchestrator,
+    finalize_accepted_intent,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import (
+    EthernetAccessInterfaceOrchestrator,
+)
 
 
 # TODO: When all interface modules using `interface_names: list` are merged, lift
@@ -622,6 +808,11 @@ def main() -> None:
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(
+            nd_state_machine.model_orchestrator if nd_state_machine else None,
+            module.check_mode,
+            module_log,
+        )
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -630,6 +821,11 @@ def main() -> None:
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(
+            nd_state_machine.model_orchestrator if nd_state_machine else None,
+            module.check_mode,
+            module_log,
+        )
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_ethernet_routed.py
+++ b/plugins/modules/nd_interface_ethernet_routed.py
@@ -6,7 +6,11 @@
 
 """Ansible module for managing routed-mode ethernet interfaces on Cisco Nexus Dashboard."""
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -18,6 +22,8 @@ description:
 - It supports configuring, updating, and resetting routed ethernet interfaces on switches within a fabric.
 - Physical ethernet interfaces always exist on the switch; configuring one with this module changes its mode to
   C(routed) and applies the requested policy.
+- Existing C(l3PoMember) and C(iosXeL3PoMember) interfaces can be updated with O(state=merged) without changing their
+  routed port-channel membership, but only the documented member-safe properties may be supplied.
 author:
 - Allen Robel (@allenrobel)
 options:
@@ -79,6 +85,8 @@ options:
                       V(routedHost) for C(nx-os) and V(iosXeRoutedHost) for C(ios-xe).
                     - Use V(routedHost) for an NX-OS routed host interface.
                     - Use V(iosXeRoutedHost) for an IOS-XE routed host interface.
+                    - Do not specify a member policy as input. C(l3PoMember) and C(iosXeL3PoMember) are discovered
+                      from current controller intent when updating an existing member.
                     type: str
                     choices: [ routedHost, iosXeRoutedHost ]
                   admin_state:
@@ -96,6 +104,10 @@ options:
                     description:
                     - Additional CLI configuration commands to apply to the interface.
                     - Applies to all policy_type values.
+                    - For C(l3PoMember) and C(iosXeL3PoMember), membership-changing and interface-context commands
+                      are rejected. This includes C(channel-group), C(no channel-group), C(default interface),
+                      C(default-interface), C(interface), C(exit), C(end), and C(configure terminal), including
+                      their ordinary CLI abbreviations.
                     type: str
                   ip:
                     description:
@@ -217,16 +229,22 @@ options:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
     - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
       Resources on ND that are not specified in the configuration will be left unchanged.
-    - Use O(state=replaced) to replace the resources specified in the configuration.
+      For C(l3PoMember) and C(iosXeL3PoMember), this is the only supported state and only O(config[].config_data.network_os.policy.admin_state),
+      O(config[].config_data.network_os.policy.description), and O(config[].config_data.network_os.policy.extra_config)
+      may be supplied; the member policy, owning port-channel identifier, mode, and all other modeled configurable fields are preserved.
+    - Use O(state=replaced) to replace the resources specified in the configuration. An explicitly named
+      C(l3PoMember) or C(iosXeL3PoMember) is rejected; use O(state=merged) for its member-safe fields.
     - Use O(state=overridden) to enforce the configuration as the single source of truth. Named interfaces are
       modified to exactly match the configuration. For NX-OS, every C(routedHost) interface in the fabric that is not
       present in the configuration is reset to its fabric default (fabric-wide remove-omitted semantics); use with
       extra caution. IOS-XE interfaces are merge-only under this state, so named C(iosXeRoutedHost) interfaces converge
-      but omitted IOS-XE interfaces are left untouched and must be reset explicitly with O(state=deleted).
+      but omitted IOS-XE interfaces are left untouched and must be reset explicitly with O(state=deleted). Routed
+      port-channel members remain outside remove-omitted scope and are rejected when explicitly named.
     - Use O(state=deleted) to reset the specified interfaces to their fabric default configuration. Physical
       ethernet interfaces cannot be truly deleted from a switch. NX-OS interfaces reset to the fabric default
       C(trunkHost) policy, taking them out of routed mode; IOS-XE interfaces reset to a default routed
-      configuration with all policy fields cleared.
+      configuration with all policy fields cleared. An explicitly named C(l3PoMember) or C(iosXeL3PoMember) is
+      rejected because reset would change its port-channel membership.
     type: str
     default: merged
     choices: [ merged, replaced, overridden, deleted ]
@@ -237,15 +255,30 @@ notes:
 - This module is only supported on Nexus Dashboard.
 - This module supports both NX-OS and IOS-XE routed ethernet interfaces (interface_type C(ethernet), mode C(routed)),
   selected via O(config[].config_data.network_os.network_os_type).
-- This module manages the C(routedHost) (NX-OS) and C(iosXeRoutedHost) (IOS-XE) policy templates. System routed
-  policy types (fabric links, multi-site link members, VRF-Lite link members, and similar) are never read or modified
-  by this module, so O(state=overridden) cannot affect fabric underlay configuration.
+- This module manages the C(routedHost) (NX-OS) and C(iosXeRoutedHost) (IOS-XE) policy templates. An explicitly named
+  C(l3PoMember) or C(iosXeL3PoMember) is also supported under O(state=merged), but only for C(admin_state),
+  C(description), and C(extra_config). The update retains the member policy, owning port-channel identifier and mode,
+  and all other modeled configurable fields. Qualified controller response-only echoes are not replayed; any
+  unrecognized nested configuration field fails closed before mutation so a full PUT cannot silently discard future
+  intent.
+- System routed policy types (fabric links, multi-site link members, VRF-Lite link members, C(l3PoMemberInternal),
+  C(iosXeInternalL3PoMember), and similar) are never modified by this module, so O(state=overridden) cannot affect
+  fabric underlay configuration.
 - An interface named in O(config) that is currently owned by the fabric is rejected before any change is written,
   in check mode too. This covers an NX-OS interface carrying a system policy (fabric link, multi-site or VRF-Lite
   link member, vPC keep-alive, MPLS uplink, and similar) and an IOS-XE interface that is an endpoint of a fabric
   link, even when that interface reads as a plain C(iosXeRoutedHost). Converting a host-facing interface
   (for example a C(trunkHost) or C(accessHost) port) to routed remains allowed.
-- Interfaces that are port-channel members have restricted mutability.
+- The collection cannot create a routed port-channel parent. C(l3PoMember) and C(iosXeL3PoMember) updates therefore
+  apply only to an aggregate and membership that already exist in controller intent; this module never attaches,
+  detaches, or reparents the member.
+- A standalone routed member update proceeds only when current controller intent proves exactly one compatible routed
+  port-channel parent claim. The member's configured port-channel identity must match the parent; the parent's
+  configured policy, mode, and network OS must be compatible; and any present positive operational identity must
+  match both. Orphaned, multiply claimed, incompatible, conflicting, or otherwise ambiguous ownership evidence fails
+  closed in normal and check mode.
+- With O(config_actions.deploy=false), a successful member update remains staged on the controller. With
+  O(config_actions.deploy=true), the changed member is included in the module's final interface deployment call.
 - O(state=overridden) operates fabric-wide for NX-OS interfaces. An empty O(config) list resets every managed
   NX-OS routed interface in the fabric to its fabric default configuration.
 - IOS-XE interfaces are merge-only under O(state=overridden), they are converged when named in O(config) and
@@ -390,6 +423,25 @@ EXAMPLES = r"""
     config_actions:
       deploy: false
     state: merged
+
+- name: Update safe properties on an existing NX-OS routed port-channel member
+  # The routed aggregate and its Ethernet1/24 membership already exist in controller intent.
+  # Membership-changing commands are not permitted in extra_config.
+  cisco.nd.nd_interface_ethernet_routed:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_name: Ethernet1/24
+        config_data:
+          network_os:
+            network_os_type: nx-os
+            policy:
+              admin_state: true
+              description: Routed port-channel member managed by Ansible
+              extra_config: "logging event link-status"
+    config_actions:
+      deploy: false
+    state: merged
 """
 
 RETURN = r"""
@@ -405,9 +457,19 @@ output_level:
   sample: normal
 before:
   description:
-  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
-  - An empty list when no matching routed interface configuration existed (for example, an interface still in trunk mode).
-  - Under O(state=overridden) it covers every managed NX-OS C(routedHost) interface in the fabric plus the IOS-XE interfaces named in O(config).
+  - The existing managed routed interface configurations before the module ran, normalized to one item per interface
+    with singular C(interface_name).
+  - For O(state=merged), O(state=replaced), and O(state=deleted), it includes all managed routed interfaces on every
+    switch named in O(config), not only the explicitly named interfaces. Unconfigured fabric-default records are
+    omitted unless explicitly named and relevant to the requested state.
+  - For O(state=overridden), it includes every managed NX-OS C(routedHost) interface in the fabric plus the IOS-XE
+    interfaces named in O(config).
+  - An empty list when no matching routed interface configuration existed in that query scope.
+  - For a supported C(l3PoMember) or C(iosXeL3PoMember) update, the entry is a host-shaped planning/reporting
+    projection containing the member identity and safe fields. It uses C(routedHost) or C(iosXeRoutedHost) as the
+    reporting policy and omits the authentic member discriminator, owning identifier, and membership metadata. It
+    does not represent a policy conversion. Each explicitly named member contributes one such entry to C(before) and
+    C(after); omitted members remain outside both lists.
   returned: always
   type: list
   elements: dict
@@ -427,9 +489,12 @@ before:
           description: L3 uplink to WAN edge
 after:
   description:
-  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - The resulting managed routed interface configurations in the same per-interface query scope and singular
+    C(interface_name) format as C(before).
   - In check mode, the configuration that would result had the module run outside of check mode.
   - An interface reset to its fabric default by O(state=deleted) or O(state=overridden) leaves the managed scope and is absent from this list.
+  - For a supported member update, the entry is the resulting host-shaped safe-field projection. The authentic member
+    policy discriminator and parent membership remain unchanged on the controller but are not included in this output projection.
   returned: always
   type: list
   elements: dict
@@ -495,14 +560,30 @@ import logging
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_routed_interface import EthernetRoutedInterfaceModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator, finalize_accepted_intent
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_routed_interface import EthernetRoutedInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_routed_interface import (
+    EthernetRoutedInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import (
+    config_actions_spec,
+    nd_argument_spec,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
+    NDBaseInterfaceOrchestrator,
+    finalize_accepted_intent,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_routed_interface import (
+    EthernetRoutedInterfaceOrchestrator,
+)
 
 
 def main():
@@ -563,7 +644,11 @@ def main():
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
-        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
+        error_msg += finalize_accepted_intent(
+            nd_state_machine.model_orchestrator if nd_state_machine else None,
+            module.check_mode,
+            module_log,
+        )
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -572,7 +657,11 @@ def main():
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
-        error_msg += finalize_accepted_intent(nd_state_machine.model_orchestrator if nd_state_machine else None, module.check_mode, module_log)
+        error_msg += finalize_accepted_intent(
+            nd_state_machine.model_orchestrator if nd_state_machine else None,
+            module.check_mode,
+            module_log,
+        )
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/plugins/modules/nd_interface_ethernet_trunk_host.py
+++ b/plugins/modules/nd_interface_ethernet_trunk_host.py
@@ -4,7 +4,11 @@
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -15,9 +19,10 @@ description:
 - Manage ethernet trunkHost interfaces on Cisco Nexus Dashboard.
 - It supports creating, updating, and deleting trunkHost interface configurations on switches within a fabric.
 - Multiple interfaces can share the same configuration via the O(config[].interface_names) list.
-- Interfaces that are port-channel members have restricted mutability; only O(config[].config_data.network_os.policy.description),
-  O(config[].config_data.network_os.policy.admin_state), and O(config[].config_data.network_os.policy.extra_config)
-  can be modified on port-channel member interfaces.
+- An NX-OS ethernet interface carrying the C(poMember) or C(vpcMember) policy can be updated with O(state=merged)
+  without changing its port-channel or vPC membership. Only O(config[].config_data.network_os.policy.admin_state),
+  O(config[].config_data.network_os.policy.description), and O(config[].config_data.network_os.policy.extra_config)
+  may be supplied for such a member.
 author:
 - Allen Robel (@allenrobel)
 options:
@@ -121,6 +126,10 @@ options:
                   extra_config:
                     description:
                     - Additional CLI configuration commands to apply to the interface.
+                    - For a C(poMember) or C(vpcMember) interface, membership-changing and interface-context
+                      commands are rejected. This includes C(channel-group), C(no channel-group),
+                      C(default interface), C(default-interface), C(interface), C(exit), C(end), and
+                      C(configure terminal), including their ordinary CLI abbreviations.
                     type: str
                   fec:
                     description:
@@ -285,6 +294,9 @@ options:
         - When V(true), all queued interface changes are deployed in a single bulk API call at the end of module
           execution via the C(interfaceActions/deploy) API. Only the interfaces modified by this task are deployed.
         - When V(false), changes are staged but not deployed. Use a separate deploy module or task to deploy later.
+        - When V(true) and the module fails after the controller has already accepted a subset of the requested changes,
+          that accepted subset is still deployed and is named in the failure message, so a failed task does not leave
+          accepted changes staged but undeployed.
         - Setting O(config_actions.deploy=false) is useful when batching changes across multiple interface tasks before a single deploy.
         - Deployment is opt-in. Set O(config_actions.deploy=true) explicitly to push changes to switches.
         type: bool
@@ -294,17 +306,22 @@ options:
     - The desired state of the network resources on the Cisco Nexus Dashboard.
     - Use O(state=merged) to create new resources and update existing ones as defined in your configuration.
       Resources on ND that are not specified in the configuration will be left unchanged.
-    - Use O(state=replaced) to replace the resources specified in the configuration.
+      For C(poMember) and C(vpcMember), this is the only supported state and only the three documented member-safe
+      fields may be supplied; all other modeled configurable member-policy fields and membership values are preserved.
+    - Use O(state=replaced) to replace the resources specified in the configuration. An explicitly named
+      C(poMember) or C(vpcMember) is rejected; use O(state=merged) for its member-safe fields.
     - Use O(state=overridden) to enforce the configuration as the single source of truth.
       The resources on ND will be modified to exactly match the configuration.
       Any resource existing on ND but not present in the configuration will be deleted. Use with extra caution.
       The scope of O(state=overridden) is fabric-wide. Specifying an empty O(config) list resets
       every trunkHost interface in the fabric to its fabric default configuration, not only the
       interfaces named in prior tasks. Use an empty O(config) with O(state=overridden) only when
-      that fabric-wide reset is the intended outcome.
+      that fabric-wide reset is the intended outcome. Omitted member interfaces remain outside the managed
+      C(trunkHost) scope, while an explicitly named C(poMember) or C(vpcMember) is rejected.
     - Use O(state=deleted) to reset the specified interfaces to their fabric default configuration via the
       C(interfaceActions/normalize) API. Physical ethernet interfaces cannot be truly deleted from a switch;
-      this operation is the API equivalent of the NX-OS C(default interface) CLI command.
+      this operation is the API equivalent of the NX-OS C(default interface) CLI command. An explicitly named
+      C(poMember) or C(vpcMember) is rejected because normalization would change its membership.
     type: str
     default: merged
     choices: [ merged, replaced, overridden, deleted ]
@@ -313,9 +330,33 @@ extends_documentation_fragment:
 - cisco.nd.check_mode
 notes:
 - This module is only supported on Nexus Dashboard.
-- This module manages NX-OS ethernet trunkHost interfaces only (interface_type C(ethernet), mode C(trunk),
-  network_os_type C(nx-os), policy_type C(trunkHost)). These values are hardcoded by the module and are not user-configurable.
-- Interfaces that are port-channel members have restricted mutability.
+- This module manages NX-OS ethernet C(trunkHost) interfaces (interface_type C(ethernet), mode C(trunk),
+  network_os_type C(nx-os), policy_type C(trunkHost)). These structural values are not user-configurable.
+- Explicitly named C(poMember) and C(vpcMember) interfaces are also supported under O(state=merged), but only for
+  C(admin_state), C(description), and C(extra_config). The update retains the authentic member policy, owning
+  identifier and mode, and every other modeled configurable member-policy field. Qualified controller response-only
+  echoes are not replayed; any unrecognized nested configuration field fails closed before mutation so a full PUT
+  cannot silently discard future intent.
+- Manage a C(poMember) parent and its C(ports) membership with
+  M(cisco.nd.nd_interface_port_channel_trunk_host). Manage a C(vpcMember) parent and peer membership with
+  M(cisco.nd.nd_interface_vpc_trunk_host). This module never attaches, detaches, or reparents an ethernet member.
+- Before updating C(poMember), the module requires exactly one compatible trunk port-channel parent on the same
+  switch. The parent must list the member, the member's configured port-channel identifier must match that parent,
+  the parent's configured policy, mode, and network OS must be compatible, and any present positive operational
+  identifier must also agree. Orphaned, multiply claimed, incompatible, or conflicting evidence fails closed before
+  mutation.
+- ND returns literal identical C(peer1*) and C(peer2*) configured values in both vPC parent echoes; only the
+  C(switchId) and C(peerSwitchId) orientation swaps. Before updating C(vpcMember), the module compares that shared
+  configured state and validates the parent policy, mode, network OS, member policies, member lists, port-channel
+  identifiers, C(primaryInterface), peer identities, and unambiguous ownership on both switches using cached
+  inventories. Missing or inconsistent evidence fails closed before any interface mutation.
+- Pair-aware validation creates one cached pair proof shared by all requested members of the same vPC. Resolving
+  that proof can add one C(/vpcPair) GET when peer identity is not already known and one cached interface-inventory
+  GET when the peer inventory has not already been read. It never adds a GET per member.
+- Peer-link members, uplink members, internal routed members, and other fabric-owned or system member policies remain
+  protected and are rejected before mutation.
+- With O(config_actions.deploy=false), a successful member update remains staged on the controller. With
+  O(config_actions.deploy=true), the changed member is included in the module's final interface deployment call.
 - O(state=overridden) operates fabric-wide. An empty O(config) list resets every trunkHost
   interface in the fabric to its fabric default configuration.
 """
@@ -468,6 +509,42 @@ EXAMPLES = r"""
     config_actions:
       deploy: false
     state: merged
+
+- name: Update safe properties on an existing trunk port-channel member
+  # The trunk port-channel and its Ethernet1/24 membership already exist.
+  # Membership-changing commands are not permitted in extra_config.
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_names:
+          - Ethernet1/24
+        config_data:
+          network_os:
+            policy:
+              admin_state: true
+              description: Trunk port-channel member managed by Ansible
+              extra_config: "logging event link-status"
+    config_actions:
+      deploy: false
+    state: merged
+
+- name: Update one member of an existing trunk vPC after reciprocal peer validation
+  # The vPC parent and both peer memberships already exist. The peer inventory is
+  # validated, but only the explicitly named Ethernet1/24 interface is updated.
+  cisco.nd.nd_interface_ethernet_trunk_host:
+    fabric_name: my_fabric
+    config:
+      - switch_ip: 192.168.1.1
+        interface_names:
+          - Ethernet1/24
+        config_data:
+          network_os:
+            policy:
+              description: Trunk vPC member managed by Ansible
+    config_actions:
+      deploy: false
+    state: merged
 """
 
 RETURN = r"""
@@ -483,15 +560,21 @@ output_level:
   sample: normal
 before:
   description:
-  - The existing configuration of the targeted interfaces before the module ran, structured the same as the O(config) parameter.
-  - An empty list when no matching interface configuration existed.
+  - The existing managed trunk interface configurations before the module ran, normalized to one item per interface
+    with singular C(interface_name), rather than grouped by O(config[].interface_names).
+  - For O(state=merged), O(state=replaced), and O(state=deleted), it includes all managed trunk interfaces on every
+    switch named in O(config), not only the explicitly named interfaces. For O(state=overridden), it is fabric-wide.
+  - An empty list when no matching trunk interface configuration existed in that query scope.
+  - For a supported C(poMember) or C(vpcMember) update, the entry is a host-shaped planning/reporting projection
+    containing the member identity and safe fields. It uses C(trunkHost) as the reporting policy and omits the
+    authentic member discriminator, owning identifier, and membership metadata. It does not represent a policy
+    conversion.
   returned: always
   type: list
   elements: dict
   sample:
   - switch_ip: 192.168.1.1
-    interface_names:
-    - Ethernet1/1
+    interface_name: Ethernet1/1
     config_data:
       network_os:
         policy:
@@ -499,33 +582,32 @@ before:
           allowed_vlans: "100-200"
 after:
   description:
-  - The configuration of the targeted interfaces after the module ran, structured the same as the O(config) parameter.
+  - The resulting managed trunk interface configurations in the same per-interface query scope and singular
+    C(interface_name) format as C(before).
   - In check mode, the configuration that would result had the module run outside of check mode.
+  - An interface reset to its fabric default by O(state=deleted) or O(state=overridden) leaves the managed trunk
+    scope and is absent from this list.
+  - For a supported member update, the entry is the resulting host-shaped safe-field projection. The authentic member
+    policy and parent membership remain unchanged on the controller but are not included in this output projection.
   returned: always
   type: list
   elements: dict
   sample:
   - switch_ip: 192.168.1.1
-    interface_names:
-    - Ethernet1/1
+    interface_name: Ethernet1/1
     config_data:
       network_os:
         policy:
           admin_state: true
           allowed_vlans: "100-300"
 diff:
-  description: The per-interface difference between C(before) and C(after).
+  description:
+  - Reserved for the per-interface difference between C(before) and C(after).
+  - Currently always an empty list for this module family; compare C(before) and C(after) directly.
   returned: always
   type: list
   elements: dict
-  sample:
-  - switch_ip: 192.168.1.1
-    interface_names:
-    - Ethernet1/1
-    config_data:
-      network_os:
-        policy:
-          allowed_vlans: "100-300"
+  sample: []
 proposed:
   description: The configuration the module proposed to apply, before reconciliation with the controller.
   returned: when O(output_level) is V(info) or V(debug)
@@ -533,21 +615,25 @@ proposed:
   elements: dict
   sample:
   - switch_ip: 192.168.1.1
-    interface_names:
-    - Ethernet1/1
+    interface_name: Ethernet1/1
     config_data:
       network_os:
         policy:
           allowed_vlans: "100-300"
 logs:
-  description: Internal diagnostic log messages collected during the run.
+  description:
+  - Reserved for internal diagnostic log messages collected during the run.
+  - Currently always an empty list for this module family; use the C(ND_LOGGING_CONFIG) file-based logging
+    described in the collection docs instead.
   returned: when O(output_level) is V(debug)
   type: list
   elements: str
-  sample:
-  - "Querying existing trunkHost interface configuration"
+  sample: []
 msg:
-  description: A human-readable error message, present only when the module fails.
+  description:
+  - A human-readable error message, present only when the module fails.
+  - When O(config_actions.deploy=true) and the controller accepted some changes before the failure, the message
+    names the interfaces whose accepted changes were deployed, or reports that deploying them also failed.
   returned: on failure
   type: str
   sample: "Configuration error: ..."
@@ -558,14 +644,30 @@ import logging
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import NDStateMachineError
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
 from ansible_collections.cisco.nd.plugins.module_utils.common.log import setup_logging
-from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import require_pydantic
-from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import EthernetTrunkHostInterfaceModel
-from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import config_actions_spec, nd_argument_spec
-from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import NDStateMachine
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import NDBaseInterfaceOrchestrator
-from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import EthernetTrunkHostInterfaceOrchestrator
+from ansible_collections.cisco.nd.plugins.module_utils.common.pydantic_compat import (
+    require_pydantic,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_trunk_host_interface import (
+    EthernetTrunkHostInterfaceModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_argument_specs import (
+    config_actions_spec,
+    nd_argument_spec,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
+    NDBaseInterfaceOrchestrator,
+    finalize_accepted_intent,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import (
+    EthernetTrunkHostInterfaceOrchestrator,
+)
 
 
 # TODO: When all interface modules using `interface_names: list` are merged, lift
@@ -764,6 +866,11 @@ def main() -> None:
         module_log.exception("NDStateMachineError during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module execution failed: {str(e)}"
+        error_msg += finalize_accepted_intent(
+            nd_state_machine.model_orchestrator if nd_state_machine else None,
+            module.check_mode,
+            module_log,
+        )
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)
@@ -772,6 +879,11 @@ def main() -> None:
         module_log.exception("Unhandled exception during module execution")
         output = nd_state_machine.output.format() if nd_state_machine else {}
         error_msg = f"Module failed: {str(e)}"
+        error_msg += finalize_accepted_intent(
+            nd_state_machine.model_orchestrator if nd_state_machine else None,
+            module.check_mode,
+            module_log,
+        )
         if module.params.get("output_level") == "debug":
             error_msg += f"\nTraceback:\n{traceback.format_exc()}"
         module.fail_json(msg=error_msg, **output)

--- a/tests/integration/targets/nd_interface_ethernet_access/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_access/tasks/main.yaml
@@ -58,5 +58,14 @@
 
     - name: Run nd_interface_ethernet_access deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
+
+    - name: Run nd_interface_ethernet_access port-channel member tests
+      ansible.builtin.include_tasks: port_channel_members.yaml
+
+    - name: Run opt-in nd_interface_ethernet_access vPC member test
+      ansible.builtin.include_tasks: vpc_member_case.yaml
+      when:
+        - access_vpc_member_case.interface_name | length > 0
+        - access_vpc_member_case.baseline_supplied | bool
   environment:
     ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_ethernet_access/tasks/port_channel_members.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_access/tasks/port_channel_members.yaml
@@ -1,0 +1,279 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# IFACE-004 regression coverage. The parent module creates an authentic
+# accessPoMember record; the ethernet module must update that record in place
+# rather than treating it as a new accessHost interface. All changes remain staged.
+
+- name: "PORT-CHANNEL MEMBER: Exercise a real accessPoMember safely"
+  block:
+    - name: "PORT-CHANNEL MEMBER SETUP: Remove a stale test parent"
+      cisco.nd.nd_interface_port_channel_access:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_name: "{{ test_member_port_channel_name }}"
+        config_actions:
+          deploy: false
+        state: deleted
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Create an access parent with one member"
+      cisco.nd.nd_interface_port_channel_access:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_name: "{{ test_member_port_channel_name }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  access_vlan: 100
+                  ports:
+                    - "{{ test_member_interface_name }}"
+                  port_channel_mode: active
+                  copy_description: false
+                  description: "IFACE-004 access parent"
+        config_actions:
+          deploy: false
+        state: merged
+      register: member_parent_create
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Resolve the test switch id"
+      cisco.nd.nd_rest:
+        path: "/api/v1/manage/fabrics/{{ test_fabric_name }}/switches"
+        method: get
+      register: member_switches
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Save the test switch id"
+      ansible.builtin.set_fact:
+        member_switch_id: >-
+          {{ (member_switches.current.switches | selectattr('fabricManagementIp', 'equalto', test_switch_ip)
+             | first).switchId }}
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Read the member before its update"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ test_fabric_name }}/switches/{{ member_switch_id }}/interfaces/{{ test_member_interface_name | replace('/', '%2F') }}
+        method: get
+      register: member_before_wire
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Verify authentic accessPoMember ownership"
+      ansible.builtin.assert:
+        that:
+          - member_parent_create is changed
+          - member_before_wire.current.configData.networkOS.policy.policyType == "accessPoMember"
+          - >-
+            (member_before_wire.current.configData.networkOS.policy.portChannelId | string | lower)
+            in [test_member_port_channel_name | lower, test_member_port_channel_name | lower | replace('port-channel', '')]
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Preview all safe fields"
+      cisco.nd.nd_interface_ethernet_access: &merge_access_member
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: false
+                  description: "IFACE-004 access member updated"
+                  extra_config: "logging event link-status"
+        config_actions:
+          deploy: false
+        state: merged
+      check_mode: true
+      register: member_check_mode
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Apply all safe fields"
+      cisco.nd.nd_interface_ethernet_access: *merge_access_member
+      register: member_update
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Verify the planned and applied update"
+      vars:
+        member_after: >-
+          {{ member_update.after | selectattr('interface_name', 'equalto', test_member_interface_name) | first }}
+      ansible.builtin.assert:
+        that:
+          - member_check_mode is changed
+          - member_update is changed
+          - member_after.config_data.network_os.policy.admin_state == false
+          - member_after.config_data.network_os.policy.description == "IFACE-004 access member updated"
+          - member_after.config_data.network_os.policy.extra_config == "logging event link-status"
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Read the updated member from the wire"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ test_fabric_name }}/switches/{{ member_switch_id }}/interfaces/{{ test_member_interface_name | replace('/', '%2F') }}
+        method: get
+      register: member_after_wire
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Read the parent from the wire"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ test_fabric_name }}/switches/{{ member_switch_id }}/interfaces/{{ test_member_port_channel_name }}
+        method: get
+      register: member_parent_wire
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Verify every modeled preservation field"
+      vars:
+        before_policy: "{{ member_before_wire.current.configData.networkOS.policy }}"
+        wire_policy: "{{ member_after_wire.current.configData.networkOS.policy }}"
+        parent_policy: "{{ member_parent_wire.current.configData.networkOS.policy }}"
+        member_preservation_fields:
+          - policyType
+          - portChannelId
+          - portChannelMode
+          - cdp
+          - lacpPortPriority
+          - lacpRate
+          - debounceTimer
+          - debounceLinkupTimer
+          - fec
+        before_preserved_policy: >-
+          {{ before_policy | dict2items
+             | selectattr('key', 'in', member_preservation_fields)
+             | list | items2dict }}
+        after_preserved_policy: >-
+          {{ wire_policy | dict2items
+             | selectattr('key', 'in', member_preservation_fields)
+             | list | items2dict }}
+      ansible.builtin.assert:
+        that:
+          - before_preserved_policy == after_preserved_policy
+          - member_after_wire.current.interfaceName == member_before_wire.current.interfaceName
+          - member_after_wire.current.interfaceType == member_before_wire.current.interfaceType
+          - member_after_wire.current.configData.mode == member_before_wire.current.configData.mode
+          - >-
+            member_after_wire.current.configData.networkOS.networkOSType
+            == member_before_wire.current.configData.networkOS.networkOSType
+          - wire_policy.adminState == false
+          - wire_policy.description == "IFACE-004 access member updated"
+          - wire_policy.extraConfig == "logging event link-status"
+          - test_member_interface_name in parent_policy.ports
+
+    - name: "PORT-CHANNEL MEMBER IDEMPOTENT: Reapply the safe update"
+      cisco.nd.nd_interface_ethernet_access: *merge_access_member
+      register: member_idempotent
+
+    - name: "PORT-CHANNEL MEMBER IDEMPOTENT: Verify no second mutation"
+      ansible.builtin.assert:
+        that:
+          - member_idempotent is not changed
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject an unsafe host-policy field"
+      cisco.nd.nd_interface_ethernet_access:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  description: "must be rejected atomically"
+                  access_vlan: 200
+        config_actions:
+          deploy: false
+        state: merged
+      register: member_unsafe_field
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject replaced state"
+      cisco.nd.nd_interface_ethernet_access:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  description: "must be rejected under replaced"
+        config_actions:
+          deploy: false
+        state: replaced
+      register: member_replaced
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject overridden state"
+      cisco.nd.nd_interface_ethernet_access:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  description: "must be rejected under overridden"
+        config_actions:
+          deploy: false
+        state: overridden
+      register: member_overridden
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject deleted state"
+      cisco.nd.nd_interface_ethernet_access:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+        config_actions:
+          deploy: false
+        state: deleted
+      register: member_deleted
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject membership-changing extra_config"
+      cisco.nd.nd_interface_ethernet_access:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  extra_config: "no channel-group 591"
+        config_actions:
+          deploy: false
+        state: merged
+      register: member_unsafe_extra_config
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Verify every unsafe request failed"
+      ansible.builtin.assert:
+        that:
+          - member_unsafe_field is failed
+          - member_replaced is failed
+          - member_overridden is failed
+          - member_deleted is failed
+          - member_unsafe_extra_config is failed
+  always:
+    - name: "PORT-CHANNEL MEMBER CLEANUP: Remove the owning access parent"
+      cisco.nd.nd_interface_port_channel_access:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_name: "{{ test_member_port_channel_name }}"
+        config_actions:
+          deploy: false
+        state: deleted

--- a/tests/integration/targets/nd_interface_ethernet_access/tasks/vpc_member_case.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_access/tasks/vpc_member_case.yaml
@@ -1,0 +1,166 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Pair-aware IFACE-004 coverage for a pre-existing access vPC member. This is
+# deliberately opt-in: the test cannot safely create or infer the operator's
+# shared vPC baseline. All controller intent remains staged (deploy: false).
+
+- name: "VPC MEMBER: Exercise an existing accessVpcPoMember safely"
+  block:
+    - name: "VPC MEMBER SETUP: Initialize the mutation guard"
+      ansible.builtin.set_fact:
+        access_vpc_member_mutation_attempted: false
+
+    - name: "VPC MEMBER SETUP: Resolve the selected switch id"
+      cisco.nd.nd_rest:
+        path: "/api/v1/manage/fabrics/{{ access_vpc_member_case.fabric_name }}/switches"
+        method: get
+      register: access_vpc_member_switches
+
+    - name: "VPC MEMBER SETUP: Save the selected switch id"
+      ansible.builtin.set_fact:
+        access_vpc_member_switch_id: >-
+          {{ (access_vpc_member_switches.current.switches
+             | selectattr('fabricManagementIp', 'equalto', access_vpc_member_case.switch_ip)
+             | first).switchId }}
+
+    - name: "VPC MEMBER SETUP: Read the original selected member"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ access_vpc_member_case.fabric_name }}/switches/{{ access_vpc_member_switch_id }}/interfaces/{{ access_vpc_member_case.interface_name | replace('/', '%2F') }}
+        method: get
+      register: access_vpc_member_before_wire
+
+    - name: "VPC MEMBER SETUP: Verify policy and exact restoration baseline"
+      vars:
+        original_policy: "{{ access_vpc_member_before_wire.current.configData.networkOS.policy }}"
+      ansible.builtin.assert:
+        that:
+          - access_vpc_member_case.baseline_supplied | bool
+          - access_vpc_member_case.baseline_admin_state is boolean
+          - access_vpc_member_case.baseline_description is string
+          - access_vpc_member_case.baseline_extra_config is string
+          - original_policy.policyType == access_vpc_member_case.expected_policy_type
+          - original_policy.portChannelId is defined
+          - (original_policy.adminState | bool) == (access_vpc_member_case.baseline_admin_state | bool)
+          - (original_policy.description | default(none)) == access_vpc_member_case.baseline_description
+          - (original_policy.extraConfig | default(none)) == access_vpc_member_case.baseline_extra_config
+        fail_msg: >-
+          Refusing to mutate {{ access_vpc_member_case.interface_name }}. Explicitly supplied
+          baseline values must exactly match its current adminState, description, and extraConfig.
+
+    - name: "VPC MEMBER MERGED: Preview all safe fields"
+      cisco.nd.nd_interface_ethernet_access: &merge_access_vpc_member
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ access_vpc_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ access_vpc_member_case.switch_ip }}"
+            interface_names:
+              - "{{ access_vpc_member_case.interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: "{{ not (access_vpc_member_case.baseline_admin_state | bool) }}"
+                  description: "{{ access_vpc_member_case.updated_description }}"
+                  extra_config: "{{ access_vpc_member_case.updated_extra_config }}"
+        config_actions:
+          deploy: false
+        state: merged
+      check_mode: true
+      register: access_vpc_member_check_mode
+
+    - name: "VPC MEMBER MERGED: Mark the mutation attempt"
+      ansible.builtin.set_fact:
+        access_vpc_member_mutation_attempted: true
+
+    - name: "VPC MEMBER MERGED: Apply all safe fields"
+      cisco.nd.nd_interface_ethernet_access: *merge_access_vpc_member
+      register: access_vpc_member_update
+
+    - name: "VPC MEMBER MERGED: Verify the planned and applied update"
+      vars:
+        member_after: >-
+          {{ access_vpc_member_update.after
+             | selectattr('interface_name', 'equalto', access_vpc_member_case.interface_name)
+             | first }}
+      ansible.builtin.assert:
+        that:
+          - access_vpc_member_check_mode is changed
+          - access_vpc_member_update is changed
+          - member_after.config_data.network_os.policy.admin_state == (not (access_vpc_member_case.baseline_admin_state | bool))
+          - member_after.config_data.network_os.policy.description == access_vpc_member_case.updated_description
+          - member_after.config_data.network_os.policy.extra_config == access_vpc_member_case.updated_extra_config
+
+    - name: "VPC MEMBER MERGED: Read the updated member from the wire"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ access_vpc_member_case.fabric_name }}/switches/{{ access_vpc_member_switch_id }}/interfaces/{{ access_vpc_member_case.interface_name | replace('/', '%2F') }}
+        method: get
+      register: access_vpc_member_after_wire
+
+    - name: "VPC MEMBER MERGED: Verify every modeled preservation field"
+      vars:
+        before_policy: "{{ access_vpc_member_before_wire.current.configData.networkOS.policy }}"
+        after_policy: "{{ access_vpc_member_after_wire.current.configData.networkOS.policy }}"
+        member_preservation_fields:
+          - policyType
+          - portChannelId
+          - portChannelMode
+          - cdp
+          - lacpPortPriority
+          - lacpRate
+          - debounceTimer
+          - debounceLinkupTimer
+          - fec
+          - primaryInterface
+        before_preserved_policy: >-
+          {{ before_policy | dict2items
+             | selectattr('key', 'in', member_preservation_fields)
+             | list | items2dict }}
+        after_preserved_policy: >-
+          {{ after_policy | dict2items
+             | selectattr('key', 'in', member_preservation_fields)
+             | list | items2dict }}
+      ansible.builtin.assert:
+        that:
+          - before_preserved_policy == after_preserved_policy
+          - access_vpc_member_after_wire.current.interfaceName == access_vpc_member_before_wire.current.interfaceName
+          - access_vpc_member_after_wire.current.interfaceType == access_vpc_member_before_wire.current.interfaceType
+          - access_vpc_member_after_wire.current.configData.mode == access_vpc_member_before_wire.current.configData.mode
+          - >-
+            access_vpc_member_after_wire.current.configData.networkOS.networkOSType
+            == access_vpc_member_before_wire.current.configData.networkOS.networkOSType
+          - after_policy.adminState == (not (access_vpc_member_case.baseline_admin_state | bool))
+          - after_policy.description == access_vpc_member_case.updated_description
+          - after_policy.extraConfig == access_vpc_member_case.updated_extra_config
+
+    - name: "VPC MEMBER IDEMPOTENT: Reapply the safe update"
+      cisco.nd.nd_interface_ethernet_access: *merge_access_vpc_member
+      register: access_vpc_member_idempotent
+
+    - name: "VPC MEMBER IDEMPOTENT: Verify no second mutation"
+      ansible.builtin.assert:
+        that:
+          - access_vpc_member_idempotent is not changed
+  always:
+    - name: "VPC MEMBER CLEANUP: Restore the validated baseline"
+      cisco.nd.nd_interface_ethernet_access:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ access_vpc_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ access_vpc_member_case.switch_ip }}"
+            interface_names:
+              - "{{ access_vpc_member_case.interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: "{{ access_vpc_member_case.baseline_admin_state }}"
+                  description: "{{ access_vpc_member_case.baseline_description }}"
+                  extra_config: "{{ access_vpc_member_case.baseline_extra_config }}"
+        config_actions:
+          deploy: false
+        state: merged
+      when:
+        - access_vpc_member_mutation_attempted | default(false) | bool

--- a/tests/integration/targets/nd_interface_ethernet_access/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_access/vars/main.yaml
@@ -7,6 +7,32 @@
 test_fabric_name: "{{ nd_test_fabric_name | default('test_fabric') }}"
 test_switch_ip: "{{ nd_test_switch_ip | default('192.168.1.1') }}"
 
+# A separate interface and parent are reserved for authentic accessPoMember tests.
+# Override these when the defaults are unavailable on the test switch.
+test_member_interface_name: "{{ nd_test_access_member_interface_name | default('Ethernet1/39') }}"
+test_member_port_channel_name: "{{ nd_test_access_member_port_channel_name | default('port-channel591') }}"
+
+# Pair-aware accessVpcPoMember coverage is opt-in. The selected interface must
+# already be an authentic member of a consistent vPC on both peers. Explicitly
+# supply all three current safe-field values; the scenario compares them to the
+# controller before its first write and restores them after an attempted update.
+# admin_state must be boolean; description and extra_config must be strings.
+access_vpc_member_case:
+  fabric_name: "{{ nd_test_access_vpc_member_fabric_name | default(test_fabric_name) }}"
+  switch_ip: "{{ nd_test_access_vpc_member_switch_ip | default(test_switch_ip) }}"
+  interface_name: "{{ nd_test_access_vpc_member_interface_name | default('') }}"
+  expected_policy_type: accessVpcPoMember
+  baseline_supplied: >-
+    {{ nd_test_access_vpc_member_baseline_admin_state is defined
+       and nd_test_access_vpc_member_baseline_description is defined
+       and nd_test_access_vpc_member_baseline_extra_config is defined }}
+  baseline_admin_state: "{{ nd_test_access_vpc_member_baseline_admin_state | default(none) }}"
+  baseline_description: "{{ nd_test_access_vpc_member_baseline_description | default(none) }}"
+  baseline_extra_config: "{{ nd_test_access_vpc_member_baseline_extra_config | default(none) }}"
+
+  updated_description: IFACE-004 access vPC member updated
+  updated_extra_config: logging event trunk-status
+
 # Ethernet interfaces used across tests.
 # Ethernet1/41 through Ethernet1/50 are reserved for these integration tests.
 # These interfaces must exist on the test switch and must NOT be port-channel members.

--- a/tests/integration/targets/nd_interface_ethernet_routed/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_routed/tasks/main.yaml
@@ -54,6 +54,16 @@
     - name: Run IOS-XE routed tests (requires nd_test_xe_switch_ip)
       ansible.builtin.include_tasks: xe.yaml
       when: nd_test_xe_switch_ip is defined and nd_test_xe_switch_ip | length > 0
+
+    - name: Run opt-in routed port-channel member tests
+      ansible.builtin.include_tasks: port_channel_member_case.yaml
+      loop: "{{ routed_member_test_cases }}"
+      loop_control:
+        loop_var: routed_member_case
+        label: "{{ routed_member_case.expected_policy_type }} {{ routed_member_case.interface_name }}"
+      when:
+        - routed_member_case.interface_name | length > 0
+        - routed_member_case.baseline_supplied | bool
   vars:
     ansible_command_timeout: 300
   environment:

--- a/tests/integration/targets/nd_interface_ethernet_routed/tasks/port_channel_member_case.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_routed/tasks/port_channel_member_case.yaml
@@ -1,0 +1,262 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# IFACE-004 regression coverage for a pre-existing user-owned routed aggregate.
+# The collection cannot create this parent, so main.yaml skips this file unless
+# an NX-OS or IOS-XE routed member interface is explicitly supplied.
+
+- name: "ROUTED PORT-CHANNEL MEMBER: Exercise {{ routed_member_case.expected_policy_type }} safely"
+  block:
+    - name: "ROUTED PORT-CHANNEL MEMBER SETUP: Initialize the mutation guard"
+      ansible.builtin.set_fact:
+        routed_member_mutation_attempted: false
+
+    - name: "ROUTED PORT-CHANNEL MEMBER SETUP: Resolve the test switch id"
+      cisco.nd.nd_rest:
+        path: "/api/v1/manage/fabrics/{{ routed_member_case.fabric_name }}/switches"
+        method: get
+      register: routed_member_switches
+
+    - name: "ROUTED PORT-CHANNEL MEMBER SETUP: Save the test switch id"
+      ansible.builtin.set_fact:
+        routed_member_switch_id: >-
+          {{ (routed_member_switches.current.switches
+             | selectattr('fabricManagementIp', 'equalto', routed_member_case.switch_ip) | first).switchId }}
+
+    - name: "ROUTED PORT-CHANNEL MEMBER SETUP: Read the original member"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ routed_member_case.fabric_name }}/switches/{{ routed_member_switch_id }}/interfaces/{{ routed_member_case.interface_name | replace('/', '%2F') }}
+        method: get
+      register: routed_member_before_wire
+
+    - name: "ROUTED PORT-CHANNEL MEMBER SETUP: Verify policy and exact restoration baseline"
+      vars:
+        original_policy: "{{ routed_member_before_wire.current.configData.networkOS.policy }}"
+      ansible.builtin.assert:
+        that:
+          - routed_member_case.baseline_supplied | bool
+          - routed_member_case.baseline_admin_state is boolean
+          - routed_member_case.baseline_description is string
+          - routed_member_case.baseline_extra_config is string
+          - original_policy.policyType == routed_member_case.expected_policy_type
+          - routed_member_before_wire.current.configData.networkOS.networkOSType == routed_member_case.network_os_type
+          - original_policy.portChannelId is defined
+          - (original_policy.adminState | bool) == (routed_member_case.baseline_admin_state | bool)
+          - (original_policy.description | default(none)) == routed_member_case.baseline_description
+          - (original_policy.extraConfig | default(none)) == routed_member_case.baseline_extra_config
+        fail_msg: >-
+          Refusing to mutate {{ routed_member_case.interface_name }}. Explicitly supplied
+          baseline values must exactly match its current adminState, description, and extraConfig.
+
+    - name: "ROUTED PORT-CHANNEL MEMBER MERGED: Preview all safe fields"
+      cisco.nd.nd_interface_ethernet_routed: &merge_routed_member
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ routed_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ routed_member_case.switch_ip }}"
+            interface_name: "{{ routed_member_case.interface_name }}"
+            config_data:
+              network_os:
+                network_os_type: "{{ routed_member_case.network_os_type }}"
+                policy:
+                  admin_state: "{{ not (routed_member_case.baseline_admin_state | bool) }}"
+                  description: "IFACE-004 {{ routed_member_case.expected_policy_type }} updated"
+                  extra_config: "logging event trunk-status"
+        config_actions:
+          deploy: false
+        state: merged
+      check_mode: true
+      register: routed_member_check_mode
+
+    - name: "ROUTED PORT-CHANNEL MEMBER MERGED: Mark the mutation attempt"
+      ansible.builtin.set_fact:
+        routed_member_mutation_attempted: true
+
+    - name: "ROUTED PORT-CHANNEL MEMBER MERGED: Apply all safe fields"
+      cisco.nd.nd_interface_ethernet_routed: *merge_routed_member
+      register: routed_member_update
+
+    - name: "ROUTED PORT-CHANNEL MEMBER MERGED: Verify the planned and applied update"
+      vars:
+        routed_member_after: >-
+          {{ routed_member_update.after
+             | selectattr('interface_name', 'equalto', routed_member_case.interface_name) | first }}
+      ansible.builtin.assert:
+        that:
+          - routed_member_check_mode is changed
+          - routed_member_update is changed
+          - routed_member_after.config_data.network_os.policy.admin_state == (not (routed_member_case.baseline_admin_state | bool))
+          - routed_member_after.config_data.network_os.policy.description == "IFACE-004 " ~ routed_member_case.expected_policy_type ~ " updated"
+          - routed_member_after.config_data.network_os.policy.extra_config == "logging event trunk-status"
+
+    - name: "ROUTED PORT-CHANNEL MEMBER MERGED: Read the updated member from the wire"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ routed_member_case.fabric_name }}/switches/{{ routed_member_switch_id }}/interfaces/{{ routed_member_case.interface_name | replace('/', '%2F') }}
+        method: get
+      register: routed_member_after_wire
+
+    - name: "ROUTED PORT-CHANNEL MEMBER MERGED: Verify every modeled preservation field"
+      vars:
+        before_policy: "{{ routed_member_before_wire.current.configData.networkOS.policy }}"
+        after_policy: "{{ routed_member_after_wire.current.configData.networkOS.policy }}"
+        routed_member_preservation_fields:
+          - policyType
+          - portChannelId
+          - portChannelMode
+          - fec
+        before_preserved_policy: >-
+          {{ before_policy | dict2items
+             | selectattr('key', 'in', routed_member_preservation_fields)
+             | list | items2dict }}
+        after_preserved_policy: >-
+          {{ after_policy | dict2items
+             | selectattr('key', 'in', routed_member_preservation_fields)
+             | list | items2dict }}
+      ansible.builtin.assert:
+        that:
+          - before_preserved_policy == after_preserved_policy
+          - routed_member_after_wire.current.interfaceName == routed_member_before_wire.current.interfaceName
+          - routed_member_after_wire.current.interfaceType == routed_member_before_wire.current.interfaceType
+          - routed_member_after_wire.current.configData.mode == routed_member_before_wire.current.configData.mode
+          - >-
+            routed_member_after_wire.current.configData.networkOS.networkOSType
+            == routed_member_before_wire.current.configData.networkOS.networkOSType
+          - after_policy.adminState == (not (routed_member_case.baseline_admin_state | bool))
+          - after_policy.description == "IFACE-004 " ~ routed_member_case.expected_policy_type ~ " updated"
+          - after_policy.extraConfig == "logging event trunk-status"
+
+    - name: "ROUTED PORT-CHANNEL MEMBER IDEMPOTENT: Reapply the safe update"
+      cisco.nd.nd_interface_ethernet_routed: *merge_routed_member
+      register: routed_member_idempotent
+
+    - name: "ROUTED PORT-CHANNEL MEMBER IDEMPOTENT: Verify no second mutation"
+      ansible.builtin.assert:
+        that:
+          - routed_member_idempotent is not changed
+
+    - name: "ROUTED PORT-CHANNEL MEMBER NEGATIVE: Reject an unsafe field"
+      cisco.nd.nd_interface_ethernet_routed:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ routed_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ routed_member_case.switch_ip }}"
+            interface_name: "{{ routed_member_case.interface_name }}"
+            config_data:
+              network_os:
+                network_os_type: "{{ routed_member_case.network_os_type }}"
+                policy:
+                  description: "must be rejected atomically"
+                  mtu: 9000
+        config_actions:
+          deploy: false
+        state: merged
+      register: routed_member_unsafe_field
+      ignore_errors: true
+      check_mode: true
+
+    - name: "ROUTED PORT-CHANNEL MEMBER NEGATIVE: Reject membership-changing extra_config"
+      cisco.nd.nd_interface_ethernet_routed:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ routed_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ routed_member_case.switch_ip }}"
+            interface_name: "{{ routed_member_case.interface_name }}"
+            config_data:
+              network_os:
+                network_os_type: "{{ routed_member_case.network_os_type }}"
+                policy:
+                  extra_config: "no channel-group 590"
+        config_actions:
+          deploy: false
+        state: merged
+      register: routed_member_unsafe_extra_config
+      ignore_errors: true
+      check_mode: true
+
+    - name: "ROUTED PORT-CHANNEL MEMBER NEGATIVE: Reject replaced state"
+      cisco.nd.nd_interface_ethernet_routed:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ routed_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ routed_member_case.switch_ip }}"
+            interface_name: "{{ routed_member_case.interface_name }}"
+            config_data:
+              network_os:
+                network_os_type: "{{ routed_member_case.network_os_type }}"
+                policy:
+                  description: "must be rejected under replaced"
+        config_actions:
+          deploy: false
+        state: replaced
+      register: routed_member_replaced
+      ignore_errors: true
+      check_mode: true
+
+    - name: "ROUTED PORT-CHANNEL MEMBER NEGATIVE: Reject overridden state"
+      cisco.nd.nd_interface_ethernet_routed:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ routed_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ routed_member_case.switch_ip }}"
+            interface_name: "{{ routed_member_case.interface_name }}"
+            config_data:
+              network_os:
+                network_os_type: "{{ routed_member_case.network_os_type }}"
+                policy:
+                  description: "must be rejected under overridden"
+        config_actions:
+          deploy: false
+        state: overridden
+      register: routed_member_overridden
+      ignore_errors: true
+      check_mode: true
+
+    - name: "ROUTED PORT-CHANNEL MEMBER NEGATIVE: Reject deleted state"
+      cisco.nd.nd_interface_ethernet_routed:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ routed_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ routed_member_case.switch_ip }}"
+            interface_name: "{{ routed_member_case.interface_name }}"
+            config_data:
+              network_os:
+                network_os_type: "{{ routed_member_case.network_os_type }}"
+        config_actions:
+          deploy: false
+        state: deleted
+      register: routed_member_deleted
+      ignore_errors: true
+      check_mode: true
+
+    - name: "ROUTED PORT-CHANNEL MEMBER NEGATIVE: Verify every unsafe request failed"
+      ansible.builtin.assert:
+        that:
+          - routed_member_unsafe_field is failed
+          - routed_member_unsafe_extra_config is failed
+          - routed_member_replaced is failed
+          - routed_member_overridden is failed
+          - routed_member_deleted is failed
+  always:
+    - name: "ROUTED PORT-CHANNEL MEMBER CLEANUP: Restore the validated baseline"
+      cisco.nd.nd_interface_ethernet_routed:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ routed_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ routed_member_case.switch_ip }}"
+            interface_name: "{{ routed_member_case.interface_name }}"
+            config_data:
+              network_os:
+                network_os_type: "{{ routed_member_case.network_os_type }}"
+                policy:
+                  admin_state: "{{ routed_member_case.baseline_admin_state }}"
+                  description: "{{ routed_member_case.baseline_description }}"
+                  extra_config: "{{ routed_member_case.baseline_extra_config }}"
+        config_actions:
+          deploy: false
+        state: merged
+      when:
+        - routed_member_mutation_attempted | default(false) | bool

--- a/tests/integration/targets/nd_interface_ethernet_routed/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_routed/vars/main.yaml
@@ -114,6 +114,39 @@ routed_34_configured:
 test_xe_fabric_name: "{{ nd_test_xe_fabric_name | default(test_fabric_name) }}"
 test_xe_interface_name: "{{ nd_test_xe_interface_name | default('GigabitEthernet3') }}"
 
+# IFACE-004 routed-member coverage is opt-in because this collection cannot
+# create routed port-channel parents. Supply an interface that already carries
+# the expected member policy and explicitly supply all three safe-field baseline
+# values. The scenario verifies that the live values exactly match the supplied
+# baseline before attempting its first write and restores that baseline after an
+# attempted mutation. admin_state must be boolean; description and extra_config
+# must be strings. No baseline value is inferred or defaulted.
+routed_member_test_cases:
+  - fabric_name: "{{ nd_test_routed_nxos_member_fabric_name | default(test_fabric_name) }}"
+    switch_ip: "{{ nd_test_routed_nxos_member_switch_ip | default(test_switch_ip) }}"
+    interface_name: "{{ nd_test_routed_nxos_member_interface_name | default('') }}"
+    network_os_type: nx-os
+    expected_policy_type: l3PoMember
+    baseline_supplied: >-
+      {{ nd_test_routed_nxos_member_baseline_admin_state is defined
+         and nd_test_routed_nxos_member_baseline_description is defined
+         and nd_test_routed_nxos_member_baseline_extra_config is defined }}
+    baseline_admin_state: "{{ nd_test_routed_nxos_member_baseline_admin_state | default(none) }}"
+    baseline_description: "{{ nd_test_routed_nxos_member_baseline_description | default(none) }}"
+    baseline_extra_config: "{{ nd_test_routed_nxos_member_baseline_extra_config | default(none) }}"
+  - fabric_name: "{{ nd_test_routed_iosxe_member_fabric_name | default(test_xe_fabric_name) }}"
+    switch_ip: "{{ nd_test_routed_iosxe_member_switch_ip | default(nd_test_xe_switch_ip | default('')) }}"
+    interface_name: "{{ nd_test_routed_iosxe_member_interface_name | default('') }}"
+    network_os_type: ios-xe
+    expected_policy_type: iosXeL3PoMember
+    baseline_supplied: >-
+      {{ nd_test_routed_iosxe_member_baseline_admin_state is defined
+         and nd_test_routed_iosxe_member_baseline_description is defined
+         and nd_test_routed_iosxe_member_baseline_extra_config is defined }}
+    baseline_admin_state: "{{ nd_test_routed_iosxe_member_baseline_admin_state | default(none) }}"
+    baseline_description: "{{ nd_test_routed_iosxe_member_baseline_description | default(none) }}"
+    baseline_extra_config: "{{ nd_test_routed_iosxe_member_baseline_extra_config | default(none) }}"
+
 xe_routed:
   switch_ip: "{{ nd_test_xe_switch_ip | default('') }}"
   interface_name: "{{ test_xe_interface_name }}"

--- a/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/main.yaml
@@ -58,5 +58,14 @@
 
     - name: Run nd_interface_ethernet_trunk_host deleted state tests
       ansible.builtin.include_tasks: deleted.yaml
+
+    - name: Run nd_interface_ethernet_trunk_host port-channel member tests
+      ansible.builtin.include_tasks: port_channel_members.yaml
+
+    - name: Run opt-in nd_interface_ethernet_trunk_host vPC member test
+      ansible.builtin.include_tasks: vpc_member_case.yaml
+      when:
+        - trunk_vpc_member_case.interface_name | length > 0
+        - trunk_vpc_member_case.baseline_supplied | bool
   environment:
     ND_LOGGING_CONFIG: "{{ nd_logging_config | default('') }}"

--- a/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/port_channel_members.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/port_channel_members.yaml
@@ -1,0 +1,280 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# IFACE-004 regression coverage. The parent module creates an authentic
+# poMember record; the ethernet module must update that record in place rather
+# than treating it as a new trunkHost interface. All changes remain staged.
+
+- name: "PORT-CHANNEL MEMBER: Exercise a real poMember safely"
+  block:
+    - name: "PORT-CHANNEL MEMBER SETUP: Remove a stale test parent"
+      cisco.nd.nd_interface_port_channel_trunk_host:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_name: "{{ test_member_port_channel_name }}"
+        config_actions:
+          deploy: false
+        state: deleted
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Create a trunk parent with one member"
+      cisco.nd.nd_interface_port_channel_trunk_host:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_name: "{{ test_member_port_channel_name }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: true
+                  allowed_vlans: "100-200"
+                  ports:
+                    - "{{ test_member_interface_name }}"
+                  port_channel_mode: active
+                  copy_description: false
+                  description: "IFACE-004 trunk parent"
+        config_actions:
+          deploy: false
+        state: merged
+      register: member_parent_create
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Resolve the test switch id"
+      cisco.nd.nd_rest:
+        path: "/api/v1/manage/fabrics/{{ test_fabric_name }}/switches"
+        method: get
+      register: member_switches
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Save the test switch id"
+      ansible.builtin.set_fact:
+        member_switch_id: >-
+          {{ (member_switches.current.switches | selectattr('fabricManagementIp', 'equalto', test_switch_ip)
+             | first).switchId }}
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Read the member before its update"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ test_fabric_name }}/switches/{{ member_switch_id }}/interfaces/{{ test_member_interface_name | replace('/', '%2F') }}
+        method: get
+      register: member_before_wire
+
+    - name: "PORT-CHANNEL MEMBER SETUP: Verify authentic poMember ownership"
+      ansible.builtin.assert:
+        that:
+          - member_parent_create is changed
+          - member_before_wire.current.configData.networkOS.policy.policyType == "poMember"
+          - >-
+            (member_before_wire.current.configData.networkOS.policy.portChannelId | string | lower)
+            in [test_member_port_channel_name | lower, test_member_port_channel_name | lower | replace('port-channel', '')]
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Preview all safe fields"
+      cisco.nd.nd_interface_ethernet_trunk_host: &merge_trunk_member
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: false
+                  description: "IFACE-004 trunk member updated"
+                  extra_config: "logging event link-status"
+        config_actions:
+          deploy: false
+        state: merged
+      check_mode: true
+      register: member_check_mode
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Apply all safe fields"
+      cisco.nd.nd_interface_ethernet_trunk_host: *merge_trunk_member
+      register: member_update
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Verify the planned and applied update"
+      vars:
+        member_after: >-
+          {{ member_update.after | selectattr('interface_name', 'equalto', test_member_interface_name) | first }}
+      ansible.builtin.assert:
+        that:
+          - member_check_mode is changed
+          - member_update is changed
+          - member_after.config_data.network_os.policy.admin_state == false
+          - member_after.config_data.network_os.policy.description == "IFACE-004 trunk member updated"
+          - member_after.config_data.network_os.policy.extra_config == "logging event link-status"
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Read the updated member from the wire"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ test_fabric_name }}/switches/{{ member_switch_id }}/interfaces/{{ test_member_interface_name | replace('/', '%2F') }}
+        method: get
+      register: member_after_wire
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Read the parent from the wire"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ test_fabric_name }}/switches/{{ member_switch_id }}/interfaces/{{ test_member_port_channel_name }}
+        method: get
+      register: member_parent_wire
+
+    - name: "PORT-CHANNEL MEMBER MERGED: Verify every modeled preservation field"
+      vars:
+        before_policy: "{{ member_before_wire.current.configData.networkOS.policy }}"
+        wire_policy: "{{ member_after_wire.current.configData.networkOS.policy }}"
+        parent_policy: "{{ member_parent_wire.current.configData.networkOS.policy }}"
+        member_preservation_fields:
+          - policyType
+          - portChannelId
+          - portChannelMode
+          - cdp
+          - lacpPortPriority
+          - lacpRate
+          - debounceTimer
+          - debounceLinkupTimer
+          - fec
+          - allowedVlans
+        before_preserved_policy: >-
+          {{ before_policy | dict2items
+             | selectattr('key', 'in', member_preservation_fields)
+             | list | items2dict }}
+        after_preserved_policy: >-
+          {{ wire_policy | dict2items
+             | selectattr('key', 'in', member_preservation_fields)
+             | list | items2dict }}
+      ansible.builtin.assert:
+        that:
+          - before_preserved_policy == after_preserved_policy
+          - member_after_wire.current.interfaceName == member_before_wire.current.interfaceName
+          - member_after_wire.current.interfaceType == member_before_wire.current.interfaceType
+          - member_after_wire.current.configData.mode == member_before_wire.current.configData.mode
+          - >-
+            member_after_wire.current.configData.networkOS.networkOSType
+            == member_before_wire.current.configData.networkOS.networkOSType
+          - wire_policy.adminState == false
+          - wire_policy.description == "IFACE-004 trunk member updated"
+          - wire_policy.extraConfig == "logging event link-status"
+          - test_member_interface_name in parent_policy.ports
+
+    - name: "PORT-CHANNEL MEMBER IDEMPOTENT: Reapply the safe update"
+      cisco.nd.nd_interface_ethernet_trunk_host: *merge_trunk_member
+      register: member_idempotent
+
+    - name: "PORT-CHANNEL MEMBER IDEMPOTENT: Verify no second mutation"
+      ansible.builtin.assert:
+        that:
+          - member_idempotent is not changed
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject an unsafe host-policy field"
+      cisco.nd.nd_interface_ethernet_trunk_host:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  description: "must be rejected atomically"
+                  allowed_vlans: "300-400"
+        config_actions:
+          deploy: false
+        state: merged
+      register: member_unsafe_field
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject replaced state"
+      cisco.nd.nd_interface_ethernet_trunk_host:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  description: "must be rejected under replaced"
+        config_actions:
+          deploy: false
+        state: replaced
+      register: member_replaced
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject overridden state"
+      cisco.nd.nd_interface_ethernet_trunk_host:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  description: "must be rejected under overridden"
+        config_actions:
+          deploy: false
+        state: overridden
+      register: member_overridden
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject deleted state"
+      cisco.nd.nd_interface_ethernet_trunk_host:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+        config_actions:
+          deploy: false
+        state: deleted
+      register: member_deleted
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Reject membership-changing extra_config"
+      cisco.nd.nd_interface_ethernet_trunk_host:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_names:
+              - "{{ test_member_interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  extra_config: "no channel-group 590"
+        config_actions:
+          deploy: false
+        state: merged
+      register: member_unsafe_extra_config
+      ignore_errors: true
+      check_mode: true
+
+    - name: "PORT-CHANNEL MEMBER NEGATIVE: Verify every unsafe request failed"
+      ansible.builtin.assert:
+        that:
+          - member_unsafe_field is failed
+          - member_replaced is failed
+          - member_overridden is failed
+          - member_deleted is failed
+          - member_unsafe_extra_config is failed
+  always:
+    - name: "PORT-CHANNEL MEMBER CLEANUP: Remove the owning trunk parent"
+      cisco.nd.nd_interface_port_channel_trunk_host:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ test_fabric_name }}"
+        config:
+          - switch_ip: "{{ test_switch_ip }}"
+            interface_name: "{{ test_member_port_channel_name }}"
+        config_actions:
+          deploy: false
+        state: deleted

--- a/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/vpc_member_case.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_trunk_host/tasks/vpc_member_case.yaml
@@ -1,0 +1,167 @@
+---
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Pair-aware IFACE-004 coverage for a pre-existing trunk vPC member. This is
+# deliberately opt-in: the test cannot safely create or infer the operator's
+# shared vPC baseline. All controller intent remains staged (deploy: false).
+
+- name: "VPC MEMBER: Exercise an existing vpcMember safely"
+  block:
+    - name: "VPC MEMBER SETUP: Initialize the mutation guard"
+      ansible.builtin.set_fact:
+        trunk_vpc_member_mutation_attempted: false
+
+    - name: "VPC MEMBER SETUP: Resolve the selected switch id"
+      cisco.nd.nd_rest:
+        path: "/api/v1/manage/fabrics/{{ trunk_vpc_member_case.fabric_name }}/switches"
+        method: get
+      register: trunk_vpc_member_switches
+
+    - name: "VPC MEMBER SETUP: Save the selected switch id"
+      ansible.builtin.set_fact:
+        trunk_vpc_member_switch_id: >-
+          {{ (trunk_vpc_member_switches.current.switches
+             | selectattr('fabricManagementIp', 'equalto', trunk_vpc_member_case.switch_ip)
+             | first).switchId }}
+
+    - name: "VPC MEMBER SETUP: Read the original selected member"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ trunk_vpc_member_case.fabric_name }}/switches/{{ trunk_vpc_member_switch_id }}/interfaces/{{ trunk_vpc_member_case.interface_name | replace('/', '%2F') }}
+        method: get
+      register: trunk_vpc_member_before_wire
+
+    - name: "VPC MEMBER SETUP: Verify policy and exact restoration baseline"
+      vars:
+        original_policy: "{{ trunk_vpc_member_before_wire.current.configData.networkOS.policy }}"
+      ansible.builtin.assert:
+        that:
+          - trunk_vpc_member_case.baseline_supplied | bool
+          - trunk_vpc_member_case.baseline_admin_state is boolean
+          - trunk_vpc_member_case.baseline_description is string
+          - trunk_vpc_member_case.baseline_extra_config is string
+          - original_policy.policyType == trunk_vpc_member_case.expected_policy_type
+          - original_policy.portChannelId is defined
+          - (original_policy.adminState | bool) == (trunk_vpc_member_case.baseline_admin_state | bool)
+          - (original_policy.description | default(none)) == trunk_vpc_member_case.baseline_description
+          - (original_policy.extraConfig | default(none)) == trunk_vpc_member_case.baseline_extra_config
+        fail_msg: >-
+          Refusing to mutate {{ trunk_vpc_member_case.interface_name }}. Explicitly supplied
+          baseline values must exactly match its current adminState, description, and extraConfig.
+
+    - name: "VPC MEMBER MERGED: Preview all safe fields"
+      cisco.nd.nd_interface_ethernet_trunk_host: &merge_trunk_vpc_member
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ trunk_vpc_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ trunk_vpc_member_case.switch_ip }}"
+            interface_names:
+              - "{{ trunk_vpc_member_case.interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: "{{ not (trunk_vpc_member_case.baseline_admin_state | bool) }}"
+                  description: "{{ trunk_vpc_member_case.updated_description }}"
+                  extra_config: "{{ trunk_vpc_member_case.updated_extra_config }}"
+        config_actions:
+          deploy: false
+        state: merged
+      check_mode: true
+      register: trunk_vpc_member_check_mode
+
+    - name: "VPC MEMBER MERGED: Mark the mutation attempt"
+      ansible.builtin.set_fact:
+        trunk_vpc_member_mutation_attempted: true
+
+    - name: "VPC MEMBER MERGED: Apply all safe fields"
+      cisco.nd.nd_interface_ethernet_trunk_host: *merge_trunk_vpc_member
+      register: trunk_vpc_member_update
+
+    - name: "VPC MEMBER MERGED: Verify the planned and applied update"
+      vars:
+        member_after: >-
+          {{ trunk_vpc_member_update.after
+             | selectattr('interface_name', 'equalto', trunk_vpc_member_case.interface_name)
+             | first }}
+      ansible.builtin.assert:
+        that:
+          - trunk_vpc_member_check_mode is changed
+          - trunk_vpc_member_update is changed
+          - member_after.config_data.network_os.policy.admin_state == (not (trunk_vpc_member_case.baseline_admin_state | bool))
+          - member_after.config_data.network_os.policy.description == trunk_vpc_member_case.updated_description
+          - member_after.config_data.network_os.policy.extra_config == trunk_vpc_member_case.updated_extra_config
+
+    - name: "VPC MEMBER MERGED: Read the updated member from the wire"
+      cisco.nd.nd_rest:
+        path: >-
+          /api/v1/manage/fabrics/{{ trunk_vpc_member_case.fabric_name }}/switches/{{ trunk_vpc_member_switch_id }}/interfaces/{{ trunk_vpc_member_case.interface_name | replace('/', '%2F') }}
+        method: get
+      register: trunk_vpc_member_after_wire
+
+    - name: "VPC MEMBER MERGED: Verify every modeled preservation field"
+      vars:
+        before_policy: "{{ trunk_vpc_member_before_wire.current.configData.networkOS.policy }}"
+        after_policy: "{{ trunk_vpc_member_after_wire.current.configData.networkOS.policy }}"
+        member_preservation_fields:
+          - policyType
+          - portChannelId
+          - portChannelMode
+          - cdp
+          - lacpPortPriority
+          - lacpRate
+          - debounceTimer
+          - debounceLinkupTimer
+          - fec
+          - allowedVlans
+          - primaryInterface
+        before_preserved_policy: >-
+          {{ before_policy | dict2items
+             | selectattr('key', 'in', member_preservation_fields)
+             | list | items2dict }}
+        after_preserved_policy: >-
+          {{ after_policy | dict2items
+             | selectattr('key', 'in', member_preservation_fields)
+             | list | items2dict }}
+      ansible.builtin.assert:
+        that:
+          - before_preserved_policy == after_preserved_policy
+          - trunk_vpc_member_after_wire.current.interfaceName == trunk_vpc_member_before_wire.current.interfaceName
+          - trunk_vpc_member_after_wire.current.interfaceType == trunk_vpc_member_before_wire.current.interfaceType
+          - trunk_vpc_member_after_wire.current.configData.mode == trunk_vpc_member_before_wire.current.configData.mode
+          - >-
+            trunk_vpc_member_after_wire.current.configData.networkOS.networkOSType
+            == trunk_vpc_member_before_wire.current.configData.networkOS.networkOSType
+          - after_policy.adminState == (not (trunk_vpc_member_case.baseline_admin_state | bool))
+          - after_policy.description == trunk_vpc_member_case.updated_description
+          - after_policy.extraConfig == trunk_vpc_member_case.updated_extra_config
+
+    - name: "VPC MEMBER IDEMPOTENT: Reapply the safe update"
+      cisco.nd.nd_interface_ethernet_trunk_host: *merge_trunk_vpc_member
+      register: trunk_vpc_member_idempotent
+
+    - name: "VPC MEMBER IDEMPOTENT: Verify no second mutation"
+      ansible.builtin.assert:
+        that:
+          - trunk_vpc_member_idempotent is not changed
+  always:
+    - name: "VPC MEMBER CLEANUP: Restore the validated baseline"
+      cisco.nd.nd_interface_ethernet_trunk_host:
+        output_level: "{{ nd_info.output_level }}"
+        fabric_name: "{{ trunk_vpc_member_case.fabric_name }}"
+        config:
+          - switch_ip: "{{ trunk_vpc_member_case.switch_ip }}"
+            interface_names:
+              - "{{ trunk_vpc_member_case.interface_name }}"
+            config_data:
+              network_os:
+                policy:
+                  admin_state: "{{ trunk_vpc_member_case.baseline_admin_state }}"
+                  description: "{{ trunk_vpc_member_case.baseline_description }}"
+                  extra_config: "{{ trunk_vpc_member_case.baseline_extra_config }}"
+        config_actions:
+          deploy: false
+        state: merged
+      when:
+        - trunk_vpc_member_mutation_attempted | default(false) | bool

--- a/tests/integration/targets/nd_interface_ethernet_trunk_host/vars/main.yaml
+++ b/tests/integration/targets/nd_interface_ethernet_trunk_host/vars/main.yaml
@@ -7,6 +7,32 @@
 test_fabric_name: "{{ nd_test_fabric_name | default('test_fabric') }}"
 test_switch_ip: "{{ nd_test_switch_ip | default('192.168.1.1') }}"
 
+# A separate interface and parent are reserved for authentic poMember tests.
+# Override these when the defaults are unavailable on the test switch.
+test_member_interface_name: "{{ nd_test_trunk_member_interface_name | default('Ethernet1/40') }}"
+test_member_port_channel_name: "{{ nd_test_trunk_member_port_channel_name | default('port-channel590') }}"
+
+# Pair-aware vpcMember coverage is opt-in. The selected interface must already
+# be an authentic member of a consistent vPC on both peers. Explicitly supply
+# all three current safe-field values; the scenario compares them to the
+# controller before its first write and restores them after an attempted update.
+# admin_state must be boolean; description and extra_config must be strings.
+trunk_vpc_member_case:
+  fabric_name: "{{ nd_test_trunk_vpc_member_fabric_name | default(test_fabric_name) }}"
+  switch_ip: "{{ nd_test_trunk_vpc_member_switch_ip | default(test_switch_ip) }}"
+  interface_name: "{{ nd_test_trunk_vpc_member_interface_name | default('') }}"
+  expected_policy_type: vpcMember
+  baseline_supplied: >-
+    {{ nd_test_trunk_vpc_member_baseline_admin_state is defined
+       and nd_test_trunk_vpc_member_baseline_description is defined
+       and nd_test_trunk_vpc_member_baseline_extra_config is defined }}
+  baseline_admin_state: "{{ nd_test_trunk_vpc_member_baseline_admin_state | default(none) }}"
+  baseline_description: "{{ nd_test_trunk_vpc_member_baseline_description | default(none) }}"
+  baseline_extra_config: "{{ nd_test_trunk_vpc_member_baseline_extra_config | default(none) }}"
+
+  updated_description: IFACE-004 trunk vPC member updated
+  updated_extra_config: logging event trunk-status
+
 # Ethernet interfaces used across tests.
 # Ethernet1/41 through Ethernet1/48 are reserved for these integration tests.
 # These interfaces must exist on the test switch and must NOT be port-channel members.

--- a/tests/unit/module_utils/models/test_ethernet_member_interface.py
+++ b/tests/unit/module_utils/models/test_ethernet_member_interface.py
@@ -1,0 +1,399 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Focused tests for the internal ethernet port-channel member model layer."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.models.interfaces.ethernet_member_interface import (
+    MEMBER_POLICY_DESCRIPTORS,
+    EthernetMemberInterfaceModel,
+    MemberPolicyDisposition,
+    UnmodeledMemberConfigurationError,
+    UnsafeMemberUpdateError,
+    UnsupportedMemberPolicyError,
+    build_member_update_payload,
+    classify_member_policy,
+    get_member_policy_descriptor,
+    is_member_policy,
+    is_supported_member_policy,
+    normalize_port_channel_id,
+    normalize_safe_member_updates,
+    parse_member_interface_response,
+)
+from pydantic import ValidationError
+
+
+def member_record(policy_type="poMember", *, mode="trunk", network_os="nx-os"):
+    """Return an authentic-shaped member inventory record with response-only noise."""
+
+    policy = {
+        "policyType": policy_type,
+        "portChannelId": "port-channel20",
+        "portChannelMode": "active",
+        "description": "existing member",
+        "extraConfig": "logging event link-status",
+        "adminState": True,
+    }
+    if network_os == "nx-os":
+        policy["ptp"] = False
+    if policy_type in {"poMember", "vpcMember"}:
+        policy.update(
+            {
+                "allowedVlans": "1-100",
+                "cdp": True,
+                "lacpPortPriority": 32768,
+                "lacpRate": "fast",
+                "debounceTimer": 100,
+                "debounceLinkupTimer": 1000,
+                "fec": "auto",
+            }
+        )
+    if policy_type in {"accessPoMember", "accessVpcPoMember"}:
+        policy.update(
+            {
+                "cdp": False,
+                "lacpPortPriority": 100,
+                "lacpRate": "normal",
+                "debounceTimer": 200,
+                "debounceLinkupTimer": 2000,
+                "fec": "off",
+            }
+        )
+    if policy_type in {"vpcMember", "accessVpcPoMember"}:
+        policy["primaryInterface"] = "vPC20"
+    return {
+        "switchId": "SERIAL1",
+        "switchIp": "192.0.2.10",
+        "interfaceName": "Ethernet1/24",
+        "interfaceType": "ethernet",
+        "configData": {
+            "mode": mode,
+            "networkOS": {"networkOSType": network_os, "policy": policy},
+        },
+        "operData": {"portChannelId": 20, "adminStatus": "up"},
+        "fabricName": "fabric1",
+    }
+
+
+@pytest.mark.parametrize(
+    "policy_type,family,network_os,wire_mode,parent_type,parent_policy,parent_mode,parent_os,pair_aware",
+    [
+        ("poMember", "trunk", "nx-os", "trunk", "portChannel", "trunkPoHost", "trunk", "nx-os", False),
+        (
+            "accessPoMember",
+            "access",
+            "nx-os",
+            "access",
+            "portChannel",
+            "accessPoHost",
+            "access",
+            "nx-os",
+            False,
+        ),
+        ("l3PoMember", "routed", "nx-os", "routed", "portChannel", "l3Po", "routed", "nx-os", False),
+        (
+            "iosXeL3PoMember",
+            "routed",
+            "ios-xe",
+            "routed",
+            "portChannel",
+            "iosXeL3PortChannel",
+            "routed",
+            "ios-xe",
+            False,
+        ),
+        ("vpcMember", "trunk", "nx-os", "trunk", "vpc", "trunkVpcHost", "trunk", "nx-os", True),
+        (
+            "accessVpcPoMember",
+            "access",
+            "nx-os",
+            "access",
+            "vpc",
+            "accessVpcHost",
+            "access",
+            "nx-os",
+            True,
+        ),
+    ],
+)
+def test_member_policy_descriptor_metadata(
+    policy_type,
+    family,
+    network_os,
+    wire_mode,
+    parent_type,
+    parent_policy,
+    parent_mode,
+    parent_os,
+    pair_aware,
+):
+    descriptor = get_member_policy_descriptor(policy_type)
+    assert descriptor is not None
+    assert descriptor.family == family
+    assert descriptor.network_os == network_os
+    assert descriptor.wire_mode == wire_mode
+    assert descriptor.parent_interface_type == parent_type
+    assert descriptor.parent_policy_types == (parent_policy,)
+    assert descriptor.parent_wire_mode == parent_mode
+    assert descriptor.parent_network_os == parent_os
+    assert descriptor.pair_aware is pair_aware
+
+
+def test_member_policy_classification_fails_closed():
+    assert classify_member_policy("poMember") == MemberPolicyDisposition.SUPPORTED
+    assert classify_member_policy("vpcMember") == MemberPolicyDisposition.PAIR_AWARE
+    assert classify_member_policy("l3PoMemberInternal") == MemberPolicyDisposition.PROTECTED
+    assert classify_member_policy("futureControllerMember") == MemberPolicyDisposition.PROTECTED
+    assert classify_member_policy("trunkHost") == MemberPolicyDisposition.NOT_MEMBER
+    assert is_member_policy("futureControllerMember") is True
+    assert is_supported_member_policy("vpcMember") is False
+    assert is_supported_member_policy("vpcMember", include_pair_aware=True) is True
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (20, 20),
+        ("20", 20),
+        ("Port-channel20", 20),
+        ("portchannel20", 20),
+        (" PORT-CHANNEL 20 ", 20),
+        (-1, None),
+        ("-1", None),
+        (None, None),
+    ],
+)
+def test_normalize_port_channel_id(value, expected):
+    assert normalize_port_channel_id(value) == expected
+
+
+@pytest.mark.parametrize("value", [True, "Ethernet1/1", "Port-channel4097", 4097, 0, "0", -2, "-2", object()])
+def test_normalize_port_channel_id_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        normalize_port_channel_id(value)
+
+
+@pytest.mark.parametrize(
+    "policy_type,mode,network_os",
+    [
+        ("poMember", "trunk", "nx-os"),
+        ("accessPoMember", "access", "nx-os"),
+        ("l3PoMember", "routed", "nx-os"),
+        ("iosXeL3PoMember", "routed", "ios-xe"),
+        ("vpcMember", "trunk", "nx-os"),
+        ("accessVpcPoMember", "access", "nx-os"),
+    ],
+)
+def test_parse_all_modeled_member_policies(policy_type, mode, network_os):
+    model = parse_member_interface_response(member_record(policy_type, mode=mode, network_os=network_os))
+    assert isinstance(model, EthernetMemberInterfaceModel)
+    assert model.policy_type == policy_type
+    assert model.descriptor == MEMBER_POLICY_DESCRIPTORS[policy_type]
+    assert model.normalized_port_channel_id == 20
+
+
+def test_parse_access_po_member_captured_nd_wire_shape():
+    """Intent mode is access even when operational mode reports trunk."""
+
+    captured_record = {
+        "interfaceName": "Ethernet1/46",
+        "interfaceType": "ethernet",
+        "switchId": "SERIAL1",
+        "configData": {
+            "mode": "access",
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "policyType": "accessPoMember",
+                    "portChannelId": "port-channel901",
+                    "portMode": "normal",
+                    "adminState": True,
+                    "cdp": True,
+                    "debounceTimer": 100,
+                    "fec": "auto",
+                    "lacpPortPriority": 32768,
+                    "lacpRate": "normal",
+                    "portChannelMode": "active",
+                    "ptp": False,
+                },
+            },
+        },
+        "operData": {"adminStatus": "up", "mode": "trunk", "portChannelId": 901},
+    }
+
+    model = parse_member_interface_response(captured_record)
+
+    assert model.config_data.mode == "access"
+    assert model.policy_type == "accessPoMember"
+    assert model.normalized_port_channel_id == 901
+
+    payload = build_member_update_payload(captured_record, {"description": "updated"})
+    assert "portMode" not in payload["configData"]["networkOS"]["policy"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["configData", "configData.networkOS", "configData.networkOS.policy"],
+)
+def test_parse_rejects_unclassified_nested_configuration(path):
+    response = member_record()
+    target = response
+    for component in path.split("."):
+        target = target[component]
+    target["futureControllerField"] = "must-not-be-dropped"
+
+    with pytest.raises(UnmodeledMemberConfigurationError, match="futureControllerField"):
+        parse_member_interface_response(response)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("ptp", 1), ("portMode", False)],
+)
+def test_parse_rejects_malformed_response_only_field(field, value):
+    response = member_record(policy_type="accessPoMember", mode="access")
+    response["configData"]["networkOS"]["policy"][field] = value
+
+    with pytest.raises(UnmodeledMemberConfigurationError, match=field):
+        parse_member_interface_response(response)
+
+
+def test_safe_overlay_preserves_declared_fields_and_strips_response_only_data():
+    response = member_record()
+    original = copy.deepcopy(response)
+    payload = build_member_update_payload(
+        response,
+        {
+            "admin_state": False,
+            "description": "updated",
+            "extra_config": "logging event trunk-status",
+        },
+        switch_id="SERIAL2",
+    )
+
+    assert response == original
+    assert payload["switchId"] == "SERIAL2"
+    assert "switchIp" not in payload
+    assert "operData" not in payload
+    assert "fabricName" not in payload
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert policy["policyType"] == "poMember"
+    assert policy["portChannelId"] == "port-channel20"
+    assert policy["portChannelMode"] == "active"
+    assert policy["allowedVlans"] == "1-100"
+    assert policy["lacpPortPriority"] == 32768
+    assert policy["adminState"] is False
+    assert policy["description"] == "updated"
+    assert policy["extraConfig"] == "logging event trunk-status"
+    assert "ptp" not in policy
+
+
+def test_safe_overlay_accepts_wire_aliases():
+    assert normalize_safe_member_updates({"adminState": False, "extraConfig": "description helper"}) == {
+        "admin_state": False,
+        "extra_config": "description helper",
+    }
+
+
+@pytest.mark.parametrize("field", ["allowed_vlans", "portChannelMode", "policy_type", "speed"])
+def test_safe_overlay_rejects_non_safe_fields(field):
+    with pytest.raises(UnsafeMemberUpdateError, match="may update only"):
+        normalize_safe_member_updates({field: "unsafe"})
+
+
+@pytest.mark.parametrize(
+    "extra_config",
+    [
+        "channel-group 30 mode active",
+        "no channel-group 20",
+        "default channel-group",
+        "default interface Ethernet1/24",
+        "description safe ; no channel-group 20",
+        "description safe\rdefault interface Ethernet1/24",
+        "exit ; interface port-channel20 ; shutdown",
+        "end\ninterface Ethernet1/24\nno channel-group 20",
+        "do configure terminal ; interface Port-channel20",
+    ],
+)
+def test_safe_overlay_rejects_membership_changing_extra_config(extra_config):
+    with pytest.raises(UnsafeMemberUpdateError, match="must not change channel-group"):
+        normalize_safe_member_updates({"extra_config": extra_config})
+
+
+@pytest.mark.parametrize(
+    "extra_config",
+    [
+        "ch 30 mode active",
+        "chan 30 mode active",
+        "no ch 20",
+        "default channel-g",
+        "def chan",
+        "int Ethernet1/24",
+        "default int Ethernet1/24",
+        "def inte Ethernet1/24",
+        "default-int Ethernet1/24",
+        "ex",
+        "exi",
+        "en",
+        "conf t",
+        "configure term",
+        "do conf t",
+        "description safe ; NO CH 20",
+    ],
+)
+def test_safe_overlay_rejects_abbreviated_membership_and_context_commands(extra_config):
+    with pytest.raises(UnsafeMemberUpdateError, match="must not change channel-group"):
+        normalize_safe_member_updates({"extra_config": extra_config})
+
+
+@pytest.mark.parametrize(
+    "extra_config",
+    [
+        "description channel-group is documentation",
+        "description conf t is documentation",
+        "no cdp enable",
+        "default cdp",
+        "channel-protocol lacp",
+        "no channel-protocol lacp",
+        "default channel-protocol",
+        "ip address 192.0.2.1/31",
+        "inherit port-profile EDGE",
+        "configuration checkpoint member-safe",
+        "endpoint tracker",
+        "exit-rate 10",
+    ],
+)
+def test_safe_overlay_accepts_benign_abbreviation_near_misses(extra_config):
+    assert normalize_safe_member_updates({"extra_config": extra_config}) == {"extra_config": extra_config}
+
+
+def test_pair_aware_payload_requires_validation_attestation():
+    response = member_record("vpcMember")
+    with pytest.raises(UnsafeMemberUpdateError, match="pair-aware"):
+        build_member_update_payload(response, {"description": "updated"})
+    payload = build_member_update_payload(response, {"description": "updated"}, pair_validated=True)
+    assert payload["configData"]["networkOS"]["policy"]["policyType"] == "vpcMember"
+
+
+@pytest.mark.parametrize(
+    "policy_type,mode,network_os",
+    [
+        ("poMember", "access", "nx-os"),
+        ("poMember", "trunk", "ios-xe"),
+        ("iosXeL3PoMember", "trunk", "ios-xe"),
+    ],
+)
+def test_policy_envelope_rejects_mode_or_os_mismatch(policy_type, mode, network_os):
+    with pytest.raises(ValidationError):
+        parse_member_interface_response(member_record(policy_type, mode=mode, network_os=network_os))
+
+
+@pytest.mark.parametrize("policy_type", ["l3PoMemberInternal", "futureControllerMember", "trunkHost"])
+def test_parse_rejects_unmodeled_policy(policy_type):
+    with pytest.raises(UnsupportedMemberPolicyError):
+        parse_member_interface_response(member_record(policy_type))

--- a/tests/unit/module_utils/orchestrators/test_ethernet_access_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_ethernet_access_interface.py
@@ -389,6 +389,9 @@ def test_ethernet_access_orchestrator_00430() -> None:
 # =============================================================================
 # Test: port-channel membership enforcement (create / update / create_bulk)
 # =============================================================================
+# NOTE: The legacy fixtures in 00500-00565 intentionally combine a host policy with a
+# positive operData portChannelId. They validate fail-closed handling of inconsistent
+# evidence; authentic member-policy behavior lives in test_ethernet_member_updates.py.
 
 
 def test_ethernet_access_orchestrator_00500() -> None:
@@ -422,7 +425,7 @@ def test_ethernet_access_orchestrator_00500() -> None:
     instance = EthernetAccessInterfaceOrchestrator(rest_send=rest_send)
     model = _build_access_model({"access_vlan": 100})
 
-    with pytest.raises(RuntimeError, match=r"Create failed for.*member of port-channel 10.*access_vlan"):
+    with pytest.raises(RuntimeError, match=r"Create failed for.*operational port-channel membership 10.*configured policy is 'accessHost'.*inconsistent"):
         instance.create(model)
 
     assert instance._pending_deploys == []
@@ -432,14 +435,14 @@ def test_ethernet_access_orchestrator_00510() -> None:
     """
     # Summary
 
-    Verify `create` succeeds on a port-channel member when only whitelisted policy fields are being changed.
+    Verify `create` rejects contradictory membership evidence even when only a safe field is requested.
 
     ## Test
 
     - switches-list resolves 192.168.1.1 -> FDO11111AAA
-    - interfaceList reports Ethernet1/1 as a member of port-channel 10
-    - The model changes only `description`, which is in `PORT_CHANNEL_MODIFIABLE_FIELDS`
-    - `create` does not raise; the POST is issued and a deploy is queued
+    - interfaceList reports `accessHost` while operData claims port-channel 10
+    - The model changes only the otherwise-safe `description` field
+    - `create` raises before POST and queues no deploy
 
     ## Classes and Methods
 
@@ -457,12 +460,12 @@ def test_ethernet_access_orchestrator_00510() -> None:
     instance = EthernetAccessInterfaceOrchestrator(rest_send=rest_send)
     model = _build_access_model({"description": "uplink to host"})
 
-    with does_not_raise():
+    with pytest.raises(RuntimeError, match=r"Create failed for.*operational port-channel membership 10.*configured policy is 'accessHost'.*inconsistent"):
         instance.create(model)
 
-    assert rest_send.verb == HttpVerbEnum.POST.value
+    assert rest_send.verb != HttpVerbEnum.POST.value
     assert rest_send.path == "/api/v1/manage/fabrics/fabric_1/switches/FDO11111AAA/interfaces"
-    assert instance._pending_deploys == [("Ethernet1/1", "FDO11111AAA")]
+    assert instance._pending_deploys == []
 
 
 def test_ethernet_access_orchestrator_00520() -> None:
@@ -531,7 +534,7 @@ def test_ethernet_access_orchestrator_00530() -> None:
     instance = EthernetAccessInterfaceOrchestrator(rest_send=rest_send)
     model = _build_access_model({"access_vlan": 100})
 
-    with pytest.raises(RuntimeError, match=r"Update failed for.*member of port-channel 10.*access_vlan"):
+    with pytest.raises(RuntimeError, match=r"Update failed for.*operational port-channel membership 10.*configured policy is 'accessHost'.*inconsistent"):
         instance.update(model)
 
     assert instance._pending_deploys == []
@@ -567,7 +570,7 @@ def test_ethernet_access_orchestrator_00540() -> None:
     instance = EthernetAccessInterfaceOrchestrator(rest_send=rest_send)
     model = _build_access_model({"access_vlan": 100})
 
-    with pytest.raises(RuntimeError, match=r"Bulk create failed.*member of port-channel 10.*access_vlan"):
+    with pytest.raises(RuntimeError, match=r"Bulk create failed.*operational port-channel membership 10.*configured policy is 'accessHost'.*inconsistent"):
         instance.create_bulk([model])
 
     assert instance._pending_deploys == []
@@ -577,18 +580,18 @@ def test_ethernet_access_orchestrator_00550() -> None:
     """
     # Summary
 
-    Verify `update` succeeds on a port-channel member when the post-merge model carries non-whitelisted
-    wire-side values (e.g. `access_vlan`, `mtu`) that the user did NOT change. Regression test for the
-    state:merged path where the state machine merges the existing model into the proposed one before
-    calling `update`.
+    Verify `update` rejects contradictory membership evidence even when all carried host-policy values
+    match the wire except for a safe description. A host-policy record plus a positive operational
+    port-channel ID is stale or corrupt evidence, not an authentic member that may use the safe-update
+    path.
 
     ## Test
 
     - switches-list resolves 192.168.1.1 -> FDO11111AAA
-    - interfaceList reports Ethernet1/1 as a member of port-channel 10 with `accessVlan=10`, `mtu=jumbo`
-    - The model passed to `update` carries `description='new'` (the user-set field) AND the existing
-      `access_vlan=10` / `mtu=jumbo` carried over by the state machine's merge step
-    - Only `description` differs from the wire; `access_vlan` / `mtu` match -> no flag -> `update` succeeds
+    - interfaceList reports `accessHost` plus operational port-channel 10
+    - The proposed access values match the wire except for `description`
+    - The evidence mismatch takes precedence over field comparison
+    - `update` raises without PUT or deploy
 
     ## Classes and Methods
 
@@ -606,10 +609,10 @@ def test_ethernet_access_orchestrator_00550() -> None:
     instance = EthernetAccessInterfaceOrchestrator(rest_send=rest_send)
     model = _build_access_model({"description": "new", "access_vlan": 10, "mtu": "jumbo"})
 
-    with does_not_raise():
+    with pytest.raises(RuntimeError, match=r"Update failed for.*operational port-channel membership 10.*configured policy is 'accessHost'.*inconsistent"):
         instance.update(model)
 
-    assert instance._pending_deploys == [("Ethernet1/1", "FDO11111AAA")]
+    assert instance._pending_deploys == []
 
 
 def test_ethernet_access_orchestrator_00560() -> None:
@@ -642,7 +645,7 @@ def test_ethernet_access_orchestrator_00560() -> None:
     instance = EthernetAccessInterfaceOrchestrator(rest_send=rest_send)
     model = _build_access_model({"access_vlan": 100})
 
-    with pytest.raises(RuntimeError, match=r"Update failed for.*member of port-channel 10.*access_vlan"):
+    with pytest.raises(RuntimeError, match=r"Update failed for.*operational port-channel membership 10.*configured policy is 'accessHost'.*inconsistent"):
         instance.update(model)
 
     assert instance._pending_deploys == []
@@ -652,17 +655,17 @@ def test_ethernet_access_orchestrator_00565() -> None:
     """
     # Summary
 
-    Verify `update` does NOT raise on a port-channel member when the wire echoes a non-whitelisted field
-    with a different scalar type than the model's coercion (ND returns `stormControlBroadcastLevel` as the
-    string `"50"` while the model carries float `50.0`). Regression for the float-vs-raw-wire comparison
-    that flagged an unchanged field as modified and wrongly blocked an idempotent re-run.
+    Verify scalar coercion cannot bypass contradictory membership evidence. The wire returns an
+    `accessHost` policy and positive operational port-channel ID while also echoing
+    `stormControlBroadcastLevel` as string `"50"`; the model carries the equivalent float `50.0`, but the
+    host/member mismatch must still fail closed.
 
     ## Test
 
     - switches-list resolves 192.168.1.1 -> FDO11111AAA
-    - interfaceList reports Ethernet1/1 as a port-channel member with `stormControlBroadcastLevel="50"` (str)
-    - The model carries `storm_control_broadcast_level=50.0` (float) — same logical value, different type
-    - Both sides are coerced through the model, so the field is NOT flagged -> `update` succeeds and deploys
+    - interfaceList reports `accessHost`, operational port-channel 10, and the string level `"50"`
+    - The model carries the logically equal float value `50.0`
+    - `update` rejects the evidence mismatch without PUT or deploy
 
     ## Classes and Methods
 
@@ -680,10 +683,10 @@ def test_ethernet_access_orchestrator_00565() -> None:
     instance = EthernetAccessInterfaceOrchestrator(rest_send=rest_send)
     model = _build_access_model({"storm_control_broadcast_level": 50.0})
 
-    with does_not_raise():
+    with pytest.raises(RuntimeError, match=r"Update failed for.*operational port-channel membership 10.*configured policy is 'accessHost'.*inconsistent"):
         instance.update(model)
 
-    assert instance._pending_deploys == [("Ethernet1/1", "FDO11111AAA")]
+    assert instance._pending_deploys == []
 
 
 def test_ethernet_access_orchestrator_00570() -> None:

--- a/tests/unit/module_utils/orchestrators/test_ethernet_member_updates.py
+++ b/tests/unit/module_utils/orchestrators/test_ethernet_member_updates.py
@@ -1,0 +1,789 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Regression tests for safe updates to authentic port-channel member records (IFACE-004).
+
+These tests deliberately exercise the real ``NDStateMachine`` and concrete access,
+trunk, and routed orchestrators.  The controller transport is replaced with a small
+in-memory recorder, but discovery, member projection, diff planning, preflight, and
+payload construction all remain production code.
+
+The fixtures use the real policy discriminators returned by Nexus Dashboard:
+``accessPoMember``, ``poMember``, ``l3PoMember``, and ``iosXeL3PoMember``.  A host
+policy decorated with ``operData.portChannelId`` is not a valid member fixture and
+must never be used to test this feature.
+"""
+
+# pylint: disable=protected-access
+# pylint: disable=too-many-arguments
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from types import MethodType
+from typing import Any
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import (
+    EthernetAccessInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_routed_interface import (
+    EthernetRoutedInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import (
+    EthernetTrunkHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
+    MockAnsibleModule,
+)
+
+SWITCH_IP = "192.168.1.1"
+SWITCH_ID = "FDO11111AAA"
+PORT_CHANNEL_ID = 20
+
+
+@dataclass(frozen=True)
+class _MemberCase:
+    """One supported member-policy family and its user-facing host orchestrator."""
+
+    name: str
+    orchestrator_class: type
+    member_policy_type: str
+    parent_policy_type: str
+    member_mode: str
+    parent_mode: str
+    network_os_type: str
+    interface_name: str
+    preserved_policy: dict[str, Any]
+    unsafe_policy: dict[str, Any]
+
+
+MEMBER_CASES = (
+    _MemberCase(
+        name="access_nxos",
+        orchestrator_class=EthernetAccessInterfaceOrchestrator,
+        member_policy_type="accessPoMember",
+        parent_policy_type="accessPoHost",
+        # Captured ND intent uses access mode even though operational data can
+        # report trunk mode after the member joins its port-channel.
+        member_mode="access",
+        parent_mode="access",
+        network_os_type="nx-os",
+        interface_name="Ethernet1/24",
+        preserved_policy={
+            "cdp": False,
+            "debounceTimer": 250,
+            "debounceLinkupTimer": 2000,
+            "fec": "rsFec",
+            "lacpPortPriority": 4096,
+            "lacpRate": "fast",
+        },
+        unsafe_policy={"access_vlan": 200},
+    ),
+    _MemberCase(
+        name="trunk_nxos",
+        orchestrator_class=EthernetTrunkHostInterfaceOrchestrator,
+        member_policy_type="poMember",
+        parent_policy_type="trunkPoHost",
+        member_mode="trunk",
+        parent_mode="trunk",
+        network_os_type="nx-os",
+        interface_name="Ethernet1/25",
+        preserved_policy={
+            "allowedVlans": "10-20,100",
+            "cdp": False,
+            "debounceTimer": 250,
+            "debounceLinkupTimer": 2000,
+            "fec": "rsFec",
+            "lacpPortPriority": 4096,
+            "lacpRate": "fast",
+        },
+        unsafe_policy={"allowed_vlans": "200-300"},
+    ),
+    _MemberCase(
+        name="routed_nxos",
+        orchestrator_class=EthernetRoutedInterfaceOrchestrator,
+        member_policy_type="l3PoMember",
+        parent_policy_type="l3Po",
+        member_mode="routed",
+        parent_mode="routed",
+        network_os_type="nx-os",
+        interface_name="Ethernet1/26",
+        preserved_policy={"fec": "rsFec"},
+        unsafe_policy={"mtu": 9000},
+    ),
+    _MemberCase(
+        name="routed_iosxe",
+        orchestrator_class=EthernetRoutedInterfaceOrchestrator,
+        member_policy_type="iosXeL3PoMember",
+        parent_policy_type="iosXeL3PortChannel",
+        member_mode="routed",
+        parent_mode="routed",
+        network_os_type="ios-xe",
+        interface_name="GigabitEthernet3",
+        preserved_policy={},
+        unsafe_policy={"mtu": 9000},
+    ),
+)
+
+
+def _case_id(case: _MemberCase) -> str:
+    return case.name
+
+
+@dataclass
+class _Controller:
+    """Record controller calls and serve one switch's interface inventory."""
+
+    interfaces: list[dict[str, Any]]
+    calls: list[dict[str, Any]] = field(default_factory=list)
+    fail_put: bool = False
+    fail_put_number: int | None = None
+
+    def request(
+        self,
+        _orchestrator,
+        path: str,
+        verb: HttpVerbEnum,
+        data: dict[str, Any] | None = None,
+        not_found_ok: bool = False,
+        operation_type=None,
+    ) -> dict[str, Any]:
+        """Return deterministic GET/PUT responses and reject unexpected requests."""
+        del not_found_ok, operation_type
+        verb_value = verb.value if isinstance(verb, HttpVerbEnum) else str(verb)
+        self.calls.append({"path": path, "verb": verb_value, "data": deepcopy(data)})
+        if verb_value == HttpVerbEnum.GET.value and path.endswith(f"/switches/{SWITCH_ID}/interfaces"):
+            return {"interfaces": deepcopy(self.interfaces)}
+        if verb_value == HttpVerbEnum.GET.value and "/api/v1/manage/links" in path:
+            return {"links": []}
+        if verb_value == HttpVerbEnum.PUT.value and "/interfaces/" in path:
+            put_number = sum(call["verb"] == HttpVerbEnum.PUT.value for call in self.calls)
+            if self.fail_put or put_number == self.fail_put_number:
+                raise RuntimeError("injected member PUT failure")
+            return {}
+        raise AssertionError(f"Unexpected controller request: {verb_value} {path}; data={data}")
+
+    @property
+    def _encoded_member_name(self) -> str:
+        member = next(item for item in self.interfaces if item.get("interfaceType") == "ethernet")
+        return member["interfaceName"].replace("/", "%2F")
+
+
+class _FabricContext:
+    """Minimal already-loaded fabric context used by interface orchestrators."""
+
+    switch_map = {SWITCH_IP: SWITCH_ID}
+
+    @staticmethod
+    def validate_for_mutation() -> None:
+        """The synthetic fabric is local, present, and not frozen."""
+
+    @staticmethod
+    def get_switch_id(switch_ip: str) -> str:
+        """Resolve the sole test switch."""
+        if switch_ip != SWITCH_IP:
+            raise RuntimeError(f"Switch with IP '{switch_ip}' not found in fabric 'fabric_1'.")
+        return SWITCH_ID
+
+
+def _member_record(
+    case: _MemberCase,
+    *,
+    policy_overrides: dict[str, Any] | None = None,
+    operational_port_channel_id: Any = PORT_CHANNEL_ID,
+) -> dict[str, Any]:
+    """Return an authentic configured port-channel member response."""
+    policy = {
+        "policyType": case.member_policy_type,
+        "portChannelId": f"Port-channel{PORT_CHANNEL_ID}",
+        "portChannelMode": "active",
+        "adminState": True,
+        "description": "old member description",
+        "extraConfig": "logging event link-status",
+        **case.preserved_policy,
+        **(policy_overrides or {}),
+    }
+    # ND 4.2.1 injects this undeclared key on NX-OS member reads.  It is useful
+    # evidence that response-only/unknown data is not blindly replayed.
+    if case.network_os_type == "nx-os":
+        policy["ptp"] = False
+    return {
+        "interfaceName": case.interface_name,
+        "interfaceType": "ethernet",
+        "switchId": SWITCH_ID,
+        "configData": {
+            "mode": case.member_mode,
+            "networkOS": {
+                "networkOSType": case.network_os_type,
+                "policy": policy,
+            },
+        },
+        "operData": {"portChannelId": operational_port_channel_id},
+    }
+
+
+def _parent_record(case: _MemberCase) -> dict[str, Any]:
+    """Return the compatible parent that proves ownership of the member."""
+    return {
+        "interfaceName": f"port-channel{PORT_CHANNEL_ID}",
+        "interfaceType": "portChannel",
+        "switchId": SWITCH_ID,
+        "configData": {
+            "mode": case.parent_mode,
+            "networkOS": {
+                "networkOSType": case.network_os_type,
+                "policy": {
+                    "policyType": case.parent_policy_type,
+                    "ports": [case.interface_name],
+                    "portChannelMode": "active",
+                },
+            },
+        },
+    }
+
+
+def _config(
+    case: _MemberCase,
+    policy: dict[str, Any] | None = None,
+    *,
+    interface_name: str | None = None,
+) -> dict[str, Any]:
+    """Return valid user input for the case's host-facing standalone module."""
+    network_os: dict[str, Any] = {"policy": policy or {}}
+    if case.name.startswith("routed_"):
+        network_os["network_os_type"] = case.network_os_type
+    return {
+        "switch_ip": SWITCH_IP,
+        "interface_name": interface_name or case.interface_name,
+        "config_data": {"network_os": network_os},
+    }
+
+
+def _host_record(case: _MemberCase, interface_name: str) -> dict[str, Any]:
+    """Return an ordinary host-policy response owned by the tested orchestrator."""
+    policy_type = {
+        "access_nxos": "accessHost",
+        "trunk_nxos": "trunkHost",
+        "routed_nxos": "routedHost",
+        "routed_iosxe": "iosXeRoutedHost",
+    }[case.name]
+    return {
+        "interfaceName": interface_name,
+        "interfaceType": "ethernet",
+        "switchId": SWITCH_ID,
+        "configData": {
+            "mode": case.parent_mode,
+            "networkOS": {
+                "networkOSType": case.network_os_type,
+                "policy": {
+                    "policyType": policy_type,
+                    "description": "managed host",
+                },
+            },
+        },
+        "operData": {"portChannelId": -1},
+    }
+
+
+def _rest_send(params: dict[str, Any]) -> RestSend:
+    """Build the RestSend required by a concrete orchestrator."""
+    rest_send = RestSend({**params, "check_mode": False})
+    rest_send.response_handler = ResponseHandler()
+    return rest_send
+
+
+def _state_machine(
+    case: _MemberCase,
+    *,
+    state: str,
+    policy: dict[str, Any] | None = None,
+    check_mode: bool = False,
+    member_policy_overrides: dict[str, Any] | None = None,
+    operational_port_channel_id: Any = PORT_CHANNEL_ID,
+    config_override: list[dict[str, Any]] | None = None,
+    inventory_override: list[dict[str, Any]] | None = None,
+    fail_put: bool = False,
+    fail_put_number: int | None = None,
+) -> tuple[NDStateMachine, _Controller]:
+    """Construct a state machine backed by authentic member and parent inventory."""
+    if config_override is not None:
+        config = config_override
+    elif state == "deleted":
+        config = [{"switch_ip": SWITCH_IP, "interface_name": case.interface_name}]
+    else:
+        config = [_config(case, policy)]
+    params = {
+        "state": state,
+        "config": config,
+        "output_level": "normal",
+        "ignore_errors": False,
+        "fabric_name": "fabric_1",
+        "config_actions": {"deploy": False},
+    }
+    orchestrator = case.orchestrator_class(rest_send=_rest_send(params))
+    inventory = inventory_override or [
+        _parent_record(case),
+        _member_record(
+            case,
+            policy_overrides=member_policy_overrides,
+            operational_port_channel_id=operational_port_channel_id,
+        ),
+    ]
+    controller = _Controller(inventory, fail_put=fail_put, fail_put_number=fail_put_number)
+    object.__setattr__(orchestrator, "_fabric_context", _FabricContext())
+    object.__setattr__(orchestrator, "_request", MethodType(controller.request, orchestrator))
+
+    module = MockAnsibleModule()
+    module.params = params
+    module.check_mode = check_mode
+    module.no_log_values = set()
+    return NDStateMachine(module=module, model_orchestrator=orchestrator), controller
+
+
+def _write_calls(controller: _Controller) -> list[dict[str, Any]]:
+    """Return all recorded PUT/POST/DELETE requests."""
+    return [call for call in controller.calls if call["verb"] != HttpVerbEnum.GET.value]
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_member_merge_is_planned_as_update_and_preserves_member_payload(
+    case: _MemberCase,
+) -> None:
+    """A named real member is updated with PUT and retains its policy/parent fields."""
+    state_machine, controller = _state_machine(
+        case,
+        state="merged",
+        policy={
+            "admin_state": False,
+            "description": "updated by standalone module",
+            "extra_config": "logging event trunk-status",
+        },
+    )
+
+    before = list(state_machine.before)
+    assert [(item.switch_ip, item.interface_name) for item in before] == [(SWITCH_IP, case.interface_name)]
+
+    state_machine.manage_state()
+
+    writes = _write_calls(controller)
+    assert len(writes) == 1
+    assert writes[0]["verb"] == HttpVerbEnum.PUT.value
+    assert writes[0]["path"].endswith("/interfaces/" + case.interface_name.replace("/", "%2F"))
+    payload = writes[0]["data"]
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert payload["interfaceName"] == case.interface_name
+    assert payload["switchId"] == SWITCH_ID
+    assert payload["configData"]["mode"] == case.member_mode
+    assert payload["configData"]["networkOS"]["networkOSType"] == case.network_os_type
+    assert policy["policyType"] == case.member_policy_type
+    assert policy["portChannelId"] == f"Port-channel{PORT_CHANNEL_ID}"
+    assert policy["portChannelMode"] == "active"
+    assert policy["adminState"] is False
+    assert policy["description"] == "updated by standalone module"
+    assert policy["extraConfig"] == "logging event trunk-status"
+    for key, value in case.preserved_policy.items():
+        assert policy[key] == value
+    assert "ptp" not in policy
+    assert "operData" not in payload
+    assert not any(call["verb"] == HttpVerbEnum.POST.value for call in controller.calls)
+    inventory_gets = [
+        call for call in controller.calls if call["verb"] == HttpVerbEnum.GET.value and call["path"].endswith(f"/switches/{SWITCH_ID}/interfaces")
+    ]
+    assert len(inventory_gets) == 1
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+@pytest.mark.parametrize(
+    "requested_policy",
+    (
+        {"admin_state": False},
+        {"description": "safe member description"},
+        {"extra_config": "logging event trunk-status"},
+    ),
+    ids=("admin_state", "description", "extra_config"),
+)
+def test_each_safe_member_field_uses_put(case: _MemberCase, requested_policy: dict[str, Any]) -> None:
+    """Each documented member-safe field is independently mutable."""
+    state_machine, controller = _state_machine(case, state="merged", policy=requested_policy)
+
+    state_machine.manage_state()
+
+    writes = _write_calls(controller)
+    assert [call["verb"] for call in writes] == [HttpVerbEnum.PUT.value]
+    assert not any(call["verb"] == HttpVerbEnum.POST.value for call in controller.calls)
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_idempotent_member_merge_performs_no_write(case: _MemberCase) -> None:
+    """A safe field already at the requested value is neither PUT nor deployed."""
+    state_machine, controller = _state_machine(case, state="merged", policy={"description": "old member description"})
+
+    state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+    assert state_machine.output.format()["changed"] is False
+    assert state_machine.model_orchestrator._pending_deploys == []
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_unsafe_member_field_fails_atomically_before_write(case: _MemberCase) -> None:
+    """A mixed safe/unsafe request is rejected without a partial member update."""
+    requested = {"description": "must not be partially applied", **case.unsafe_policy}
+    state_machine, controller = _state_machine(case, state="merged", policy=requested)
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*(only|cannot|safe)"):
+        state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+    assert state_machine.model_orchestrator._pending_deploys == []
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+@pytest.mark.parametrize("state", ("replaced", "overridden"))
+def test_member_update_rejects_replacement_states(case: _MemberCase, state: str) -> None:
+    """Standalone modules require merged semantics for a member-safe update."""
+    state_machine, controller = _state_machine(case, state=state, policy={"description": "replacement is unsafe"})
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*merged"):
+        state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_explicit_member_delete_is_rejected(case: _MemberCase) -> None:
+    """Deleting/defaulting a member remains a parent-controlled operation."""
+    state_machine, controller = _state_machine(case, state="deleted")
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*(delete|normalize|parent)"):
+        state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_check_mode_plans_change_without_sending_member_put(case: _MemberCase) -> None:
+    """Check mode runs member validation and reports the planned update without I/O."""
+    state_machine, controller = _state_machine(
+        case,
+        state="merged",
+        policy={"description": "check mode update"},
+        check_mode=True,
+    )
+
+    state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+    assert state_machine.output.format()["changed"] is True
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_gathered_keeps_members_out_of_host_family_output(case: _MemberCase) -> None:
+    """Gathered output remains scoped to host policies and does not expose planning projections."""
+    state_machine, controller = _state_machine(case, state="gathered")
+
+    state_machine.manage_state()
+
+    assert list(state_machine.before) == []
+    assert _write_calls(controller) == []
+    assert state_machine.output.format()["changed"] is False
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+@pytest.mark.parametrize("operational_id", (-1, None), ids=("stale_minus_one", "missing"))
+def test_configured_member_delete_is_rejected_when_operational_membership_is_stale(case: _MemberCase, operational_id: Any) -> None:
+    """Configured member intent blocks deletion even when operData is stale."""
+    state_machine, controller = _state_machine(
+        case,
+        state="deleted",
+        operational_port_channel_id=operational_id,
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*(delete|normalize|parent)"):
+        state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_unsafe_member_request_is_rejected_in_check_mode(case: _MemberCase) -> None:
+    """Dry-run preflight enforces the same safe-field allowlist as execution."""
+    state_machine, controller = _state_machine(
+        case,
+        state="merged",
+        policy={"description": "must not apply", **case.unsafe_policy},
+        check_mode=True,
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*(only|cannot|safe)"):
+        state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_member_delete_is_rejected_in_check_mode(case: _MemberCase) -> None:
+    """Dry-run delete cannot report a member normalization execution would refuse."""
+    state_machine, controller = _state_machine(case, state="deleted", check_mode=True)
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*(delete|normalize|parent)"):
+        state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+@pytest.mark.parametrize("operation", ("create", "create_bulk"))
+def test_direct_create_paths_never_post_an_existing_member(case: _MemberCase, operation: str) -> None:
+    """Defensive direct calls cannot bypass UPDATE planning and issue POST."""
+    state_machine, controller = _state_machine(case, state="merged", policy={"description": "direct"})
+    model = next(iter(state_machine.proposed))
+    orchestrator = state_machine.model_orchestrator
+
+    with pytest.raises(RuntimeError, match=r"(?i)member.*never.*create"):
+        if operation == "create":
+            orchestrator.create(model)
+        else:
+            orchestrator.create_bulk([model])
+
+    assert _write_calls(controller) == []
+    assert not any(call["verb"] == HttpVerbEnum.POST.value for call in controller.calls)
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+@pytest.mark.parametrize("operation", ("delete", "delete_bulk"))
+def test_direct_delete_paths_reject_configured_member_with_stale_operdata(case: _MemberCase, operation: str) -> None:
+    """Configured membership guards every delete entry point without relying on operData."""
+    state_machine, controller = _state_machine(
+        case,
+        state="deleted",
+        operational_port_channel_id=-1,
+    )
+    model = next(iter(state_machine.proposed))
+    orchestrator = state_machine.model_orchestrator
+
+    with pytest.raises(RuntimeError, match=r"(?i)member.*(normalize|strip)"):
+        if operation == "delete":
+            orchestrator.delete(model)
+        else:
+            orchestrator.delete_bulk([model])
+
+    assert _write_calls(controller) == []
+    assert orchestrator._pending_normalizes == []
+    assert orchestrator._pending_resets == []
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_overridden_omits_member_from_host_family_scope(case: _MemberCase) -> None:
+    """An omitted member is preserved while an ordinary host remains converged."""
+    host_name = "Ethernet1/30" if case.network_os_type == "nx-os" else "GigabitEthernet4"
+    inventory = [
+        _parent_record(case),
+        _member_record(
+            case,
+            operational_port_channel_id=-1,
+        ),
+        _host_record(case, host_name),
+    ]
+    state_machine, controller = _state_machine(
+        case,
+        state="overridden",
+        config_override=[
+            _config(
+                case,
+                {"description": "managed host"},
+                interface_name=host_name,
+            )
+        ],
+        inventory_override=inventory,
+    )
+    assert [item.interface_name for item in state_machine.before] == [host_name]
+
+    state_machine.manage_state()
+
+    assert state_machine.output.format()["changed"] is False
+    assert _write_calls(controller) == []
+    assert state_machine.model_orchestrator._pending_normalizes == []
+    assert state_machine.model_orchestrator._pending_resets == []
+
+
+@pytest.mark.parametrize(
+    "case,unsafe_policy,member_policy_overrides",
+    [
+        (MEMBER_CASES[0], {"cdp": False}, {"cdp": False}),
+        (MEMBER_CASES[1], {"allowed_vlans": "10-20,100"}, {"allowedVlans": "10-20,100"}),
+        (MEMBER_CASES[2], {"fec": "rsFec"}, {"fec": "rsFec"}),
+    ],
+    ids=("access_nxos", "trunk_nxos", "routed_nxos"),
+)
+def test_explicit_unsafe_field_is_rejected_even_when_equal_to_current(
+    case: _MemberCase,
+    unsafe_policy: dict[str, Any],
+    member_policy_overrides: dict[str, Any],
+) -> None:
+    """A real shared-but-unsafe member field is rejected even when unchanged."""
+    state_machine, controller = _state_machine(
+        case,
+        state="merged",
+        policy=unsafe_policy,
+        member_policy_overrides=member_policy_overrides,
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*(only|cannot|safe)"):
+        state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_member_put_failure_never_falls_back_to_post_or_queues_deploy(
+    case: _MemberCase,
+) -> None:
+    """A rejected member PUT fails closed without host-policy fallback or deployment."""
+    state_machine, controller = _state_machine(
+        case,
+        state="merged",
+        policy={"description": "controller will reject"},
+        fail_put=True,
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"injected member PUT failure"):
+        state_machine.manage_state()
+
+    writes = _write_calls(controller)
+    assert [call["verb"] for call in writes] == [HttpVerbEnum.PUT.value]
+    assert not any(call["verb"] == HttpVerbEnum.POST.value for call in controller.calls)
+    assert state_machine.model_orchestrator._pending_deploys == []
+
+
+@pytest.mark.parametrize(
+    ("target_case", "member_case"),
+    (
+        (MEMBER_CASES[0], MEMBER_CASES[1]),
+        (MEMBER_CASES[1], MEMBER_CASES[0]),
+        (MEMBER_CASES[2], MEMBER_CASES[1]),
+        (MEMBER_CASES[3], MEMBER_CASES[1]),
+    ),
+    ids=(
+        "access_vs_trunk",
+        "trunk_vs_access",
+        "routed_nx_vs_trunk",
+        "routed_xe_vs_trunk",
+    ),
+)
+@pytest.mark.parametrize("state", ("merged", "deleted"))
+def test_wrong_family_member_is_rejected_without_write(target_case: _MemberCase, member_case: _MemberCase, state: str) -> None:
+    """A standalone family cannot create over or delete another family's member."""
+    inventory = [_parent_record(member_case), _member_record(member_case)]
+    if state == "deleted":
+        config = [{"switch_ip": SWITCH_IP, "interface_name": member_case.interface_name}]
+    else:
+        config = [
+            _config(
+                target_case,
+                {"description": "wrong family"},
+                interface_name=member_case.interface_name,
+            )
+        ]
+    state_machine, controller = _state_machine(
+        target_case,
+        state=state,
+        config_override=config,
+        inventory_override=inventory,
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member"):
+        state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+    assert not any(call["verb"] == HttpVerbEnum.POST.value for call in controller.calls)
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+@pytest.mark.parametrize("state", ("merged", "deleted"))
+def test_protected_internal_member_is_rejected_without_write(case: _MemberCase, state: str) -> None:
+    """Known internal member intent cannot be overwritten or normalized."""
+    state_machine, controller = _state_machine(
+        case,
+        state=state,
+        member_policy_overrides={"policyType": "l3PoMemberInternal"},
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)(member|protected|fabric)"):
+        state_machine.manage_state()
+
+    assert _write_calls(controller) == []
+    assert not any(call["verb"] == HttpVerbEnum.POST.value for call in controller.calls)
+
+
+@pytest.mark.parametrize("case", MEMBER_CASES, ids=_case_id)
+def test_direct_update_rejects_protected_internal_member(case: _MemberCase) -> None:
+    """Direct update calls retain the protected-policy ownership guard."""
+    state_machine, controller = _state_machine(
+        case,
+        state="merged",
+        policy={"description": "must not apply"},
+        member_policy_overrides={"policyType": "l3PoMemberInternal"},
+    )
+    model = next(iter(state_machine.proposed))
+
+    with pytest.raises(RuntimeError, match=r"(?i)(protected|unsupported|fabric)"):
+        state_machine.model_orchestrator.update(model)
+
+    assert _write_calls(controller) == []
+
+
+def test_second_member_put_failure_preserves_only_first_accepted_deploy() -> None:
+    """Sequential member updates fail closed without POST fallback or false deploys."""
+    case = MEMBER_CASES[1]
+    second_name = "Ethernet1/27"
+    first_member = _member_record(case)
+    second_member = deepcopy(first_member)
+    second_member["interfaceName"] = second_name
+    parent = _parent_record(case)
+    parent["configData"]["networkOS"]["policy"]["ports"] = [
+        case.interface_name,
+        second_name,
+    ]
+    config = [
+        _config(case, {"description": "first accepted"}),
+        _config(
+            case,
+            {"description": "second rejected"},
+            interface_name=second_name,
+        ),
+    ]
+    state_machine, controller = _state_machine(
+        case,
+        state="merged",
+        config_override=config,
+        inventory_override=[parent, first_member, second_member],
+        fail_put_number=2,
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"injected member PUT failure"):
+        state_machine.manage_state()
+
+    writes = _write_calls(controller)
+    assert [call["verb"] for call in writes] == [
+        HttpVerbEnum.PUT.value,
+        HttpVerbEnum.PUT.value,
+    ]
+    assert not any(call["verb"] == HttpVerbEnum.POST.value for call in controller.calls)
+    assert state_machine.model_orchestrator._pending_deploys == [(case.interface_name, SWITCH_ID)]

--- a/tests/unit/module_utils/orchestrators/test_ethernet_routed_interface.py
+++ b/tests/unit/module_utils/orchestrators/test_ethernet_routed_interface.py
@@ -648,8 +648,11 @@ def _user_nx_model(policy_kwargs: dict, interface_name: str = "Ethernet1/7", swi
     )
 
 
-def _pc_member_wire(policy: dict, interface_name: str = "Ethernet1/7", port_channel_id: int = 10) -> dict:
-    """Build the wire-state dict of a routed port-channel member carrying `policy` (policyType added)."""
+# This is deliberately not an authentic member record. It exercises the fail-closed
+# path for contradictory evidence; authentic routed member policies are covered in
+# test_ethernet_member_updates.py.
+def _inconsistent_routed_host_wire(policy: dict, interface_name: str = "Ethernet1/7", port_channel_id: int = 10) -> dict:
+    """Build stale evidence: routedHost policy plus an operational port-channel ID."""
     return {
         "interfaceName": interface_name,
         "interfaceType": "ethernet",
@@ -682,10 +685,10 @@ def test_ethernet_routed_orchestrator_00600() -> None:
         yield responses_ethernet_routed("test_update_pc_member_replaced_00600a")
 
     orchestrator = _build_orchestrator(ResponseGenerator(responses()), params={"state": "replaced"})
-    existing = _pc_member_wire({"adminState": True, "description": "Old description", "ip": "10.10.10.1", "prefix": 30, "mtu": 9000})
+    existing = _inconsistent_routed_host_wire({"adminState": True, "description": "Old description", "ip": "10.10.10.1", "prefix": 30, "mtu": 9000})
     model = _user_nx_model({"description": "New description"})
 
-    with pytest.raises(RuntimeError, match=r"Update failed for.*member of port-channel 10.*\['ip', 'mtu', 'prefix'\]"):
+    with pytest.raises(RuntimeError, match=r"Update failed for.*operational port-channel membership 10.*configured policy is 'routedHost'.*inconsistent"):
         orchestrator.update(model, existing_data=existing)
     assert orchestrator._pending_deploys == []
 
@@ -694,15 +697,15 @@ def test_ethernet_routed_orchestrator_00610() -> None:
     """
     # Summary
 
-    Verify `update` under `state: replaced` allows a replacement of a port-channel member when every omitted field already sits
-    at its template default (clearing a default is a no-op, mirroring the reverse-diff scrub in `get_diff`) and the carried
-    fields are unchanged or whitelisted.
+    Verify `update` under `state: replaced` rejects contradictory membership evidence even when carried routed-host fields are
+    unchanged and omitted values sit at defaults. A `routedHost` policy with a positive operational port-channel ID is not an
+    authentic member and must fail closed before PUT.
 
     ## Test
 
-    - state is `replaced`; existing member carries ip/prefix, default mtu 9216, and an old description
-    - Proposed model carries the same ip/prefix and a new description (mtu omitted)
-    - `update` does not raise; the PUT is issued and a deploy is queued
+    - Existing state carries `routedHost`, ip/prefix/default MTU, and operational port-channel 10
+    - Proposed model carries the same ip/prefix and a new description
+    - `update` rejects the evidence mismatch without PUT or deploy
 
     ## Classes and Methods
 
@@ -715,27 +718,27 @@ def test_ethernet_routed_orchestrator_00610() -> None:
         yield responses_ethernet_routed("test_update_pc_member_replaced_00610b")
 
     orchestrator = _build_orchestrator(ResponseGenerator(responses()), params={"state": "replaced"})
-    existing = _pc_member_wire({"adminState": True, "description": "Old description", "ip": "10.10.10.1", "prefix": 30, "mtu": 9216})
+    existing = _inconsistent_routed_host_wire({"adminState": True, "description": "Old description", "ip": "10.10.10.1", "prefix": 30, "mtu": 9216})
     model = _user_nx_model({"description": "New description", "ip": "10.10.10.1", "prefix": 30})
 
-    with does_not_raise():
+    with pytest.raises(RuntimeError, match=r"Update failed for.*operational port-channel membership 10.*configured policy is 'routedHost'.*inconsistent"):
         orchestrator.update(model, existing_data=existing)
-    assert orchestrator.rest_send.verb == HttpVerbEnum.PUT.value
-    assert orchestrator._pending_deploys == [("Ethernet1/7", "FDO11111AAA")]
+    assert orchestrator.rest_send.verb != HttpVerbEnum.PUT.value
+    assert orchestrator._pending_deploys == []
 
 
 def test_ethernet_routed_orchestrator_00620() -> None:
     """
     # Summary
 
-    Verify the removal-aware check does NOT apply under `state: merged`: an omitted field is not a removal there (the state
-    machine merges it from existing state), so a description-only merge on a member carrying ip/prefix/mtu is allowed.
+    Verify `state: merged` also rejects a `routedHost` record whose operData claims membership; merge semantics cannot make
+    contradictory ownership evidence safe.
 
     ## Test
 
-    - state is `merged`; existing member carries ip/prefix/mtu 9000
+    - Existing state carries `routedHost`, ip/prefix/MTU, and operational port-channel 10
     - Proposed model carries only a new description
-    - `update` does not raise; the PUT is issued and a deploy is queued
+    - `update` rejects the evidence mismatch without PUT or deploy
 
     ## Classes and Methods
 
@@ -748,12 +751,12 @@ def test_ethernet_routed_orchestrator_00620() -> None:
         yield responses_ethernet_routed("test_update_pc_member_merged_00620b")
 
     orchestrator = _build_orchestrator(ResponseGenerator(responses()), params={"state": "merged"})
-    existing = _pc_member_wire({"adminState": True, "description": "Old description", "ip": "10.10.10.1", "prefix": 30, "mtu": 9000})
+    existing = _inconsistent_routed_host_wire({"adminState": True, "description": "Old description", "ip": "10.10.10.1", "prefix": 30, "mtu": 9000})
     model = _user_nx_model({"description": "New description"})
 
-    with does_not_raise():
+    with pytest.raises(RuntimeError, match=r"Update failed for.*operational port-channel membership 10.*configured policy is 'routedHost'.*inconsistent"):
         orchestrator.update(model, existing_data=existing)
-    assert orchestrator._pending_deploys == [("Ethernet1/7", "FDO11111AAA")]
+    assert orchestrator._pending_deploys == []
 
 
 # =============================================================================
@@ -816,7 +819,7 @@ def test_ethernet_routed_orchestrator_00710() -> None:
     orchestrator = _build_orchestrator(ResponseGenerator(responses()), params={"state": "merged"})
     model = _user_nx_model({"mtu": 9000})
 
-    with pytest.raises(RuntimeError, match=r"member of port-channel 10.*\['mtu'\]"):
+    with pytest.raises(RuntimeError, match=r"operational port-channel membership 10.*configured policy is 'routedHost'.*inconsistent"):
         orchestrator.preflight([model])
 
 

--- a/tests/unit/module_utils/orchestrators/test_ethernet_vpc_member_prefetch.py
+++ b/tests/unit/module_utils/orchestrators/test_ethernet_vpc_member_prefetch.py
@@ -1,0 +1,424 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Scale regressions for pair-aware Ethernet member inventory prefetch."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from types import MethodType
+from typing import Any
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators import (
+    ethernet_base,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import (
+    EthernetTrunkHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
+    MockAnsibleModule,
+)
+
+
+@dataclass
+class _Topology:
+    switch_map: dict[str, str]
+    inventories: dict[str, list[dict[str, Any]]]
+    config: list[dict[str, Any]]
+    local_serials: list[str]
+    peer_serials: list[str]
+    pair_records: dict[str, dict[str, Any]]
+
+
+@dataclass
+class _Controller:
+    inventories: dict[str, list[dict[str, Any]]]
+    pair_records: dict[str, dict[str, Any]] = field(default_factory=dict)
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def request(
+        self,
+        _orchestrator,
+        path: str,
+        verb: HttpVerbEnum,
+        data: dict[str, Any] | None = None,
+        not_found_ok: bool = False,
+        operation_type=None,
+    ) -> dict[str, Any]:
+        del not_found_ok, operation_type
+        verb_value = verb.value if isinstance(verb, HttpVerbEnum) else str(verb)
+        self.calls.append({"path": path, "verb": verb_value, "data": deepcopy(data)})
+        if verb_value == HttpVerbEnum.GET.value:
+            for switch_id, records in self.inventories.items():
+                if path.endswith(f"/switches/{switch_id}/interfaces"):
+                    return {"interfaces": deepcopy(records)}
+            if path.endswith("/vpcPair"):
+                for switch_id, record in self.pair_records.items():
+                    if path.endswith(f"/switches/{switch_id}/vpcPair"):
+                        return deepcopy(record)
+                return {}
+        if verb_value == HttpVerbEnum.PUT.value and "/interfaces/" in path:
+            return {}
+        raise AssertionError(f"Unexpected controller request: {verb_value} {path}; data={data}")
+
+
+class _FabricContext:
+    def __init__(self, switch_map: dict[str, str]) -> None:
+        self.switch_map = switch_map
+
+    @staticmethod
+    def validate_for_mutation() -> None:
+        pass
+
+    def get_switch_id(self, switch_ip: str) -> str:
+        try:
+            return self.switch_map[switch_ip]
+        except KeyError as exc:
+            raise RuntimeError(f"Unknown switch {switch_ip!r}") from exc
+
+
+def _member(
+    switch_id: str,
+    interface_name: str,
+    parent_name: str,
+    port_channel_id: int,
+) -> dict[str, Any]:
+    return {
+        "interfaceName": interface_name,
+        "interfaceType": "ethernet",
+        "switchId": switch_id,
+        "configData": {
+            "mode": "trunk",
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "policyType": "vpcMember",
+                    "portChannelId": f"Port-channel{port_channel_id}",
+                    "portChannelMode": "active",
+                    "primaryInterface": parent_name,
+                    "adminState": True,
+                    "description": "existing vPC member",
+                    "extraConfig": "logging event link-status",
+                },
+            },
+        },
+        "operData": {
+            "portChannelId": port_channel_id,
+            "interfaceStatus": "connected",
+        },
+    }
+
+
+def _parent(
+    switch_id: str,
+    peer_switch_id: object,
+    parent_name: str,
+    local_port_channel_id: int,
+    peer_port_channel_id: int,
+    local_members: list[str],
+    peer_members: list[str],
+) -> dict[str, Any]:
+    return {
+        "interfaceName": parent_name,
+        "interfaceType": "vpc",
+        "switchId": switch_id,
+        "configData": {
+            "mode": "trunk",
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "policyType": "trunkVpcHost",
+                    "peerSwitchId": peer_switch_id,
+                    "peer1PortChannelId": local_port_channel_id,
+                    "peer2PortChannelId": peer_port_channel_id,
+                    "peer1MemberPorts": local_members,
+                    "peer2MemberPorts": peer_members,
+                },
+            },
+        },
+    }
+
+
+def _topology(
+    pair_count: int,
+    *,
+    members_per_pair: int = 1,
+    parent_peer_value: str = "declared",
+) -> _Topology:
+    switch_map: dict[str, str] = {}
+    inventories: dict[str, list[dict[str, Any]]] = {}
+    config: list[dict[str, Any]] = []
+    local_serials: list[str] = []
+    peer_serials: list[str] = []
+    pair_records: dict[str, dict[str, Any]] = {}
+
+    for pair_index in range(pair_count):
+        local_ip = f"192.0.2.{pair_index + 1}"
+        peer_ip = f"198.51.100.{pair_index + 1}"
+        local_serial = f"LOCAL-{pair_index:03d}"
+        peer_serial = f"PEER-{pair_index:03d}"
+        parent_name = f"vpc{pair_index + 100}"
+        local_id = pair_index + 100
+        peer_id = pair_index + 200
+        name_offset = pair_index * members_per_pair
+        local_names = [f"Ethernet1/{name_offset + member_index + 1}" for member_index in range(members_per_pair)]
+        peer_names = [f"Ethernet1/{name_offset + member_index + 21}" for member_index in range(members_per_pair)]
+
+        if parent_peer_value == "declared":
+            local_parent_peer: object = peer_serial
+            peer_parent_peer: object = local_serial
+        elif parent_peer_value == "empty":
+            local_parent_peer = ""
+            peer_parent_peer = ""
+        else:
+            raise ValueError(f"Unsupported parent_peer_value {parent_peer_value!r}")
+
+        local_parent = _parent(
+            local_serial,
+            local_parent_peer,
+            parent_name,
+            local_id,
+            peer_id,
+            local_names,
+            peer_names,
+        )
+        peer_parent = _parent(
+            peer_serial,
+            peer_parent_peer,
+            parent_name,
+            local_id,
+            peer_id,
+            local_names,
+            peer_names,
+        )
+        inventories[local_serial] = [
+            local_parent,
+            *[_member(local_serial, name, parent_name, local_id) for name in local_names],
+        ]
+        inventories[peer_serial] = [
+            peer_parent,
+            *[_member(peer_serial, name, parent_name, peer_id) for name in peer_names],
+        ]
+        switch_map[local_ip] = local_serial
+        switch_map[peer_ip] = peer_serial
+        config.extend(
+            {
+                "switch_ip": local_ip,
+                "interface_name": name,
+                "config_data": {
+                    "network_os": {
+                        "policy": {
+                            "description": f"updated pair {pair_index}",
+                        }
+                    }
+                },
+            }
+            for name in local_names
+        )
+        local_serials.append(local_serial)
+        peer_serials.append(peer_serial)
+        pair_records[local_serial] = {
+            "switchId": local_serial,
+            "peerSwitchId": peer_serial,
+        }
+
+    return _Topology(
+        switch_map=switch_map,
+        inventories=inventories,
+        config=config,
+        local_serials=local_serials,
+        peer_serials=peer_serials,
+        pair_records=pair_records,
+    )
+
+
+def _rest_send(params: dict[str, Any]) -> RestSend:
+    rest_send = RestSend({**params, "check_mode": False})
+    rest_send.response_handler = ResponseHandler()
+    return rest_send
+
+
+def _state_machine(
+    topology: _Topology,
+) -> tuple[NDStateMachine, _Controller]:
+    params = {
+        "state": "merged",
+        "config": topology.config,
+        "output_level": "normal",
+        "ignore_errors": False,
+        "fabric_name": "fabric_1",
+        "config_actions": {"deploy": False},
+    }
+    orchestrator = EthernetTrunkHostInterfaceOrchestrator(rest_send=_rest_send(params))
+    controller = _Controller(topology.inventories, topology.pair_records)
+    object.__setattr__(orchestrator, "_fabric_context", _FabricContext(topology.switch_map))
+    object.__setattr__(orchestrator, "_request", MethodType(controller.request, orchestrator))
+    module = MockAnsibleModule()
+    module.params = params
+    module.check_mode = False
+    module.no_log_values = set()
+    return NDStateMachine(module=module, model_orchestrator=orchestrator), controller
+
+
+def _inventory_gets(controller: _Controller) -> list[dict[str, Any]]:
+    return [call for call in controller.calls if call["verb"] == HttpVerbEnum.GET.value and call["path"].endswith("/interfaces")]
+
+
+def _pair_gets(controller: _Controller) -> list[dict[str, Any]]:
+    return [call for call in controller.calls if call["verb"] == HttpVerbEnum.GET.value and call["path"].endswith("/vpcPair")]
+
+
+def _writes(controller: _Controller) -> list[dict[str, Any]]:
+    return [call for call in controller.calls if call["verb"] != HttpVerbEnum.GET.value]
+
+
+def _install_counting_index(monkeypatch):
+    real_index = ethernet_base.EthernetMembershipIndex
+
+    class CountingMembershipIndex(real_index):
+        builds = 0
+        instances = []
+
+        def __init__(self, *args, **kwargs) -> None:
+            type(self).builds += 1
+            super().__init__(*args, **kwargs)
+            type(self).instances.append(self)
+
+    monkeypatch.setattr(ethernet_base, "EthernetMembershipIndex", CountingMembershipIndex)
+    return CountingMembershipIndex
+
+
+def test_many_distinct_pairs_build_one_index_and_retain_it_across_puts(monkeypatch) -> None:
+    topology = _topology(8)
+    state_machine, controller = _state_machine(topology)
+    counting_index = _install_counting_index(monkeypatch)
+
+    state_machine.manage_state()
+
+    assert counting_index.builds == 1
+    assert len(_inventory_gets(controller)) == 16
+    assert _pair_gets(controller) == []
+    assert len(_writes(controller)) == 8
+    assert state_machine.model_orchestrator._membership_index_cache is counting_index.instances[0]
+    assert len(state_machine.model_orchestrator._validated_member_ownership) == 8
+
+
+def test_direct_updates_rebuild_only_when_a_new_switch_inventory_is_loaded(monkeypatch) -> None:
+    topology = _topology(2)
+    params = {
+        "state": "merged",
+        "config": topology.config,
+        "fabric_name": "fabric_1",
+        "config_actions": {"deploy": False},
+    }
+    orchestrator = EthernetTrunkHostInterfaceOrchestrator(rest_send=_rest_send(params))
+    controller = _Controller(topology.inventories, topology.pair_records)
+    object.__setattr__(orchestrator, "_fabric_context", _FabricContext(topology.switch_map))
+    object.__setattr__(orchestrator, "_request", MethodType(controller.request, orchestrator))
+    counting_index = _install_counting_index(monkeypatch)
+    models = [orchestrator.model_class.from_config(item, context={"state": "merged"}) for item in topology.config]
+
+    orchestrator.update(models[0])
+    first_index = orchestrator._membership_index_cache
+    orchestrator.update(models[1])
+
+    assert counting_index.builds == 2
+    assert first_index is not orchestrator._membership_index_cache
+    assert len(_inventory_gets(controller)) == 4
+    assert _pair_gets(controller) == []
+    assert len(_writes(controller)) == 2
+
+
+def test_same_pair_members_share_empty_peer_fallback_inventory_and_index(monkeypatch) -> None:
+    topology = _topology(1, members_per_pair=6, parent_peer_value="empty")
+    state_machine, controller = _state_machine(topology)
+    counting_index = _install_counting_index(monkeypatch)
+
+    state_machine.manage_state()
+
+    assert counting_index.builds == 1
+    assert len(_inventory_gets(controller)) == 2
+    assert len(_pair_gets(controller)) == 1
+    assert len(_writes(controller)) == 6
+    assert state_machine.model_orchestrator._membership_index_cache is counting_index.instances[0]
+
+
+def test_pair_endpoint_is_used_only_for_parent_that_omits_peer(monkeypatch) -> None:
+    topology = _topology(2)
+    omitted_local = topology.local_serials[1]
+    omitted_peer = topology.peer_serials[1]
+    topology.inventories[omitted_local][0]["configData"]["networkOS"]["policy"]["peerSwitchId"] = ""
+    topology.inventories[omitted_peer][0]["configData"]["networkOS"]["policy"]["peerSwitchId"] = ""
+    counting_index = _install_counting_index(monkeypatch)
+    state_machine, controller = _state_machine(topology)
+
+    state_machine.manage_state()
+
+    assert counting_index.builds == 1
+    assert len(_pair_gets(controller)) == 1
+    assert _pair_gets(controller)[0]["path"].endswith(f"/switches/{omitted_local}/vpcPair")
+    assert len(_inventory_gets(controller)) == 4
+    assert len(_writes(controller)) == 2
+
+
+def test_conflicting_parent_pair_ids_fail_before_peer_get_index_or_write(monkeypatch) -> None:
+    topology = _topology(2)
+    shared_local = topology.local_serials[0]
+    second_local = topology.local_serials[1]
+    second_local_ip = next(switch_ip for switch_ip, switch_id in topology.switch_map.items() if switch_id == second_local)
+    first_local_ip = next(switch_ip for switch_ip, switch_id in topology.switch_map.items() if switch_id == shared_local)
+    second_records = topology.inventories.pop(second_local)
+    for record in second_records:
+        record["switchId"] = shared_local
+    topology.inventories[shared_local].extend(second_records)
+    topology.switch_map.pop(second_local_ip)
+    for item in topology.config:
+        if item["switch_ip"] == second_local_ip:
+            item["switch_ip"] = first_local_ip
+    counting_index = _install_counting_index(monkeypatch)
+    state_machine, controller = _state_machine(topology)
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)conflicting vPC pair evidence"):
+        state_machine.manage_state()
+
+    assert counting_index.builds == 0
+    assert len(_inventory_gets(controller)) == 1
+    assert _pair_gets(controller) == []
+    assert _writes(controller) == []
+
+
+@pytest.mark.parametrize("invalid_peer", (42, "LOCAL-000"))
+def test_invalid_parent_peer_id_fails_before_peer_get_index_or_write(
+    invalid_peer: object,
+    monkeypatch,
+) -> None:
+    topology = _topology(1)
+    topology.inventories[topology.local_serials[0]][0]["configData"]["networkOS"]["policy"]["peerSwitchId"] = invalid_peer
+    counting_index = _install_counting_index(monkeypatch)
+    state_machine, controller = _state_machine(topology)
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)(valid peerSwitchId|points to itself)"):
+        state_machine.manage_state()
+
+    assert counting_index.builds == 0
+    assert len(_inventory_gets(controller)) == 1
+    assert _pair_gets(controller) == []
+    assert _writes(controller) == []

--- a/tests/unit/module_utils/orchestrators/test_ethernet_vpc_member_updates.py
+++ b/tests/unit/module_utils/orchestrators/test_ethernet_vpc_member_updates.py
@@ -1,0 +1,531 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Pair-aware regression tests for safe updates to authentic vPC members."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from types import MethodType
+from typing import Any
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.enums import HttpVerbEnum
+from ansible_collections.cisco.nd.plugins.module_utils.nd_state_machine import (
+    NDStateMachine,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_access_interface import (
+    EthernetAccessInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.ethernet_trunk_host_interface import (
+    EthernetTrunkHostInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.response_handler_nd import (
+    ResponseHandler,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.tests.unit.module_utils.mock_ansible_module import (
+    MockAnsibleModule,
+)
+
+LOCAL_IP = "192.168.1.1"
+PEER_IP = "192.168.1.2"
+LOCAL_SERIAL = "FDO11111AAA"
+PEER_SERIAL = "FDO22222BBB"
+VPC_NAME = "vpc100"
+
+
+@dataclass(frozen=True)
+class _VpcCase:
+    name: str
+    orchestrator_class: type
+    member_policy_type: str
+    parent_policy_type: str
+    mode: str
+    unsafe_field: tuple[str, object]
+
+
+VPC_CASES = (
+    _VpcCase(
+        name="trunk_vpc",
+        orchestrator_class=EthernetTrunkHostInterfaceOrchestrator,
+        member_policy_type="vpcMember",
+        parent_policy_type="trunkVpcHost",
+        mode="trunk",
+        unsafe_field=("allowed_vlans", "200-300"),
+    ),
+    _VpcCase(
+        name="access_vpc",
+        orchestrator_class=EthernetAccessInterfaceOrchestrator,
+        member_policy_type="accessVpcPoMember",
+        parent_policy_type="accessVpcHost",
+        mode="access",
+        unsafe_field=("access_vlan", 200),
+    ),
+)
+
+
+def _case_id(case: _VpcCase) -> str:
+    return case.name
+
+
+def _member(
+    case: _VpcCase,
+    switch_id: str,
+    interface_name: str,
+    port_channel_id: int,
+) -> dict[str, Any]:
+    return {
+        "interfaceName": interface_name,
+        "interfaceType": "ethernet",
+        "switchId": switch_id,
+        "configData": {
+            "mode": case.mode,
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "policyType": case.member_policy_type,
+                    "portChannelId": f"Port-channel{port_channel_id}",
+                    "portChannelMode": "active",
+                    "primaryInterface": VPC_NAME,
+                    "adminState": True,
+                    "description": "existing vPC member",
+                    "extraConfig": "logging event link-status",
+                    "cdp": False,
+                    "debounceTimer": 250,
+                    "debounceLinkupTimer": 2000,
+                    "fec": "rsFec",
+                    "lacpPortPriority": 4096,
+                    "lacpRate": "fast",
+                    "ptp": False,
+                },
+            },
+        },
+        "operData": {
+            "portChannelId": port_channel_id,
+            "interfaceStatus": "connected",
+        },
+    }
+
+
+def _parent(
+    case: _VpcCase,
+    switch_id: str,
+    peer_switch_id: str,
+    local_members: list[str],
+    peer_members: list[str],
+    local_port_channel_id: int,
+    peer_port_channel_id: int,
+) -> dict[str, Any]:
+    return {
+        "interfaceName": VPC_NAME,
+        "interfaceType": "vpc",
+        "switchId": switch_id,
+        "configData": {
+            "mode": case.mode,
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "policyType": case.parent_policy_type,
+                    "peerSwitchId": peer_switch_id,
+                    "peer1PortChannelId": local_port_channel_id,
+                    "peer2PortChannelId": peer_port_channel_id,
+                    "peer1MemberPorts": local_members,
+                    "peer2MemberPorts": peer_members,
+                },
+            },
+        },
+    }
+
+
+def _parent_side_port_channel(case: _VpcCase, switch_id: str, port_channel_id: int) -> dict[str, Any]:
+    policy_type = "accessVpcMember" if case.mode == "access" else "trunkVpcMember"
+    return {
+        "interfaceName": f"port-channel{port_channel_id}",
+        "interfaceType": "portChannel",
+        "switchId": switch_id,
+        "configData": {
+            "mode": case.mode,
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "policyType": policy_type,
+                    "portChannelId": f"port-channel{port_channel_id}",
+                    "primaryInterface": VPC_NAME,
+                },
+            },
+        },
+        "operData": {"portChannelId": -1},
+    }
+
+
+def _inventories(
+    case: _VpcCase,
+    *,
+    local_names: tuple[str, ...] = ("Ethernet1/24",),
+    peer_names: tuple[str, ...] = ("Ethernet1/25",),
+) -> dict[str, list[dict[str, Any]]]:
+    local_members = [_member(case, LOCAL_SERIAL, name, 20) for name in local_names]
+    peer_members = [_member(case, PEER_SERIAL, name, 30) for name in peer_names]
+    local_parent = _parent(
+        case,
+        LOCAL_SERIAL,
+        PEER_SERIAL,
+        list(local_names),
+        list(peer_names),
+        20,
+        30,
+    )
+    peer_parent = _parent(
+        case,
+        PEER_SERIAL,
+        LOCAL_SERIAL,
+        list(local_names),
+        list(peer_names),
+        20,
+        30,
+    )
+    return {
+        LOCAL_SERIAL: [local_parent, _parent_side_port_channel(case, LOCAL_SERIAL, 20), *local_members],
+        PEER_SERIAL: [peer_parent, _parent_side_port_channel(case, PEER_SERIAL, 30), *peer_members],
+    }
+
+
+@dataclass
+class _Controller:
+    inventories: dict[str, list[dict[str, Any]]]
+    pair_records: dict[str, dict[str, Any]] = field(default_factory=dict)
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def request(
+        self,
+        _orchestrator,
+        path: str,
+        verb: HttpVerbEnum,
+        data: dict[str, Any] | None = None,
+        not_found_ok: bool = False,
+        operation_type=None,
+    ) -> dict[str, Any]:
+        del not_found_ok, operation_type
+        verb_value = verb.value if isinstance(verb, HttpVerbEnum) else str(verb)
+        self.calls.append({"path": path, "verb": verb_value, "data": deepcopy(data)})
+        if verb_value == HttpVerbEnum.GET.value:
+            for switch_id, records in self.inventories.items():
+                if path.endswith(f"/switches/{switch_id}/interfaces"):
+                    return {"interfaces": deepcopy(records)}
+            if path.endswith("/vpcPair"):
+                for switch_id, record in self.pair_records.items():
+                    if path.endswith(f"/switches/{switch_id}/vpcPair"):
+                        return deepcopy(record)
+                return {}
+            if "/api/v1/manage/links" in path:
+                return {"links": []}
+        if verb_value == HttpVerbEnum.PUT.value and "/interfaces/Ethernet1%2F" in path:
+            return {}
+        raise AssertionError(f"Unexpected controller request: {verb_value} {path}; data={data}")
+
+
+class _FabricContext:
+    switch_map = {LOCAL_IP: LOCAL_SERIAL, PEER_IP: PEER_SERIAL}
+
+    @staticmethod
+    def validate_for_mutation() -> None:
+        pass
+
+    @staticmethod
+    def get_switch_id(switch_ip: str) -> str:
+        try:
+            return _FabricContext.switch_map[switch_ip]
+        except KeyError as exc:
+            raise RuntimeError(f"Unknown switch {switch_ip!r}") from exc
+
+
+def _state_machine(
+    case: _VpcCase,
+    *,
+    state: str = "merged",
+    requested_policy: dict[str, Any] | None = None,
+    inventories: dict[str, list[dict[str, Any]]] | None = None,
+    local_names: tuple[str, ...] = ("Ethernet1/24",),
+    pair_records: dict[str, dict[str, Any]] | None = None,
+) -> tuple[NDStateMachine, _Controller]:
+    if state == "deleted":
+        config = [{"switch_ip": LOCAL_IP, "interface_name": name} for name in local_names]
+    else:
+        config = [
+            {
+                "switch_ip": LOCAL_IP,
+                "interface_name": name,
+                "config_data": {"network_os": {"policy": requested_policy or {}}},
+            }
+            for name in local_names
+        ]
+    params = {
+        "state": state,
+        "config": config,
+        "output_level": "normal",
+        "ignore_errors": False,
+        "fabric_name": "fabric_1",
+        "config_actions": {"deploy": False},
+    }
+    orchestrator = case.orchestrator_class(rest_send=_rest_send(params))
+    controller = _Controller(
+        inventories or _inventories(case, local_names=local_names),
+        pair_records=pair_records or {},
+    )
+    object.__setattr__(orchestrator, "_fabric_context", _FabricContext())
+    object.__setattr__(orchestrator, "_request", MethodType(controller.request, orchestrator))
+    module = MockAnsibleModule()
+    module.params = params
+    module.check_mode = False
+    module.no_log_values = set()
+    return NDStateMachine(module=module, model_orchestrator=orchestrator), controller
+
+
+def _rest_send(params: dict[str, Any]) -> RestSend:
+    rest_send = RestSend({**params, "check_mode": False})
+    rest_send.response_handler = ResponseHandler()
+    return rest_send
+
+
+def _writes(controller: _Controller) -> list[dict[str, Any]]:
+    return [call for call in controller.calls if call["verb"] != HttpVerbEnum.GET.value]
+
+
+def _inventory_gets(controller: _Controller, switch_id: str) -> list[dict[str, Any]]:
+    return [call for call in controller.calls if call["verb"] == HttpVerbEnum.GET.value and call["path"].endswith(f"/switches/{switch_id}/interfaces")]
+
+
+def _pair_gets(controller: _Controller) -> list[dict[str, Any]]:
+    return [call for call in controller.calls if call["verb"] == HttpVerbEnum.GET.value and call["path"].endswith("/vpcPair")]
+
+
+@pytest.mark.parametrize("case", VPC_CASES, ids=_case_id)
+def test_pair_aware_safe_merge_preserves_authentic_member_payload(
+    case: _VpcCase,
+) -> None:
+    state_machine, controller = _state_machine(
+        case,
+        requested_policy={
+            "admin_state": False,
+            "description": "updated pair-aware member",
+            "extra_config": "logging event trunk-status",
+        },
+    )
+
+    state_machine.manage_state()
+
+    assert len(_inventory_gets(controller, LOCAL_SERIAL)) == 1
+    assert len(_inventory_gets(controller, PEER_SERIAL)) == 1
+    assert _pair_gets(controller) == []
+    writes = _writes(controller)
+    assert len(writes) == 1
+    assert writes[0]["verb"] == HttpVerbEnum.PUT.value
+    assert writes[0]["path"].endswith("/interfaces/Ethernet1%2F24")
+    payload = writes[0]["data"]
+    policy = payload["configData"]["networkOS"]["policy"]
+    assert payload["interfaceName"] == "Ethernet1/24"
+    assert payload["interfaceType"] == "ethernet"
+    assert payload["switchId"] == LOCAL_SERIAL
+    assert payload["configData"]["mode"] == case.mode
+    assert policy["policyType"] == case.member_policy_type
+    assert policy["portChannelId"] == "Port-channel20"
+    assert policy["portChannelMode"] == "active"
+    assert policy["primaryInterface"] == VPC_NAME
+    assert policy["adminState"] is False
+    assert policy["description"] == "updated pair-aware member"
+    assert policy["extraConfig"] == "logging event trunk-status"
+    for key, value in {
+        "cdp": False,
+        "debounceTimer": 250,
+        "debounceLinkupTimer": 2000,
+        "fec": "rsFec",
+        "lacpPortPriority": 4096,
+        "lacpRate": "fast",
+    }.items():
+        assert policy[key] == value
+    assert "ptp" not in policy
+    assert "operData" not in payload
+    assert not any(call["verb"] == HttpVerbEnum.POST.value for call in controller.calls)
+
+
+@pytest.mark.parametrize("case", VPC_CASES, ids=_case_id)
+def test_two_vpc_members_share_one_local_and_one_peer_inventory_get(
+    case: _VpcCase,
+) -> None:
+    local_names = ("Ethernet1/24", "Ethernet1/26")
+    peer_names = ("Ethernet1/25", "Ethernet1/27")
+    state_machine, controller = _state_machine(
+        case,
+        requested_policy={"description": "same safe overlay"},
+        inventories=_inventories(case, local_names=local_names, peer_names=peer_names),
+        local_names=local_names,
+    )
+
+    state_machine.manage_state()
+
+    assert len(_inventory_gets(controller, LOCAL_SERIAL)) == 1
+    assert len(_inventory_gets(controller, PEER_SERIAL)) == 1
+    writes = _writes(controller)
+    assert len(writes) == 2
+    assert {call["verb"] for call in writes} == {HttpVerbEnum.PUT.value}
+    assert not any(call["verb"] == HttpVerbEnum.POST.value for call in controller.calls)
+
+
+@pytest.mark.parametrize("case", VPC_CASES, ids=_case_id)
+@pytest.mark.parametrize("peer_failure", ("missing", "inconsistent"))
+def test_missing_or_inconsistent_peer_evidence_rejects_before_write(case: _VpcCase, peer_failure: str) -> None:
+    inventories = _inventories(case)
+    if peer_failure == "missing":
+        inventories[PEER_SERIAL] = []
+        error = r"(?i)peer.*does not contain.*parent"
+    else:
+        peer_parent = inventories[PEER_SERIAL][0]
+        peer_parent["configData"]["networkOS"]["policy"]["peer2MemberPorts"] = ["Ethernet1/99"]
+        error = r"(?i)inconsistent literal configured data"
+    state_machine, controller = _state_machine(
+        case,
+        requested_policy={"description": "must not write"},
+        inventories=inventories,
+    )
+
+    with pytest.raises(NDStateMachineError, match=error):
+        state_machine.manage_state()
+
+    assert len(_inventory_gets(controller, LOCAL_SERIAL)) == 1
+    assert len(_inventory_gets(controller, PEER_SERIAL)) == 1
+    assert _writes(controller) == []
+
+
+@pytest.mark.parametrize("case", VPC_CASES, ids=_case_id)
+@pytest.mark.parametrize("state", ("replaced", "overridden"))
+def test_vpc_member_rejects_replacement_states_before_peer_fetch(case: _VpcCase, state: str) -> None:
+    state_machine, controller = _state_machine(
+        case,
+        state=state,
+        requested_policy={"description": "must not replace"},
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*merged"):
+        state_machine.manage_state()
+
+    assert len(_inventory_gets(controller, LOCAL_SERIAL)) == 1
+    # overridden is intentionally fabric-wide and therefore discovers both peers
+    # up front; replaced remains scoped to the explicitly named local switch.
+    assert len(_inventory_gets(controller, PEER_SERIAL)) == (1 if state == "overridden" else 0)
+    assert _writes(controller) == []
+
+
+@pytest.mark.parametrize("case", VPC_CASES, ids=_case_id)
+def test_explicit_vpc_member_delete_rejects_without_peer_fetch(
+    case: _VpcCase,
+) -> None:
+    state_machine, controller = _state_machine(case, state="deleted")
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*(normalize|parent)"):
+        state_machine.manage_state()
+
+    assert len(_inventory_gets(controller, LOCAL_SERIAL)) == 1
+    assert len(_inventory_gets(controller, PEER_SERIAL)) == 0
+    assert _writes(controller) == []
+
+
+@pytest.mark.parametrize("case", VPC_CASES, ids=_case_id)
+def test_unsafe_vpc_member_field_rejects_without_peer_fetch(case: _VpcCase) -> None:
+    field_name, value = case.unsafe_field
+    state_machine, controller = _state_machine(
+        case,
+        requested_policy={"description": "must be atomic", field_name: value},
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)member.*only"):
+        state_machine.manage_state()
+
+    assert len(_inventory_gets(controller, LOCAL_SERIAL)) == 1
+    assert len(_inventory_gets(controller, PEER_SERIAL)) == 0
+    assert _writes(controller) == []
+
+
+@pytest.mark.parametrize("case", VPC_CASES, ids=_case_id)
+def test_missing_parent_peer_ids_use_one_cached_pair_and_peer_get(
+    case: _VpcCase,
+) -> None:
+    inventories = _inventories(case)
+    for records in inventories.values():
+        parent = next(item for item in records if item["interfaceType"] == "vpc")
+        parent["configData"]["networkOS"]["policy"].pop("peerSwitchId")
+    state_machine, controller = _state_machine(
+        case,
+        requested_policy={"description": "resolved through pair evidence"},
+        inventories=inventories,
+        pair_records={
+            LOCAL_SERIAL: {
+                "switchId": LOCAL_SERIAL,
+                "peerSwitchId": PEER_SERIAL,
+            }
+        },
+    )
+
+    state_machine.manage_state()
+
+    assert len(_pair_gets(controller)) == 1
+    assert len(_inventory_gets(controller, LOCAL_SERIAL)) == 1
+    assert len(_inventory_gets(controller, PEER_SERIAL)) == 1
+    assert [call["verb"] for call in _writes(controller)] == [HttpVerbEnum.PUT.value]
+
+
+@pytest.mark.parametrize("case", VPC_CASES, ids=_case_id)
+def test_two_members_with_missing_peer_ids_share_pair_and_inventory_gets(
+    case: _VpcCase,
+) -> None:
+    local_names = ("Ethernet1/24", "Ethernet1/26")
+    peer_names = ("Ethernet1/25", "Ethernet1/27")
+    inventories = _inventories(case, local_names=local_names, peer_names=peer_names)
+    for records in inventories.values():
+        parent = next(item for item in records if item["interfaceType"] == "vpc")
+        parent["configData"]["networkOS"]["policy"].pop("peerSwitchId")
+    state_machine, controller = _state_machine(
+        case,
+        requested_policy={"description": "shared fallback"},
+        inventories=inventories,
+        local_names=local_names,
+        pair_records={LOCAL_SERIAL: {"peerSwitchId": PEER_SERIAL}},
+    )
+
+    state_machine.manage_state()
+
+    assert len(_pair_gets(controller)) == 1
+    assert len(_inventory_gets(controller, LOCAL_SERIAL)) == 1
+    assert len(_inventory_gets(controller, PEER_SERIAL)) == 1
+    assert len(_writes(controller)) == 2
+
+
+@pytest.mark.parametrize("case", VPC_CASES, ids=_case_id)
+def test_missing_parent_peer_id_without_pair_evidence_fails_before_peer_get(
+    case: _VpcCase,
+) -> None:
+    inventories = _inventories(case)
+    local_parent = next(item for item in inventories[LOCAL_SERIAL] if item["interfaceType"] == "vpc")
+    local_parent["configData"]["networkOS"]["policy"].pop("peerSwitchId")
+    state_machine, controller = _state_machine(
+        case,
+        requested_policy={"description": "must not write"},
+        inventories=inventories,
+    )
+
+    with pytest.raises(NDStateMachineError, match=r"(?i)vpcPair.*no pair evidence"):
+        state_machine.manage_state()
+
+    assert len(_pair_gets(controller)) == 1
+    assert len(_inventory_gets(controller, LOCAL_SERIAL)) == 1
+    assert len(_inventory_gets(controller, PEER_SERIAL)) == 0
+    assert _writes(controller) == []

--- a/tests/unit/module_utils/test_interface_membership.py
+++ b/tests/unit/module_utils/test_interface_membership.py
@@ -1,0 +1,720 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Focused tests for cached ethernet membership ownership validation."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.interface_membership import (
+    EthernetMembershipIndex,
+    MembershipValidationError,
+    MissingPeerIdentityError,
+    MissingPeerInventoryError,
+)
+
+
+def _inventory(*records):
+    return {record["interfaceName"].lower(): record for record in records}
+
+
+def _member(
+    switch_id="SERIAL1",
+    interface_name="Ethernet1/24",
+    *,
+    policy_type="poMember",
+    configured_id=20,
+    operational_id=20,
+    primary_interface=None,
+):
+    metadata = {
+        "poMember": ("trunk", "nx-os"),
+        "accessPoMember": ("access", "nx-os"),
+        "l3PoMember": ("routed", "nx-os"),
+        "iosXeL3PoMember": ("routed", "ios-xe"),
+        "vpcMember": ("trunk", "nx-os"),
+        "accessVpcPoMember": ("access", "nx-os"),
+    }
+    mode, network_os = metadata.get(policy_type, ("trunk", "nx-os"))
+    policy = {
+        "policyType": policy_type,
+        "portChannelId": f"port-channel{configured_id}",
+        "portChannelMode": "active",
+        "adminState": True,
+        "description": "existing member",
+        "extraConfig": "logging event link-status",
+    }
+    if primary_interface is not None:
+        policy["primaryInterface"] = primary_interface
+    return {
+        "switchId": switch_id,
+        "interfaceName": interface_name,
+        "interfaceType": "ethernet",
+        "configData": {
+            "mode": mode,
+            "networkOS": {
+                "networkOSType": network_os,
+                "policy": policy,
+            },
+        },
+        "operData": {"portChannelId": operational_id},
+    }
+
+
+def _parent(
+    switch_id="SERIAL1",
+    interface_name="port-channel20",
+    *,
+    policy_type="trunkPoHost",
+    member_names=("Ethernet1/24",),
+    interface_type="portChannel",
+    policy_extra=None,
+):
+    mode, network_os = {
+        "trunkPoHost": ("trunk", "nx-os"),
+        "accessPoHost": ("access", "nx-os"),
+        "l3Po": ("routed", "nx-os"),
+        "iosXeL3PortChannel": ("routed", "ios-xe"),
+    }.get(policy_type, ("trunk", "nx-os"))
+    policy = {"policyType": policy_type, "ports": list(member_names)}
+    policy.update(policy_extra or {})
+    return {
+        "switchId": switch_id,
+        "interfaceName": interface_name,
+        "interfaceType": interface_type,
+        "configData": {
+            "mode": mode,
+            "networkOS": {"networkOSType": network_os, "policy": policy},
+        },
+    }
+
+
+def _vpc_parent(
+    switch_id,
+    peer_switch_id,
+    *,
+    interface_name="vpc100",
+    policy_type="trunkVpcHost",
+    peer1_id,
+    peer2_id,
+    peer1_members,
+    peer2_members,
+    policy_extra=None,
+):
+    mode = {"trunkVpcHost": "trunk", "accessVpcHost": "access"}.get(policy_type, "trunk")
+    policy = {
+        "policyType": policy_type,
+        "peerSwitchId": peer_switch_id,
+        "peer1PortChannelId": peer1_id,
+        "peer2PortChannelId": peer2_id,
+        "peer1MemberPorts": list(peer1_members),
+        "peer2MemberPorts": list(peer2_members),
+    }
+    policy.update(policy_extra or {})
+    return {
+        "switchId": switch_id,
+        "interfaceName": interface_name,
+        "interfaceType": "vpc",
+        "configData": {
+            "mode": mode,
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": policy,
+            },
+        },
+    }
+
+
+def _vpc_parent_side_port_channel(switch_id, port_channel_id, policy_type):
+    mode = "access" if policy_type == "accessVpcMember" else "trunk"
+    return {
+        "switchId": switch_id,
+        "interfaceName": f"port-channel{port_channel_id}",
+        "interfaceType": "portChannel",
+        "configData": {
+            "mode": mode,
+            "networkOS": {
+                "networkOSType": "nx-os",
+                "policy": {
+                    "policyType": policy_type,
+                    "portChannelId": f"port-channel{port_channel_id}",
+                    "primaryInterface": "vpc100",
+                },
+            },
+        },
+        "operData": {"portChannelId": -1},
+    }
+
+
+def _valid_vpc_inventories(*, policy_type="vpcMember"):
+    parent_policy = {
+        "vpcMember": "trunkVpcHost",
+        "accessVpcPoMember": "accessVpcHost",
+    }[policy_type]
+    parent_side_policy = {
+        "vpcMember": "trunkVpcMember",
+        "accessVpcPoMember": "accessVpcMember",
+    }[policy_type]
+    s1_member = _member(
+        "SERIAL1",
+        "Ethernet1/24",
+        policy_type=policy_type,
+        configured_id=20,
+        operational_id=20,
+        primary_interface="vPC100",
+    )
+    s2_member = _member(
+        "SERIAL2",
+        "Ethernet1/25",
+        policy_type=policy_type,
+        configured_id=30,
+        operational_id=30,
+        primary_interface="vpc100",
+    )
+    s1_parent = _vpc_parent(
+        "SERIAL1",
+        "SERIAL2",
+        policy_type=parent_policy,
+        peer1_id=20,
+        peer2_id=30,
+        peer1_members=("Ethernet1/24",),
+        peer2_members=("Ethernet1/25",),
+    )
+    s2_parent = _vpc_parent(
+        "SERIAL2",
+        "SERIAL1",
+        policy_type=parent_policy,
+        peer1_id=20,
+        peer2_id=30,
+        peer1_members=("Ethernet1/24",),
+        peer2_members=("Ethernet1/25",),
+    )
+    return {
+        "SERIAL1": _inventory(s1_member, s1_parent, _vpc_parent_side_port_channel("SERIAL1", 20, parent_side_policy)),
+        "SERIAL2": _inventory(s2_member, s2_parent, _vpc_parent_side_port_channel("SERIAL2", 30, parent_side_policy)),
+    }
+
+
+@pytest.mark.parametrize(
+    "policy_type,parent_policy",
+    [
+        ("poMember", "trunkPoHost"),
+        ("accessPoMember", "accessPoHost"),
+        ("l3PoMember", "l3Po"),
+        ("iosXeL3PoMember", "iosXeL3PortChannel"),
+    ],
+)
+def test_validate_standalone_member_uses_one_cached_inventory(policy_type, parent_policy):
+    member = _member(policy_type=policy_type)
+    parent = _parent(policy_type=parent_policy)
+    inventories = {"SERIAL1": _inventory(member, parent)}
+
+    result = EthernetMembershipIndex(inventories).validate("SERIAL1", "ethernet1/24")
+
+    assert result.member.policy_type == policy_type
+    assert result.owner.interface_name == "port-channel20"
+    assert result.owner.policy_type == parent_policy
+    assert result.owner.port_channel_id == 20
+    assert result.configured_port_channel_id == 20
+    assert result.operational_port_channel_id == 20
+    assert result.peer_owner is None
+    assert result.peer_members == ()
+    assert result.pair_validated is False
+
+
+def test_index_keys_members_by_serial_and_lower_case_name():
+    supported = _member(interface_name="Ethernet1/24")
+    protected = _member(interface_name="Ethernet1/25", policy_type="futureControllerMember")
+    host = copy.deepcopy(supported)
+    host["interfaceName"] = "Ethernet1/26"
+    host["configData"]["networkOS"]["policy"]["policyType"] = "trunkHost"
+    index = EthernetMembershipIndex({"SERIAL1": _inventory(supported, protected, host)})
+
+    assert index.member_keys == (
+        ("SERIAL1", "ethernet1/24"),
+        ("SERIAL1", "ethernet1/25"),
+    )
+    assert index.get_member("SERIAL1", "ETHERNET1/24") is not None
+    assert index.get_member("SERIAL1", "Ethernet1/26") is None
+    with pytest.raises(MembershipValidationError, match="protected or unsupported"):
+        index.validate("SERIAL1", "Ethernet1/25")
+
+
+@pytest.mark.parametrize("operational_id", [None, -1, "-1"])
+def test_unset_operational_id_does_not_override_valid_configured_id(
+    operational_id,
+):
+    member = _member(operational_id=operational_id)
+    parent = _parent()
+
+    result = EthernetMembershipIndex({"SERIAL1": _inventory(member, parent)}).validate("SERIAL1", "Ethernet1/24")
+
+    assert result.configured_port_channel_id == 20
+    assert result.operational_port_channel_id is None
+
+
+@pytest.mark.parametrize("operational_id", [0, "0", -2, "-2"])
+def test_malformed_operational_id_fails_closed(operational_id):
+    member = _member(configured_id=20, operational_id=operational_id)
+    parent = _parent()
+
+    with pytest.raises(MembershipValidationError, match="Cannot validate member"):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member, parent)}).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_configured_and_operational_port_channel_ids_must_agree():
+    member = _member(configured_id=20, operational_id=21)
+    parent = _parent()
+
+    with pytest.raises(
+        MembershipValidationError,
+        match="configured port-channel ID 20 but operational ID 21",
+    ):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member, parent)}).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_member_requires_a_parent_claim():
+    member = _member()
+
+    with pytest.raises(MembershipValidationError, match="orphaned"):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member)}).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_member_rejects_multiple_parent_claims():
+    member = _member()
+    parent1 = _parent(interface_name="port-channel20")
+    parent2 = _parent(interface_name="port-channel21")
+
+    with pytest.raises(MembershipValidationError, match="multiple parent owners"):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member, parent1, parent2)}).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_standalone_member_rejects_a_second_wrong_type_parent_claim():
+    member = _member()
+    parent = _parent()
+    vpc_parent = _vpc_parent(
+        "SERIAL1",
+        "SERIAL2",
+        peer1_id=40,
+        peer2_id=50,
+        peer1_members=("Ethernet1/30",),
+        peer2_members=("Ethernet1/24",),
+    )
+
+    with pytest.raises(MembershipValidationError, match="multiple parent owners"):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member, parent, vpc_parent)}).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_member_rejects_incompatible_parent_policy():
+    member = _member(policy_type="poMember")
+    parent = _parent(policy_type="accessPoHost")
+
+    with pytest.raises(MembershipValidationError, match="incompatible parent policy"):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member, parent)}).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_member_and_parent_port_channel_ids_must_agree():
+    member = _member(configured_id=20, operational_id=20)
+    parent = _parent(interface_name="port-channel21")
+
+    with pytest.raises(
+        MembershipValidationError,
+        match="declares port-channel ID 20, but parent 'port-channel21' resolves to ID 21",
+    ):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member, parent)}).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_parent_policy_id_cannot_disagree_with_parent_name():
+    member = _member()
+    parent = _parent(policy_extra={"portChannelId": "port-channel21"})
+
+    with pytest.raises(MembershipValidationError, match="name ID 20.*policy"):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member, parent)}).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_parent_must_claim_standalone_member_through_ports():
+    member = _member()
+    parent = _parent(member_names=())
+    policy = parent["configData"]["networkOS"]["policy"]
+    policy["peer1MemberPorts"] = ["Ethernet1/24"]
+
+    with pytest.raises(MembershipValidationError, match="required field 'ports'"):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member, parent)}).validate("SERIAL1", "Ethernet1/24")
+
+
+@pytest.mark.parametrize(
+    "policy_type,parent_policy",
+    [
+        ("poMember", "trunkPoHost"),
+        ("accessPoMember", "accessPoHost"),
+        ("l3PoMember", "l3Po"),
+        ("iosXeL3PoMember", "iosXeL3PortChannel"),
+    ],
+)
+@pytest.mark.parametrize("field", ("mode", "network_os"))
+def test_standalone_parent_requires_matching_mode_and_network_os(policy_type, parent_policy, field):
+    member = _member(policy_type=policy_type)
+    parent = _parent(policy_type=parent_policy)
+    if field == "mode":
+        parent["configData"]["mode"] = "invalid-mode"
+        error = "has mode"
+    else:
+        parent["configData"]["networkOS"]["networkOSType"] = "invalid-os"
+        error = "has networkOSType"
+
+    with pytest.raises(MembershipValidationError, match=error):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member, parent)}).validate("SERIAL1", "Ethernet1/24")
+
+
+@pytest.mark.parametrize("policy_type", ["vpcMember", "accessVpcPoMember"])
+def test_validate_vpc_member_requires_reciprocal_pair_evidence(policy_type):
+    inventories = _valid_vpc_inventories(policy_type=policy_type)
+
+    result = EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+    assert result.member.policy_type == policy_type
+    assert result.owner.interface_name == "vpc100"
+    assert result.owner.port_channel_id == 20
+    assert result.peer_owner is not None
+    assert result.peer_owner.switch_id == "SERIAL2"
+    assert result.peer_owner.port_channel_id == 30
+    assert [item.key for item in result.peer_members] == [("SERIAL2", "ethernet1/25")]
+    assert result.pair_validated is True
+
+
+@pytest.mark.parametrize("policy_type", ["vpcMember", "accessVpcPoMember"])
+def test_vpc_literal_peer2_slot_maps_to_second_switch(policy_type):
+    inventories = _valid_vpc_inventories(policy_type=policy_type)
+
+    result = EthernetMembershipIndex(inventories).validate("SERIAL2", "Ethernet1/25")
+
+    assert result.owner.switch_id == "SERIAL2"
+    assert result.owner.port_channel_id == 30
+    assert result.owner.claim_fields == ("peer2MemberPorts",)
+    assert result.peer_owner is not None
+    assert result.peer_owner.switch_id == "SERIAL1"
+    assert result.peer_owner.port_channel_id == 20
+
+
+def test_vpc_validation_reports_exact_missing_peer_inventory():
+    inventories = _valid_vpc_inventories()
+    inventories.pop("SERIAL2")
+
+    with pytest.raises(MissingPeerInventoryError) as exc_info:
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+    assert exc_info.value.peer_switch_id == "SERIAL2"
+
+
+def test_vpc_requires_parent_copy_on_peer():
+    inventories = _valid_vpc_inventories()
+    inventories["SERIAL2"].pop("vpc100")
+
+    with pytest.raises(MembershipValidationError, match="does not contain vPC parent"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_parent_peer_switch_ids_must_be_reciprocal():
+    inventories = _valid_vpc_inventories()
+    peer_parent = inventories["SERIAL2"]["vpc100"]
+    peer_parent["configData"]["networkOS"]["policy"]["peerSwitchId"] = "SERIAL3"
+
+    with pytest.raises(MembershipValidationError, match="not reciprocal"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_parent_copies_require_compatible_policies():
+    inventories = _valid_vpc_inventories()
+    peer_parent = inventories["SERIAL2"]["vpc100"]
+    peer_parent["configData"]["networkOS"]["policy"]["policyType"] = "accessVpcHost"
+
+    with pytest.raises(MembershipValidationError, match="incompatible policy"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_parent_copies_require_identical_literal_port_channel_ids():
+    inventories = _valid_vpc_inventories()
+    peer_parent = inventories["SERIAL2"]["vpc100"]
+    peer_parent["configData"]["networkOS"]["policy"]["peer2PortChannelId"] = 21
+
+    with pytest.raises(MembershipValidationError, match="inconsistent literal configured data"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_parent_copies_require_identical_literal_member_lists():
+    inventories = _valid_vpc_inventories()
+    peer_parent = inventories["SERIAL2"]["vpc100"]
+    peer_parent["configData"]["networkOS"]["policy"]["peer2MemberPorts"] = ["Ethernet1/99"]
+
+    with pytest.raises(MembershipValidationError, match="inconsistent literal configured data"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_parent_copies_require_consistent_full_config_data():
+    inventories = _valid_vpc_inventories()
+    peer_policy = inventories["SERIAL2"]["vpc100"]["configData"]["networkOS"]["policy"]
+    peer_policy["nativeVlan"] = 200
+
+    with pytest.raises(MembershipValidationError, match="inconsistent literal configured data"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_parent_fingerprint_ignores_echo_metadata_and_member_presentation():
+    inventories = _valid_vpc_inventories()
+    local_parent = inventories["SERIAL1"]["vpc100"]
+    peer_parent = inventories["SERIAL2"]["vpc100"]
+    local_parent["configData"]["networkOS"]["policy"]["policyId"] = "LOCAL-POLICY-ID"
+    peer_policy = peer_parent["configData"]["networkOS"]["policy"]
+    peer_policy["policyId"] = "PEER-POLICY-ID"
+    peer_policy["peer1MemberPorts"] = [" ethernet1/24 "]
+    peer_policy["peer2MemberPorts"] = ["ETHERNET1/25"]
+
+    result = EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+    assert result.pair_validated is True
+
+
+@pytest.mark.parametrize(
+    "field,value,error",
+    [
+        ("policyType", "accessVpcPoMember", "uses policy"),
+        ("portChannelId", "port-channel31", "declares port-channel ID"),
+        ("primaryInterface", "vpc999", "member-set mismatch"),
+    ],
+)
+def test_vpc_peer_member_records_must_match_pair(field, value, error):
+    inventories = _valid_vpc_inventories()
+    peer_member_policy = inventories["SERIAL2"]["ethernet1/25"]["configData"]["networkOS"]["policy"]
+    peer_member_policy[field] = value
+    if field == "portChannelId":
+        inventories["SERIAL2"]["ethernet1/25"]["operData"]["portChannelId"] = 31
+
+    with pytest.raises(MembershipValidationError, match=error):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_member_must_be_claimed_by_its_evidenced_slot():
+    inventories = _valid_vpc_inventories()
+    for inventory in inventories.values():
+        policy = inventory["vpc100"]["configData"]["networkOS"]["policy"]
+        policy["peer1MemberPorts"] = ["Ethernet1/99"]
+
+    with pytest.raises(MembershipValidationError, match="orphaned"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_target_member_rejects_a_second_stale_parent_claim():
+    inventories = _valid_vpc_inventories()
+    inventories["SERIAL1"]["vpc200"] = _vpc_parent(
+        "SERIAL1",
+        "SERIAL2",
+        interface_name="vpc200",
+        peer1_id=40,
+        peer2_id=50,
+        peer1_members=("Ethernet1/30",),
+        peer2_members=("Ethernet1/24",),
+    )
+
+    with pytest.raises(MembershipValidationError, match="multiple parent owners"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_non_target_peer_member_rejects_a_second_stale_parent_claim():
+    inventories = _valid_vpc_inventories()
+    inventories["SERIAL2"]["vpc200"] = _vpc_parent(
+        "SERIAL2",
+        "SERIAL1",
+        interface_name="vpc200",
+        peer1_id=40,
+        peer2_id=50,
+        peer1_members=("Ethernet1/30",),
+        peer2_members=("Ethernet1/25",),
+    )
+
+    with pytest.raises(MembershipValidationError, match="multiple parent owners"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+@pytest.mark.parametrize("policy_type", ["vpcMember", "accessVpcPoMember"])
+@pytest.mark.parametrize("side", ["SERIAL1", "SERIAL2"])
+@pytest.mark.parametrize("field", ["mode", "network_os"])
+def test_vpc_parent_requires_matching_mode_and_network_os(policy_type, side, field):
+    inventories = _valid_vpc_inventories(policy_type=policy_type)
+    parent = inventories[side]["vpc100"]
+    if field == "mode":
+        parent["configData"]["mode"] = "invalid-mode"
+        error = "has mode"
+    else:
+        parent["configData"]["networkOS"]["networkOSType"] = "invalid-os"
+        error = "has networkOSType"
+
+    with pytest.raises(MembershipValidationError, match=error):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_rejects_ambiguous_non_equivalent_slot_assignment():
+    inventories = _valid_vpc_inventories()
+    inventories["SERIAL2"].pop("ethernet1/25")
+    inventories["SERIAL2"]["ethernet1/24"] = _member(
+        "SERIAL2",
+        "Ethernet1/24",
+        policy_type="vpcMember",
+        configured_id=20,
+        operational_id=20,
+        primary_interface="vpc100",
+    )
+    for inventory in inventories.values():
+        policy = inventory["vpc100"]["configData"]["networkOS"]["policy"]
+        policy["peer1PortChannelId"] = 20
+        policy["peer2PortChannelId"] = 20
+        policy["peer1MemberPorts"] = ["Ethernet1/24"]
+        policy["peer2MemberPorts"] = ["Ethernet1/24"]
+        policy["peer1PortChannelDescription"] = "non-equivalent peer one"
+        policy["peer2PortChannelDescription"] = "non-equivalent peer two"
+
+    with pytest.raises(MembershipValidationError, match="unambiguously map non-equivalent"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_allows_indistinguishable_identical_slot_assignment():
+    inventories = _valid_vpc_inventories()
+    inventories["SERIAL2"].pop("ethernet1/25")
+    inventories["SERIAL2"]["ethernet1/24"] = _member(
+        "SERIAL2",
+        "Ethernet1/24",
+        policy_type="vpcMember",
+        configured_id=20,
+        operational_id=20,
+        primary_interface="vpc100",
+    )
+    for inventory in inventories.values():
+        policy = inventory["vpc100"]["configData"]["networkOS"]["policy"]
+        policy["peer1PortChannelId"] = 20
+        policy["peer2PortChannelId"] = 20
+        policy["peer1MemberPorts"] = ["Ethernet1/24"]
+        policy["peer2MemberPorts"] = ["ethernet1/24"]
+
+    result = EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+    assert result.pair_validated is True
+    assert result.owner.port_channel_id == 20
+    assert result.peer_owner is not None
+    assert result.peer_owner.port_channel_id == 20
+
+
+def test_vpc_pair_validation_caches_all_members_with_linear_work(monkeypatch):
+    inventories = _valid_vpc_inventories()
+    inventories["SERIAL1"]["ethernet1/26"] = _member(
+        "SERIAL1", "Ethernet1/26", policy_type="vpcMember", configured_id=20, operational_id=20, primary_interface="vpc100"
+    )
+    inventories["SERIAL2"]["ethernet1/27"] = _member(
+        "SERIAL2", "Ethernet1/27", policy_type="vpcMember", configured_id=30, operational_id=30, primary_interface="vpc100"
+    )
+    for inventory in inventories.values():
+        policy = inventory["vpc100"]["configData"]["networkOS"]["policy"]
+        policy["peer1MemberPorts"] = ["Ethernet1/26", "Ethernet1/24"]
+        policy["peer2MemberPorts"] = ["Ethernet1/27", "Ethernet1/25"]
+
+    index = EthernetMembershipIndex(inventories)
+    original = index._member_port_channel_ids
+    validation_count = 0
+
+    def count_member_validation(member):
+        nonlocal validation_count
+        validation_count += 1
+        return original(member)
+
+    monkeypatch.setattr(index, "_member_port_channel_ids", count_member_validation)
+    first = index.validate("SERIAL1", "Ethernet1/24")
+    count_after_pair = validation_count
+    second = index.validate("SERIAL1", "Ethernet1/26")
+    peer = index.validate("SERIAL2", "Ethernet1/27")
+
+    assert first.pair_validated is True
+    assert second.pair_validated is True
+    assert peer.pair_validated is True
+    assert count_after_pair == 4
+    assert validation_count == count_after_pair
+
+
+def test_inventory_record_switch_id_must_match_outer_cache_key():
+    member = _member(switch_id="SERIAL2")
+
+    with pytest.raises(MembershipValidationError, match="stored under switch"):
+        EthernetMembershipIndex({"SERIAL1": _inventory(member)})
+
+
+def test_vpc_parent_echoes_without_peer_ids_use_cached_reciprocal_evidence():
+    inventories = _valid_vpc_inventories()
+    for inventory in inventories.values():
+        inventory["vpc100"]["configData"]["networkOS"]["policy"].pop("peerSwitchId")
+
+    result = EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+    assert result.peer_owner is not None
+    assert result.peer_owner.switch_id == "SERIAL2"
+    assert result.pair_validated is True
+
+
+def test_vpc_missing_peer_ids_use_authoritative_pair_evidence():
+    inventories = _valid_vpc_inventories()
+    for inventory in inventories.values():
+        inventory["vpc100"]["configData"]["networkOS"]["policy"].pop("peerSwitchId")
+    pair_evidence = {"SERIAL1": "SERIAL2", "SERIAL2": "SERIAL1"}
+
+    result = EthernetMembershipIndex(inventories, peer_switch_ids=pair_evidence).validate("SERIAL1", "Ethernet1/24")
+
+    assert result.peer_owner is not None
+    assert result.peer_owner.switch_id == "SERIAL2"
+
+
+def test_vpc_authoritative_pair_evidence_identifies_uncached_peer():
+    inventories = _valid_vpc_inventories()
+    inventories.pop("SERIAL2")
+    inventories["SERIAL1"]["vpc100"]["configData"]["networkOS"]["policy"].pop("peerSwitchId")
+
+    with pytest.raises(MissingPeerInventoryError) as exc_info:
+        EthernetMembershipIndex(
+            inventories,
+            peer_switch_ids={"SERIAL1": "SERIAL2", "SERIAL2": "SERIAL1"},
+        ).validate("SERIAL1", "Ethernet1/24")
+
+    assert exc_info.value.peer_switch_id == "SERIAL2"
+
+
+def test_vpc_missing_peer_identity_fails_closed_without_evidence():
+    inventories = _valid_vpc_inventories()
+    inventories.pop("SERIAL2")
+    inventories["SERIAL1"]["vpc100"]["configData"]["networkOS"]["policy"].pop("peerSwitchId")
+
+    with pytest.raises(MissingPeerIdentityError) as exc_info:
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+    assert exc_info.value.switch_id == "SERIAL1"
+    assert exc_info.value.parent_name == "vpc100"
+
+
+def test_vpc_cached_peer_inference_rejects_ambiguous_reciprocal_copies():
+    inventories = _valid_vpc_inventories()
+    for inventory in inventories.values():
+        inventory["vpc100"]["configData"]["networkOS"]["policy"].pop("peerSwitchId")
+    third_inventory = copy.deepcopy(inventories["SERIAL2"])
+    for record in third_inventory.values():
+        record["switchId"] = "SERIAL3"
+    inventories["SERIAL3"] = third_inventory
+
+    with pytest.raises(MembershipValidationError, match="ambiguous"):
+        EthernetMembershipIndex(inventories).validate("SERIAL1", "Ethernet1/24")
+
+
+def test_vpc_parent_echo_must_agree_with_authoritative_pair_evidence():
+    inventories = _valid_vpc_inventories()
+
+    with pytest.raises(MembershipValidationError, match="authoritative pair evidence"):
+        EthernetMembershipIndex(
+            inventories,
+            peer_switch_ids={"SERIAL1": "SERIAL3", "SERIAL3": "SERIAL1"},
+        ).validate("SERIAL1", "Ethernet1/24")

--- a/tests/unit/modules/test_nd_interface_ethernet_member_finalization.py
+++ b/tests/unit/modules/test_nd_interface_ethernet_member_finalization.py
@@ -1,0 +1,198 @@
+# Copyright: (c) 2026, Mike Wiebe (@mikewiebe) mwiebe@cisco.com
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Failure-path deployment parity for access/trunk member updates (IFACE-004)."""
+
+# pylint: disable=protected-access,too-few-public-methods,unused-argument
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from ansible_collections.cisco.nd.plugins.module_utils.common.exceptions import (
+    NDStateMachineError,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.base import (
+    NDEndpointBaseModel,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.endpoints.v1.manage.manage_interfaces import (
+    EpManageInterfacesDelete,
+    EpManageInterfacesGet,
+    EpManageInterfacesListGet,
+    EpManageInterfacesPost,
+    EpManageInterfacesPut,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.orchestrators.base_interface import (
+    NDBaseInterfaceOrchestrator,
+)
+from ansible_collections.cisco.nd.plugins.module_utils.rest.rest_send import RestSend
+from ansible_collections.cisco.nd.plugins.modules import (
+    nd_interface_ethernet_access,
+    nd_interface_ethernet_trunk_host,
+)
+
+ACCEPTED_PAIR = ("Ethernet1/24", "FDO12345ABC")
+ACCEPTED_NOTE = (
+    " NOTE: before the failure, the controller had already accepted changes for interface(s) "
+    "[Ethernet1/24 (switchId FDO12345ABC)]; those changes were deployed."
+)
+MODULES = (
+    nd_interface_ethernet_access,
+    nd_interface_ethernet_trunk_host,
+)
+
+
+class _FailJson(Exception):
+    """Capture module failure output."""
+
+
+class _FakeAnsibleModule:
+    """Small AnsibleModule stand-in for the two wrapper entrypoints."""
+
+    def __init__(
+        self,
+        *,
+        config_actions: dict[str, bool] | None,
+        check_mode: bool,
+        **_kwargs: Any,
+    ) -> None:
+        self.params = {
+            "config": [],
+            "state": "merged",
+            "config_actions": config_actions,
+            "output_level": "normal",
+        }
+        self.check_mode = check_mode
+
+    def fail_json(self, **kwargs: Any) -> None:
+        """Raise the captured failure payload."""
+        raise _FailJson(kwargs)
+
+    def exit_json(self, **_kwargs: Any) -> None:
+        """A failure test must never reach successful exit."""
+        raise AssertionError("unexpected successful module exit")
+
+
+class _RecordingOrchestrator(NDBaseInterfaceOrchestrator):
+    """Record finalizer deploys without contacting a controller."""
+
+    create_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPost
+    update_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesPut
+    delete_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesDelete
+    query_one_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesGet
+    query_all_endpoint: type[NDEndpointBaseModel] = EpManageInterfacesListGet
+
+    def model_post_init(self, __context) -> None:
+        super().model_post_init(__context)
+        self._deployed: list[list[tuple[str, str]]] = []  # pylint: disable=attribute-defined-outside-init
+
+    def _deploy_interfaces(self, pairs: list[tuple[str, str]]) -> dict[str, Any]:
+        self._deployed.append(list(pairs))
+        return {"RETURN_CODE": 200, "MESSAGE": "OK", "DATA": {}}
+
+
+class _FakeStateMachine:
+    """Queue one accepted mutation, then simulate a later operation failure."""
+
+    failure: Exception
+    last_instance: _FakeStateMachine | None = None
+
+    def __init__(self, module: Any, model_orchestrator: Any) -> None:
+        del module, model_orchestrator
+        self.model_orchestrator = _RecordingOrchestrator(rest_send=RestSend({"check_mode": False, "fabric_name": "fabric_1"}))
+        self.model_orchestrator._queue_deploy(*ACCEPTED_PAIR)
+        self.output = SimpleNamespace(format=lambda: {})
+        type(self).last_instance = self
+
+    def manage_state(self) -> None:
+        raise self.failure
+
+
+def _run_main(
+    monkeypatch: pytest.MonkeyPatch,
+    module_under_test,
+    *,
+    failure: Exception,
+    deploy: bool,
+    check_mode: bool = False,
+) -> tuple[dict[str, Any], _RecordingOrchestrator]:
+    class _StateMachine(_FakeStateMachine):
+        pass
+
+    _StateMachine.failure = failure
+    monkeypatch.setattr(
+        module_under_test,
+        "AnsibleModule",
+        lambda **kwargs: _FakeAnsibleModule(
+            config_actions={"deploy": deploy},
+            check_mode=check_mode,
+            **kwargs,
+        ),
+    )
+    monkeypatch.setattr(module_under_test, "NDStateMachine", _StateMachine)
+    monkeypatch.setattr(module_under_test, "require_pydantic", lambda module: None)
+    monkeypatch.setattr(module_under_test, "setup_logging", lambda module: None)
+
+    with pytest.raises(_FailJson) as exc_info:
+        module_under_test.main()
+    assert _StateMachine.last_instance is not None
+    return (
+        exc_info.value.args[0],
+        _StateMachine.last_instance.model_orchestrator,
+    )
+
+
+@pytest.mark.parametrize("module_under_test", MODULES)
+@pytest.mark.parametrize(
+    "failure,prefix",
+    (
+        (NDStateMachineError("later update failed"), "Module execution failed"),
+        (RuntimeError("unexpected update failure"), "Module failed"),
+    ),
+)
+def test_failure_handlers_deploy_earlier_accepted_member(
+    monkeypatch: pytest.MonkeyPatch,
+    module_under_test,
+    failure: Exception,
+    prefix: str,
+) -> None:
+    """Both failure handlers finalize an earlier successful member PUT."""
+    output, orchestrator = _run_main(
+        monkeypatch,
+        module_under_test,
+        failure=failure,
+        deploy=True,
+    )
+
+    assert output["msg"] == f"{prefix}: {failure}{ACCEPTED_NOTE}"
+    assert orchestrator._deployed == [[ACCEPTED_PAIR]]
+    assert orchestrator._pending_deploys == []
+
+
+@pytest.mark.parametrize("module_under_test", MODULES)
+@pytest.mark.parametrize(
+    "deploy,check_mode",
+    ((False, False), (True, True)),
+)
+def test_failure_finalizer_respects_staging_and_check_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    module_under_test,
+    deploy: bool,
+    check_mode: bool,
+) -> None:
+    """Deploy false remains staged, and check mode never sends a deploy."""
+    failure = NDStateMachineError("later update failed")
+    output, orchestrator = _run_main(
+        monkeypatch,
+        module_under_test,
+        failure=failure,
+        deploy=deploy,
+        check_mode=check_mode,
+    )
+
+    assert output["msg"] == f"Module execution failed: {failure}"
+    assert orchestrator._deployed == []
+    assert orchestrator._pending_deploys == [ACCEPTED_PAIR]


### PR DESCRIPTION
## Related Issue(s)

Implements [IFACE-004 in #533](https://github.com/CiscoDevNet/ansible-nd/issues/533#iface-004).

This PR addresses the standalone-module implementation tracked by IFACE-004. It does not close #533 because that issue tracks multiple independent interface findings.

## Proposed Changes

Enable the standalone Ethernet access, trunk-host, and routed modules to recognize and safely update authentic port-channel and vPC member policies.

### Supported member policies

| Module | Supported existing member policies |
| --- | --- |
| `cisco.nd.nd_interface_ethernet_access` | `accessPoMember`, `accessVpcPoMember` |
| `cisco.nd.nd_interface_ethernet_trunk_host` | `poMember`, `vpcMember` |
| `cisco.nd.nd_interface_ethernet_routed` | `l3PoMember`, `iosXeL3PoMember` |

Member interfaces have the following deliberately restricted contract:

- Only explicitly targeted members using `state: merged` are eligible.
- Only `admin_state`, `description`, and `extra_config` can be changed.
- The update starts from the authentic controller member record and preserves its exact policy type, parent identity, port-channel or vPC membership, and all other modeled configuration.
- Existing members use the singular per-interface `PUT`; they can never fall back to a host-policy `POST`.
- `state: replaced` and `state: deleted` reject explicit members. `state: overridden` leaves omitted members outside the host-policy scope and rejects explicitly named members.
- Check mode reports the planned safe-field update without issuing a write.

### Ownership and safety validation

- Build a shared membership index from cached switch inventories and require one compatible parent for ordinary port-channel members.
- Validate configured and operational port-channel identifiers, parent policy, mode, network OS, parent member lists, duplicate claims, orphaned members, and wrong-family or fabric-owned policies.
- For vPC members, require reciprocal peer identity, consistent literal parent records on both peers, exact member ownership, and an unambiguous mapping of peer member slots to switches.
- Reject `extra_config` commands, including common abbreviations, that could change channel-group membership, change interface context, default an interface, or escape configuration context.
- Permit and discard only qualified response-only `ptp` and access-member `portMode` echoes. Reject any other unrecognized nested member configuration before constructing the full `PUT` payload.
- Queue deployment only after a confirmed successful write, while retaining previously accepted deployment intent if a later operation fails.

### Scale behavior

- Reuse one in-memory membership index for the normal state-machine batch.
- Reuse cached interface inventory and fetch each unique vPC peer inventory at most once.
- Add no discovery `GET` per member.
- Issue zero `PUT` requests for idempotent members.
- Retain one singular `PUT` per changed member on ND 4.2.1 and ND 4.3.1. Version-gated bulk interface updates remain separate work in #553.

## Test Notes

Local validation was completed after rebasing on `develop` commit `c6369920`:

- `black --check --line-length 159` passed for all 17 changed Python files.
- `git diff --check` passed.
- Ethernet member model unit suite: **86 passed**.
- Focused IFACE-004 unit suite: **406 passed**.
- Complete unit suite: **4,893 passed**.
- Targeted Pylint sanity for `ethernet_member_interface.py` passed with the actual `ansible-core` stable-2.18 (`2.18.19`) and stable-2.19 (`2.19.13`) test environments using Docker target Python 3.13.
- Complete `ansible-test sanity --docker --python 3.13` passed with both `ansible-core` stable-2.18 (`2.18.19`) and stable-2.19 (`2.19.13`).
- The CI compatibility correction replaces the PEP 604 runtime model union with `typing.Union`, preserving all five supported member-policy model variants while avoiding the Pylint `unsupported-binary-operation` failure.
- GitHub Actions completed on head `24cb0db1`: **56 checks passed**, one intentionally disabled Integration Tests job was skipped, and there were zero failures or cancellations.
- Added guarded integration coverage for standalone access and trunk members, pair-aware access and trunk vPC members, and NX-OS and IOS XE routed members. The scenarios verify exact baselines, preserve non-safe fields and membership, exercise idempotence, and restore state after attempted mutation.

Live Nexus Dashboard qualification of this implementation has not yet been run. The guarded live integration scenarios remain opt-in.

## Cisco Nexus Dashboard Version

IFACE-004 was identified while testing Nexus Dashboard 4.2.1 (`build_version: 4.2.1.10`). This implementation preserves the existing singular interface-update path for ND 4.2.1 and ND 4.3.1. Live qualification of the new member-update behavior remains pending on both versions.

## Related ND API Resource Category

* [ ] analyze
* [ ] infra
* [x] manage
* [ ] onemanage
* [ ] other

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
